### PR TITLE
fix(runtime): remove duplicate cfg attribute and merge split impl blocks on SimpleAgentRuntime

### DIFF
--- a/crates/mofa-runtime/src/lib.rs
+++ b/crates/mofa-runtime/src/lib.rs
@@ -448,15 +448,6 @@ pub struct SimpleAgentRuntime<A: MoFAAgent> {
 
 #[cfg(not(feature = "dora"))]
 impl<A: MoFAAgent> SimpleAgentRuntime<A> {
-    pub async fn inject_event(&self, event: AgentEvent) {
-        // 将事件发送到事件通道
-        let _ = self.event_tx.send(event).await;
-    }
-}
-
-#[cfg(not(feature = "dora"))]
-#[cfg(not(feature = "dora"))]
-impl<A: MoFAAgent> SimpleAgentRuntime<A> {
     /// 获取智能体引用
     pub fn agent(&self) -> &A {
         &self.agent
@@ -500,6 +491,11 @@ impl<A: MoFAAgent> SimpleAgentRuntime<A> {
     /// 获取默认超时时间
     pub fn default_timeout(&self) -> Duration {
         self.default_timeout
+    }
+
+    /// 注入事件
+    pub async fn inject_event(&self, event: AgentEvent) {
+        let _ = self.event_tx.send(event).await;
     }
 
     /// 初始化插件


### PR DESCRIPTION
## Summary
Removed a duplicate `#[cfg(not(feature = "dora"))]` attribute and merged two
split `impl<A: MoFAAgent> SimpleAgentRuntime<A>` blocks into one in
`crates/mofa-runtime/src/lib.rs`.

## Motivation
The duplicate `#[cfg]` at line 458 was a copy-paste error — redundant and
misleading. The two separate `impl` blocks guarded by the same flag were
unnecessarily split, making the type's API surface harder to navigate.

## Changes
- **`mofa-runtime/src/lib.rs`** — removed duplicate `#[cfg(not(feature = "dora"))]`
  at line 458
- **`mofa-runtime/src/lib.rs`** — merged two `impl<A: MoFAAgent> SimpleAgentRuntime<A>`
  blocks (lines 449-615) into one unified block; `inject_event` moved into the
  consolidated impl

## Testing
- `cargo check -p mofa-runtime` — ✅
- `cargo test -p mofa-runtime` — ✅

## Checklist
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes with no warnings
- [x] `cargo test` passes
- [x] Architecture layer rules respected
- [x] Relevant documentation updated