### PR TITLE
[PROJECT 3 PR 2] feat: implement Hardware Discovery Service for cross-platform orchest…

### DIFF
--- a/crates/mofa-foundation/src/hardware.rs
+++ b/crates/mofa-foundation/src/hardware.rs
@@ -1,0 +1,105 @@
+use std::env::consts;
+
+/// Represents the operating system of the host machine.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OsClassification {
+    MacOS,
+    Windows,
+    Linux,
+    Other(String),
+}
+
+/// Represents the CPU family/architecture of the host machine.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CpuFamily {
+    AppleSilicon,
+    X86_64,
+    Arm,
+    Other(String),
+}
+
+/// Holds information about the host environment's hardware capabilities.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HardwareCapability {
+    pub os: OsClassification,
+    pub cpu_family: CpuFamily,
+    pub gpu_available: bool,
+}
+
+/// Detects the host machine's hardware capabilities dynamically.
+pub fn detect_hardware() -> HardwareCapability {
+    let os = match consts::OS {
+        "macos" => OsClassification::MacOS,
+        "windows" => OsClassification::Windows,
+        "linux" => OsClassification::Linux,
+        other => OsClassification::Other(other.to_string()),
+    };
+
+    let cpu_family = match consts::ARCH {
+        "x86_64" => CpuFamily::X86_64,
+        "aarch64" => {
+            if os == OsClassification::MacOS {
+                CpuFamily::AppleSilicon
+            } else {
+                CpuFamily::Arm
+            }
+        }
+        "arm" => CpuFamily::Arm,
+        other => CpuFamily::Other(other.to_string()),
+    };
+
+    // Basic stubs/checks for GPU availability
+    let gpu_available = match os {
+        OsClassification::MacOS => {
+            // Apple Silicon inherently has Metal acceleration available.
+            cpu_family == CpuFamily::AppleSilicon
+        }
+        OsClassification::Windows | OsClassification::Linux => {
+            // A basic stub: check if nvidia-smi command is available in the path
+            // This is a naive check to be expanded later.
+            std::process::Command::new("nvidia-smi")
+                .arg("--version")
+                .output()
+                .is_ok()
+        }
+        _ => false,
+    };
+
+    HardwareCapability {
+        os,
+        cpu_family,
+        gpu_available,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_hardware() {
+        let hardware = detect_hardware();
+        println!("Detected Hardware Configuration: {:#?}", hardware);
+
+        // Assert that the fields have been populated with something meaningful.
+        // We can't do exact asserts since this runs on different CI/dev environments,
+        // but it shouldn't be unknown/other usually (unless we are testing on an exotic arch).
+
+        match hardware.os {
+            OsClassification::MacOS | OsClassification::Windows | OsClassification::Linux => (),
+            OsClassification::Other(_) => {
+                // Warning, unexpected OS but not a failure condition technically
+            }
+        }
+
+        match hardware.cpu_family {
+            CpuFamily::AppleSilicon | CpuFamily::X86_64 | CpuFamily::Arm => (),
+            CpuFamily::Other(_) => {
+                // Warning, unexpected CPU family
+            }
+        }
+
+        // GPU availability is environment-dependent, we just ensure it doesn't panic
+        let _ = hardware.gpu_available;
+    }
+}

--- a/crates/mofa-foundation/src/lib.rs
+++ b/crates/mofa-foundation/src/lib.rs
@@ -7,6 +7,9 @@
 // orchestrator module - Model Lifecycle & Allocation
 pub mod orchestrator;
 
+// hardware discovery module
+pub mod hardware;
+
 // prompt module
 pub mod prompt;
 


### PR DESCRIPTION
## 📋 Summary

Implement a Hardware Discovery Service within `mofa-foundation` that dynamically detects the host machine's OS, CPU architecture, and basic GPU availability. This is a prerequisite for the multi-backend dispatch logic in the General Model Orchestrator (e.g., routing to MLX on Mac or Candle on Windows).

## 🔗 Related Issues
#221 

---

## 🧠 Context

As part of the GSoC 2026 General Model Orchestrator project, the orchestrator needs to know what hardware it's running on before it can route inference to the correct backend. This PR adds a lightweight, zero-external-dependency hardware detection module that identifies the OS, CPU family (including Apple Silicon distinction), and provides basic GPU availability stubs.

---

## 🛠️ Changes

- Added [crates/mofa-foundation/src/hardware.rs](cci:7://file:///c:/Users/singh/Documents/GitHub/mofa/crates/mofa-foundation/src/hardware.rs:0:0-0:0) with [HardwareCapability](cci:2://file:///c:/Users/singh/Documents/GitHub/mofa/crates/mofa-foundation/src/hardware.rs:22:0-26:1) struct, `OsClassification` and `CpuFamily` enums, and [detect_hardware()](cci:1://file:///c:/Users/singh/Documents/GitHub/mofa/crates/mofa-foundation/src/hardware.rs:28:0-72:1) function.
- Exported the new [hardware](cci:1://file:///c:/Users/singh/Documents/GitHub/mofa/crates/mofa-foundation/src/hardware.rs:28:0-72:1) module in [crates/mofa-foundation/src/lib.rs](cci:7://file:///c:/Users/singh/Documents/GitHub/mofa/crates/mofa-foundation/src/lib.rs:0:0-0:0).
- Added unit test [test_detect_hardware()](cci:1://file:///c:/Users/singh/Documents/GitHub/mofa/crates/mofa-foundation/src/hardware.rs:78:4-103:5) to validate the detection logic.

---

## 🧪 How you Tested

1. `cargo build --workspace` — builds successfully with zero new warnings.
2. `cargo test -p mofa-foundation hardware` — hardware test passes.
3. `cargo clippy` — no warnings from changed files (only pre-existing warning in `mofa-plugins`).

---

## 📸 Screenshots / Logs (if applicable)
<img width="813" height="231" alt="Screenshot 2026-02-22 151516" src="https://github.com/user-attachments/assets/1b3d8e85-e613-4a0c-87c1-35b29fac2826" />



---

## ⚠️ Breaking Changes

- [x] No breaking changes

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [x] Public APIs documented
- [x] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---

## 🚀 Deployment Notes (if applicable)

None — no migrations, config changes, or env vars required.

---

## 🧩 Additional Notes for Reviewers

- GPU detection is intentionally a basic stub (checks for `nvidia-smi` on Windows/Linux, assumes Metal on Apple Silicon macOS). This will be expanded in a future issue.
- No external dependencies were added; the module uses only `std::env::consts` and `std::process::Command`.


