### PR TITLE
fix(kernel): correct TaskPriority Ord impl to cover all variants

### DIFF
--- a/crates/mofa-kernel/src/message/mod.rs
+++ b/crates/mofa-kernel/src/message/mod.rs
@@ -142,20 +142,11 @@ impl PartialOrd for TaskPriority {
 
 impl Ord for TaskPriority {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        match (self, other) {
-            (TaskPriority::Critical, _) => std::cmp::Ordering::Greater,
-            (_, TaskPriority::Critical) => std::cmp::Ordering::Less,
-            (TaskPriority::High, TaskPriority::Medium | TaskPriority::Low) => {
-                std::cmp::Ordering::Greater
-            }
-            (TaskPriority::Medium, TaskPriority::Low) => std::cmp::Ordering::Greater,
-            (TaskPriority::Low, TaskPriority::Medium | TaskPriority::High) => {
-                std::cmp::Ordering::Less
-            }
-            (TaskPriority::Medium, TaskPriority::High) => std::cmp::Ordering::Less,
-            (a, b) if a == b => std::cmp::Ordering::Equal,
-            _ => unreachable!("All cases should be covered"),
-        }
+        // Lower discriminant = higher priority (Critical=0 is highest).
+        // Reverse the natural ordering so that higher-priority sorts Greater.
+        let lhs = self.clone() as u8;
+        let rhs = other.clone() as u8;
+        lhs.cmp(&rhs).reverse()
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes a correctness and safety issue in `TaskPriority::cmp`.

The previous manual `match` implementation:

- Did not handle all enum variants (`Highest`, `Normal`)
- Used `unreachable!()` for missing cases, causing runtime panics
- Returned incorrect results for identical variants (e.g. `Critical.cmp(&Critical)` returned `Greater` instead of `Equal`)

This violated the `Ord` contract and could corrupt ordering logic in
`sort`, `BinaryHeap`, `BTreeMap`, or any structure relying on total ordering.

The implementation has been replaced with a discriminant-based comparison,
which guarantees correctness and exhaustiveness.

---

## Context

The manual `match` logic was brittle and incomplete. When new variants
(`Highest`, `Normal`) were added, the comparison logic was not updated,
leading to:

- Panics via `unreachable!()`
- Invalid ordering results
- Broken `Ord` invariants

Violating `Ord` invariants can cause subtle and dangerous bugs in ordered
collections.

The new implementation compares enum discriminants directly:

- Lower discriminant = higher priority
- Natural `u8` ordering is reversed to maintain intended priority semantics

This ensures:

- All variants are handled
- `cmp(a, a) == Equal`
- Transitivity and total ordering are preserved

---

## Changes

- Removed manual `match`-based comparison
- Replaced with discriminant-based comparison using `as u8`
- Reversed ordering to maintain priority semantics
- Eliminated `unreachable!()` panic path

---

## How to Test

1. Run:

```bash
cargo fmt
cargo clippy --workspace --all-features -- -D warnings
```

2. Run:

```bash
cargo test --workspace --all-features --exclude mofa-ffi
```

3. Verify:
   - Sorting `Vec<TaskPriority>` produces stable correct ordering
   - `BTreeMap<TaskPriority, _>` behaves correctly
   - No panic occurs for any variant comparisons

All tests pass. No warnings.

---

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (describe below)

Behavior is now correct and consistent with `Ord`.

---

## Checklist

### Code Quality

- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing

- [x] `cargo test` passes locally without errors

### PR Hygiene

- [x] PR is small and focused on one logical change
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit message explains **why**, not just **what**

---

## Notes for Reviewers

This change removes a potential runtime panic and restores a valid total
ordering for `TaskPriority`. The new approach is simpler, safer, and
automatically covers future variants without requiring manual updates to
comparison logic.