### PR TITLE
feat: Visual Time-Travel Debugger — Telemetry Infrastructure (#113)

### DIFF
--- a/crates/mofa-foundation/examples/telemetry_demo.rs
+++ b/crates/mofa-foundation/examples/telemetry_demo.rs
@@ -1,0 +1,268 @@
+//! Time-Travel Debugger Telemetry Demo
+//!
+//! This example demonstrates the telemetry infrastructure by running a simple
+//! workflow with a ChannelTelemetryEmitter attached, then displaying the
+//! captured execution trace in a formatted timeline.
+//!
+//! Run with: cargo run --example telemetry_demo -p mofa-foundation
+
+use mofa_foundation::workflow::{
+    ChannelTelemetryEmitter, ExecutorConfig, InMemorySessionRecorder, WorkflowExecutor,
+    WorkflowGraph, WorkflowNode, WorkflowValue,
+};
+use mofa_kernel::workflow::telemetry::{DebugEvent, DebugSession, SessionRecorder};
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() {
+    println!();
+    println!("╔══════════════════════════════════════════════════════════════╗");
+    println!("║       🕰️  MoFA Time-Travel Debugger — Telemetry Demo       ║");
+    println!("╚══════════════════════════════════════════════════════════════╝");
+    println!();
+
+    // ─── 1. Build a sample workflow ────────────────────────────────────
+    let mut graph = WorkflowGraph::new("data_pipeline", "Data Processing Pipeline");
+
+    graph.add_node(WorkflowNode::start("start"));
+    graph.add_node(WorkflowNode::task(
+        "validate",
+        "Validate Input",
+        |_ctx, input| async move {
+            let value = input.as_i64().unwrap_or(0);
+            if value > 0 {
+                Ok(WorkflowValue::Int(value))
+            } else {
+                Err("Input must be positive".to_string())
+            }
+        },
+    ));
+    graph.add_node(WorkflowNode::task(
+        "transform",
+        "Transform Data",
+        |_ctx, input| async move {
+            let value = input.as_i64().unwrap_or(0);
+            Ok(WorkflowValue::Int(value * 3 + 7))
+        },
+    ));
+    graph.add_node(WorkflowNode::task(
+        "enrich",
+        "Enrich Results",
+        |_ctx, input| async move {
+            let value = input.as_i64().unwrap_or(0);
+            Ok(WorkflowValue::Map({
+                let mut m = std::collections::HashMap::new();
+                m.insert("result".to_string(), WorkflowValue::Int(value));
+                m.insert(
+                    "label".to_string(),
+                    WorkflowValue::String(format!("processed_{}", value)),
+                );
+                m
+            }))
+        },
+    ));
+    graph.add_node(WorkflowNode::end("end"));
+
+    graph.connect("start", "validate");
+    graph.connect("validate", "transform");
+    graph.connect("transform", "enrich");
+    graph.connect("enrich", "end");
+
+    // ─── 2. Set up telemetry ───────────────────────────────────────────
+    let (emitter, mut rx) = ChannelTelemetryEmitter::new(256);
+    let recorder = Arc::new(InMemorySessionRecorder::new());
+
+    // Start a debug session
+    let session = DebugSession::new("demo-session-001", "data_pipeline", "exec-001");
+    recorder.start_session(&session).await.unwrap();
+
+    println!("📋 Session: {}", session.session_id);
+    println!("📊 Workflow: {} ({})", "Data Processing Pipeline", "data_pipeline");
+    println!("🔢 Input: 42");
+    println!();
+    println!("─── Execution Timeline ────────────────────────────────────────");
+    println!();
+
+    // ─── 3. Execute with telemetry ─────────────────────────────────────
+    let executor = WorkflowExecutor::new(ExecutorConfig::default())
+        .with_telemetry(Arc::new(emitter));
+
+    let result = executor
+        .execute(&graph, WorkflowValue::Int(42))
+        .await
+        .unwrap();
+
+    // ─── 4. Display captured events ────────────────────────────────────
+    let mut events = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        events.push(event);
+    }
+
+    // Also record events to the session recorder (simulating production use)
+    for event in &events {
+        recorder
+            .record_event("demo-session-001", event)
+            .await
+            .unwrap();
+    }
+    recorder
+        .end_session("demo-session-001", "completed")
+        .await
+        .unwrap();
+
+    let base_ts = events.first().map(|e| e.timestamp_ms()).unwrap_or(0);
+
+    for (i, event) in events.iter().enumerate() {
+        let relative_ms = event.timestamp_ms() - base_ts;
+        let prefix = if i == events.len() - 1 {
+            "└──"
+        } else {
+            "├──"
+        };
+
+        match event {
+            DebugEvent::WorkflowStart {
+                workflow_id,
+                execution_id,
+                ..
+            } => {
+                println!(
+                    "  {} ⚡ [{:>4}ms] WORKFLOW START  │ workflow={}, exec={}",
+                    prefix, relative_ms, workflow_id, execution_id
+                );
+            }
+            DebugEvent::NodeStart {
+                node_id,
+                state_snapshot,
+                ..
+            } => {
+                let state_preview = serde_json::to_string(state_snapshot)
+                    .unwrap_or_default();
+                let truncated = if state_preview.len() > 60 {
+                    format!("{}...", &state_preview[..57])
+                } else {
+                    state_preview
+                };
+                println!(
+                    "  {} 🟢 [{:>4}ms] NODE START      │ node={:<12} │ state={}",
+                    prefix, relative_ms, node_id, truncated
+                );
+            }
+            DebugEvent::NodeEnd {
+                node_id,
+                duration_ms,
+                state_snapshot,
+                ..
+            } => {
+                let state_preview = serde_json::to_string(state_snapshot)
+                    .unwrap_or_default();
+                let truncated = if state_preview.len() > 50 {
+                    format!("{}...", &state_preview[..47])
+                } else {
+                    state_preview
+                };
+                println!(
+                    "  {} 🔵 [{:>4}ms] NODE END        │ node={:<12} │ took={}ms │ out={}",
+                    prefix, relative_ms, node_id, duration_ms, truncated
+                );
+            }
+            DebugEvent::WorkflowEnd {
+                status,
+                ..
+            } => {
+                println!(
+                    "  {} 🏁 [{:>4}ms] WORKFLOW END    │ status={}",
+                    prefix, relative_ms, status
+                );
+            }
+            DebugEvent::Error {
+                node_id, error, ..
+            } => {
+                println!(
+                    "  {} ❌ [{:>4}ms] ERROR           │ node={:?} │ {}",
+                    prefix, relative_ms, node_id, error
+                );
+            }
+            DebugEvent::StateChange {
+                node_id,
+                key,
+                old_value,
+                new_value,
+                ..
+            } => {
+                println!(
+                    "  {} 🔄 [{:>4}ms] STATE CHANGE    │ node={} │ {}={} → {}",
+                    prefix,
+                    relative_ms,
+                    node_id,
+                    key,
+                    old_value
+                        .as_ref()
+                        .map(|v| v.to_string())
+                        .unwrap_or("∅".to_string()),
+                    new_value
+                );
+            }
+        }
+    }
+
+    println!();
+    println!("─── Session Recorder Summary ──────────────────────────────────");
+    println!();
+
+    // ─── 5. Show session recorder data ─────────────────────────────────
+    let session_data = recorder.get_session("demo-session-001").await.unwrap();
+    if let Some(s) = session_data {
+        println!("  📦 Session ID:    {}", s.session_id);
+        println!("  📊 Workflow:      {}", s.workflow_id);
+        println!("  🔢 Event Count:   {}", s.event_count);
+        println!("  📌 Status:        {}", s.status);
+        println!("  ⏱️  Started:       {}ms", s.started_at);
+        if let Some(ended) = s.ended_at {
+            println!("  ⏱️  Ended:         {}ms", ended);
+            println!("  ⏱️  Duration:      {}ms", ended - s.started_at);
+        }
+    }
+
+    // ─── 6. Demonstrate replay capability ──────────────────────────────
+    println!();
+    println!("─── Time-Travel Replay (from SessionRecorder) ──────────────");
+    println!();
+
+    let recorded_events = recorder.get_events("demo-session-001").await.unwrap();
+    println!("  📼 Replaying {} events from stored session...", recorded_events.len());
+    println!();
+
+    for (step, event) in recorded_events.iter().enumerate() {
+        let event_json = serde_json::to_string_pretty(event).unwrap();
+        let first_line = event_json.lines().next().unwrap_or("");
+        println!(
+            "  Step {}/{}: {} {}",
+            step + 1,
+            recorded_events.len(),
+            event.event_type(),
+            first_line
+        );
+    }
+
+    println!();
+    println!("─── Execution Result ──────────────────────────────────────────");
+    println!();
+    println!("  ✅ Status: {:?}", result.status);
+    println!("  📊 Nodes executed: {}", result.node_records.len());
+    for record in &result.node_records {
+        println!(
+            "     • {} ({:?}, {}ms)",
+            record.node_id,
+            record.status,
+            record.ended_at - record.started_at
+        );
+    }
+
+    println!();
+    println!("╔══════════════════════════════════════════════════════════════╗");
+    println!("║  ✅ Demo complete! Telemetry infrastructure is working.     ║");
+    println!("║  Next: Build time-travel UI on top of this data layer.      ║");
+    println!("╚══════════════════════════════════════════════════════════════╝");
+    println!();
+}

