### PR TITLE
fix: remove .get_mut() call on EventResponseConfig

### DIFF
--- a/crates/mofa-foundation/src/secretary/monitoring/plugin.rs
+++ b/crates/mofa-foundation/src/secretary/monitoring/plugin.rs
@@ -106,7 +106,7 @@ impl BaseEventResponsePlugin {
         // Note: max_impact_scope is stored here for when decision logic reads it.
         // Plugins that override config independently should also set this field
         // in their own EventResponseConfig.
-        self.config.get_mut().max_impact_scope = scope.to_string();
+        self.config.max_impact_scope = scope.to_string();
         self
     }
 }


### PR DESCRIPTION
## Summary
Fixes regression introduced by the interaction between #248 and #261.
PR #248 removed `RwLock<EventResponseConfig>` from `BaseEventResponsePlugin`,
making `config` a plain `EventResponseConfig`. PR #261 still called
`.get_mut()` on it — which only exists on `RwLock`. This broke `cargo check`
on main.

## Changes
- `mofa-foundation/src/secretary/monitoring/plugin.rs:109` — removed
  `.get_mut()` call, now directly assigns `self.config.max_impact_scope`

## Testing
- `cargo check -p mofa-foundation` — ✅
- `cargo test -p mofa-foundation` — ✅

## Checklist
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes with no warnings
- [x] `cargo test` passes
- [x] Architecture layer rules respected
- [x] Relevant documentation updated