### PR TITLE
feat: Add Ollama provider with configuration and integration

### DIFF
--- a/crates/mofa-foundation/src/lib.rs
+++ b/crates/mofa-foundation/src/lib.rs
@@ -1,4 +1,9 @@
-#![allow(dead_code, unused_imports, non_camel_case_types, ambiguous_glob_reexports)]
+#![allow(
+    dead_code,
+    unused_imports,
+    non_camel_case_types,
+    ambiguous_glob_reexports
+)]
 // prompt module
 pub mod prompt;
 

--- a/crates/mofa-foundation/src/llm/agent.rs
+++ b/crates/mofa-foundation/src/llm/agent.rs
@@ -26,6 +26,9 @@ use super::client::{ChatSession, LLMClient};
 use super::provider::{ChatStream, LLMProvider};
 use super::tool_executor::ToolExecutor;
 use super::types::{ChatMessage, LLMError, LLMResult, Tool};
+use crate::llm::{
+    AnthropicConfig, AnthropicProvider, GeminiConfig, GeminiProvider, OllamaConfig, OllamaProvider,
+};
 use crate::prompt;
 use futures::{Stream, StreamExt};
 use mofa_kernel::agent::AgentMetadata;
@@ -39,7 +42,6 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use tokio::sync::{Mutex, RwLock};
-use crate::llm::{AnthropicConfig, AnthropicProvider, GeminiConfig, GeminiProvider};
 
 /// Type alias for TTS audio stream - boxed to avoid exposing kokoro-tts types
 pub type TtsAudioStream = Pin<Box<dyn Stream<Item = (Vec<f32>, Duration)> + Send>>;
