### PR TITLE
fix(monitoring): replace hardcoded zeros with real system metrics via sysinfo (fixes #152)

### DIFF
--- a/crates/mofa-monitoring/Cargo.toml
+++ b/crates/mofa-monitoring/Cargo.toml
@@ -36,6 +36,9 @@ tower-http = { version = "0.5", features = ["fs", "cors", "trace"] }
 rust-embed = { version = "8.0", features = ["compression"] }
 mime_guess = "2.0"
 
+# System metrics
+sysinfo = "0.33"
+
 # Local dependencies
 mofa-kernel = { path = "../mofa-kernel", version = "0.1" }
 futures = "0.3.31"


### PR DESCRIPTION
## Problem

`collect_system_metrics()` in `mofa-monitoring/src/dashboard/metrics.rs` returned hardcoded zeros for all system metrics (CPU, memory, threads), making the entire observability pipeline produce useless data.

## Fix

- Added `sysinfo = "0.33"` dependency (cross-platform, well-maintained)
- Cache a `sysinfo::System` instance on `MetricsCollector` via `Arc<RwLock<System>>` (avoids expensive re-creation each collection tick)
- `collect_system_metrics()` now reads real values:
  - `cpu_usage` → `sys.global_cpu_usage()`
  - `memory_used` / `memory_total` → `sys.used_memory()` / `sys.total_memory()`
  - `thread_count` → per-process task enumeration via `Pid::from_u32(std::process::id())`
- Changed method from sync to async for `RwLock` access

## Testing

- `cargo check -p mofa-monitoring` ✅ (0 errors)

Closes #152