### PR TITLE
feat: add ruff configuration at root level

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.ruff]
+line-length = 88
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "W"]


### PR DESCRIPTION
## Summary

Add root-level pyproject.toml with ruff linting configuration to ensure consistent code quality across the project.

## Context

Currently, there is no root-level linting configuration for Python code. While there's a pyproject.toml in the Python bindings directory, the root of the project lacks a unified ruff configuration.

## Changes

Added pyproject.toml with:
- line-length: 88 (Ruff default)
- target-version: py310
- lint rules: E (pycodestyle errors), F (pyflakes), I (isort), N (naming conventions), W (pycodestyle warnings)

## Related Issues

Closes #302

## Checklist

- [x] Code follows project conventions