### PR TITLE
fix(plugins): fail fast when Kokoro TTS init fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 /target/
 .DS_Store
+
+.worktrees/

--- a/crates/mofa-plugins/Cargo.toml
+++ b/crates/mofa-plugins/Cargo.toml
@@ -46,8 +46,8 @@ which = "7"
 # TTS support (optional - using rodio for audio playback)
 rodio = { version = "0.17", optional = true }
 # Kokoro TTS (optional)
-kokoro-tts = { version = "0.2.8", optional = true }
-# Pin ort version for kokoro-tts compatibility
+kokoro-tts = { version = "=0.2.9", optional = true }
+# Pin ort version for kokoro-tts compatibility across workspace resolution
 ort = { version = "=2.0.0-rc.10", optional = true }
 # Model download support
 hf-hub = "0.4"


### PR DESCRIPTION
## Summary
- make  fail fast when  feature is enabled and Kokoro engine initialization fails
- keep non-kokoro behavior unchanged (mock engine fallback)
- add targeted tests for both kokoro and non-kokoro init paths
- align  pin to  with pinned 
- remove stale comments claiming Kokoro integration is disabled

## Why
Issue #145 reports silent fallback to , producing non-real audio even when Kokoro is intended. This change ensures Kokoro-enabled builds surface initialization errors explicitly instead of silently degrading.

## Testing
- 
running 1 test
test tts::tests::test_init_plugin_without_kokoro_uses_mock_engine ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 80 filtered out; finished in 0.07s (pass)
- 
running 1 test
test tts::tests::test_init_plugin_kokoro_mode_fails_instead_of_mock_fallback ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 82 filtered out; finished in 0.03s (blocked locally by crates.io DNS/network for  download)

Closes #145