### PR TITLE
fix(plugins): sync Rhai extracted metadata to kernel_metadata

### DIFF
--- a/crates/mofa-plugins/src/rhai_runtime/plugin.rs
+++ b/crates/mofa-plugins/src/rhai_runtime/plugin.rs
@@ -352,6 +352,7 @@ impl RhaiPlugin {
                 && let Some(name) = result.value.as_str()
             {
                 self.metadata.name = name.to_string();
+                self.kernel_metadata.name = name.to_string();
             }
 
             // Try to extract plugin_version
@@ -360,6 +361,7 @@ impl RhaiPlugin {
                 && let Some(version) = result.value.as_str()
             {
                 self.metadata.version = version.to_string();
+                self.kernel_metadata.version = version.to_string();
             }
 
             // Try to extract plugin_description
@@ -368,6 +370,7 @@ impl RhaiPlugin {
                 && let Some(description) = result.value.as_str()
             {
                 self.metadata.description = description.to_string();
+                self.kernel_metadata.description = description.to_string();
             }
         }
 


### PR DESCRIPTION
## Summary
This PR fixes a bug where dynamically loaded Rhai plugins (`RhaiPlugin`) would permanently appear to the local MoFA kernel and MCP server with blank, empty default metadata values, making them undiscoverable to LLMs.

## Motivation
In the `extract_metadata` method, the dynamic `plugin_name`, `plugin_version`, and `plugin_description` were successfully extracted from the `.rhai` script and synchronized to the internal `self.metadata` property, but were never propagated to `self.kernel_metadata`. 

Because `AgentPlugin::metadata(&self)` returns `&self.kernel_metadata`, the tool registry and microkernel permanently saw the tool with the empty fallback names initialized during `RhaiPlugin::new`.

## Changes
- `crates/mofa-plugins/src/rhai_runtime/plugin.rs`: Synchronized the extracted name, version, and description to `self.kernel_metadata` during runtime `load()`.

## Related Issues
Closes #330 




