### PR TITLE
fix(foundation): return error for unimplemented hot_reload_plugin

### DIFF
--- a/crates/mofa-foundation/src/agent/tools/registry.rs
+++ b/crates/mofa-foundation/src/agent/tools/registry.rs
@@ -229,7 +229,9 @@ impl ToolRegistry {
     pub async fn hot_reload_plugin(&mut self, _path: &str) -> AgentResult<Vec<String>> {
         // TODO: 实际插件热加载实现
         // TODO: actual hot reload implementation
-        Ok(vec![])
+        Err(mofa_kernel::agent::error::AgentError::Other(
+            "Plugin hot reloading is not yet implemented".to_string(),
+        ))
     }
 
     /// 获取工具来源


### PR DESCRIPTION
## Summary
The `hot_reload_plugin` method in `ToolRegistry` was an unimplemented stub that silently returned an empty vector (`Ok(vec![])`). This PR changes the stub to accurately return an `AgentError::Other` stating that the feature is not yet implemented, providing better error propagation until the actual implementation is added.
## Motivation
Returning `Ok(vec![])` creates hidden bugs for developers who assume the hot-reload successfully completed but loaded 0 new tools.
## Changes
- `crates/mofa-foundation/src/agent/tools/registry.rs`: Changed the return value of `hot_reload_plugin` from `Ok(vec![])` to an `Err(AgentError::Other(...))`.
## Related Issues
Closes #287 
## Testing
Manual verification. `cargo check` and `cargo test` pass.