### PR TITLE
fix: correct boolean parsing of IS_WRITE_LOG and WRITE_LOG env vars

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.1.36 (2026-02-11)
+------------------
+
+* Auto-release: Merge pull request #105 from mofa-org/copilot/update-readme-mofa-full-name
+
 0.1.35 (2025-11-07)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MoFA 开发框架
+# MoFA (Modular Framework for AI Agents) 开发框架
 
 [English](README_en.md) | [简体中文](README.md)
 
@@ -34,7 +34,7 @@
 
 ## 1. 设计理念
 
-MoFA 是一个用于构建可组合 AI 智能体的软件框架。通过 MoFA，开发者可以通过模板创建智能体（Agent），并以堆叠方式组合形成更强大的超级智能体（Super Agent）。
+MoFA（Modular Framework for AI Agents）是一个用于构建可组合 AI 智能体的软件框架。通过 MoFA，开发者可以通过模板创建智能体（Agent），并以堆叠方式组合形成更强大的超级智能体（Super Agent）。
 
 ### 1.1 核心设计哲学
 

--- a/README_en.md
+++ b/README_en.md
@@ -1,4 +1,4 @@
-# MoFA Development Framework
+# MoFA (Modular Framework for AI Agents) Development Framework
 
 [English](README_en.md) | [简体中文](README.md)
 
@@ -34,7 +34,7 @@
 
 ## 1. Design Philosophy
 
-MoFA is a software framework for building composable AI agents. With MoFA, developers can create agents through templates and combine them in a stacking manner to form more powerful super agents.
+MoFA (Modular Framework for AI Agents) is a software framework for building composable AI agents. With MoFA, developers can create agents through templates and combine them in a stacking manner to form more powerful super agents.
 
 ### 1.1 Core Design Philosophy
 

--- a/mofa/agent_build/base/base_agent.py
+++ b/mofa/agent_build/base/base_agent.py
@@ -106,8 +106,11 @@ class MofaAgent:
                 load_dotenv(dotenv_path=env_file)
         log_params = ['IS_WRITE_LOG', 'WRITE_LOG']
         for log_status in log_params:
-            if os.getenv(log_status, None) is not None:
-                self.is_write_log = os.getenv(log_status)
+            env_val = os.getenv(log_status)
+            if env_val is not None:
+                val = env_val.strip().lower()
+                # Explicitly check for True-ish values
+                self.is_write_log = val in ("true", "1", "t", "y", "yes")
         self.agent_log = MofaLogger(agent_name=self.agent_name, log_file=self.log_file)
 
     def __init_mcp(self):

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
     data_files=data_files,
     test_suite='tests',
     tests_require=test_requirements,
-    version='0.1.35',
+    version='0.1.36',
     zip_safe=False,
     dependency_links=[],
     cmdclass={


### PR DESCRIPTION
Fixes #109 

## Problem
`os.getenv()` returns a string, so setting `WRITE_LOG=False` results in 
the string `"False"` which Python evaluates as `True`, making it impossible 
to disable logging via environment variables.

## Fix
Parse the env var string explicitly by checking against known truthy 
representations (`"true"`, `"1"`, `"t"`, `"y"`, `"yes"`) instead of 
relying on Python's implicit string truthiness.

## Changes
- `mofa/agent_build/base/base_agent.py`: Updated `__attrs_post_init__` 
  to correctly parse boolean environment variables.