--- a/crates/mofa-foundation/src/agent/tools/mod.rs
+++ b/crates/mofa-foundation/src/agent/tools/mod.rs
@@ -17,4 +17,3 @@ pub mod mcp;
 
 pub use adapters::{BuiltinTools, ClosureTool, FunctionTool};
 pub use registry::{ToolRegistry, ToolSearcher};
-

--- a/crates/mofa-foundation/src/agent/tools/registry.rs
+++ b/crates/mofa-foundation/src/agent/tools/registry.rs
@@ -121,9 +121,7 @@ impl ToolRegistry {
         let client = self
             .mcp_client
             .get_or_insert_with(|| {
-                std::sync::Arc::new(tokio::sync::RwLock::new(
-                    super::mcp::McpClientManager::new(),
-                ))
+                std::sync::Arc::new(tokio::sync::RwLock::new(super::mcp::McpClientManager::new()))
             })
             .clone();
 
@@ -143,11 +141,8 @@ impl ToolRegistry {
         let mut registered_names = Vec::new();
         for tool_info in tools {
             let name = tool_info.name.clone();
-            let adapter = super::mcp::McpToolAdapter::new(
-                endpoint.clone(),
-                tool_info,
-                client.clone(),
-            );
+            let adapter =
+                super::mcp::McpToolAdapter::new(endpoint.clone(), tool_info, client.clone());
             self.register_with_source(
                 std::sync::Arc::new(adapter),
                 ToolSource::Mcp {

--- a/crates/mofa-foundation/src/lib.rs
+++ b/crates/mofa-foundation/src/lib.rs
@@ -1,4 +1,9 @@
-#![allow(dead_code, unused_imports, non_camel_case_types, ambiguous_glob_reexports)]
+#![allow(
+    dead_code,
+    unused_imports,
+    non_camel_case_types,
+    ambiguous_glob_reexports
+)]
 // prompt module
 pub mod prompt;
 

--- a/crates/mofa-foundation/src/llm/agent.rs
+++ b/crates/mofa-foundation/src/llm/agent.rs
@@ -26,6 +26,7 @@ use super::client::{ChatSession, LLMClient};
 use super::provider::{ChatStream, LLMProvider};
 use super::tool_executor::ToolExecutor;
 use super::types::{ChatMessage, LLMError, LLMResult, Tool};
+use crate::llm::{AnthropicConfig, AnthropicProvider, GeminiConfig, GeminiProvider};
 use crate::prompt;
 use futures::{Stream, StreamExt};
 use mofa_kernel::agent::AgentMetadata;
@@ -39,7 +40,6 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use tokio::sync::{Mutex, RwLock};
-use crate::llm::{AnthropicConfig, AnthropicProvider, GeminiConfig, GeminiProvider};
 
 /// Type alias for TTS audio stream - boxed to avoid exposing kokoro-tts types
 pub type TtsAudioStream = Pin<Box<dyn Stream<Item = (Vec<f32>, Duration)> + Send>>;

--- a/crates/mofa-foundation/src/workflow/executor.rs
+++ b/crates/mofa-foundation/src/workflow/executor.rs
@@ -865,8 +865,8 @@ mod tests {
         graph.connect("double", "end");
 
         let (emitter, mut rx) = ChannelTelemetryEmitter::new(64);
-        let executor = WorkflowExecutor::new(ExecutorConfig::default())
-            .with_telemetry(Arc::new(emitter));
+        let executor =
+            WorkflowExecutor::new(ExecutorConfig::default()).with_telemetry(Arc::new(emitter));
 
         let result = executor
             .execute(&graph, WorkflowValue::Int(5))

--- a/crates/mofa-foundation/src/workflow/executor.rs
+++ b/crates/mofa-foundation/src/workflow/executor.rs
@@ -1,6 +1,10 @@
 //! 工作流执行器
 //!
 //! 负责工作流的执行调度
+//!
+//! Supports optional telemetry emission for the time-travel debugger.
+//! When a `TelemetryEmitter` is attached via `with_telemetry()`, the
+//! executor emits `DebugEvent`s at key execution points.
 
 use super::graph::WorkflowGraph;
 use super::node::{NodeType, WorkflowNode};
@@ -8,6 +12,7 @@ use super::state::{
     ExecutionRecord, NodeExecutionRecord, NodeResult, NodeStatus, WorkflowContext, WorkflowStatus,
     WorkflowValue,
 };
+use mofa_kernel::workflow::telemetry::{DebugEvent, TelemetryEmitter};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
@@ -76,6 +81,8 @@ pub struct WorkflowExecutor {
     config: ExecutorConfig,
     /// 事件发送器
     event_tx: Option<mpsc::Sender<ExecutionEvent>>,
+    /// Telemetry emitter for the time-travel debugger (optional)
+    telemetry: Option<Arc<dyn TelemetryEmitter>>,
     /// 子工作流注册表
     sub_workflows: Arc<RwLock<HashMap<String, Arc<WorkflowGraph>>>>,
     /// 外部事件等待器
@@ -90,6 +97,7 @@ impl WorkflowExecutor {
         Self {
             config,
             event_tx: None,
+            telemetry: None,
             sub_workflows: Arc::new(RwLock::new(HashMap::new())),
             event_waiters: Arc::new(RwLock::new(HashMap::new())),
             semaphore,
@@ -100,6 +108,24 @@ impl WorkflowExecutor {
     pub fn with_event_sender(mut self, tx: mpsc::Sender<ExecutionEvent>) -> Self {
         self.event_tx = Some(tx);
         self
+    }
+
+    /// Attach a telemetry emitter for time-travel debugger support.
+    ///
+    /// When set, the executor will emit `DebugEvent`s at key execution points
+    /// (workflow start/end, node start/end).
+    pub fn with_telemetry(mut self, emitter: Arc<dyn TelemetryEmitter>) -> Self {
+        self.telemetry = Some(emitter);
+        self
+    }
+
+    /// Emit a debug telemetry event (no-op if no emitter is set).
+    async fn emit_debug(&self, event: DebugEvent) {
+        if let Some(ref emitter) = self.telemetry {
+            if emitter.is_enabled() {
+                emitter.emit(event).await;
+            }
+        }
     }
 
     /// 注册子工作流
@@ -139,6 +165,14 @@ impl WorkflowExecutor {
         self.emit_event(ExecutionEvent::WorkflowStarted {
             workflow_id: graph.id.clone(),
             execution_id: ctx.execution_id.clone(),
+        })
+        .await;
+
+        // Emit debug telemetry: WorkflowStart
+        self.emit_debug(DebugEvent::WorkflowStart {
+            workflow_id: graph.id.clone(),
+            execution_id: ctx.execution_id.clone(),
+            timestamp_ms: DebugEvent::now_ms(),
         })
         .await;
 
@@ -185,22 +219,33 @@ impl WorkflowExecutor {
                 .as_millis() as u64,
         );
 
-        match result {
+        let final_status = match result {
             Ok(_) => {
                 execution_record.status = WorkflowStatus::Completed;
                 info!("Workflow {} completed in {:?}", graph.name, duration);
+                "completed".to_string()
             }
             Err(ref e) => {
                 execution_record.status = WorkflowStatus::Failed(e.clone());
                 error!("Workflow {} failed: {}", graph.name, e);
+                format!("failed: {}", e)
             }
-        }
+        };
 
         // 发送完成事件
         self.emit_event(ExecutionEvent::WorkflowCompleted {
             workflow_id: graph.id.clone(),
             execution_id: ctx.execution_id.clone(),
             status: execution_record.status.clone(),
+        })
+        .await;
+
+        // Emit debug telemetry: WorkflowEnd
+        self.emit_debug(DebugEvent::WorkflowEnd {
+            workflow_id: graph.id.clone(),
+            execution_id: ctx.execution_id.clone(),
+            timestamp_ms: DebugEvent::now_ms(),
+            status: final_status,
         })
         .await;
 
@@ -229,6 +274,14 @@ impl WorkflowExecutor {
                 .await;
             self.emit_event(ExecutionEvent::NodeStarted {
                 node_id: current_node_id.clone(),
+            })
+            .await;
+
+            // Emit debug telemetry: NodeStart
+            self.emit_debug(DebugEvent::NodeStart {
+                node_id: current_node_id.clone(),
+                timestamp_ms: DebugEvent::now_ms(),
+                state_snapshot: serde_json::to_value(&current_input).unwrap_or_default(),
             })
             .await;
 
@@ -276,6 +329,18 @@ impl WorkflowExecutor {
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_millis() as u64;
+
+            // Emit debug telemetry: NodeEnd
+            self.emit_debug(DebugEvent::NodeEnd {
+                node_id: current_node_id.clone(),
+                timestamp_ms: end_time,
+                state_snapshot: match &result {
+                    Ok(output) => serde_json::to_value(output).unwrap_or_default(),
+                    Err(e) => serde_json::json!({"error": e}),
+                },
+                duration_ms: end_time.saturating_sub(start_time),
+            })
+            .await;
 
             // 记录节点执行
             record.node_records.push(NodeExecutionRecord {
@@ -776,5 +841,82 @@ mod tests {
             .await
             .unwrap();
         assert!(matches!(result.status, WorkflowStatus::Completed));
+    }
+
+    #[tokio::test]
+    async fn test_workflow_with_telemetry() {
+        use crate::workflow::telemetry::ChannelTelemetryEmitter;
+        use mofa_kernel::workflow::telemetry::DebugEvent;
+
+        let mut graph = WorkflowGraph::new("test_telemetry", "Telemetry Workflow");
+
+        graph.add_node(WorkflowNode::start("start"));
+        graph.add_node(WorkflowNode::task(
+            "double",
+            "Double",
+            |_ctx, input| async move {
+                let value = input.as_i64().unwrap_or(0);
+                Ok(WorkflowValue::Int(value * 2))
+            },
+        ));
+        graph.add_node(WorkflowNode::end("end"));
+
+        graph.connect("start", "double");
+        graph.connect("double", "end");
+
+        let (emitter, mut rx) = ChannelTelemetryEmitter::new(64);
+        let executor = WorkflowExecutor::new(ExecutorConfig::default())
+            .with_telemetry(Arc::new(emitter));
+
+        let result = executor
+            .execute(&graph, WorkflowValue::Int(5))
+            .await
+            .unwrap();
+        assert!(matches!(result.status, WorkflowStatus::Completed));
+
+        // Collect all emitted events
+        let mut events: Vec<DebugEvent> = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            events.push(event);
+        }
+
+        // Should have: WorkflowStart, NodeStart(start), NodeEnd(start),
+        //              NodeStart(double), NodeEnd(double),
+        //              NodeStart(end), NodeEnd(end), WorkflowEnd
+        assert!(
+            events.len() >= 4,
+            "Expected at least 4 events, got {}",
+            events.len()
+        );
+
+        // First event should be WorkflowStart
+        assert_eq!(events[0].event_type(), "workflow_start");
+
+        // Last event should be WorkflowEnd
+        assert_eq!(events.last().unwrap().event_type(), "workflow_end");
+
+        // Should contain NodeStart and NodeEnd events
+        let node_starts: Vec<&DebugEvent> = events
+            .iter()
+            .filter(|e| e.event_type() == "node_start")
+            .collect();
+        let node_ends: Vec<&DebugEvent> = events
+            .iter()
+            .filter(|e| e.event_type() == "node_end")
+            .collect();
+
+        assert!(
+            !node_starts.is_empty(),
+            "Should have at least one NodeStart event"
+        );
+        assert!(
+            !node_ends.is_empty(),
+            "Should have at least one NodeEnd event"
+        );
+        assert_eq!(
+            node_starts.len(),
+            node_ends.len(),
+            "NodeStart and NodeEnd counts should match"
+        );
     }
 }

--- a/crates/mofa-foundation/src/workflow/mod.rs
+++ b/crates/mofa-foundation/src/workflow/mod.rs
@@ -8,6 +8,7 @@
 //! - 错误处理与重试
 //! - 检查点与恢复
 //! - DSL (YAML/TOML) 配置支持
+//! - Time-Travel Debugger telemetry and session recording
 //!
 //! # StateGraph API (LangGraph-inspired)
 //!
@@ -32,8 +33,10 @@ mod executor;
 mod graph;
 mod node;
 mod reducers;
+pub mod session_recorder;
 mod state;
 mod state_graph;
+pub mod telemetry;
 
 pub mod dsl;
 
@@ -42,6 +45,11 @@ pub use mofa_kernel::workflow::{
     Command, CompiledGraph, ControlFlow, GraphConfig, GraphState, JsonState, NodeFunc,
     Reducer, ReducerType, RemainingSteps, RuntimeContext, SendCommand, StateSchema, StateUpdate,
     END, START,
+};
+
+// Re-export kernel telemetry types
+pub use mofa_kernel::workflow::telemetry::{
+    DebugEvent, DebugSession, SessionRecorder, TelemetryEmitter,
 };
 
 // Re-export kernel StateGraph trait
@@ -54,5 +62,8 @@ pub use executor::*;
 pub use graph::*;
 pub use node::*;
 pub use reducers::*;
+pub use session_recorder::InMemorySessionRecorder;
 pub use state::*;
 pub use state_graph::{CompiledGraphImpl, StateGraphImpl};
+pub use telemetry::{ChannelTelemetryEmitter, RecordingTelemetryEmitter};
+

--- a/crates/mofa-foundation/src/workflow/mod.rs
+++ b/crates/mofa-foundation/src/workflow/mod.rs
@@ -42,9 +42,9 @@ pub mod dsl;
 
 // Re-export kernel workflow types for convenience
 pub use mofa_kernel::workflow::{
-    Command, CompiledGraph, ControlFlow, GraphConfig, GraphState, JsonState, NodeFunc,
-    Reducer, ReducerType, RemainingSteps, RuntimeContext, SendCommand, StateSchema, StateUpdate,
-    END, START,
+    Command, CompiledGraph, ControlFlow, END, GraphConfig, GraphState, JsonState, NodeFunc,
+    Reducer, ReducerType, RemainingSteps, RuntimeContext, START, SendCommand, StateSchema,
+    StateUpdate,
 };
 
 // Re-export kernel telemetry types
@@ -66,4 +66,3 @@ pub use session_recorder::InMemorySessionRecorder;
 pub use state::*;
 pub use state_graph::{CompiledGraphImpl, StateGraphImpl};
 pub use telemetry::{ChannelTelemetryEmitter, RecordingTelemetryEmitter};
-

--- a/crates/mofa-foundation/src/workflow/reducers.rs
+++ b/crates/mofa-foundation/src/workflow/reducers.rs
@@ -183,11 +183,7 @@ impl Reducer for MergeReducer {
     }
 
     fn name(&self) -> &str {
-        if self.deep {
-            "merge_deep"
-        } else {
-            "merge"
-        }
+        if self.deep { "merge_deep" } else { "merge" }
     }
 
     fn reducer_type(&self) -> ReducerType {
@@ -451,10 +447,7 @@ mod tests {
         assert_eq!(result, json!([1, 2, 3, 4]));
 
         // Single item extends
-        let result = reducer
-            .reduce(Some(&json!([1])), &json!(2))
-            .await
-            .unwrap();
+        let result = reducer.reduce(Some(&json!([1])), &json!(2)).await.unwrap();
         assert_eq!(result, json!([1, 2]));
     }
 
@@ -560,17 +553,12 @@ mod tests {
     #[tokio::test]
     async fn test_custom_reducer() {
         let reducer = CustomReducer::new("sum", |current, update| {
-            let curr = current
-                .and_then(|v| v.as_i64())
-                .unwrap_or(0);
+            let curr = current.and_then(|v| v.as_i64()).unwrap_or(0);
             let upd = update.as_i64().unwrap_or(0);
             Ok(json!(curr + upd))
         });
 
-        let result = reducer
-            .reduce(Some(&json!(10)), &json!(5))
-            .await
-            .unwrap();
+        let result = reducer.reduce(Some(&json!(10)), &json!(5)).await.unwrap();
         assert_eq!(result, json!(15));
 
         assert_eq!(reducer.name(), "sum");

--- a/crates/mofa-foundation/src/workflow/session_recorder.rs
+++ b/crates/mofa-foundation/src/workflow/session_recorder.rs
@@ -63,9 +63,9 @@ impl SessionRecorder for InMemorySessionRecorder {
 
     async fn record_event(&self, session_id: &str, event: &DebugEvent) -> AgentResult<()> {
         let mut events = self.events.write().await;
-        let entry = events
-            .get_mut(session_id)
-            .ok_or_else(|| AgentError::InvalidInput(format!("Session not found: {}", session_id)))?;
+        let entry = events.get_mut(session_id).ok_or_else(|| {
+            AgentError::InvalidInput(format!("Session not found: {}", session_id))
+        })?;
         entry.push(event.clone());
 
         // Update event count in session metadata
@@ -79,9 +79,9 @@ impl SessionRecorder for InMemorySessionRecorder {
 
     async fn end_session(&self, session_id: &str, status: &str) -> AgentResult<()> {
         let mut sessions = self.sessions.write().await;
-        let session = sessions
-            .get_mut(session_id)
-            .ok_or_else(|| AgentError::InvalidInput(format!("Session not found: {}", session_id)))?;
+        let session = sessions.get_mut(session_id).ok_or_else(|| {
+            AgentError::InvalidInput(format!("Session not found: {}", session_id))
+        })?;
 
         session.ended_at = Some(DebugEvent::now_ms());
         session.status = status.to_string();

--- a/crates/mofa-foundation/src/workflow/session_recorder.rs
+++ b/crates/mofa-foundation/src/workflow/session_recorder.rs
@@ -1,0 +1,218 @@
+//! Session Recorder Implementations
+//!
+//! Concrete implementations of `SessionRecorder` for persisting debug sessions.
+
+use async_trait::async_trait;
+use mofa_kernel::agent::error::{AgentError, AgentResult};
+use mofa_kernel::workflow::telemetry::{DebugEvent, DebugSession, SessionRecorder};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+// ============================================================================
+// InMemorySessionRecorder
+// ============================================================================
+
+/// In-memory session recorder for testing and single-session debugging.
+///
+/// Stores all sessions and events in memory. Data is lost when the
+/// recorder is dropped.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use mofa_foundation::workflow::session_recorder::InMemorySessionRecorder;
+/// use mofa_kernel::workflow::telemetry::{SessionRecorder, DebugSession};
+///
+/// let recorder = InMemorySessionRecorder::new();
+/// let session = DebugSession::new("s-1", "wf-1", "exec-1");
+/// recorder.start_session(&session).await?;
+/// ```
+pub struct InMemorySessionRecorder {
+    sessions: Arc<RwLock<HashMap<String, DebugSession>>>,
+    events: Arc<RwLock<HashMap<String, Vec<DebugEvent>>>>,
+}
+
+impl InMemorySessionRecorder {
+    /// Create a new in-memory session recorder.
+    pub fn new() -> Self {
+        Self {
+            sessions: Arc::new(RwLock::new(HashMap::new())),
+            events: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+}
+
+impl Default for InMemorySessionRecorder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SessionRecorder for InMemorySessionRecorder {
+    async fn start_session(&self, session: &DebugSession) -> AgentResult<()> {
+        let mut sessions = self.sessions.write().await;
+        sessions.insert(session.session_id.clone(), session.clone());
+
+        let mut events = self.events.write().await;
+        events.insert(session.session_id.clone(), Vec::new());
+
+        Ok(())
+    }
+
+    async fn record_event(&self, session_id: &str, event: &DebugEvent) -> AgentResult<()> {
+        let mut events = self.events.write().await;
+        let entry = events
+            .get_mut(session_id)
+            .ok_or_else(|| AgentError::InvalidInput(format!("Session not found: {}", session_id)))?;
+        entry.push(event.clone());
+
+        // Update event count in session metadata
+        let mut sessions = self.sessions.write().await;
+        if let Some(session) = sessions.get_mut(session_id) {
+            session.event_count = entry.len() as u64;
+        }
+
+        Ok(())
+    }
+
+    async fn end_session(&self, session_id: &str, status: &str) -> AgentResult<()> {
+        let mut sessions = self.sessions.write().await;
+        let session = sessions
+            .get_mut(session_id)
+            .ok_or_else(|| AgentError::InvalidInput(format!("Session not found: {}", session_id)))?;
+
+        session.ended_at = Some(DebugEvent::now_ms());
+        session.status = status.to_string();
+
+        Ok(())
+    }
+
+    async fn get_session(&self, session_id: &str) -> AgentResult<Option<DebugSession>> {
+        let sessions = self.sessions.read().await;
+        Ok(sessions.get(session_id).cloned())
+    }
+
+    async fn get_events(&self, session_id: &str) -> AgentResult<Vec<DebugEvent>> {
+        let events = self.events.read().await;
+        Ok(events.get(session_id).cloned().unwrap_or_default())
+    }
+
+    async fn list_sessions(&self) -> AgentResult<Vec<DebugSession>> {
+        let sessions = self.sessions.read().await;
+        Ok(sessions.values().cloned().collect())
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mofa_kernel::workflow::telemetry::DebugEvent;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn test_in_memory_recorder_start_session() {
+        let recorder = InMemorySessionRecorder::new();
+        let session = DebugSession::new("s-1", "wf-1", "exec-1");
+
+        recorder.start_session(&session).await.unwrap();
+
+        let retrieved = recorder.get_session("s-1").await.unwrap();
+        assert!(retrieved.is_some());
+        let s = retrieved.unwrap();
+        assert_eq!(s.session_id, "s-1");
+        assert_eq!(s.workflow_id, "wf-1");
+        assert_eq!(s.status, "running");
+    }
+
+    #[tokio::test]
+    async fn test_in_memory_recorder_record_events() {
+        let recorder = InMemorySessionRecorder::new();
+        let session = DebugSession::new("s-1", "wf-1", "exec-1");
+        recorder.start_session(&session).await.unwrap();
+
+        let event1 = DebugEvent::NodeStart {
+            node_id: "n1".to_string(),
+            timestamp_ms: 1000,
+            state_snapshot: json!({}),
+        };
+        let event2 = DebugEvent::NodeEnd {
+            node_id: "n1".to_string(),
+            timestamp_ms: 1010,
+            state_snapshot: json!({"result": "done"}),
+            duration_ms: 10,
+        };
+
+        recorder.record_event("s-1", &event1).await.unwrap();
+        recorder.record_event("s-1", &event2).await.unwrap();
+
+        let events = recorder.get_events("s-1").await.unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].event_type(), "node_start");
+        assert_eq!(events[1].event_type(), "node_end");
+
+        // Check event count is updated
+        let s = recorder.get_session("s-1").await.unwrap().unwrap();
+        assert_eq!(s.event_count, 2);
+    }
+
+    #[tokio::test]
+    async fn test_in_memory_recorder_end_session() {
+        let recorder = InMemorySessionRecorder::new();
+        let session = DebugSession::new("s-1", "wf-1", "exec-1");
+        recorder.start_session(&session).await.unwrap();
+
+        recorder.end_session("s-1", "completed").await.unwrap();
+
+        let s = recorder.get_session("s-1").await.unwrap().unwrap();
+        assert_eq!(s.status, "completed");
+        assert!(s.ended_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_in_memory_recorder_list_sessions() {
+        let recorder = InMemorySessionRecorder::new();
+        recorder
+            .start_session(&DebugSession::new("s-1", "wf-1", "e-1"))
+            .await
+            .unwrap();
+        recorder
+            .start_session(&DebugSession::new("s-2", "wf-2", "e-2"))
+            .await
+            .unwrap();
+
+        let sessions = recorder.list_sessions().await.unwrap();
+        assert_eq!(sessions.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_in_memory_recorder_missing_session() {
+        let recorder = InMemorySessionRecorder::new();
+
+        // record_event for non-existent session should fail
+        let event = DebugEvent::NodeStart {
+            node_id: "n1".to_string(),
+            timestamp_ms: 0,
+            state_snapshot: json!(null),
+        };
+        let result = recorder.record_event("nonexistent", &event).await;
+        assert!(result.is_err());
+
+        // end_session for non-existent session should fail
+        let result = recorder.end_session("nonexistent", "failed").await;
+        assert!(result.is_err());
+
+        // get_session for non-existent session should return None
+        let result = recorder.get_session("nonexistent").await.unwrap();
+        assert!(result.is_none());
+
+        // get_events for non-existent session should return empty
+        let events = recorder.get_events("nonexistent").await.unwrap();
+        assert!(events.is_empty());
+    }
+}

--- a/crates/mofa-foundation/src/workflow/telemetry.rs
+++ b/crates/mofa-foundation/src/workflow/telemetry.rs
@@ -1,0 +1,163 @@
+//! Telemetry Emitter Implementations
+//!
+//! Concrete implementations of `TelemetryEmitter` for use with the workflow executor.
+
+use async_trait::async_trait;
+use mofa_kernel::workflow::telemetry::{DebugEvent, TelemetryEmitter};
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+// ============================================================================
+// ChannelTelemetryEmitter — sends events over an mpsc channel
+// ============================================================================
+
+/// Sends `DebugEvent`s over a `tokio::sync::mpsc` channel.
+///
+/// This emitter is designed for real-time consumption: a future time-travel UI
+/// or any subscriber can receive events as they are produced by the executor.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use mofa_foundation::workflow::telemetry::ChannelTelemetryEmitter;
+///
+/// let (emitter, mut rx) = ChannelTelemetryEmitter::new(1024);
+///
+/// // Attach emitter to executor
+/// let executor = WorkflowExecutor::new(config).with_telemetry(Arc::new(emitter));
+///
+/// // Consume events in another task
+/// tokio::spawn(async move {
+///     while let Some(event) = rx.recv().await {
+///         println!("{:?}", event);
+///     }
+/// });
+/// ```
+pub struct ChannelTelemetryEmitter {
+    tx: mpsc::Sender<DebugEvent>,
+}
+
+impl ChannelTelemetryEmitter {
+    /// Create a new channel emitter with the given buffer capacity.
+    ///
+    /// Returns the emitter and the receiving half of the channel.
+    pub fn new(buffer: usize) -> (Self, mpsc::Receiver<DebugEvent>) {
+        let (tx, rx) = mpsc::channel(buffer);
+        (Self { tx }, rx)
+    }
+}
+
+#[async_trait]
+impl TelemetryEmitter for ChannelTelemetryEmitter {
+    async fn emit(&self, event: DebugEvent) {
+        // Non-blocking send — if the channel is full, drop the event
+        let _ = self.tx.try_send(event);
+    }
+}
+
+// ============================================================================
+// RecordingTelemetryEmitter — forwards to SessionRecorder + optional channel
+// ============================================================================
+
+/// Wraps a `SessionRecorder` and forwards events both to the recorder
+/// and an optional downstream channel.
+///
+/// This is the typical emitter used in production: it persists events
+/// to storage while optionally streaming them to a live consumer.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use mofa_foundation::workflow::telemetry::RecordingTelemetryEmitter;
+/// use mofa_foundation::workflow::session_recorder::InMemorySessionRecorder;
+///
+/// let recorder = Arc::new(InMemorySessionRecorder::new());
+/// let emitter = RecordingTelemetryEmitter::new("session-1", recorder);
+/// ```
+pub struct RecordingTelemetryEmitter {
+    session_id: String,
+    recorder: Arc<dyn mofa_kernel::workflow::telemetry::SessionRecorder>,
+    downstream: Option<mpsc::Sender<DebugEvent>>,
+}
+
+impl RecordingTelemetryEmitter {
+    /// Create a new recording emitter that persists to the given recorder.
+    pub fn new(
+        session_id: impl Into<String>,
+        recorder: Arc<dyn mofa_kernel::workflow::telemetry::SessionRecorder>,
+    ) -> Self {
+        Self {
+            session_id: session_id.into(),
+            recorder,
+            downstream: None,
+        }
+    }
+
+    /// Also forward events to a downstream channel for real-time consumption.
+    pub fn with_downstream(mut self, tx: mpsc::Sender<DebugEvent>) -> Self {
+        self.downstream = Some(tx);
+        self
+    }
+}
+
+#[async_trait]
+impl TelemetryEmitter for RecordingTelemetryEmitter {
+    async fn emit(&self, event: DebugEvent) {
+        // Record to persistent storage (ignore errors to avoid disrupting execution)
+        let _ = self.recorder.record_event(&self.session_id, &event).await;
+
+        // Forward to downstream channel if present
+        if let Some(ref tx) = self.downstream {
+            let _ = tx.try_send(event);
+        }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn test_channel_emitter_sends_events() {
+        let (emitter, mut rx) = ChannelTelemetryEmitter::new(16);
+
+        let event = DebugEvent::NodeStart {
+            node_id: "test_node".to_string(),
+            timestamp_ms: 1000,
+            state_snapshot: json!({}),
+        };
+
+        emitter.emit(event).await;
+
+        let received = rx.try_recv().unwrap();
+        assert_eq!(received.node_id(), Some("test_node"));
+        assert_eq!(received.timestamp_ms(), 1000);
+    }
+
+    #[tokio::test]
+    async fn test_channel_emitter_drops_when_full() {
+        let (emitter, _rx) = ChannelTelemetryEmitter::new(1);
+
+        let event = DebugEvent::WorkflowStart {
+            workflow_id: "w".to_string(),
+            execution_id: "e".to_string(),
+            timestamp_ms: 0,
+        };
+
+        // Fill the buffer
+        emitter.emit(event.clone()).await;
+        // This should not panic even though buffer is full
+        emitter.emit(event).await;
+    }
+
+    #[tokio::test]
+    async fn test_channel_emitter_is_enabled() {
+        let (emitter, _rx) = ChannelTelemetryEmitter::new(1);
+        assert!(emitter.is_enabled());
+    }
+}

--- a/crates/mofa-kernel/src/agent/components/mcp.rs
+++ b/crates/mofa-kernel/src/agent/components/mcp.rs
@@ -102,11 +102,7 @@ pub struct McpServerConfig {
 
 impl McpServerConfig {
     /// 创建 Stdio 类型的 MCP 服务器配置
-    pub fn stdio(
-        name: impl Into<String>,
-        command: impl Into<String>,
-        args: Vec<String>,
-    ) -> Self {
+    pub fn stdio(name: impl Into<String>, command: impl Into<String>, args: Vec<String>) -> Self {
         Self {
             name: name.into(),
             transport: McpTransportConfig::Stdio {
@@ -250,13 +246,9 @@ mod tests {
 
     #[test]
     fn test_mcp_server_config_stdio() {
-        let config = McpServerConfig::stdio(
-            "test-server",
-            "node",
-            vec!["server.js".to_string()],
-        )
-        .with_env("API_KEY", "test-key")
-        .with_auto_connect(false);
+        let config = McpServerConfig::stdio("test-server", "node", vec!["server.js".to_string()])
+            .with_env("API_KEY", "test-key")
+            .with_auto_connect(false);
 
         assert_eq!(config.name, "test-server");
         assert!(!config.auto_connect);

--- a/crates/mofa-kernel/src/workflow/command.rs
+++ b/crates/mofa-kernel/src/workflow/command.rs
@@ -173,7 +173,11 @@ impl SendCommand {
     }
 
     /// Create a send command with a branch ID
-    pub fn with_branch(target: impl Into<String>, input: Value, branch_id: impl Into<String>) -> Self {
+    pub fn with_branch(
+        target: impl Into<String>,
+        input: Value,
+        branch_id: impl Into<String>,
+    ) -> Self {
         Self {
             target: target.into(),
             input,
@@ -201,9 +205,7 @@ mod tests {
 
     #[test]
     fn test_command_continue() {
-        let cmd = Command::new()
-            .update("result", json!("done"))
-            .continue_();
+        let cmd = Command::new().update("result", json!("done")).continue_();
 
         assert_eq!(cmd.control, ControlFlow::Continue);
         assert!(!cmd.is_return());
@@ -211,9 +213,7 @@ mod tests {
 
     #[test]
     fn test_command_return() {
-        let cmd = Command::new()
-            .update("final", json!("result"))
-            .return_();
+        let cmd = Command::new().update("final", json!("result")).return_();
 
         assert!(cmd.is_return());
     }
@@ -239,11 +239,8 @@ mod tests {
         assert_eq!(send.target, "process");
         assert!(send.branch_id.is_none());
 
-        let send_with_branch = SendCommand::with_branch(
-            "process",
-            json!({"data": "test"}),
-            "branch-1",
-        );
+        let send_with_branch =
+            SendCommand::with_branch("process", json!({"data": "test"}), "branch-1");
         assert_eq!(send_with_branch.branch_id, Some("branch-1".to_string()));
     }
 

--- a/crates/mofa-kernel/src/workflow/context.rs
+++ b/crates/mofa-kernel/src/workflow/context.rs
@@ -383,6 +383,9 @@ mod tests {
         );
 
         assert!(ctx.is_sub_workflow());
-        assert_eq!(ctx.parent_execution_id, Some("parent-execution-123".to_string()));
+        assert_eq!(
+            ctx.parent_execution_id,
+            Some("parent-execution-123".to_string())
+        );
     }
 }

--- a/crates/mofa-kernel/src/workflow/graph.rs
+++ b/crates/mofa-kernel/src/workflow/graph.rs
@@ -152,7 +152,11 @@ pub trait StateGraph: Send + Sync {
     /// # Arguments
     /// * `id` - Unique node identifier
     /// * `node` - Node function implementation
-    fn add_node(&mut self, id: impl Into<String>, node: Box<dyn NodeFunc<Self::State>>) -> &mut Self;
+    fn add_node(
+        &mut self,
+        id: impl Into<String>,
+        node: Box<dyn NodeFunc<Self::State>>,
+    ) -> &mut Self;
 
     /// Add an edge between two nodes
     ///
@@ -256,10 +260,7 @@ pub trait CompiledGraph<S: GraphState>: Send + Sync {
 #[derive(Debug, Clone)]
 pub enum StreamEvent<S: GraphState> {
     /// A node started executing
-    NodeStart {
-        node_id: String,
-        state: S,
-    },
+    NodeStart { node_id: String, state: S },
     /// A node finished executing
     NodeEnd {
         node_id: String,
@@ -267,9 +268,7 @@ pub enum StreamEvent<S: GraphState> {
         command: Command,
     },
     /// Graph execution completed
-    End {
-        final_state: S,
-    },
+    End { final_state: S },
     /// Error occurred
     Error {
         node_id: Option<String>,

--- a/crates/mofa-kernel/src/workflow/mod.rs
+++ b/crates/mofa-kernel/src/workflow/mod.rs
@@ -45,6 +45,7 @@ pub mod context;
 pub mod graph;
 pub mod reducer;
 pub mod state;
+pub mod telemetry;
 
 // Re-export public API
 pub use command::{Command, ControlFlow, SendCommand};
@@ -52,3 +53,4 @@ pub use context::{GraphConfig, RemainingSteps, RuntimeContext};
 pub use graph::{CompiledGraph, EdgeTarget, NodeFunc, StateGraph, StreamEvent, StepResult, END, START};
 pub use reducer::{Reducer, ReducerType, StateUpdate};
 pub use state::{GraphState, JsonState, StateSchema};
+pub use telemetry::{DebugEvent, DebugSession, SessionRecorder, TelemetryEmitter};

--- a/crates/mofa-kernel/src/workflow/mod.rs
+++ b/crates/mofa-kernel/src/workflow/mod.rs
@@ -50,7 +50,9 @@ pub mod telemetry;
 // Re-export public API
 pub use command::{Command, ControlFlow, SendCommand};
 pub use context::{GraphConfig, RemainingSteps, RuntimeContext};
-pub use graph::{CompiledGraph, EdgeTarget, NodeFunc, StateGraph, StreamEvent, StepResult, END, START};
+pub use graph::{
+    CompiledGraph, END, EdgeTarget, NodeFunc, START, StateGraph, StepResult, StreamEvent,
+};
 pub use reducer::{Reducer, ReducerType, StateUpdate};
 pub use state::{GraphState, JsonState, StateSchema};
 pub use telemetry::{DebugEvent, DebugSession, SessionRecorder, TelemetryEmitter};

--- a/crates/mofa-kernel/src/workflow/state.rs
+++ b/crates/mofa-kernel/src/workflow/state.rs
@@ -124,11 +124,7 @@ impl StateSchema {
     }
 
     /// Add a simple field
-    pub fn field(
-        mut self,
-        name: impl Into<String>,
-        type_name: impl Into<String>,
-    ) -> Self {
+    pub fn field(mut self, name: impl Into<String>, type_name: impl Into<String>) -> Self {
         self.fields.push(StateField {
             name: name.into(),
             type_name: type_name.into(),

--- a/crates/mofa-kernel/src/workflow/telemetry.rs
+++ b/crates/mofa-kernel/src/workflow/telemetry.rs
@@ -1,0 +1,438 @@
+//! Time-Travel Debugger Telemetry
+//!
+//! Defines the core telemetry types and traits for the visual time-travel debugger.
+//! The kernel layer defines only trait interfaces and data types — concrete
+//! implementations are provided in `mofa-foundation`.
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌──────────────────────────────────────────────────────┐
+//! │                  Telemetry Pipeline                   │
+//! ├──────────────────────────────────────────────────────┤
+//! │                                                       │
+//! │  WorkflowExecutor ──emit──▶ TelemetryEmitter         │
+//! │                                  │                    │
+//! │                          ┌───────┴───────┐           │
+//! │                          ▼               ▼           │
+//! │                    Channel          SessionRecorder   │
+//! │                  (real-time)        (persistence)     │
+//! │                                                       │
+//! └──────────────────────────────────────────────────────┘
+//! ```
+//!
+//! # Event Types
+//!
+//! - `DebugEvent::WorkflowStart` — emitted when workflow execution begins
+//! - `DebugEvent::NodeStart` — emitted when a node begins execution
+//! - `DebugEvent::StateChange` — emitted on state mutations within a node
+//! - `DebugEvent::NodeEnd` — emitted when a node finishes execution
+//! - `DebugEvent::WorkflowEnd` — emitted when workflow execution completes
+//! - `DebugEvent::Error` — emitted on errors during execution
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::agent::error::AgentResult;
+
+// ============================================================================
+// DebugEvent — Telemetry event types
+// ============================================================================
+
+/// Debug telemetry event emitted during workflow execution.
+///
+/// These events form the backbone of the time-travel debugger, capturing
+/// the complete execution trace of a workflow including state mutations.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use mofa_kernel::workflow::telemetry::DebugEvent;
+///
+/// let event = DebugEvent::NodeStart {
+///     node_id: "process".to_string(),
+///     timestamp_ms: 1700000000000,
+///     state_snapshot: serde_json::json!({"messages": ["hello"]}),
+/// };
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum DebugEvent {
+    /// Workflow execution started
+    WorkflowStart {
+        /// Workflow graph ID
+        workflow_id: String,
+        /// Unique execution ID
+        execution_id: String,
+        /// Timestamp in milliseconds since epoch
+        timestamp_ms: u64,
+    },
+
+    /// A node started executing
+    NodeStart {
+        /// Node identifier
+        node_id: String,
+        /// Timestamp in milliseconds since epoch
+        timestamp_ms: u64,
+        /// Snapshot of the state when the node started
+        state_snapshot: serde_json::Value,
+    },
+
+    /// A state key was mutated during node execution
+    StateChange {
+        /// Node that caused the change
+        node_id: String,
+        /// Timestamp in milliseconds since epoch
+        timestamp_ms: u64,
+        /// State key that changed
+        key: String,
+        /// Previous value (None if key was new)
+        old_value: Option<serde_json::Value>,
+        /// New value
+        new_value: serde_json::Value,
+    },
+
+    /// A node finished executing
+    NodeEnd {
+        /// Node identifier
+        node_id: String,
+        /// Timestamp in milliseconds since epoch
+        timestamp_ms: u64,
+        /// Snapshot of the state after node execution
+        state_snapshot: serde_json::Value,
+        /// Duration of node execution in milliseconds
+        duration_ms: u64,
+    },
+
+    /// Workflow execution completed
+    WorkflowEnd {
+        /// Workflow graph ID
+        workflow_id: String,
+        /// Unique execution ID
+        execution_id: String,
+        /// Timestamp in milliseconds since epoch
+        timestamp_ms: u64,
+        /// Final status description
+        status: String,
+    },
+
+    /// Error during execution
+    Error {
+        /// Node where the error occurred (if applicable)
+        node_id: Option<String>,
+        /// Timestamp in milliseconds since epoch
+        timestamp_ms: u64,
+        /// Error description
+        error: String,
+    },
+}
+
+impl DebugEvent {
+    /// Get the timestamp of this event in milliseconds since epoch
+    pub fn timestamp_ms(&self) -> u64 {
+        match self {
+            Self::WorkflowStart { timestamp_ms, .. } => *timestamp_ms,
+            Self::NodeStart { timestamp_ms, .. } => *timestamp_ms,
+            Self::StateChange { timestamp_ms, .. } => *timestamp_ms,
+            Self::NodeEnd { timestamp_ms, .. } => *timestamp_ms,
+            Self::WorkflowEnd { timestamp_ms, .. } => *timestamp_ms,
+            Self::Error { timestamp_ms, .. } => *timestamp_ms,
+        }
+    }
+
+    /// Get the node ID associated with this event, if any
+    pub fn node_id(&self) -> Option<&str> {
+        match self {
+            Self::WorkflowStart { .. } => None,
+            Self::NodeStart { node_id, .. } => Some(node_id),
+            Self::StateChange { node_id, .. } => Some(node_id),
+            Self::NodeEnd { node_id, .. } => Some(node_id),
+            Self::WorkflowEnd { .. } => None,
+            Self::Error { node_id, .. } => node_id.as_deref(),
+        }
+    }
+
+    /// Get the current timestamp in milliseconds since epoch
+    pub fn now_ms() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64
+    }
+
+    /// Returns a human-readable event type name
+    pub fn event_type(&self) -> &'static str {
+        match self {
+            Self::WorkflowStart { .. } => "workflow_start",
+            Self::NodeStart { .. } => "node_start",
+            Self::StateChange { .. } => "state_change",
+            Self::NodeEnd { .. } => "node_end",
+            Self::WorkflowEnd { .. } => "workflow_end",
+            Self::Error { .. } => "error",
+        }
+    }
+}
+
+// ============================================================================
+// DebugSession — Session metadata
+// ============================================================================
+
+/// Metadata for a recorded debugging session.
+///
+/// A session corresponds to a single workflow execution, capturing
+/// all telemetry events from start to finish.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DebugSession {
+    /// Unique session identifier
+    pub session_id: String,
+    /// Workflow graph ID
+    pub workflow_id: String,
+    /// Execution ID (from RuntimeContext)
+    pub execution_id: String,
+    /// Session start timestamp (ms since epoch)
+    pub started_at: u64,
+    /// Session end timestamp (ms since epoch), None if still running
+    pub ended_at: Option<u64>,
+    /// Final status ("running", "completed", "failed")
+    pub status: String,
+    /// Total number of events recorded
+    pub event_count: u64,
+}
+
+impl DebugSession {
+    /// Create a new debug session
+    pub fn new(
+        session_id: impl Into<String>,
+        workflow_id: impl Into<String>,
+        execution_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            session_id: session_id.into(),
+            workflow_id: workflow_id.into(),
+            execution_id: execution_id.into(),
+            started_at: DebugEvent::now_ms(),
+            ended_at: None,
+            status: "running".to_string(),
+            event_count: 0,
+        }
+    }
+}
+
+// ============================================================================
+// TelemetryEmitter — Trait for emitting debug events
+// ============================================================================
+
+/// Trait for emitting telemetry events during workflow execution.
+///
+/// Implementations can forward events to channels, recorders, loggers, etc.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use mofa_kernel::workflow::telemetry::{TelemetryEmitter, DebugEvent};
+///
+/// struct LoggingEmitter;
+///
+/// #[async_trait]
+/// impl TelemetryEmitter for LoggingEmitter {
+///     async fn emit(&self, event: DebugEvent) {
+///         println!("[{}] {:?}", event.event_type(), event);
+///     }
+/// }
+/// ```
+#[async_trait]
+pub trait TelemetryEmitter: Send + Sync {
+    /// Emit a debug event
+    async fn emit(&self, event: DebugEvent);
+
+    /// Check if telemetry collection is enabled
+    ///
+    /// When false, the executor may skip expensive operations like
+    /// state snapshot serialization.
+    fn is_enabled(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// SessionRecorder — Trait for persisting debug sessions
+// ============================================================================
+
+/// Trait for persisting and querying debug sessions.
+///
+/// Implementations store the complete execution trace to enable
+/// time-travel debugging: replaying the exact sequence of events
+/// and state mutations step-by-step.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use mofa_kernel::workflow::telemetry::{SessionRecorder, DebugSession, DebugEvent};
+///
+/// // Start a session
+/// let session = DebugSession::new("session-1", "workflow-1", "exec-1");
+/// recorder.start_session(&session).await?;
+///
+/// // Record events during execution
+/// recorder.record_event("session-1", &event).await?;
+///
+/// // End the session
+/// recorder.end_session("session-1").await?;
+///
+/// // Later: replay the session
+/// let events = recorder.get_events("session-1").await?;
+/// for event in events {
+///     // Step through each event in the time-travel UI
+/// }
+/// ```
+#[async_trait]
+pub trait SessionRecorder: Send + Sync {
+    /// Start recording a new debug session
+    async fn start_session(&self, session: &DebugSession) -> AgentResult<()>;
+
+    /// Record a telemetry event within a session
+    async fn record_event(&self, session_id: &str, event: &DebugEvent) -> AgentResult<()>;
+
+    /// End a recording session (sets ended_at and final status)
+    async fn end_session(&self, session_id: &str, status: &str) -> AgentResult<()>;
+
+    /// Retrieve session metadata by ID
+    async fn get_session(&self, session_id: &str) -> AgentResult<Option<DebugSession>>;
+
+    /// Retrieve all events for a session, ordered by timestamp
+    async fn get_events(&self, session_id: &str) -> AgentResult<Vec<DebugEvent>>;
+
+    /// List all recorded sessions
+    async fn list_sessions(&self) -> AgentResult<Vec<DebugSession>>;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_debug_event_serialization() {
+        let event = DebugEvent::NodeStart {
+            node_id: "process".to_string(),
+            timestamp_ms: 1700000000000,
+            state_snapshot: json!({"messages": ["hello"]}),
+        };
+
+        let serialized = serde_json::to_string(&event).unwrap();
+        let deserialized: DebugEvent = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized.event_type(), "node_start");
+        assert_eq!(deserialized.node_id(), Some("process"));
+        assert_eq!(deserialized.timestamp_ms(), 1700000000000);
+    }
+
+    #[test]
+    fn test_debug_event_all_variants_serialize() {
+        let events = vec![
+            DebugEvent::WorkflowStart {
+                workflow_id: "wf-1".to_string(),
+                execution_id: "exec-1".to_string(),
+                timestamp_ms: 1000,
+            },
+            DebugEvent::NodeStart {
+                node_id: "n1".to_string(),
+                timestamp_ms: 1001,
+                state_snapshot: json!({}),
+            },
+            DebugEvent::StateChange {
+                node_id: "n1".to_string(),
+                timestamp_ms: 1002,
+                key: "count".to_string(),
+                old_value: Some(json!(0)),
+                new_value: json!(1),
+            },
+            DebugEvent::NodeEnd {
+                node_id: "n1".to_string(),
+                timestamp_ms: 1003,
+                state_snapshot: json!({"count": 1}),
+                duration_ms: 2,
+            },
+            DebugEvent::WorkflowEnd {
+                workflow_id: "wf-1".to_string(),
+                execution_id: "exec-1".to_string(),
+                timestamp_ms: 1004,
+                status: "completed".to_string(),
+            },
+            DebugEvent::Error {
+                node_id: Some("n2".to_string()),
+                timestamp_ms: 1005,
+                error: "something failed".to_string(),
+            },
+        ];
+
+        for event in &events {
+            let json = serde_json::to_string(event).unwrap();
+            let round_trip: DebugEvent = serde_json::from_str(&json).unwrap();
+            assert_eq!(event.event_type(), round_trip.event_type());
+            assert_eq!(event.timestamp_ms(), round_trip.timestamp_ms());
+        }
+    }
+
+    #[test]
+    fn test_debug_event_node_id() {
+        let start = DebugEvent::WorkflowStart {
+            workflow_id: "w".to_string(),
+            execution_id: "e".to_string(),
+            timestamp_ms: 0,
+        };
+        assert_eq!(start.node_id(), None);
+
+        let node = DebugEvent::NodeStart {
+            node_id: "n1".to_string(),
+            timestamp_ms: 0,
+            state_snapshot: json!(null),
+        };
+        assert_eq!(node.node_id(), Some("n1"));
+
+        let error_with_node = DebugEvent::Error {
+            node_id: Some("n2".to_string()),
+            timestamp_ms: 0,
+            error: "err".to_string(),
+        };
+        assert_eq!(error_with_node.node_id(), Some("n2"));
+
+        let error_without = DebugEvent::Error {
+            node_id: None,
+            timestamp_ms: 0,
+            error: "err".to_string(),
+        };
+        assert_eq!(error_without.node_id(), None);
+    }
+
+    #[test]
+    fn test_debug_session_creation() {
+        let session = DebugSession::new("s-1", "wf-1", "exec-1");
+        assert_eq!(session.session_id, "s-1");
+        assert_eq!(session.workflow_id, "wf-1");
+        assert_eq!(session.execution_id, "exec-1");
+        assert_eq!(session.status, "running");
+        assert!(session.ended_at.is_none());
+        assert_eq!(session.event_count, 0);
+        assert!(session.started_at > 0);
+    }
+
+    #[test]
+    fn test_debug_session_serialization() {
+        let session = DebugSession::new("s-1", "wf-1", "exec-1");
+        let json = serde_json::to_string(&session).unwrap();
+        let round_trip: DebugSession = serde_json::from_str(&json).unwrap();
+        assert_eq!(round_trip.session_id, "s-1");
+        assert_eq!(round_trip.status, "running");
+    }
+
+    #[test]
+    fn test_now_ms() {
+        let ts = DebugEvent::now_ms();
+        // Should be a reasonable timestamp (after 2020)
+        assert!(ts > 1_577_836_800_000);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the foundational telemetry infrastructure for the **Visual Time-Travel Debugger & Session Recorder** feature (Issue #113).

This PR adds the **backend instrumentation layer** — the kernel trait definitions and foundation implementations that capture execution traces during workflow execution.

## Changes

### mofa-kernel (Trait Definitions)
- **`DebugEvent` enum** — rich telemetry events: `WorkflowStart`, `NodeStart`, `StateChange`, `NodeEnd`, `WorkflowEnd`, `Error`
- **`TelemetryEmitter` trait** — async interface to emit events
- **`SessionRecorder` trait** — async interface to persist/query execution traces
- **`DebugSession` struct** — session metadata

### mofa-foundation (Concrete Implementations)
- **`ChannelTelemetryEmitter`** — streams events over a tokio mpsc channel (real-time)
- **`RecordingTelemetryEmitter`** — bridges emitter + recorder for persistence
- **`InMemorySessionRecorder`** — in-memory storage for testing/debugging
- **`WorkflowExecutor`** — wired with optional `with_telemetry()` builder

## Architecture

Follows the microkernel pattern:
- **Traits** in `mofa-kernel` (no concrete implementations)
- **Implementations** in `mofa-foundation`
- **Opt-in** — no behavior change when telemetry is not configured

## Tests

- 6 kernel telemetry unit tests (serialization, event types, session creation)
- 5 InMemorySessionRecorder unit tests (CRUD, edge cases)
- 3 ChannelTelemetryEmitter unit tests (send, backpressure, enabled flag)
- 1 executor integration test (verifies correct event sequence)

All existing tests continue to pass.

Closes #113