### PR TITLE
fix(cli): fix invalid struct field syntax in axum template `HealthResponse`

### DIFF
--- a/crates/mofa-cli/src/commands/new.rs
+++ b/crates/mofa-cli/src/commands/new.rs
@@ -294,7 +294,7 @@ struct SessionInfo {
 #[derive(Debug, Serialize)]
 struct HealthResponse {
     status: String,
-    version: env!("CARGO_PKG_VERSION"),
+    version: String,
 }
 
 /// Error response


### PR DESCRIPTION
## 📋 Summary

The `mofa new --template axum` command generates a `HealthResponse` struct with invalid Rust syntax — `env!("CARGO_PKG_VERSION")` is used as a **type annotation** instead of `String`, causing the generated project to fail to compile immediately.

This PR fixes the struct field type so generated projects compile correctly out of the box.

---

## 🔗 Related Issues

Closes #245

---

## 🧠 Context

The `env!()` macro returns a `&'static str` at compile time. However, it was incorrectly placed in the struct field's **type position**, where a type (such as `String`) is expected.

As a result, any user running:

```bash
mofa new my-project --template axum
```

(or using `http` / `http-service` templates)

would get a project that **fails to compile immediately**, leading to a poor first experience.

The handler function (around line ~341) already correctly constructs the struct using:

```rust
version: env!("CARGO_PKG_VERSION").to_string()
```

So only the struct definition was incorrect.

---

## 🛠️ Changes

Changed:

```rust
version: env!("CARGO_PKG_VERSION"),
```

To:

```rust
version: String,
```

Location:

```
crates/mofa-cli/src/commands/new.rs
```

This ensures the generated template produces valid Rust syntax.

---

## 🧪 How This Was Tested

1. Generated a new project using:

   ```bash
   mofa new test-project --template axum
   ```

2. Verified the generated `HealthResponse` struct now contains:

   ```rust
   struct HealthResponse {
       status: String,
       version: String,
   }
   ```

3. Ran:

   ```bash
   cargo check
   ```

   and confirmed the project compiles successfully.

4. Verified the handler already constructs `HealthResponse` using:

   ```rust
   version: env!("CARGO_PKG_VERSION").to_string()
   ```

   so no additional changes were required.

---

## 📸 Before & After

### Before (Compiler Error)

```rust
struct HealthResponse {
    status: String,
    version: env!("CARGO_PKG_VERSION"),  // Invalid type position
}
```

### After (Valid Syntax)

```rust
struct HealthResponse {
    status: String,
    version: String,
}
```

---

## ⚠️ Breaking Changes

None.

This is a bug fix that restores expected functionality.

---

## 🧹 Checklist

### Code Quality

* [x] Code follows Rust idioms and project conventions
* [x] `cargo fmt` run
* [x] `cargo clippy` passes without warnings

### Testing

* [x] Verified template generates valid Rust code
* [x] `cargo check` passes locally
* [x] `cargo test` passes locally

### PR Hygiene

* [x] PR is small and focused (single-line fix)
* [x] Branch is up to date with `main`
* [x] No unrelated commits
* [x] Commit message explains **why**, not only **what**

---

## 🧩 Additional Notes for Reviewers

This is a single-line fix.

The handler constructing `HealthResponse` (around line ~341) already correctly uses:

```rust
env!("CARGO_PKG_VERSION").to_string()
```

Only the struct definition incorrectly used the macro in the type position.

This ensures new users can successfully compile projects generated with the `axum`, `http`, and `http-service` templates without manual fixes.
