### PR TITLE
docs: phase 2A centralized docs and agent hub baseline (#233)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -37,8 +37,8 @@ jobs:
 
       - name: Install mdBook
         run: |
-          cargo install mdbook
-          cargo install mdbook-mermaid
+          cargo install mdbook --version 0.5.2 --locked
+          cargo install mdbook-mermaid --version 0.17.0 --locked
 
       - name: Build mdBook (EN + ZH)
         run: ./scripts/build-docs.sh


### PR DESCRIPTION
## 📋 Summary

<!--
Explain WHAT this PR does and WHY.
Focus on the motivation and impact rather than implementation details.
-->

Builds Phase 2A of the centralized documentation effort by adding an Agent Hub section to the existing mdBook docs and strengthening CI validation for mdBook output.

This reduces onboarding friction for contributors and users by making hub-oriented discovery and usage guidance available in the main docs site, while keeping the current mdBook deployment model stable.

## 🔗 Related Issues

Closes #233

Related to #233

---

## 🧠 Context

<!--
Why is this change needed?
What problem does it solve?
Any relevant background or design decisions.
-->

MoFA has strong standalone docs, but lacked a clear, centralized Agent Hub entry point in the primary mdBook navigation. This PR delivers a scoped Phase 2A iteration (docs + DX) without introducing infrastructure-heavy changes like a full hybrid docs stack.

Design decision: keep mdBook as the current source of truth for now, add hub-focused docs pages, and enforce mdBook build checks in CI so doc regressions are caught early.

---

## 🛠️ Changes

<!--
High-level list of changes.
Avoid low-level diffs — reviewers can see those.
-->

- Added new Agent Hub documentation pages under `docs/mofa-doc/src/agent-hub/`:
  - `overview.md`
  - `catalog.md`
  - `integration.md`
  - `copy-to-studio.md`
- Updated mdBook navigation in `docs/mofa-doc/src/SUMMARY.md` with a new top-level **Agent Hub** section.
- Updated `docs/mofa-doc/README.md` to reflect Agent Hub docs structure and CI mdBook validation.
- Extended `.github/workflows/ci.yml` docs job to:
  - install `mdbook` and `mdbook-mermaid`
  - run `docs/mofa-doc/scripts/build-docs.sh`
  - verify `book/index.html` and `book/zh/index.html` artifacts exist.

---

## 🧪 How you Tested

<!--
Provide clear steps for reviewers to validate the change.
Include commands, endpoints, or scenarios.
-->

1. Built docs locally:
   - `cd docs/mofa-doc`
   - `./scripts/build-docs.sh`
2. Verified output artifacts:
   - `test -f book/index.html`
   - `test -f book/zh/index.html`
3. Verified nav/docs wiring:
   - Confirmed Agent Hub entries appear in `docs/mofa-doc/src/SUMMARY.md`
   - Confirmed all new pages resolve in successful mdBook build output.

---

## 📸 Screenshots / Logs (if applicable)

<!-- CLI output, logs, or UI screenshots -->

Local build log highlights:
- `INFO HTML book written to .../docs/mofa-doc/book/html`
- `INFO HTML book written to .../docs/mofa-doc/book/zh`
- `EN OK`
- `ZH OK`

---

## ⚠️ Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (describe below)

If breaking:

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [ ] `cargo fmt` run
- [ ] `cargo clippy` passes without warnings

### Testing
- [ ] Tests added/updated
- [ ] `cargo test` passes locally without any error

### Documentation
- [x] Public APIs documented
- [x] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---

## 🚀 Deployment Notes (if applicable)

<!-- migrations, config changes, env vars, rollout steps -->

No migrations or env var changes. Existing mdBook deployment remains in place; CI now also validates mdBook artifacts.

---

## 🧩 Additional Notes for Reviewers

<!-- Anything reviewers should pay attention to -->

This PR intentionally covers **Phase 2A only** (docs + DX baseline). Hybrid docs stack rollout (if required) is planned as follow-up scope.
