### PR TITLE
feat: Implement Chat Bubble Widget with User/Assistant/System Roles (Idea 6)

### DIFF
--- a/crates/makepad-chat/src/chat_bubble.rs
+++ b/crates/makepad-chat/src/chat_bubble.rs
@@ -1,0 +1,105 @@
+use makepad_widgets::*;
+use crate::markdown_renderer::MarkdownRenderer;
+use crate::streaming_text::StreamingText;
+
+live_design! {
+    import makepad_widgets::base::*;
+    import makepad_widgets::theme_desktop_dark::*;
+    import crate::markdown_renderer::MarkdownRenderer;
+    import crate::streaming_text::StreamingText;
+
+    ChatBubble = {{ChatBubble}} {
+        width: Fill,
+        height: Fit,
+        margin: {left: 10, right: 10, top: 5, bottom: 5},
+        padding: 10,
+        
+        draw_bg: {
+            fn pixel(self) -> vec4 {
+                return self.color
+            }
+        }
+
+        layout: {
+            align: {x: 0.0, y: 0.0},
+            flow: Down,
+        }
+
+
+        markdown = <MarkdownRenderer> { visible: true }
+        streaming = <StreamingText> { visible: false }
+    }
+}
+
+#[derive(Live, LiveHook, Widget)]
+pub struct ChatBubble {
+    #[deref] view: View,
+    #[live] pub role: ChatRole,
+}
+
+#[derive(Live, LiveHook, Clone, Copy, PartialEq)]
+pub enum ChatRole {
+    #[pick] User,
+    Assistant,
+    System,
+}
+
+impl Default for ChatRole {
+    fn default() -> Self { Self::User }
+}
+
+impl Widget for ChatBubble {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.view.handle_event(cx, event, scope)
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        match self.role {
+            ChatRole::User => {
+                self.view.apply_over(cx, live! {
+                    draw_bg: {color: #x4444ff},
+                    layout: {align: {x: 1.0, y: 0.0}},
+                });
+            }
+            ChatRole::Assistant => {
+                self.view.apply_over(cx, live! {
+                    draw_bg: {color: #x444444},
+                    layout: {align: {x: 0.0, y: 0.0}},
+                });
+            }
+            ChatRole::System => {
+                self.view.apply_over(cx, live! {
+                    draw_bg: {color: #x222222},
+                    layout: {align: {x: 0.5, y: 0.0}},
+                });
+            }
+        }
+        self.view.draw_walk(cx, scope, walk)
+    }
+}
+
+impl ChatBubble {
+    pub fn set_text(&mut self, cx: &mut Cx, text: &str) {
+        self.view.widget(id!(streaming)).set_visible(false);
+        self.view.widget(id!(markdown)).set_visible(true);
+        if let Some(mut markdown) = self.view.widget(id!(markdown)).borrow_mut::<MarkdownRenderer>() {
+            markdown.render_markdown(cx, text);
+        } else {
+            self.label(id!(label)).set_text(text);
+        }
+    }
+
+    pub fn start_streaming(&mut self, cx: &mut Cx, text: &str) {
+        self.view.widget(id!(markdown)).set_visible(false);
+        self.view.widget(id!(streaming)).set_visible(true);
+        if let Some(mut streaming) = self.view.widget(id!(streaming)).borrow_mut::<StreamingText>() {
+            streaming.start_streaming(cx, text);
+        }
+    }
+
+    pub fn add_token(&mut self, cx: &mut Cx, token: &str) {
+        if let Some(mut streaming) = self.view.widget(id!(streaming)).borrow_mut::<StreamingText>() {
+            streaming.add_token(cx, token);
+        }
+    }
+}

--- a/crates/makepad-chat/src/streaming_text.rs
+++ b/crates/makepad-chat/src/streaming_text.rs
@@ -1,0 +1,55 @@
+use makepad_widgets::*;
+
+live_design! {
+    import makepad_widgets::base::*;
+    import makepad_widgets::theme_desktop_dark::*;
+
+    StreamingText = {{StreamingText}} {
+        width: Fill,
+        height: Fit,
+        draw_text: {
+            color: #x fff
+        }
+    }
+}
+
+#[derive(Live, LiveHook, Widget)]
+pub struct StreamingText {
+    #[deref] label: Label,
+    #[live] full_text: String,
+    #[live] displayed_length: usize,
+    #[rust] last_anim_time: f64,
+}
+
+impl Widget for StreamingText {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, _scope: &mut Scope) {
+        if let Event::Signal = event {
+            if self.displayed_length < self.full_text.len() {
+                self.displayed_length += 1;
+                let text = &self.full_text[..self.displayed_length];
+                self.label.set_text(text);
+                self.redraw(cx);
+            }
+        }
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.label.draw_walk(cx, scope, walk)
+    }
+}
+
+impl StreamingText {
+    pub fn start_streaming(&mut self, cx: &mut Cx, text: &str) {
+        self.full_text = text.to_string();
+        self.displayed_length = self.full_text.len();
+        self.label.set_text(&self.full_text);
+        self.redraw(cx);
+    }
+
+    pub fn add_token(&mut self, cx: &mut Cx, token: &str) {
+        self.full_text.push_str(token);
+        self.displayed_length = self.full_text.len();
+        self.label.set_text(&self.full_text);
+        self.redraw(cx);
+    }
+}

--- a/examples/makepad_chat_demo/src/main.rs
+++ b/examples/makepad_chat_demo/src/main.rs
@@ -1,0 +1,140 @@
+use makepad_chat::*;
+use makepad_widgets::*;
+
+live_design! {
+    import makepad_widgets::base::*;
+    import makepad_widgets::theme_desktop_dark::*;
+    import makepad_chat::chat_bubble::ChatBubble;
+
+    App = {{App}} {
+        ui: <Window> {
+            body = <View> {
+                flow: Down,
+                width: Fill,
+                height: Fill,
+
+                chat_list = <ScrollYView> {
+                    width: Fill,
+                    height: Fill,
+                    flow: Down,
+
+                    user_msg = <ChatBubble> {
+                        role: User,
+                    }
+
+                    assistant_msg = <ChatBubble> {
+                        role: Assistant,
+                    }
+                }
+
+                input_bar = <View> {
+                    width: Fill,
+                    height: Fit,
+                    padding: 10,
+                    spacing: 10,
+
+                    button = <Button> {
+                        text: "Simulate Assistant Response"
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[derive(Live, LiveHook)]
+pub struct App {
+    #[live]
+    ui: WidgetRef,
+    #[rust]
+    initialized: bool,
+    #[rust]
+    streaming_timer: Timer,
+    #[rust]
+    streaming_content: String,
+    #[rust]
+    current_token_index: usize,
+}
+
+impl LiveRegister for App {
+    fn live_register(cx: &mut Cx) {
+        makepad_widgets::live_design(cx);
+        makepad_chat::live_design(cx);
+    }
+}
+
+impl MatchEvent for App {
+    fn handle_startup(&mut self, _cx: &mut Cx) {}
+
+    fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions) {
+        if self.ui.button(id!(button)).clicked(actions) {
+            self.start_streaming_simulation(cx);
+        }
+    }
+
+    fn handle_timer(&mut self, cx: &mut Cx, event: &TimerEvent) {
+        if self.streaming_timer.is_timer(event) {
+            self.update_streaming_simulation(cx);
+        }
+    }
+}
+
+impl AppMain for App {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event) {
+        self.match_event(cx, event);
+        self.ui.handle_event(cx, event, &mut Scope::empty());
+    }
+}
+
+impl App {
+    fn start_streaming_simulation(&mut self, cx: &mut Cx) {
+        if self.streaming_timer != Timer::default() {
+            return;
+        }
+
+        let chat_list = self.ui.view(id!(chat_list));
+        
+        // Reset user message
+        if let Some(mut bubble) = chat_list.widget(id!(user_msg)).borrow_mut::<ChatBubble>() {
+            bubble.set_text(cx, "Can you show me a Rust example with markdown?");
+        }
+
+        // Prepare assistant streaming
+        self.streaming_content = "Sure! Here's a **Rust** example:\n\n```rust\nfn main() {\n    println!(\"Hello MoFA!\");\n}\n```\n\nHope this helps!".to_string();
+        self.current_token_index = 0;
+        
+        if let Some(mut bubble) = chat_list.widget(id!(assistant_msg)).borrow_mut::<ChatBubble>() {
+            bubble.start_streaming(cx, "");
+        }
+
+        self.streaming_timer = cx.start_timer(0.05, true);
+    }
+
+    fn update_streaming_simulation(&mut self, cx: &mut Cx) {
+        if self.current_token_index < self.streaming_content.len() {
+            // Simulate variable token sizes
+            let end = (self.current_token_index + 3).min(self.streaming_content.len());
+            let token = &self.streaming_content[self.current_token_index..end];
+            
+            let chat_list = self.ui.view(id!(chat_list));
+            if let Some(mut bubble) = chat_list.widget(id!(assistant_msg)).borrow_mut::<ChatBubble>() {
+                bubble.add_token(cx, token);
+            }
+            
+            self.current_token_index = end;
+        } else {
+            // Once finished, convert to full markdown for final rendering
+            let chat_list = self.ui.view(id!(chat_list));
+            if let Some(mut bubble) = chat_list.widget(id!(assistant_msg)).borrow_mut::<ChatBubble>() {
+                bubble.set_text(cx, &self.streaming_content);
+            }
+            cx.stop_timer(self.streaming_timer);
+            self.streaming_timer = Timer::default();
+        }
+        cx.redraw_all();
+    }
+}
+
+fn main() {
+    app_main!(App);
+}


### PR DESCRIPTION
This PR completes the Chat Interface Components track for Idea 6.

Implements ChatBubble with role-based styling.
Integrates StreamingText for real-time token rendering.
Enhances MarkdownRenderer for rich text support.
Provides an interactive demo with streaming simulation.
Closes #226