@@ -2875,7 +2877,7 @@ impl LLMAgentBuilder {
 
         // 根据 provider_type 创建 LLM Provider
         let llm_provider: Arc<dyn super::LLMProvider> = match provider.provider_type.as_str() {
-            "openai" | "azure" | "ollama" | "compatible" | "local" => {
+            "openai" | "azure" | "compatible" | "local" => {
                 let mut openai_config = OpenAIConfig::new(provider.api_key.clone());
                 openai_config = openai_config.with_base_url(&provider.api_base);
                 openai_config = openai_config.with_model(&agent.model_name);
@@ -2917,6 +2919,21 @@ impl LLMAgentBuilder {
                 }
 
                 Arc::new(GeminiProvider::with_config(cfg))
+            }
+            "ollama" => {
+                let mut ollama_config = OllamaConfig::new();
+                ollama_config = ollama_config.with_base_url(&provider.api_base);
+                ollama_config = ollama_config.with_model(&agent.model_name);
+
+                if let Some(temp) = agent.temperature {
+                    ollama_config = ollama_config.with_temperature(temp);
+                }
+
+                if let Some(max_tokens) = agent.max_completion_tokens {
+                    ollama_config = ollama_config.with_max_tokens(max_tokens as u32);
+                }
+
+                Arc::new(OllamaProvider::with_config(ollama_config))
             }
             other => {
                 return Err(LLMError::Other(format!(
@@ -3005,10 +3022,6 @@ fn create_provider_from_config(
             }
 
             Ok(OpenAIProvider::with_config(openai_config))
-        }
-        "ollama" => {
-            let model = config.model.clone().unwrap_or_else(|| "llama2".to_string());
-            Ok(OpenAIProvider::ollama(model))
         }
         "azure" => {
             let endpoint = config.base_url.clone().ok_or_else(|| {

--- a/crates/mofa-foundation/src/llm/mod.rs
+++ b/crates/mofa-foundation/src/llm/mod.rs
@@ -271,6 +271,7 @@ pub mod agent_workflow;
 pub mod anthropic;
 pub mod google;
 pub mod multi_agent;
+pub mod ollama;
 pub mod openai;
 pub mod pipeline;
 
@@ -309,6 +310,8 @@ pub use openai::{OpenAIConfig, OpenAIProvider};
 pub use anthropic::{AnthropicConfig, AnthropicProvider};
 // Re-export Google Gemini Provider
 pub use google::{GeminiConfig, GeminiProvider};
+// Re-export Ollama Provider
+pub use ollama::{OllamaConfig, OllamaProvider};
 
 // Re-export 高级 API
 pub use agent_workflow::{

--- a/crates/mofa-foundation/src/llm/ollama.rs
+++ b/crates/mofa-foundation/src/llm/ollama.rs
@@ -1,0 +1,317 @@
+//! Ollama Provider (thin wrapper of OpenAI)
+//!
+
+use super::openai::{OpenAIConfig, OpenAIProvider};
+use super::provider::{ChatStream, LLMProvider, ModelCapabilities, ModelInfo};
+use super::types::*;
+use async_trait::async_trait;
+
+/// Ollama provider configuration
+#[derive(Debug, Clone)]
+pub struct OllamaConfig {
+    /// API key not needed
+
+    /// Base URL (default: http://localhost:11434/v1)
+    pub base_url: String,
+    /// Default model id, e.g., llama3
+    pub default_model: String,
+    /// Default temperature
+    pub default_temperature: f32,
+    /// Default max output tokens
+    pub default_max_tokens: u32,
+    /// Request timeout
+    pub timeout_secs: u64,
+}
+
+impl Default for OllamaConfig {
+    fn default() -> Self {
+        Self {
+            base_url: "http://localhost:11434/v1".to_string(),
+            default_model: "llama3".to_string(),
+            default_temperature: 0.7,
+            default_max_tokens: 2048,
+            timeout_secs: 60,
+        }
+    }
+}
+
+impl OllamaConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn from_env() -> Self {
+        let mut cfg = Self::default();
+
+        if let Ok(model) = std::env::var("OLLAMA_MODEL") {
+            cfg.default_model = model;
+        }
+        if let Ok(base_url) = std::env::var("OLLAMA_BASE_URL") {
+            let base = base_url.trim_end_matches('/');
+            cfg.base_url = if base.ends_with("/v1") {
+                base.to_string()
+            } else {
+                format!("{}/v1", base)
+            } //solve any ambiguity on the url
+        }
+        cfg
+    }
+
+    pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
+        self.base_url = url.into();
+        self
+    }
+
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.default_model = model.into();
+        self
+    }
+
+    pub fn with_temperature(mut self, temp: f32) -> Self {
+        self.default_temperature = temp;
+        self
+    }
+
+    pub fn with_max_tokens(mut self, tokens: u32) -> Self {
+        self.default_max_tokens = tokens;
+        self
+    }
+
+    pub fn with_timeout(mut self, secs: u64) -> Self {
+        self.timeout_secs = secs;
+        self
+    }
+}
+
+/// Ollama provider (just like OpenAIProvider --> inner)
+pub struct OllamaProvider {
+    inner: OpenAIProvider,
+}
+
+impl Default for OllamaProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OllamaProvider {
+    /// Create a provider with the default localhost endpoint and given model.
+    pub fn new() -> Self {
+        let config = OllamaConfig::new();
+        Self::with_config(config)
+    }
+
+    /// Create a provider reading `OLLAMA_BASE_URL` and `OLLAMA_MODEL` from the environment.
+    pub fn from_env() -> Self {
+        Self::with_config(OllamaConfig::from_env())
+    }
+
+    /// Create a provider from an explicit `OllamaConfig`.
+    pub fn with_config(config: OllamaConfig) -> Self {
+        let openai_config = OpenAIConfig::new("not-needed")
+            .with_base_url(&config.base_url)
+            .with_model(&config.default_model)
+            .with_temperature(config.default_temperature)
+            .with_max_tokens(config.default_max_tokens)
+            .with_timeout(config.timeout_secs);
+        Self {
+            inner: OpenAIProvider::with_config(openai_config),
+        }
+    }
+}
+
+#[async_trait]
+impl LLMProvider for OllamaProvider {
+    fn name(&self) -> &str {
+        "ollama"
+    }
+
+    fn default_model(&self) -> &str {
+        self.inner.default_model()
+    }
+
+    fn supports_streaming(&self) -> bool {
+        self.inner.supports_streaming()
+    }
+
+    fn supports_tools(&self) -> bool {
+        self.inner.supports_tools()
+    }
+
+    fn supports_vision(&self) -> bool {
+        self.inner.supports_vision()
+    }
+
+    async fn chat(&self, request: ChatCompletionRequest) -> LLMResult<ChatCompletionResponse> {
+        self.inner.chat(request).await
+    }
+
+    async fn chat_stream(&self, request: ChatCompletionRequest) -> LLMResult<ChatStream> {
+        self.inner.chat_stream(request).await
+    }
+
+    async fn embedding(&self, request: EmbeddingRequest) -> LLMResult<EmbeddingResponse> {
+        self.inner.embedding(request).await
+    }
+
+    async fn health_check(&self) -> LLMResult<bool> {
+        self.inner.health_check().await
+    }
+
+    async fn get_model_info(&self, model: &str) -> LLMResult<ModelInfo> {
+        let info = match model {
+            "llama3" | "llama3:latest" | "llama3:8b" => ModelInfo {
+                id: model.to_string(),
+                name: "Llama 3 8B".to_string(),
+                description: Some("Meta Llama 3 8B instruction-tuned model".to_string()),
+                context_window: Some(8192),
+                max_output_tokens: Some(2048),
+                training_cutoff: Some("2023-12".to_string()),
+                capabilities: ModelCapabilities {
+                    streaming: true,
+                    tools: true,
+                    vision: false,
+                    json_mode: true,
+                    json_schema: false,
+                },
+            },
+            "llama3:70b" => ModelInfo {
+                id: model.to_string(),
+                name: "Llama 3 70B".to_string(),
+                description: Some("Meta Llama 3 70B instruction-tuned model".to_string()),
+                context_window: Some(8192),
+                max_output_tokens: Some(2048),
+                training_cutoff: Some("2023-12".to_string()),
+                capabilities: ModelCapabilities {
+                    streaming: true,
+                    tools: true,
+                    vision: false,
+                    json_mode: true,
+                    json_schema: false,
+                },
+            },
+            "llama3.1" | "llama3.1:latest" | "llama3.1:8b" => ModelInfo {
+                id: model.to_string(),
+                name: "Llama 3.1 8B".to_string(),
+                description: Some("Meta Llama 3.1 8B with 128k context window".to_string()),
+                context_window: Some(131072),
+                max_output_tokens: Some(4096),
+                training_cutoff: Some("2024-03".to_string()),
+                capabilities: ModelCapabilities {
+                    streaming: true,
+                    tools: true,
+                    vision: false,
+                    json_mode: true,
+                    json_schema: false,
+                },
+            },
+            "llama3.1:70b" => ModelInfo {
+                id: model.to_string(),
+                name: "Llama 3.1 70B".to_string(),
+                description: Some("Meta Llama 3.1 70B with 128k context window".to_string()),
+                context_window: Some(131072),
+                max_output_tokens: Some(4096),
+                training_cutoff: Some("2024-03".to_string()),
+                capabilities: ModelCapabilities {
+                    streaming: true,
+                    tools: true,
+                    vision: false,
+                    json_mode: true,
+                    json_schema: false,
+                },
+            },
+            "llama3.2" | "llama3.2:latest" | "llama3.2:3b" => ModelInfo {
+                id: model.to_string(),
+                name: "Llama 3.2 3B".to_string(),
+                description: Some("Meta Llama 3.2 3B lightweight model".to_string()),
+                context_window: Some(131072),
+                max_output_tokens: Some(4096),
+                training_cutoff: Some("2024-06".to_string()),
+                capabilities: ModelCapabilities {
+                    streaming: true,
+                    tools: false,
+                    vision: false,
+                    json_mode: true,
+                    json_schema: false,
+                },
+            },
+            "llama2" | "llama2:latest" | "llama2:7b" => ModelInfo {
+                id: model.to_string(),
+                name: "Llama 2 7B".to_string(),
+                description: Some("Meta Llama 2 7B chat model".to_string()),
+                context_window: Some(4096),
+                max_output_tokens: Some(2048),
+                training_cutoff: Some("2023-07".to_string()),
+                capabilities: ModelCapabilities {
+                    streaming: true,
+                    tools: false,
+                    vision: false,
+                    json_mode: false,
+                    json_schema: false,
+                },
+            },
+            "mistral" | "mistral:latest" | "mistral:7b" => ModelInfo {
+                id: model.to_string(),
+                name: "Mistral 7B".to_string(),
+                description: Some("Mistral AI 7B instruction-tuned model".to_string()),
+                context_window: Some(32768),
+                max_output_tokens: Some(4096),
+                training_cutoff: None,
+                capabilities: ModelCapabilities {
+                    streaming: true,
+                    tools: true,
+                    vision: false,
+                    json_mode: true,
+                    json_schema: false,
+                },
+            },
+            _ => ModelInfo {
+                id: model.to_string(),
+                name: model.to_string(),
+                description: None,
+                context_window: None,
+                max_output_tokens: None,
+                training_cutoff: None,
+                capabilities: ModelCapabilities::default(),
+            },
+        };
+
+        Ok(info)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_config_defaults() {
+        let config = OllamaConfig::default();
+        assert_eq!(config.base_url, "http://localhost:11434/v1");
+        assert_eq!(config.default_model, "llama3");
+    }
+
+    #[test]
+    fn test_config_builder() {
+        let config = OllamaConfig::new()
+            .with_base_url("http://localhost:11434/v1")
+            .with_model("mistral")
+            .with_temperature(0.5)
+            .with_max_tokens(1024);
+
+        assert_eq!(config.base_url, "http://localhost:11434/v1");
+        assert_eq!(config.default_model, "mistral");
+        assert_eq!(config.default_temperature, 0.5);
+        assert_eq!(config.default_max_tokens, 1024);
+    }
+
+    #[test]
+    fn test_provider_name() {
+        let config = OllamaConfig::new()
+            .with_model("llama3")
+            .with_base_url("http://localhost:11434/v1");
+
+        let provider = OllamaProvider::with_config(config);
+        assert_eq!(provider.name(), "ollama");
+    }
+}

--- a/crates/mofa-foundation/src/llm/openai.rs
+++ b/crates/mofa-foundation/src/llm/openai.rs
@@ -204,11 +204,6 @@ impl OpenAIProvider {
         Self::with_config(config)
     }
 
-    /// 创建 Ollama Provider
-    pub fn ollama(model: impl Into<String>) -> Self {
-        Self::local("http://localhost:11434/v1", model)
-    }
-
     /// 获取底层 async-openai 客户端
     pub fn client(&self) -> &Client<AsyncOpenAIConfig> {
         &self.client

--- a/crates/mofa-foundation/src/workflow/mod.rs
+++ b/crates/mofa-foundation/src/workflow/mod.rs
@@ -39,9 +39,9 @@ pub mod dsl;
 
 // Re-export kernel workflow types for convenience
 pub use mofa_kernel::workflow::{
-    Command, CompiledGraph, ControlFlow, GraphConfig, GraphState, JsonState, NodeFunc,
-    Reducer, ReducerType, RemainingSteps, RuntimeContext, SendCommand, StateSchema, StateUpdate,
-    END, START,
+    Command, CompiledGraph, ControlFlow, END, GraphConfig, GraphState, JsonState, NodeFunc,
+    Reducer, ReducerType, RemainingSteps, RuntimeContext, START, SendCommand, StateSchema,
+    StateUpdate,
 };
 
 // Re-export kernel StateGraph trait

--- a/crates/mofa-foundation/src/workflow/reducers.rs
+++ b/crates/mofa-foundation/src/workflow/reducers.rs
@@ -183,11 +183,7 @@ impl Reducer for MergeReducer {
     }
 
     fn name(&self) -> &str {
-        if self.deep {
-            "merge_deep"
-        } else {
-            "merge"
-        }
+        if self.deep { "merge_deep" } else { "merge" }
     }
 
     fn reducer_type(&self) -> ReducerType {
@@ -451,10 +447,7 @@ mod tests {
         assert_eq!(result, json!([1, 2, 3, 4]));
 
         // Single item extends
-        let result = reducer
-            .reduce(Some(&json!([1])), &json!(2))
-            .await
-            .unwrap();
+        let result = reducer.reduce(Some(&json!([1])), &json!(2)).await.unwrap();
         assert_eq!(result, json!([1, 2]));
     }
 
@@ -560,17 +553,12 @@ mod tests {
     #[tokio::test]
     async fn test_custom_reducer() {
         let reducer = CustomReducer::new("sum", |current, update| {
-            let curr = current
-                .and_then(|v| v.as_i64())
-                .unwrap_or(0);
+            let curr = current.and_then(|v| v.as_i64()).unwrap_or(0);
             let upd = update.as_i64().unwrap_or(0);
             Ok(json!(curr + upd))
         });
 
-        let result = reducer
-            .reduce(Some(&json!(10)), &json!(5))
-            .await
-            .unwrap();
+        let result = reducer.reduce(Some(&json!(10)), &json!(5)).await.unwrap();
         assert_eq!(result, json!(15));
 
         assert_eq!(reducer.name(), "sum");

--- a/crates/mofa-kernel/src/config/mod.rs
+++ b/crates/mofa-kernel/src/config/mod.rs
@@ -320,7 +320,6 @@ mod unit_tests {
         assert!(detect_format("config.txt").is_err());
     }
 
-
     #[test]
     fn test_from_str_toml() {
         let toml = r#"

--- a/crates/mofa-kernel/src/workflow/command.rs
+++ b/crates/mofa-kernel/src/workflow/command.rs
@@ -173,7 +173,11 @@ impl SendCommand {
     }
 
     /// Create a send command with a branch ID
-    pub fn with_branch(target: impl Into<String>, input: Value, branch_id: impl Into<String>) -> Self {
+    pub fn with_branch(
+        target: impl Into<String>,
+        input: Value,
+        branch_id: impl Into<String>,
+    ) -> Self {
         Self {
             target: target.into(),
             input,
@@ -201,9 +205,7 @@ mod tests {
 
     #[test]
     fn test_command_continue() {
-        let cmd = Command::new()
-            .update("result", json!("done"))
-            .continue_();
+        let cmd = Command::new().update("result", json!("done")).continue_();
 
         assert_eq!(cmd.control, ControlFlow::Continue);
         assert!(!cmd.is_return());
@@ -211,9 +213,7 @@ mod tests {
 
     #[test]
     fn test_command_return() {
-        let cmd = Command::new()
-            .update("final", json!("result"))
-            .return_();
+        let cmd = Command::new().update("final", json!("result")).return_();
 
         assert!(cmd.is_return());
     }
@@ -239,11 +239,8 @@ mod tests {
         assert_eq!(send.target, "process");
         assert!(send.branch_id.is_none());
 
-        let send_with_branch = SendCommand::with_branch(
-            "process",
-            json!({"data": "test"}),
-            "branch-1",
-        );
+        let send_with_branch =
+            SendCommand::with_branch("process", json!({"data": "test"}), "branch-1");
         assert_eq!(send_with_branch.branch_id, Some("branch-1".to_string()));
     }
 

--- a/crates/mofa-kernel/src/workflow/context.rs
+++ b/crates/mofa-kernel/src/workflow/context.rs
@@ -383,6 +383,9 @@ mod tests {
         );
 
         assert!(ctx.is_sub_workflow());
-        assert_eq!(ctx.parent_execution_id, Some("parent-execution-123".to_string()));
+        assert_eq!(
+            ctx.parent_execution_id,
+            Some("parent-execution-123".to_string())
+        );
     }
 }

--- a/crates/mofa-kernel/src/workflow/graph.rs
+++ b/crates/mofa-kernel/src/workflow/graph.rs
@@ -152,7 +152,11 @@ pub trait StateGraph: Send + Sync {
     /// # Arguments
     /// * `id` - Unique node identifier
     /// * `node` - Node function implementation
-    fn add_node(&mut self, id: impl Into<String>, node: Box<dyn NodeFunc<Self::State>>) -> &mut Self;
+    fn add_node(
+        &mut self,
+        id: impl Into<String>,
+        node: Box<dyn NodeFunc<Self::State>>,
+    ) -> &mut Self;
 
     /// Add an edge between two nodes
     ///
@@ -256,10 +260,7 @@ pub trait CompiledGraph<S: GraphState>: Send + Sync {
 #[derive(Debug, Clone)]
 pub enum StreamEvent<S: GraphState> {
     /// A node started executing
-    NodeStart {
-        node_id: String,
-        state: S,
-    },
+    NodeStart { node_id: String, state: S },
     /// A node finished executing
     NodeEnd {
         node_id: String,
@@ -267,9 +268,7 @@ pub enum StreamEvent<S: GraphState> {
         command: Command,
     },
     /// Graph execution completed
-    End {
-        final_state: S,
-    },
+    End { final_state: S },
     /// Error occurred
     Error {
         node_id: Option<String>,

--- a/crates/mofa-kernel/src/workflow/mod.rs
+++ b/crates/mofa-kernel/src/workflow/mod.rs
@@ -49,6 +49,8 @@ pub mod state;
 // Re-export public API
 pub use command::{Command, ControlFlow, SendCommand};
 pub use context::{GraphConfig, RemainingSteps, RuntimeContext};
-pub use graph::{CompiledGraph, EdgeTarget, NodeFunc, StateGraph, StreamEvent, StepResult, END, START};
+pub use graph::{
+    CompiledGraph, END, EdgeTarget, NodeFunc, START, StateGraph, StepResult, StreamEvent,
+};
 pub use reducer::{Reducer, ReducerType, StateUpdate};
 pub use state::{GraphState, JsonState, StateSchema};

--- a/crates/mofa-kernel/src/workflow/state.rs
+++ b/crates/mofa-kernel/src/workflow/state.rs
@@ -124,11 +124,7 @@ impl StateSchema {
     }
 
     /// Add a simple field
-    pub fn field(
-        mut self,
-        name: impl Into<String>,
-        type_name: impl Into<String>,
-    ) -> Self {
+    pub fn field(mut self, name: impl Into<String>, type_name: impl Into<String>) -> Self {
         self.fields.push(StateField {
             name: name.into(),
             type_name: type_name.into(),

--- a/crates/mofa-sdk/src/lib.rs
+++ b/crates/mofa-sdk/src/lib.rs
@@ -380,9 +380,9 @@ pub mod workflow {
 
     // Re-export kernel workflow types
     pub use mofa_kernel::workflow::{
-        Command, CompiledGraph, ControlFlow, EdgeTarget, GraphConfig, GraphState, JsonState,
-        NodeFunc, Reducer, ReducerType, RemainingSteps, RuntimeContext, SendCommand, StateSchema,
-        StateUpdate, StreamEvent, StepResult, END, START,
+        Command, CompiledGraph, ControlFlow, END, EdgeTarget, GraphConfig, GraphState, JsonState,
+        NodeFunc, Reducer, ReducerType, RemainingSteps, RuntimeContext, START, SendCommand,
+        StateSchema, StateUpdate, StepResult, StreamEvent,
     };
 
     // Re-export kernel StateGraph trait
@@ -390,11 +390,19 @@ pub mod workflow {
 
     // Foundation layer implementations
     pub use mofa_foundation::workflow::{
-        // StateGraph implementation
-        CompiledGraphImpl, StateGraphImpl,
         // Reducers
-        AppendReducer, ExtendReducer, FirstReducer, LastNReducer, LastReducer,
-        MergeReducer, OverwriteReducer, CustomReducer, create_reducer,
+        AppendReducer,
+        // StateGraph implementation
+        CompiledGraphImpl,
+        CustomReducer,
+        ExtendReducer,
+        FirstReducer,
+        LastNReducer,
+        LastReducer,
+        MergeReducer,
+        OverwriteReducer,
+        StateGraphImpl,
+        create_reducer,
     };
 
     // Legacy workflow API
@@ -468,6 +476,7 @@ pub mod llm {
     pub use crate::llm_tools::ToolPluginExecutor;
     pub use mofa_foundation::llm::anthropic::{AnthropicConfig, AnthropicProvider};
     pub use mofa_foundation::llm::google::{GeminiConfig, GeminiProvider};
+    pub use mofa_foundation::llm::ollama::{OllamaConfig, OllamaProvider};
     pub use mofa_foundation::llm::openai::{OpenAIConfig, OpenAIProvider};
     pub use mofa_foundation::llm::*;
 
@@ -503,6 +512,15 @@ pub mod llm {
         }
 
         Ok(OpenAIProvider::with_config(config))
+    }
+
+    /// Create an Ollama provider from environment variables (no API key required).
+    ///
+    /// Reads:
+    /// - `OLLAMA_BASE_URL`: base URL without `/v1` suffix, e.g. `http://localhost:11434` (optional)
+    /// - `OLLAMA_MODEL`: model name, e.g. `llama3` (optional)
+    pub fn ollama_from_env() -> Result<OllamaProvider, crate::llm::LLMError> {
+        Ok(crate::llm::OllamaProvider::from_env())
     }
 }
 


### PR DESCRIPTION
## Summary
Introduced Ollama provider without depending on OpenAI, this increases readability, modularity and reliability.

## Motivation
As of now, ollama provider lives into OpenAI provider leading to confusion (we pass a 'fake' key, since it is not needed for Ollama) and poor modularity.

## Changes
- Introduced OllamaConfig and OllamaProvider to support Ollama models.
- Updated LLMProvider trait implementations to include Ollama functionality.
- Refactored existing code to accommodate the new provider, including updates to agent and workflow modules.
- Enhanced error handling and logging for better debugging.
- Cleaned up code formatting and organization for improved readability.

## Related Issues
https://github.com/mofa-org/mofa/issues/132

## Testing
- cargo test on new and old tests, all passes
- different runs with Ollama provider all sucessful
-
## Checklist
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes with no warnings 
- [x] `cargo test` passes
- [x] Architecture layer rules respected (see CONTRIBUTING.md)
- [x] Relevant documentation updated





