### PR TITLE
fix(security): add path boundary validation to write_file() utility

### DIFF
--- a/mofa/utils/files/write.py
+++ b/mofa/utils/files/write.py
@@ -58,7 +58,12 @@ def copy_file(input_file='.env.secret', output_file='.env', overwrite=False):
     except Exception as e:
         print(f"An error occurred: {e}")
 
-def write_file(file_path:str,data:Any):
+def write_file(file_path: str, data: Any, base_dir: str = None):
+    if base_dir is not None:
+        file_path = os.path.normpath(os.path.abspath(file_path))
+        base_dir = os.path.normpath(os.path.abspath(base_dir))
+        if not file_path.startswith(base_dir + os.sep) and file_path != base_dir:
+            raise ValueError(f"Path traversal detected: {file_path} is outside {base_dir}")
     try:
         if data is not None and data != '' and data !=' ' and data != 'null':
             if os.path.exists(file_path):


### PR DESCRIPTION
## Summary

Fixes path traversal vulnerability in `mofa/utils/files/write.py` where the `write_file()` function accepted arbitrary paths without validation.

## Changes

- `mofa/utils/files/write.py`: Add optional `base_dir` parameter with `os.path.normpath` boundary check to `write_file()`. When `base_dir` is provided, paths outside the base directory raise `ValueError`.

## Test Plan

- [ ] Verify normal file writes within expected directories still work
- [ ] Verify path traversal attempts (e.g., `../../etc/passwd`) are rejected when `base_dir` is set
- [ ] Verify backward compatibility: existing callers without `base_dir` are unaffected

Closes #188