### PR TITLE
fix(clippy): remove unnecessary &self in recursive execute_step

### DIFF
--- a/crates/mofa-extra/src/lib.rs
+++ b/crates/mofa-extra/src/lib.rs
@@ -10,7 +10,7 @@
 //! - 规则引擎
 //! - Rule engine
 //! - 脚本化工作流节点
-//! Scripted workflow nodes
+//! - Scripted workflow nodes
 
 #[cfg(feature = "rhai-scripting")]
 pub mod rhai;


### PR DESCRIPTION
## Summary

This PR resolves strict Clippy warnings in the workspace:

- **Fixes `clippy::doc_lazy_continuation`** in `mofa-extra` by correcting doc comment formatting (added missing list marker).
- **Fixes `clippy::only_used_in_recursion`** in `mofa-foundation` by removing an unnecessary `&self` method receiver from `execute_step` and converting it to an associated function.

## Changes

| File | Change |
|------|--------|
| `crates/mofa-extra/src/lib.rs` | Added `- ` prefix to doc comment line to fix list formatting |
| `crates/mofa-foundation/src/llm/pipeline.rs` | Removed `&self` from `execute_step`, updated call sites to `Self::execute_step(...)` |

## Verification

- `cargo clippy --workspace --all-features -- -D warnings` — **zero warnings**
- `cargo test --workspace --all-features --exclude mofa-ffi` — **all tests pass**

## Notes

- No behavior changes.
- No lint suppressions added.
- No unrelated formatting or refactoring.
- This is a focused lint and structural cleanup PR.
