### PR TITLE
feat(rag): add Qdrant VectorStore and RAG pipeline example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,6 +553,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,11 +617,38 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
- "axum-core",
+ "axum-core 0.5.6",
  "axum-macros",
  "base64 0.22.1",
  "bytes",
@@ -611,7 +660,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -628,6 +677,26 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -3215,6 +3284,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4130,6 +4212,12 @@ dependencies = [
 
 [[package]]
 name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -4333,6 +4421,7 @@ dependencies = [
  "mofa-kernel",
  "mofa-plugins",
  "once_cell",
+ "qdrant-client",
  "ractor",
  "rand 0.8.5",
  "regex",
@@ -4383,7 +4472,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
+ "axum 0.8.8",
  "chrono",
  "futures",
  "hex",
@@ -5590,6 +5679,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "pulley-interpreter"
 version = "40.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5682,6 +5803,28 @@ dependencies = [
  "pyo3-build-config",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "qdrant-client"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d0a9b168ecf8f30a3eb7e8f4766e3050701242ffbe99838b58e6c4251e7211"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "futures",
+ "futures-util",
+ "parking_lot",
+ "prost",
+ "prost-types",
+ "reqwest",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tonic",
 ]
 
 [[package]]
@@ -8106,6 +8249,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.7.9",
+ "base64 0.22.1",
+ "bytes",
+ "flate2",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8113,9 +8290,13 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/crates/mofa-foundation/Cargo.toml
+++ b/crates/mofa-foundation/Cargo.toml
@@ -27,6 +27,8 @@ persistence-all = ["persistence-postgres", "persistence-mysql", "persistence-sql
 kokoro = ["mofa-plugins/kokoro"]
 # Enable MCP (Model Context Protocol) client support
 mcp = ["dep:rmcp"]
+# Enable Qdrant vector database support
+qdrant = ["dep:qdrant-client"]
 
 [dependencies]
 # Workspace dependencies
@@ -78,6 +80,9 @@ mofa-plugins = { path = "../mofa-plugins", version = "0.1" }
 once_cell = "1.21.3"
 rhai = { version = "1", features = ["sync", "serde"] }
 lazy_static = "1.4"
+
+# Qdrant vector database client (optional)
+qdrant-client = { version = "1.17", optional = true }
 
 # Image encoding and MIME detection
 base64 = "0.22"

--- a/crates/mofa-foundation/src/rag/mod.rs
+++ b/crates/mofa-foundation/src/rag/mod.rs
@@ -7,9 +7,15 @@ pub mod chunker;
 pub mod similarity;
 pub mod vector_store;
 
+#[cfg(feature = "qdrant")]
+pub mod qdrant_store;
+
 pub use chunker::{ChunkConfig, TextChunker};
 pub use similarity::compute_similarity;
 pub use vector_store::InMemoryVectorStore;
+
+#[cfg(feature = "qdrant")]
+pub use qdrant_store::{QdrantConfig, QdrantVectorStore};
 
 // Re-export kernel types for convenience
 pub use mofa_kernel::rag::{DocumentChunk, SearchResult, SimilarityMetric, VectorStore};

--- a/crates/mofa-foundation/src/rag/qdrant_store.rs
+++ b/crates/mofa-foundation/src/rag/qdrant_store.rs
@@ -1,0 +1,363 @@
+//! Qdrant-backed vector store implementation
+//!
+//! Provides a production-grade VectorStore backed by Qdrant vector database.
+//! Suitable for large-scale RAG pipelines with persistent storage.
+
+use async_trait::async_trait;
+use mofa_kernel::agent::error::{AgentError, AgentResult};
+use mofa_kernel::rag::{DocumentChunk, SearchResult, SimilarityMetric, VectorStore};
+use qdrant_client::qdrant::{
+    CountPointsBuilder, CreateCollectionBuilder, DeletePointsBuilder, Distance, PointStruct,
+    PointsIdsList, QueryPointsBuilder, UpsertPointsBuilder, VectorParamsBuilder,
+};
+use qdrant_client::Qdrant;
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+
+/// Reserved payload keys for internal storage.
+const PAYLOAD_KEY_ORIGINAL_ID: &str = "_original_id";
+const PAYLOAD_KEY_TEXT: &str = "_text";
+const PAYLOAD_KEY_METADATA_PREFIX: &str = "meta_";
+
+/// Configuration for connecting to a Qdrant instance.
+pub struct QdrantConfig {
+    /// Qdrant server URL (e.g., "http://localhost:6334")
+    pub url: String,
+    /// Optional API key for Qdrant Cloud or authenticated instances
+    pub api_key: Option<String>,
+    /// Name of the collection to use
+    pub collection_name: String,
+    /// Dimensionality of embedding vectors
+    pub vector_dimensions: u64,
+    /// Similarity metric to use for the collection
+    pub metric: SimilarityMetric,
+    /// Whether to create the collection if it does not exist
+    pub create_collection: bool,
+}
+
+/// Qdrant-backed vector store.
+///
+/// Stores document chunks as Qdrant points with embeddings as vectors
+/// and text/metadata as payload fields. String IDs from DocumentChunk
+/// are mapped to u64 using a deterministic hash, with the original
+/// string ID preserved in the payload for lossless retrieval.
+pub struct QdrantVectorStore {
+    client: Qdrant,
+    collection_name: String,
+    vector_dimensions: u64,
+    metric: SimilarityMetric,
+}
+
+/// Convert a string ID to a u64 point ID for Qdrant.
+///
+/// Uses DefaultHasher for a deterministic mapping. The original string
+/// ID is always stored in the point payload so retrieval is lossless.
+fn string_id_to_u64(id: &str) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    id.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Extract a string value from a Qdrant payload Value.
+fn extract_string(val: &qdrant_client::qdrant::Value) -> Option<&str> {
+    match &val.kind {
+        Some(qdrant_client::qdrant::value::Kind::StringValue(s)) => Some(s.as_str()),
+        _ => None,
+    }
+}
+
+impl QdrantVectorStore {
+    /// Create a new QdrantVectorStore from the given configuration.
+    ///
+    /// Connects to the Qdrant instance and optionally creates the collection
+    /// if `create_collection` is true and the collection does not exist.
+    pub async fn new(config: QdrantConfig) -> AgentResult<Self> {
+        let mut builder = Qdrant::from_url(&config.url);
+        if let Some(api_key) = config.api_key {
+            builder = builder.api_key(api_key);
+        }
+        let client = builder
+            .build()
+            .map_err(|e| AgentError::InitializationFailed(format!("Qdrant connection failed: {e}")))?;
+
+        let store = Self {
+            client,
+            collection_name: config.collection_name,
+            vector_dimensions: config.vector_dimensions,
+            metric: config.metric,
+        };
+
+        if config.create_collection {
+            store.ensure_collection_exists().await?;
+        }
+
+        Ok(store)
+    }
+
+    /// Convert SimilarityMetric to Qdrant's Distance enum.
+    fn to_qdrant_distance(metric: SimilarityMetric) -> Distance {
+        match metric {
+            SimilarityMetric::Cosine => Distance::Cosine,
+            SimilarityMetric::Euclidean => Distance::Euclid,
+            SimilarityMetric::DotProduct => Distance::Dot,
+        }
+    }
+
+    /// Ensure the collection exists, creating it if it does not.
+    async fn ensure_collection_exists(&self) -> AgentResult<()> {
+        let exists = self
+            .client
+            .collection_exists(&self.collection_name)
+            .await
+            .map_err(|e| AgentError::Internal(format!("Qdrant collection check failed: {e}")))?;
+
+        if !exists {
+            let distance = Self::to_qdrant_distance(self.metric);
+            self.client
+                .create_collection(
+                    CreateCollectionBuilder::new(&self.collection_name)
+                        .vectors_config(VectorParamsBuilder::new(self.vector_dimensions, distance)),
+                )
+                .await
+                .map_err(|e| {
+                    AgentError::InitializationFailed(format!(
+                        "Failed to create Qdrant collection '{}': {e}",
+                        self.collection_name
+                    ))
+                })?;
+        }
+
+        Ok(())
+    }
+
+    /// Convert a DocumentChunk into a Qdrant PointStruct.
+    fn chunk_to_point(chunk: &DocumentChunk) -> PointStruct {
+        let point_id = string_id_to_u64(&chunk.id);
+
+        let mut payload: HashMap<String, qdrant_client::qdrant::Value> = HashMap::new();
+        payload.insert(
+            PAYLOAD_KEY_ORIGINAL_ID.to_string(),
+            chunk.id.clone().into(),
+        );
+        payload.insert(PAYLOAD_KEY_TEXT.to_string(), chunk.text.clone().into());
+
+        for (key, value) in &chunk.metadata {
+            payload.insert(
+                format!("{PAYLOAD_KEY_METADATA_PREFIX}{key}"),
+                value.clone().into(),
+            );
+        }
+
+        PointStruct::new(point_id, chunk.embedding.clone(), payload)
+    }
+
+    /// Extract a SearchResult from a Qdrant ScoredPoint.
+    fn scored_point_to_result(point: &qdrant_client::qdrant::ScoredPoint) -> SearchResult {
+        let payload = &point.payload;
+
+        let id = payload
+            .get(PAYLOAD_KEY_ORIGINAL_ID)
+            .and_then(extract_string)
+            .unwrap_or_default()
+            .to_string();
+
+        let text = payload
+            .get(PAYLOAD_KEY_TEXT)
+            .and_then(extract_string)
+            .unwrap_or_default()
+            .to_string();
+
+        let mut metadata = HashMap::new();
+        for (key, val) in payload {
+            if let Some(meta_key) = key.strip_prefix(PAYLOAD_KEY_METADATA_PREFIX) {
+                if let Some(s) = extract_string(val) {
+                    metadata.insert(meta_key.to_string(), s.to_string());
+                }
+            }
+        }
+
+        SearchResult {
+            id,
+            text,
+            score: point.score,
+            metadata,
+        }
+    }
+}
+
+#[async_trait]
+impl VectorStore for QdrantVectorStore {
+    async fn upsert(&mut self, chunk: DocumentChunk) -> AgentResult<()> {
+        let point = Self::chunk_to_point(&chunk);
+        self.client
+            .upsert_points(
+                UpsertPointsBuilder::new(&self.collection_name, vec![point]).wait(true),
+            )
+            .await
+            .map_err(|e| AgentError::Internal(format!("Qdrant upsert failed: {e}")))?;
+        Ok(())
+    }
+
+    async fn upsert_batch(&mut self, chunks: Vec<DocumentChunk>) -> AgentResult<()> {
+        if chunks.is_empty() {
+            return Ok(());
+        }
+        let points: Vec<PointStruct> = chunks.iter().map(Self::chunk_to_point).collect();
+        self.client
+            .upsert_points(
+                UpsertPointsBuilder::new(&self.collection_name, points).wait(true),
+            )
+            .await
+            .map_err(|e| AgentError::Internal(format!("Qdrant batch upsert failed: {e}")))?;
+        Ok(())
+    }
+
+    async fn search(
+        &self,
+        query_embedding: &[f32],
+        top_k: usize,
+        threshold: Option<f32>,
+    ) -> AgentResult<Vec<SearchResult>> {
+        // Request extra results when using threshold filtering since
+        // Qdrant QueryPoints does not support score thresholds natively.
+        let limit = if threshold.is_some() {
+            (top_k * 2).max(100).min(1000) as u64
+        } else {
+            top_k as u64
+        };
+
+        let response = self
+            .client
+            .query(
+                QueryPointsBuilder::new(&self.collection_name)
+                    .query(query_embedding.to_vec())
+                    .limit(limit)
+                    .with_payload(true),
+            )
+            .await
+            .map_err(|e| AgentError::Internal(format!("Qdrant search failed: {e}")))?;
+
+        let mut results: Vec<SearchResult> =
+            response.result.iter().map(Self::scored_point_to_result).collect();
+
+        if let Some(t) = threshold {
+            results.retain(|r| r.score >= t);
+        }
+
+        results.truncate(top_k);
+        Ok(results)
+    }
+
+    async fn delete(&mut self, id: &str) -> AgentResult<bool> {
+        let point_id = string_id_to_u64(id);
+        self.client
+            .delete_points(
+                DeletePointsBuilder::new(&self.collection_name)
+                    .points(PointsIdsList {
+                        ids: vec![point_id.into()],
+                    })
+                    .wait(true),
+            )
+            .await
+            .map_err(|e| AgentError::Internal(format!("Qdrant delete failed: {e}")))?;
+        Ok(true)
+    }
+
+    async fn clear(&mut self) -> AgentResult<()> {
+        // Delete and recreate the collection to clear all points.
+        let _ = self
+            .client
+            .delete_collection(&self.collection_name)
+            .await;
+
+        self.ensure_collection_exists().await?;
+        Ok(())
+    }
+
+    async fn count(&self) -> AgentResult<usize> {
+        let result = self
+            .client
+            .count(CountPointsBuilder::new(&self.collection_name))
+            .await
+            .map_err(|e| AgentError::Internal(format!("Qdrant count failed: {e}")))?;
+        Ok(result.result.map(|c| c.count as usize).unwrap_or(0))
+    }
+
+    fn similarity_metric(&self) -> SimilarityMetric {
+        self.metric
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_string_id_to_u64_deterministic() {
+        let id = "test-document-1";
+        assert_eq!(string_id_to_u64(id), string_id_to_u64(id));
+    }
+
+    #[test]
+    fn test_string_id_to_u64_different_ids() {
+        assert_ne!(string_id_to_u64("a"), string_id_to_u64("b"));
+    }
+
+    #[test]
+    fn test_to_qdrant_distance() {
+        assert_eq!(
+            QdrantVectorStore::to_qdrant_distance(SimilarityMetric::Cosine),
+            Distance::Cosine
+        );
+        assert_eq!(
+            QdrantVectorStore::to_qdrant_distance(SimilarityMetric::Euclidean),
+            Distance::Euclid
+        );
+        assert_eq!(
+            QdrantVectorStore::to_qdrant_distance(SimilarityMetric::DotProduct),
+            Distance::Dot
+        );
+    }
+
+    #[test]
+    fn test_chunk_to_point_preserves_data() {
+        let chunk = DocumentChunk::new("my-id", "hello world", vec![1.0, 2.0, 3.0])
+            .with_metadata("source", "test.txt");
+        let point = QdrantVectorStore::chunk_to_point(&chunk);
+
+        // Verify point ID is the hash of the string ID
+        assert_eq!(
+            match point.id.as_ref().unwrap().point_id_options.as_ref().unwrap() {
+                qdrant_client::qdrant::point_id::PointIdOptions::Num(n) => *n,
+                _ => 0,
+            },
+            string_id_to_u64("my-id")
+        );
+
+        // Verify payload has original ID
+        let original_id = point.payload.get(PAYLOAD_KEY_ORIGINAL_ID);
+        assert!(original_id.is_some());
+
+        // Verify payload has text
+        let text = point.payload.get(PAYLOAD_KEY_TEXT);
+        assert!(text.is_some());
+
+        // Verify metadata is stored with prefix
+        let source = point.payload.get("meta_source");
+        assert!(source.is_some());
+    }
+
+    #[test]
+    fn test_qdrant_config_creation() {
+        let config = QdrantConfig {
+            url: "http://localhost:6334".to_string(),
+            api_key: None,
+            collection_name: "test_collection".to_string(),
+            vector_dimensions: 384,
+            metric: SimilarityMetric::Cosine,
+            create_collection: true,
+        };
+        assert_eq!(config.vector_dimensions, 384);
+        assert_eq!(config.collection_name, "test_collection");
+    }
+}

--- a/crates/mofa-sdk/Cargo.toml
+++ b/crates/mofa-sdk/Cargo.toml
@@ -28,6 +28,8 @@ rodio = ["mofa-plugins/rodio"]
 kokoro = ["mofa-plugins/kokoro", "mofa-foundation/kokoro"]
 # Enable monitoring support
 monitoring = ["mofa-runtime/monitoring", "dep:mofa-monitoring"]
+# Enable Qdrant vector database support
+qdrant = ["mofa-foundation/qdrant"]
 
 [dependencies]
 # Core dependencies

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -216,6 +216,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,11 +271,38 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
- "axum-core",
+ "axum-core 0.5.6",
  "axum-macros",
  "base64 0.22.1",
  "bytes",
@@ -265,7 +314,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -282,6 +331,26 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1729,7 +1798,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 dependencies = [
  "fallible-iterator",
- "indexmap",
+ "indexmap 2.13.0",
  "stable_deref_trait",
 ]
 
@@ -1751,12 +1820,18 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1990,6 +2065,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2023,7 +2111,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.1",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2225,6 +2313,16 @@ name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
 
 [[package]]
 name = "indexmap"
@@ -2636,6 +2734,12 @@ dependencies = [
 
 [[package]]
 name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -2764,6 +2868,7 @@ dependencies = [
  "mofa-kernel",
  "mofa-plugins",
  "once_cell",
+ "qdrant-client",
  "ractor",
  "rand 0.8.5",
  "regex",
@@ -2807,7 +2912,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
+ "axum 0.8.8",
  "chrono",
  "futures",
  "hex",
@@ -2914,7 +3019,7 @@ dependencies = [
 name = "monitoring_dashboard"
 version = "0.1.0"
 dependencies = [
- "axum",
+ "axum 0.8.8",
  "mofa-sdk",
  "serde_json",
  "tokio",
@@ -3187,7 +3292,7 @@ checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "crc32fast",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "memchr",
 ]
 
@@ -3423,7 +3528,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 2.13.0",
 ]
 
 [[package]]
@@ -3631,6 +3736,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "pulley-interpreter"
 version = "40.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3654,6 +3791,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "qdrant-client"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d0a9b168ecf8f30a3eb7e8f4766e3050701242ffbe99838b58e6c4251e7211"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "futures",
+ "futures-util",
+ "parking_lot",
+ "prost",
+ "prost-types",
+ "reqwest",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3666,7 +3825,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -3703,7 +3862,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.1",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3741,6 +3900,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-time",
+]
+
+[[package]]
+name = "rag_pipeline"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "mofa-foundation",
+ "mofa-kernel",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -4269,6 +4440,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4484,7 +4664,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "itoa",
  "ryu",
  "serde",
@@ -4605,6 +4785,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
@@ -4681,7 +4871,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink 0.10.0",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "memchr",
  "once_cell",
@@ -5196,7 +5386,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.1",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -5311,7 +5501,7 @@ version = "0.9.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "serde_core",
  "serde_spanned 1.0.4",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -5344,7 +5534,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -5358,7 +5548,7 @@ version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
@@ -5386,6 +5576,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.7.9",
+ "base64 0.22.1",
+ "bytes",
+ "flate2",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tool_routing"
 version = "0.1.0"
 dependencies = [
@@ -5405,9 +5629,13 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5929,7 +6157,7 @@ dependencies = [
  "anyhow",
  "heck",
  "im-rc",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "petgraph",
  "serde",
@@ -5994,7 +6222,7 @@ checksum = "f6d8db401b0528ec316dfbe579e6ab4152d61739cfe076706d2009127970159d"
 dependencies = [
  "bitflags 2.10.0",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "semver",
  "serde",
 ]
@@ -6006,7 +6234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.10.0",
- "indexmap",
+ "indexmap 2.13.0",
  "semver",
 ]
 
@@ -6039,7 +6267,7 @@ dependencies = [
  "fxprof-processed-profile",
  "gimli",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "ittapi",
  "libc",
  "log",
@@ -6089,7 +6317,7 @@ dependencies = [
  "cranelift-bitset",
  "cranelift-entity",
  "gimli",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "object",
  "postcard",
@@ -6279,7 +6507,7 @@ dependencies = [
  "anyhow",
  "bitflags 2.10.0",
  "heck",
- "indexmap",
+ "indexmap 2.13.0",
  "wit-parser",
 ]
 
@@ -6850,7 +7078,7 @@ checksum = "df983a8608e513d8997f435bb74207bf0933d0e49ca97aa9d8a6157164b9b7fc"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "semver",
  "serde",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -24,7 +24,8 @@ members = [
     "agent_from_database_streaming",
     "workflow_dsl",
     "tool_routing",
-    "runtime_message_bus_backpressure"
+    "runtime_message_bus_backpressure",
+    "rag_pipeline"
 ]
 
 [workspace.package]

--- a/examples/rag_pipeline/Cargo.toml
+++ b/examples/rag_pipeline/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "rag_pipeline"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+mofa-foundation = { path = "../../crates/mofa-foundation", features = ["qdrant"] }
+mofa-kernel = { path = "../../crates/mofa-kernel" }
+
+tokio.workspace = true
+anyhow.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+[lints]
+workspace = true

--- a/examples/rag_pipeline/src/main.rs
+++ b/examples/rag_pipeline/src/main.rs
@@ -1,0 +1,285 @@
+//! RAG Pipeline Example
+//!
+//! Demonstrates Retrieval-Augmented Generation using MoFA's vector store
+//! abstractions with both in-memory and Qdrant backends.
+//!
+//! # Running
+//!
+//! In-memory mode (no external dependencies):
+//! ```bash
+//! cargo run -p rag_pipeline
+//! ```
+//!
+//! With Qdrant (start Qdrant first):
+//! ```bash
+//! docker run -p 6333:6333 -p 6334:6334 qdrant/qdrant
+//! QDRANT_URL=http://localhost:6334 cargo run -p rag_pipeline -- qdrant
+//! ```
+
+use anyhow::Result;
+use mofa_foundation::rag::{
+    ChunkConfig, DocumentChunk, InMemoryVectorStore, QdrantConfig, QdrantVectorStore,
+    SimilarityMetric, TextChunker, VectorStore,
+};
+
+/// Generate a simple deterministic embedding from text.
+///
+/// This is a toy embedding function for demonstration purposes only.
+/// In production, replace this with a real embedding model such as
+/// OpenAI text-embedding-3-small or a local model like all-MiniLM-L6-v2.
+fn simple_embedding(text: &str, dimensions: usize) -> Vec<f32> {
+    let mut embedding = vec![0.0_f32; dimensions];
+    for (i, byte) in text.bytes().enumerate() {
+        embedding[i % dimensions] += byte as f32 / 255.0;
+    }
+    // Normalize to unit vector for cosine similarity
+    let norm: f32 = embedding.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        for x in &mut embedding {
+            *x /= norm;
+        }
+    }
+    embedding
+}
+
+/// Demonstrates a basic RAG pipeline using the in-memory vector store.
+///
+/// Steps: chunk documents, embed, store, search, build context for LLM.
+async fn basic_rag_pipeline() -> Result<()> {
+    println!("--- Basic RAG Pipeline (In-Memory) ---\n");
+
+    let mut store = InMemoryVectorStore::cosine();
+    let dimensions = 64;
+
+    // Knowledge base: a few paragraphs about MoFA
+    let documents = vec![
+        "MoFA is a modular framework for building AI agents in Rust. It uses a microkernel \
+         architecture where the core only defines trait interfaces and concrete implementations \
+         are provided by the foundation layer.",
+        "The dual plugin system in MoFA supports both compile-time Rust/WASM plugins for \
+         performance-critical paths and runtime Rhai scripts for hot-reloadable business logic.",
+        "MoFA supports seven multi-agent coordination patterns: request-response, \
+         publish-subscribe, consensus, debate, parallel, sequential, and custom modes.",
+        "The secretary agent pattern in MoFA provides human-in-the-loop workflow management \
+         with five phases: receive ideas, clarify requirements, schedule dispatch, monitor \
+         feedback, and acceptance report.",
+        "MoFA uses UniFFI for cross-language bindings, allowing agents built in Rust to be \
+         called from Python, Java, Swift, Kotlin, and Go.",
+    ];
+
+    // Chunk and embed each document
+    let chunker = TextChunker::new(ChunkConfig {
+        chunk_size: 200,
+        chunk_overlap: 30,
+    });
+
+    let mut all_chunks = Vec::new();
+    for (doc_idx, document) in documents.iter().enumerate() {
+        let text_chunks = chunker.chunk_by_chars(document);
+        for (chunk_idx, text) in text_chunks.iter().enumerate() {
+            let id = format!("doc-{doc_idx}-chunk-{chunk_idx}");
+            let embedding = simple_embedding(text, dimensions);
+            let chunk = DocumentChunk::new(&id, text.as_str(), embedding)
+                .with_metadata("source", &format!("document_{doc_idx}"))
+                .with_metadata("chunk_index", &chunk_idx.to_string());
+            all_chunks.push(chunk);
+        }
+    }
+
+    println!("Indexed {} chunks from {} documents\n", all_chunks.len(), documents.len());
+
+    store.upsert_batch(all_chunks).await?;
+
+    // Search with a query
+    let query = "How does MoFA handle multiple agents working together?";
+    let query_embedding = simple_embedding(query, dimensions);
+
+    let results = store.search(&query_embedding, 3, None).await?;
+
+    println!("Query: \"{query}\"\n");
+    println!("Top {} results:", results.len());
+    for (i, result) in results.iter().enumerate() {
+        println!(
+            "\n  {}. [score: {:.4}] (source: {})\n     \"{}\"",
+            i + 1,
+            result.score,
+            result.metadata.get("source").unwrap_or(&"unknown".into()),
+            truncate_text(&result.text, 120),
+        );
+    }
+
+    // Build a context string that would be fed to an LLM
+    let context: String = results
+        .iter()
+        .map(|r| r.text.clone())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
+    println!("\n--- Context for LLM ---");
+    println!("Given the following context:\n{context}");
+    println!("\nAnswer the question: {query}");
+    println!("\n(In production, this context + question would be sent to an LLM)\n");
+
+    Ok(())
+}
+
+/// Demonstrates multi-document ingestion with metadata tracking.
+async fn document_ingestion_demo() -> Result<()> {
+    println!("--- Document Ingestion Demo (In-Memory) ---\n");
+
+    let mut store = InMemoryVectorStore::cosine();
+    let dimensions = 64;
+
+    // Simulate ingesting multiple files
+    let files = vec![
+        ("architecture.md", "The microkernel pattern keeps the core small and extensible. All concrete implementations live in the foundation layer. The kernel only defines trait interfaces."),
+        ("plugins.md", "Compile-time plugins use Rust traits for zero-cost abstractions. Runtime plugins use Rhai scripting with built-in JSON processing. Both layers can interoperate seamlessly."),
+        ("deployment.md", "MoFA agents can be deployed as standalone binaries, Docker containers, or as libraries embedded in other applications. The CLI tool provides project scaffolding and management."),
+    ];
+
+    let chunker = TextChunker::new(ChunkConfig::default());
+
+    let mut total_chunks = 0;
+    for (filename, content) in &files {
+        let text_chunks = chunker.chunk_by_sentences(content);
+        let mut chunks = Vec::new();
+        for (i, text) in text_chunks.iter().enumerate() {
+            let id = format!("{filename}-{i}");
+            let embedding = simple_embedding(text, dimensions);
+            let chunk = DocumentChunk::new(&id, text.as_str(), embedding)
+                .with_metadata("filename", *filename)
+                .with_metadata("chunk_index", &i.to_string());
+            chunks.push(chunk);
+        }
+        total_chunks += chunks.len();
+        store.upsert_batch(chunks).await?;
+    }
+
+    println!("Ingested {total_chunks} chunks from {} files", files.len());
+    println!("Store contains {} chunks\n", store.count().await?);
+
+    // Search across all documents
+    let query = "How are plugins implemented?";
+    let query_embedding = simple_embedding(query, dimensions);
+    let results = store.search(&query_embedding, 2, None).await?;
+
+    println!("Query: \"{query}\"");
+    for (i, result) in results.iter().enumerate() {
+        println!(
+            "  {}. [score: {:.4}] from {}: \"{}\"",
+            i + 1,
+            result.score,
+            result.metadata.get("filename").unwrap_or(&"unknown".into()),
+            truncate_text(&result.text, 100),
+        );
+    }
+
+    println!();
+    Ok(())
+}
+
+/// Demonstrates using Qdrant as the vector store backend.
+async fn qdrant_rag_pipeline(qdrant_url: &str) -> Result<()> {
+    println!("--- Qdrant RAG Pipeline ---\n");
+
+    let dimensions: u64 = 64;
+    let collection_name = "mofa_rag_example";
+
+    let config = QdrantConfig {
+        url: qdrant_url.into(),
+        api_key: std::env::var("QDRANT_API_KEY").ok(),
+        collection_name: collection_name.into(),
+        vector_dimensions: dimensions,
+        metric: SimilarityMetric::Cosine,
+        create_collection: true,
+    };
+
+    let mut store = QdrantVectorStore::new(config).await?;
+
+    // Clear any previous data
+    store.clear().await?;
+
+    let documents = vec![
+        ("intro", "MoFA stands for Modular Framework for Agents. It is built in Rust for performance and safety."),
+        ("architecture", "MoFA uses a microkernel architecture. The kernel defines traits, the foundation provides implementations."),
+        ("agents", "Agents in MoFA can coordinate using patterns like debate, consensus, parallel execution, and sequential pipelines."),
+        ("tools", "MoFA agents can use tools defined as Rust traits. Tools handle web search, code execution, file operations, and more."),
+    ];
+
+    // Ingest documents
+    let mut chunks = Vec::new();
+    for (name, text) in &documents {
+        let embedding = simple_embedding(text, dimensions as usize);
+        let chunk = DocumentChunk::new(*name, *text, embedding)
+            .with_metadata("source", *name);
+        chunks.push(chunk);
+    }
+
+    store.upsert_batch(chunks).await?;
+    println!("Stored {} documents in Qdrant collection '{collection_name}'", documents.len());
+    println!("Total count: {}\n", store.count().await?);
+
+    // Search
+    let query = "What coordination patterns does MoFA support?";
+    let query_embedding = simple_embedding(query, dimensions as usize);
+    let results = store.search(&query_embedding, 2, None).await?;
+
+    println!("Query: \"{query}\"");
+    for (i, result) in results.iter().enumerate() {
+        println!(
+            "  {}. [score: {:.4}] {}: \"{}\"",
+            i + 1,
+            result.score,
+            result.id,
+            truncate_text(&result.text, 100),
+        );
+    }
+
+    // Demonstrate delete
+    store.delete("intro").await?;
+    println!("\nDeleted 'intro', count now: {}", store.count().await?);
+
+    // Cleanup
+    store.clear().await?;
+    println!("Cleared collection, count: {}\n", store.count().await?);
+
+    Ok(())
+}
+
+/// Truncate text to a maximum length with ellipsis.
+fn truncate_text(text: &str, max_len: usize) -> String {
+    if text.len() <= max_len {
+        text.to_string()
+    } else {
+        format!("{}...", &text[..max_len])
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter("info")
+        .init();
+
+    let args: Vec<String> = std::env::args().collect();
+    let mode = args.get(1).map(|s| s.as_str()).unwrap_or("memory");
+
+    println!("=== MoFA RAG Pipeline Example ===\n");
+
+    // Always run in-memory demos
+    basic_rag_pipeline().await?;
+    document_ingestion_demo().await?;
+
+    // Run Qdrant demo if requested
+    if mode == "qdrant" {
+        let url = std::env::var("QDRANT_URL").unwrap_or_else(|_| "http://localhost:6334".into());
+        qdrant_rag_pipeline(&url).await?;
+    } else {
+        println!("--- Qdrant Demo Skipped ---");
+        println!("To run with Qdrant, start a Qdrant instance and run:");
+        println!("  QDRANT_URL=http://localhost:6334 cargo run -p rag_pipeline -- qdrant\n");
+    }
+
+    println!("=== Done ===");
+    Ok(())
+}


### PR DESCRIPTION
This follows up on the feedback from #205 where @lijingrs suggested adding a Qdrant backed implementation and a practical RAG example under the examples directory.

Added a QdrantVectorStore that implements the VectorStore trait using the qdrant-client crate behind an optional "qdrant" feature flag in mofa-foundation. It handles the full lifecycle including collection creation, upsert, batch upsert, similarity search, deletion, and count operations. String IDs from DocumentChunk are mapped to Qdrant's u64 point IDs using a deterministic hash with the original ID preserved in the payload for lossless retrieval.

Also added a rag_pipeline example under examples/ that demonstrates a complete RAG workflow. It shows document chunking, embedding, storage, similarity search, and context building for LLM queries. The example runs in memory mode by default with no external dependencies, and supports Qdrant mode when a Qdrant instance is available.

I also looked at how n8n handles RAG workflows to make sure the design covers real world usage patterns like metadata tracking across documents, batch ingestion, and threshold based filtering.