### PR TITLE
Fix requirements.txt parsing in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open('HISTORY.rst') as history_file:
 with open('requirements.txt',encoding='utf-8') as requirements_file:
     all_pkgs = requirements_file.readlines()
 
-requirements = [pkg.replace('\n', '') for pkg in all_pkgs if "#" not in pkg]
+requirements = [pkg.split('#')[0].strip() for pkg in all_pkgs if pkg.split('#')[0].strip()]
 test_requirements = []
 
 # Collect all files from agents and flows directories


### PR DESCRIPTION
The previous one-liner on line 18 had three silent bugs:

1) Inline comments caused packages to be dropped — any line containing # (e.g. openai==1.65.4 # pinned) was excluded entirely from [install_requires](vscode-file://vscode-app/c:/Users/dorot/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) instead of just stripping the comment.
2) Blank lines produced empty strings — empty lines passed through the [if "#" not in pkg](vscode-file://vscode-app/c:/Users/dorot/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) filter and ended up as "" entries in the dependency list, which can cause pip warnings.
3) Whitespace wasn't stripped — lines with leading/trailing spaces or \n characters weren't normalized, potentially causing packages to go unrecognized.

related to issue #111 