### PR TITLE
fix(robustness): add None check for spec.loader before exec_module() in dynamic import

### DIFF
--- a/mofa/utils/func/util.py
+++ b/mofa/utils/func/util.py
@@ -12,6 +12,8 @@ def load_functions_from_directory(directory_path):
             file_path = os.path.join(directory_path, file)
 
             spec = importlib.util.spec_from_file_location(module_name, file_path)
+            if spec is None or spec.loader is None:
+                raise ImportError(f"Cannot load module {module_name}: no loader available")
             module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(module)
 


### PR DESCRIPTION
## Summary

Fixes an unhandled `AttributeError` in `mofa/utils/func/util.py` where `spec.loader.exec_module()` was called without verifying that `spec.loader` is not `None`.

## Changes

- `mofa/utils/func/util.py`: Add `if spec is None or spec.loader is None` check before calling `exec_module()`. Raises a descriptive `ImportError` instead of an unhandled `AttributeError`.

## Test Plan

- [ ] Verify normal Python modules still load correctly from directories
- [ ] Verify that files with unavailable loaders raise `ImportError` with a clear message
- [ ] Verify the existing directory scanning behavior is unchanged for valid modules

Closes #190