### PR TITLE
fix(foundation): implement with_max_impact_scope() builder method was silently discarding its parameter

### DIFF
--- a/crates/mofa-foundation/src/secretary/monitoring/plugin.rs
+++ b/crates/mofa-foundation/src/secretary/monitoring/plugin.rs
@@ -103,8 +103,11 @@ impl BaseEventResponsePlugin {
     }
 
     /// Set the max impact scope
-    pub fn with_max_impact_scope(self, _scope: &str) -> Self {
-        // Max impact scope is now stored in config, update via update_config
+    pub fn with_max_impact_scope(mut self, scope: &str) -> Self {
+        // Note: max_impact_scope is stored here for when decision logic reads it.
+        // Plugins that override config independently should also set this field
+        // in their own EventResponseConfig.
+        self.config.get_mut().max_impact_scope = scope.to_string();
         self
     }
 }


### PR DESCRIPTION
## Summary
`BaseEventResponsePlugin::with_max_impact_scope()` accepted a scope parameter but
ignored it completely, returning `self` unchanged. This PR implements the method
to actually store the provided scope in the config.

## Motivation
Callers in `plugins.rs` pass `"instance"` (line 49) and `"system"` (line 254) to
scope the blast radius of fault response plugins. These values were silently
discarded — the `_scope` underscore prefix was the giveaway. All plugins ran with
the default scope `"component"` regardless of what was passed to the builder.

## Changes
- **`mofa-foundation/src/secretary/monitoring/plugin.rs:106-109`** — implemented
  `with_max_impact_scope()` to store the scope in `self.config.get_mut().max_impact_scope`
  instead of discarding it; renamed `_scope` to `scope`; added comment documenting
  the known dual-config architectural limitation for reviewers

## Known Limitation
Plugins with their own `config: RwLock<EventResponseConfig>` initialized via
`..Default::default()` will still get `"component"` unless they also set the field
in their own config. This is a pre-existing architectural issue outside the scope
of this PR and is documented in the added comment.

## Testing
- `cargo check -p mofa-foundation` — ✅
- `cargo test -p mofa-foundation` — ✅

## Checklist
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes with no warnings
- [x] `cargo test` passes
- [x] Architecture layer rules respected
- [x] Relevant documentation updated## Summary
`BaseEventResponsePlugin::with_max_impact_scope()` accepted a scope parameter but
ignored it completely, returning `self` unchanged. This PR implements the method
to actually store the provided scope in the config.

## Motivation
Callers in `plugins.rs` pass `"instance"` (line 49) and `"system"` (line 254) to
scope the blast radius of fault response plugins. These values were silently
discarded — the `_scope` underscore prefix was the giveaway. All plugins ran with
the default scope `"component"` regardless of what was passed to the builder.

## Changes
- **`mofa-foundation/src/secretary/monitoring/plugin.rs:106-109`** — implemented
  `with_max_impact_scope()` to store the scope in `self.config.get_mut().max_impact_scope`
  instead of discarding it; renamed `_scope` to `scope`; added comment documenting
  the known dual-config architectural limitation for reviewers

## Known Limitation
Plugins with their own `config: RwLock<EventResponseConfig>` initialized via
`..Default::default()` will still get `"component"` unless they also set the field
in their own config. This is a pre-existing architectural issue outside the scope
of this PR and is documented in the added comment.

## Testing
- `cargo check -p mofa-foundation` — ✅
- `cargo test -p mofa-foundation` — ✅

## Checklist
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes with no warnings
- [x] `cargo test` passes
- [x] Architecture layer rules respected
- [x] Relevant documentation updated