### PR TITLE
feat(foundation): add runtime model-adapter registry with deterministic resolution

### DIFF
--- a/crates/mofa-cli/src/commands/agent/create.rs
+++ b/crates/mofa-cli/src/commands/agent/create.rs
@@ -383,7 +383,7 @@ fn parse_provider(value: &str) -> Result<LLMProvider, CliError> {
         "anthropic" => Ok(LLMProvider::Anthropic),
         "gemini" => Ok(LLMProvider::Gemini),
         other => {
-            return Err(CliError::ConfigError(format!(
+            Err(CliError::ConfigError(format!(
                 "Unsupported llm.provider value: {other}"
             )));
         }

--- a/crates/mofa-cli/src/commands/agent/create.rs
+++ b/crates/mofa-cli/src/commands/agent/create.rs
@@ -382,11 +382,9 @@ fn parse_provider(value: &str) -> Result<LLMProvider, CliError> {
         "compatible" | "compatible_api" | "compatible-api" => Ok(LLMProvider::Compatible),
         "anthropic" => Ok(LLMProvider::Anthropic),
         "gemini" => Ok(LLMProvider::Gemini),
-        other => {
-            Err(CliError::ConfigError(format!(
-                "Unsupported llm.provider value: {other}"
-            )));
-        }
+        other => Err(CliError::ConfigError(format!(
+            "Unsupported llm.provider value: {other}"
+        ))),
     }
 }
 

--- a/crates/mofa-cli/src/commands/plugin/install.rs
+++ b/crates/mofa-cli/src/commands/plugin/install.rs
@@ -47,14 +47,13 @@ pub async fn run(
             )));
         }
 
-        if let Ok(Some(existing)) = ctx.plugin_store.get(&entry.id) {
-            if existing.enabled {
+        if let Ok(Some(existing)) = ctx.plugin_store.get(&entry.id)
+            && existing.enabled {
                 return Err(CliError::PluginError(format!(
                     "Plugin '{}' is already persisted as enabled. Use `mofa plugin uninstall` first if you want to reinstall.",
                     entry.id
                 )));
             }
-        }
 
         let spec = PluginSpecEntry {
             id: entry.id.clone(),
@@ -96,11 +95,10 @@ pub async fn run(
     // Determine plugin source type natively (Local / Url)
     use std::path::Path as StdPath;
     let mut plugin_id = normalized.to_string();
-    if let PluginSource::LocalPath(path) = &plugin_source {
-        if StdPath::new(normalized) == path {
+    if let PluginSource::LocalPath(path) = &plugin_source
+        && StdPath::new(normalized) == path {
             plugin_id = normalized.replace(['/', '\\'], "_");
         }
-    }
 
     if ctx.plugin_store.get(&plugin_id)?.is_some() {
         return Err(CliError::PluginError(format!(

--- a/crates/mofa-cli/src/utils/paths.rs
+++ b/crates/mofa-cli/src/utils/paths.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 /// Get the current working directory
 pub fn current_dir() -> Result<PathBuf, CliError> {
-    std::env::current_dir().map_err(|e| CliError::Io(e))
+    std::env::current_dir().map_err(CliError::Io)
 }
 
 /// Resolve a path relative to the current directory

--- a/crates/mofa-foundation/benches/context_compression.rs
+++ b/crates/mofa-foundation/benches/context_compression.rs
@@ -1,6 +1,7 @@
 //! Benchmarks for context compression strategies
 //!
 //! Run with: `cargo bench --package mofa-foundation --bench context_compression`
+#![allow(clippy::needless_range_loop)]
 
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use mofa_foundation::agent::components::{

--- a/crates/mofa-foundation/src/adapter/config.rs
+++ b/crates/mofa-foundation/src/adapter/config.rs
@@ -39,6 +39,12 @@ pub struct ModelConfigBuilder {
     config: ModelConfig,
 }
 
+impl Default for ModelConfigBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ModelConfigBuilder {
     pub fn new() -> Self {
         Self {
@@ -195,6 +201,12 @@ pub struct HardwareProfileBuilder {
     profile: HardwareProfile,
 }
 
+impl Default for HardwareProfileBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl HardwareProfileBuilder {
     pub fn new() -> Self {
         Self {
@@ -273,6 +285,12 @@ impl HardwarePreferences {
 #[derive(Debug)]
 pub struct HardwarePreferencesBuilder {
     preferences: HardwarePreferences,
+}
+
+impl Default for HardwarePreferencesBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl HardwarePreferencesBuilder {

--- a/crates/mofa-foundation/src/adapter/descriptor.rs
+++ b/crates/mofa-foundation/src/adapter/descriptor.rs
@@ -132,6 +132,7 @@ impl std::fmt::Display for QuantizationProfile {
 
 /// Hardware constraints for adapter execution
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default)]
 pub struct HardwareConstraint {
     /// Minimum RAM required in MB
     pub min_ram_mb: Option<u64>,
@@ -147,18 +148,6 @@ pub struct HardwareConstraint {
     pub gpu_required: bool,
 }
 
-impl Default for HardwareConstraint {
-    fn default() -> Self {
-        Self {
-            min_ram_mb: None,
-            min_vram_mb: None,
-            required_os: None,
-            required_cpu_features: None,
-            required_gpu_type: None,
-            gpu_required: false,
-        }
-    }
-}
 
 impl HardwareConstraint {
     /// Create a new hardware constraint builder
@@ -169,18 +158,16 @@ impl HardwareConstraint {
     /// Check if this hardware constraint is satisfied by the given requirements
     pub fn is_satisfied_by(&self, profile: &super::HardwareProfile) -> bool {
         // Check RAM requirement
-        if let Some(min_ram) = self.min_ram_mb {
-            if profile.available_ram_mb < min_ram {
+        if let Some(min_ram) = self.min_ram_mb
+            && profile.available_ram_mb < min_ram {
                 return false;
             }
-        }
 
         // Check VRAM requirement
-        if let Some(min_vram) = self.min_vram_mb {
-            if profile.available_vram_mb.unwrap_or(0) < min_vram {
+        if let Some(min_vram) = self.min_vram_mb
+            && profile.available_vram_mb.unwrap_or(0) < min_vram {
                 return false;
             }
-        }
 
         // Check GPU requirement
         if self.gpu_required && !profile.gpu_available {
@@ -199,11 +186,10 @@ impl HardwareConstraint {
         }
 
         // Check OS requirement
-        if let Some(ref required_os) = self.required_os {
-            if !required_os.is_empty() && !required_os.contains(&profile.os) {
+        if let Some(ref required_os) = self.required_os
+            && !required_os.is_empty() && !required_os.contains(&profile.os) {
                 return false;
             }
-        }
 
         true
     }
@@ -213,6 +199,12 @@ impl HardwareConstraint {
 #[derive(Debug)]
 pub struct HardwareConstraintBuilder {
     constraint: HardwareConstraint,
+}
+
+impl Default for HardwareConstraintBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl HardwareConstraintBuilder {
@@ -312,6 +304,12 @@ impl AdapterDescriptor {
 #[derive(Debug)]
 pub struct AdapterDescriptorBuilder {
     descriptor: AdapterDescriptor,
+}
+
+impl Default for AdapterDescriptorBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl AdapterDescriptorBuilder {

--- a/crates/mofa-foundation/src/adapter/descriptor.rs
+++ b/crates/mofa-foundation/src/adapter/descriptor.rs
@@ -1,129 +1,461 @@
-//! Adapter descriptors and capabilities.
+//! Adapter descriptor for model inference backends
 //!
-//! This module defines the types used to describe the capabilities of a model adapter,
-//! such as the supported modalities (text, vision, audio) and model file formats
-//! (GGUF, Safetensors, PyTorch).
+//! This module defines the [`AdapterDescriptor`] which describes an adapter's
+//! capabilities including supported modalities, model formats, quantization profiles,
+//! and hardware constraints.
 
+use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
-use std::fmt;
 
-/// Defines the operational modality of a model.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum ModelModality {
-    /// Text-to-text generation (e.g., standard LLMs)
-    TextGeneration,
-    /// Vision-language understanding (e.g., LLaVA)
-    VisionLanguage,
-    /// Automatic Speech Recognition (Audio-to-text)
-    SpeechToText,
-    /// Text-to-speech generation
-    TextToSpeech,
-    /// Text embeddings
+use super::error::AdapterError;
+
+/// Supported model modalities
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Modality {
+    /// Large Language Model (text generation, chat)
+    LLM,
+    /// Vision-Language Model (image understanding, multimodal)
+    VLM,
+    /// Automatic Speech Recognition (speech to text)
+    ASR,
+    /// Text-to-Speech (text to speech)
+    TTS,
+    /// Embedding model (text to vector)
     Embedding,
+    /// Image generation model
+    Diffusion,
+    /// Mixture of Experts model
+    MoE,
 }
 
-impl fmt::Display for ModelModality {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl std::fmt::Display for Modality {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::TextGeneration => write!(f, "text-generation"),
-            Self::VisionLanguage => write!(f, "vision-language"),
-            Self::SpeechToText => write!(f, "speech-to-text"),
-            Self::TextToSpeech => write!(f, "text-to-speech"),
-            Self::Embedding => write!(f, "embedding"),
+            Modality::LLM => write!(f, "llm"),
+            Modality::VLM => write!(f, "vlm"),
+            Modality::ASR => write!(f, "asr"),
+            Modality::TTS => write!(f, "tts"),
+            Modality::Embedding => write!(f, "embedding"),
+            Modality::Diffusion => write!(f, "diffusion"),
+            Modality::MoE => write!(f, "moe"),
         }
     }
 }
 
-/// Defines the underlying weight format of a model.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+/// Supported model formats
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum ModelFormat {
-    /// GGUF (used by llama.cpp)
-    Gguf,
-    /// Safetensors (standard Hugging Face format)
+    /// Safetensors format (HuggingFace)
     Safetensors,
-    /// Traditional PyTorch `bin` / `pt`
-    PyTorchCheckpoint,
-    /// Apple CoreML
-    CoreMl,
-    /// ONNX Runtime format
+    /// GGUF format (llama.cpp)
+    GGUF,
+    /// PyTorch checkpoint
+    Pytorch,
+    /// ONNX format
     Onnx,
+    /// TensorFlow SavedModel
+    Tensorflow,
+    /// MLX format (Apple Silicon)
+    MLX,
+    /// GGML format (legacy llama.cpp)
+    GGML,
+    /// Custom/Proprietary format
+    Custom(String),
 }
 
-impl fmt::Display for ModelFormat {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl std::fmt::Display for ModelFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Gguf => write!(f, "gguf"),
-            Self::Safetensors => write!(f, "safetensors"),
-            Self::PyTorchCheckpoint => write!(f, "pytorch"),
-            Self::CoreMl => write!(f, "coreml"),
-            Self::Onnx => write!(f, "onnx"),
+            ModelFormat::Safetensors => write!(f, "safetensors"),
+            ModelFormat::GGUF => write!(f, "gguf"),
+            ModelFormat::Pytorch => write!(f, "pytorch"),
+            ModelFormat::Onnx => write!(f, "onnx"),
+            ModelFormat::Tensorflow => write!(f, "tensorflow"),
+            ModelFormat::MLX => write!(f, "mlx"),
+            ModelFormat::GGML => write!(f, "ggml"),
+            ModelFormat::Custom(name) => write!(f, "custom:{}", name),
         }
     }
 }
 
-/// Describes the capabilities and constraints of a registered model adapter.
-///
-/// Each adapter declares what modalities, formats, and quantization profiles
-/// it supports. The [`AdapterRegistry`](super::AdapterRegistry) uses this
-/// information to deterministically resolve the best adapter for a given request.
-#[derive(Debug, Clone)]
-pub struct AdapterDescriptor {
-    /// Unique identifier for this adapter (e.g., "mlx-local", "llama-cpp")
-    pub id: String,
+impl ModelFormat {
+    /// Check if this format is compatible with another format
+    /// Some formats can be converted to others
+    pub fn is_compatible_with(&self, other: &ModelFormat) -> bool {
+        match (self, other) {
+            // GGML and GGUF are compatible (GGUF is the successor)
+            (ModelFormat::GGML, ModelFormat::GGUF) | (ModelFormat::GGUF, ModelFormat::GGML) => true,
+            // Same format is always compatible
+            _ => self == other,
+        }
+    }
+}
 
+/// Quantization profile for model inference
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QuantizationProfile {
+    /// Quantization name (e.g., "q4_k", "q8_0", "f16")
+    pub name: String,
+    /// Bits per parameter
+    pub bits: u8,
+    /// Description of the quantization
+    pub description: Option<String>,
+}
+
+impl QuantizationProfile {
+    /// Create a new quantization profile
+    pub fn new(name: impl Into<String>, bits: u8) -> Self {
+        Self {
+            name: name.into(),
+            bits,
+            description: None,
+        }
+    }
+
+    /// Create a new quantization profile with description
+    pub fn with_description(name: impl Into<String>, bits: u8, description: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            bits,
+            description: Some(description.into()),
+        }
+    }
+}
+
+impl std::fmt::Display for QuantizationProfile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} ({}bit)", self.name, self.bits)
+    }
+}
+
+/// Hardware constraints for adapter execution
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HardwareConstraint {
+    /// Minimum RAM required in MB
+    pub min_ram_mb: Option<u64>,
+    /// Minimum VRAM required in MB
+    pub min_vram_mb: Option<u64>,
+    /// Required OS (if any)
+    pub required_os: Option<Vec<String>>,
+    /// Required CPU features
+    pub required_cpu_features: Option<Vec<String>>,
+    /// Required GPU type (if any)
+    pub required_gpu_type: Option<String>,
+    /// Whether GPU is required
+    pub gpu_required: bool,
+}
+
+impl Default for HardwareConstraint {
+    fn default() -> Self {
+        Self {
+            min_ram_mb: None,
+            min_vram_mb: None,
+            required_os: None,
+            required_cpu_features: None,
+            required_gpu_type: None,
+            gpu_required: false,
+        }
+    }
+}
+
+impl HardwareConstraint {
+    /// Create a new hardware constraint builder
+    pub fn builder() -> HardwareConstraintBuilder {
+        HardwareConstraintBuilder::new()
+    }
+
+    /// Check if this hardware constraint is satisfied by the given requirements
+    pub fn is_satisfied_by(&self, profile: &super::HardwareProfile) -> bool {
+        // Check RAM requirement
+        if let Some(min_ram) = self.min_ram_mb {
+            if profile.available_ram_mb < min_ram {
+                return false;
+            }
+        }
+
+        // Check VRAM requirement
+        if let Some(min_vram) = self.min_vram_mb {
+            if profile.available_vram_mb.unwrap_or(0) < min_vram {
+                return false;
+            }
+        }
+
+        // Check GPU requirement
+        if self.gpu_required && !profile.gpu_available {
+            return false;
+        }
+
+        // Check GPU type requirement
+        if let Some(ref required_gpu) = self.required_gpu_type {
+            if let Some(ref available_gpu) = profile.gpu_type {
+                if available_gpu != required_gpu {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+
+        // Check OS requirement
+        if let Some(ref required_os) = self.required_os {
+            if !required_os.is_empty() && !required_os.contains(&profile.os) {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+/// Builder for hardware constraints
+#[derive(Debug)]
+pub struct HardwareConstraintBuilder {
+    constraint: HardwareConstraint,
+}
+
+impl HardwareConstraintBuilder {
+    pub fn new() -> Self {
+        Self {
+            constraint: HardwareConstraint::default(),
+        }
+    }
+
+    pub fn min_ram_mb(mut self, mb: u64) -> Self {
+        self.constraint.min_ram_mb = Some(mb);
+        self
+    }
+
+    pub fn min_vram_mb(mut self, mb: u64) -> Self {
+        self.constraint.min_vram_mb = Some(mb);
+        self
+    }
+
+    pub fn required_os(mut self, os: Vec<String>) -> Self {
+        self.constraint.required_os = Some(os);
+        self
+    }
+
+    pub fn required_gpu_type(mut self, gpu_type: impl Into<String>) -> Self {
+        self.constraint.required_gpu_type = Some(gpu_type.into());
+        self
+    }
+
+    pub fn gpu_required(mut self, required: bool) -> Self {
+        self.constraint.gpu_required = required;
+        self
+    }
+
+    pub fn build(self) -> HardwareConstraint {
+        self.constraint
+    }
+}
+
+/// Adapter descriptor describing an inference backend's capabilities
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdapterDescriptor {
+    /// Unique identifier for this adapter
+    pub id: String,
     /// Human-readable name
     pub name: String,
-
-    /// Modalities this adapter supports
-    pub modalities: HashSet<ModelModality>,
-
-    /// File formats this adapter can load
+    /// Optional description
+    pub description: Option<String>,
+    /// Supported modalities
+    pub supported_modalities: HashSet<Modality>,
+    /// Supported model formats
     pub supported_formats: HashSet<ModelFormat>,
-
-    /// Quantization profiles supported (e.g., "q4_0", "q8_0", "f16").
-    /// An empty set implies no specific quantization constraints (e.g., cloud API).
-    pub supported_quantization: HashSet<String>,
+    /// Supported quantization profiles
+    pub supported_quantizations: Vec<QuantizationProfile>,
+    /// Hardware constraints
+    pub hardware_constraint: HardwareConstraint,
+    /// Priority (higher = preferred when all else equal)
+    pub priority: i32,
+    /// Estimated latency in ms (for scoring)
+    pub estimated_latency_ms: Option<u32>,
+    /// Whether this adapter is experimental
+    pub experimental: bool,
 }
 
 impl AdapterDescriptor {
-    /// Creates a new `AdapterDescriptor`.
-    pub fn new(id: impl Into<String>, name: impl Into<String>) -> Self {
+    /// Create a new adapter descriptor builder
+    pub fn builder() -> AdapterDescriptorBuilder {
+        AdapterDescriptorBuilder::new()
+    }
+
+    /// Check if this adapter supports the given modality
+    pub fn supports_modality(&self, modality: &Modality) -> bool {
+        self.supported_modalities.contains(modality)
+    }
+
+    /// Check if this adapter supports the given format
+    pub fn supports_format(&self, format: &ModelFormat) -> bool {
+        self.supported_formats
+            .iter()
+            .any(|f| f.is_compatible_with(format))
+    }
+
+    /// Check if this adapter supports the given quantization
+    pub fn supports_quantization(&self, quantization: &str) -> bool {
+        self.supported_quantizations
+            .iter()
+            .any(|q| q.name == quantization)
+    }
+
+    /// Check if this adapter can handle the given hardware profile
+    pub fn supports_hardware(&self, profile: &super::HardwareProfile) -> bool {
+        self.hardware_constraint.is_satisfied_by(profile)
+    }
+}
+
+/// Builder for adapter descriptors
+#[derive(Debug)]
+pub struct AdapterDescriptorBuilder {
+    descriptor: AdapterDescriptor,
+}
+
+impl AdapterDescriptorBuilder {
+    pub fn new() -> Self {
         Self {
-            id: id.into(),
-            name: name.into(),
-            modalities: HashSet::new(),
-            supported_formats: HashSet::new(),
-            supported_quantization: HashSet::new(),
+            descriptor: AdapterDescriptor {
+                id: String::new(),
+                name: String::new(),
+                description: None,
+                supported_modalities: HashSet::new(),
+                supported_formats: HashSet::new(),
+                supported_quantizations: Vec::new(),
+                hardware_constraint: HardwareConstraint::default(),
+                priority: 0,
+                estimated_latency_ms: None,
+                experimental: false,
+            },
         }
     }
 
-    /// Builder: add a supported modality.
-    pub fn with_modality(mut self, modality: ModelModality) -> Self {
-        self.modalities.insert(modality);
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.descriptor.id = id.into();
         self
     }
 
-    /// Builder: add multiple supported modalities.
-    pub fn with_modalities(mut self, modalities: impl IntoIterator<Item = ModelModality>) -> Self {
-        self.modalities.extend(modalities);
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.descriptor.name = name.into();
         self
     }
 
-    /// Builder: add a supported format.
-    pub fn with_format(mut self, format: ModelFormat) -> Self {
-        self.supported_formats.insert(format);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.descriptor.description = Some(description.into());
         self
     }
 
-    /// Builder: add multiple supported formats.
-    pub fn with_formats(mut self, formats: impl IntoIterator<Item = ModelFormat>) -> Self {
-        self.supported_formats.extend(formats);
+    pub fn supported_modality(mut self, modality: Modality) -> Self {
+        self.descriptor.supported_modalities.insert(modality);
         self
     }
 
-    /// Builder: add a supported quantization profile string.
-    pub fn with_quantization(mut self, quant: impl Into<String>) -> Self {
-        self.supported_quantization.insert(quant.into());
+    pub fn supported_modalities(mut self, modalities: impl IntoIterator<Item = Modality>) -> Self {
+        self.descriptor
+            .supported_modalities
+            .extend(modalities);
         self
+    }
+
+    pub fn supported_format(mut self, format: ModelFormat) -> Self {
+        self.descriptor.supported_formats.insert(format);
+        self
+    }
+
+    pub fn supported_formats(mut self, formats: impl IntoIterator<Item = ModelFormat>) -> Self {
+        self.descriptor.supported_formats.extend(formats);
+        self
+    }
+
+    pub fn supported_quantization(mut self, quantization: impl Into<String>) -> Self {
+        self.descriptor
+            .supported_quantizations
+            .push(QuantizationProfile::new(quantization, 0));
+        self
+    }
+
+    pub fn supported_quantizations(mut self, quantizations: Vec<String>) -> Self {
+        self.descriptor.supported_quantizations = quantizations
+            .into_iter()
+            .map(|q| QuantizationProfile::new(q, 0))
+            .collect();
+        self
+    }
+
+    pub fn hardware_constraint(mut self, constraint: HardwareConstraint) -> Self {
+        self.descriptor.hardware_constraint = constraint;
+        self
+    }
+
+    pub fn priority(mut self, priority: i32) -> Self {
+        self.descriptor.priority = priority;
+        self
+    }
+
+    pub fn estimated_latency_ms(mut self, latency_ms: u32) -> Self {
+        self.descriptor.estimated_latency_ms = Some(latency_ms);
+        self
+    }
+
+    pub fn experimental(mut self, experimental: bool) -> Self {
+        self.descriptor.experimental = experimental;
+        self
+    }
+
+    pub fn build(self) -> AdapterDescriptor {
+        if self.descriptor.id.is_empty() {
+            panic!("AdapterDescriptor must have an id");
+        }
+        if self.descriptor.name.is_empty() {
+            panic!("AdapterDescriptor must have a name");
+        }
+        if self.descriptor.supported_modalities.is_empty() {
+            panic!("AdapterDescriptor must have at least one supported modality");
+        }
+        if self.descriptor.supported_formats.is_empty() {
+            panic!("AdapterDescriptor must have at least one supported format");
+        }
+        self.descriptor
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_adapter_descriptor_builder() {
+        let descriptor = AdapterDescriptor::builder()
+            .id("test-adapter")
+            .name("Test Adapter")
+            .description("A test adapter")
+            .supported_modality(Modality::LLM)
+            .supported_format(ModelFormat::Safetensors)
+            .supported_quantization("q4_k")
+            .priority(100)
+            .build();
+
+        assert_eq!(descriptor.id, "test-adapter");
+        assert_eq!(descriptor.name, "Test Adapter");
+        assert!(descriptor.supports_modality(&Modality::LLM));
+        assert!(descriptor.supports_format(&ModelFormat::Safetensors));
+        assert!(descriptor.supports_quantization("q4_k"));
+        assert_eq!(descriptor.priority, 100);
+    }
+
+    #[test]
+    fn test_format_compatibility() {
+        assert!(ModelFormat::GGUF.is_compatible_with(&ModelFormat::GGML));
+        assert!(ModelFormat::GGML.is_compatible_with(&ModelFormat::GGUF));
+        assert!(ModelFormat::Safetensors.is_compatible_with(&ModelFormat::Safetensors));
+        assert!(!ModelFormat::Safetensors.is_compatible_with(&ModelFormat::GGUF));
+    }
+
+    #[test]
+    fn test_modality_display() {
+        assert_eq!(Modality::LLM.to_string(), "llm");
+        assert_eq!(Modality::VLM.to_string(), "vlm");
     }
 }

--- a/crates/mofa-foundation/src/adapter/descriptor.rs
+++ b/crates/mofa-foundation/src/adapter/descriptor.rs
@@ -1,463 +1,129 @@
-//! Adapter descriptor for model inference backends
+//! Adapter descriptors and capabilities.
 //!
-//! This module defines the [`AdapterDescriptor`] which describes an adapter's
-//! capabilities including supported modalities, model formats, quantization profiles,
-//! and hardware constraints.
+//! This module defines the types used to describe the capabilities of a model adapter,
+//! such as the supported modalities (text, vision, audio) and model file formats
+//! (GGUF, Safetensors, PyTorch).
 
-use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
+use std::fmt;
 
-use super::error::AdapterError;
-
-/// Supported model modalities
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Modality {
-    /// Large Language Model (text generation, chat)
-    LLM,
-    /// Vision-Language Model (image understanding, multimodal)
-    VLM,
-    /// Automatic Speech Recognition (speech to text)
-    ASR,
-    /// Text-to-Speech (text to speech)
-    TTS,
-    /// Embedding model (text to vector)
+/// Defines the operational modality of a model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ModelModality {
+    /// Text-to-text generation (e.g., standard LLMs)
+    TextGeneration,
+    /// Vision-language understanding (e.g., LLaVA)
+    VisionLanguage,
+    /// Automatic Speech Recognition (Audio-to-text)
+    SpeechToText,
+    /// Text-to-speech generation
+    TextToSpeech,
+    /// Text embeddings
     Embedding,
-    /// Image generation model
-    Diffusion,
-    /// Mixture of Experts model
-    MoE,
 }
 
-impl std::fmt::Display for Modality {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for ModelModality {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Modality::LLM => write!(f, "llm"),
-            Modality::VLM => write!(f, "vlm"),
-            Modality::ASR => write!(f, "asr"),
-            Modality::TTS => write!(f, "tts"),
-            Modality::Embedding => write!(f, "embedding"),
-            Modality::Diffusion => write!(f, "diffusion"),
-            Modality::MoE => write!(f, "moe"),
+            Self::TextGeneration => write!(f, "text-generation"),
+            Self::VisionLanguage => write!(f, "vision-language"),
+            Self::SpeechToText => write!(f, "speech-to-text"),
+            Self::TextToSpeech => write!(f, "text-to-speech"),
+            Self::Embedding => write!(f, "embedding"),
         }
     }
 }
 
-/// Supported model formats
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
+/// Defines the underlying weight format of a model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ModelFormat {
-    /// Safetensors format (HuggingFace)
+    /// GGUF (used by llama.cpp)
+    Gguf,
+    /// Safetensors (standard Hugging Face format)
     Safetensors,
-    /// GGUF format (llama.cpp)
-    GGUF,
-    /// PyTorch checkpoint
-    Pytorch,
-    /// ONNX format
+    /// Traditional PyTorch `bin` / `pt`
+    PyTorchCheckpoint,
+    /// Apple CoreML
+    CoreMl,
+    /// ONNX Runtime format
     Onnx,
-    /// TensorFlow SavedModel
-    Tensorflow,
-    /// MLX format (Apple Silicon)
-    MLX,
-    /// GGML format (legacy llama.cpp)
-    GGML,
-    /// Custom/Proprietary format
-    Custom(String),
 }
 
-impl std::fmt::Display for ModelFormat {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for ModelFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ModelFormat::Safetensors => write!(f, "safetensors"),
-            ModelFormat::GGUF => write!(f, "gguf"),
-            ModelFormat::Pytorch => write!(f, "pytorch"),
-            ModelFormat::Onnx => write!(f, "onnx"),
-            ModelFormat::Tensorflow => write!(f, "tensorflow"),
-            ModelFormat::MLX => write!(f, "mlx"),
-            ModelFormat::GGML => write!(f, "ggml"),
-            ModelFormat::Custom(name) => write!(f, "custom:{}", name),
+            Self::Gguf => write!(f, "gguf"),
+            Self::Safetensors => write!(f, "safetensors"),
+            Self::PyTorchCheckpoint => write!(f, "pytorch"),
+            Self::CoreMl => write!(f, "coreml"),
+            Self::Onnx => write!(f, "onnx"),
         }
     }
 }
 
-impl ModelFormat {
-    /// Check if this format is compatible with another format
-    /// Some formats can be converted to others
-    pub fn is_compatible_with(&self, other: &ModelFormat) -> bool {
-        match (self, other) {
-            // GGML and GGUF are compatible (GGUF is the successor)
-            (ModelFormat::GGML, ModelFormat::GGUF) | (ModelFormat::GGUF, ModelFormat::GGML) => true,
-            // Same format is always compatible
-            _ => self == other,
-        }
-    }
-}
-
-/// Quantization profile for model inference
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct QuantizationProfile {
-    /// Quantization name (e.g., "q4_k", "q8_0", "f16")
-    pub name: String,
-    /// Bits per parameter
-    pub bits: u8,
-    /// Description of the quantization
-    pub description: Option<String>,
-}
-
-impl QuantizationProfile {
-    /// Create a new quantization profile
-    pub fn new(name: impl Into<String>, bits: u8) -> Self {
-        Self {
-            name: name.into(),
-            bits,
-            description: None,
-        }
-    }
-
-    /// Create a new quantization profile with description
-    pub fn with_description(
-        name: impl Into<String>,
-        bits: u8,
-        description: impl Into<String>,
-    ) -> Self {
-        Self {
-            name: name.into(),
-            bits,
-            description: Some(description.into()),
-        }
-    }
-}
-
-impl std::fmt::Display for QuantizationProfile {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} ({}bit)", self.name, self.bits)
-    }
-}
-
-/// Hardware constraints for adapter execution
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct HardwareConstraint {
-    /// Minimum RAM required in MB
-    pub min_ram_mb: Option<u64>,
-    /// Minimum VRAM required in MB
-    pub min_vram_mb: Option<u64>,
-    /// Required OS (if any)
-    pub required_os: Option<Vec<String>>,
-    /// Required CPU features
-    pub required_cpu_features: Option<Vec<String>>,
-    /// Required GPU type (if any)
-    pub required_gpu_type: Option<String>,
-    /// Whether GPU is required
-    pub gpu_required: bool,
-}
-
-impl Default for HardwareConstraint {
-    fn default() -> Self {
-        Self {
-            min_ram_mb: None,
-            min_vram_mb: None,
-            required_os: None,
-            required_cpu_features: None,
-            required_gpu_type: None,
-            gpu_required: false,
-        }
-    }
-}
-
-impl HardwareConstraint {
-    /// Create a new hardware constraint builder
-    pub fn builder() -> HardwareConstraintBuilder {
-        HardwareConstraintBuilder::new()
-    }
-
-    /// Check if this hardware constraint is satisfied by the given requirements
-    pub fn is_satisfied_by(&self, profile: &super::HardwareProfile) -> bool {
-        // Check RAM requirement
-        if let Some(min_ram) = self.min_ram_mb {
-            if profile.available_ram_mb < min_ram {
-                return false;
-            }
-        }
-
-        // Check VRAM requirement
-        if let Some(min_vram) = self.min_vram_mb {
-            if profile.available_vram_mb.unwrap_or(0) < min_vram {
-                return false;
-            }
-        }
-
-        // Check GPU requirement
-        if self.gpu_required && !profile.gpu_available {
-            return false;
-        }
-
-        // Check GPU type requirement
-        if let Some(ref required_gpu) = self.required_gpu_type {
-            if let Some(ref available_gpu) = profile.gpu_type {
-                if available_gpu != required_gpu {
-                    return false;
-                }
-            } else {
-                return false;
-            }
-        }
-
-        // Check OS requirement
-        if let Some(ref required_os) = self.required_os {
-            if !required_os.is_empty() && !required_os.contains(&profile.os) {
-                return false;
-            }
-        }
-
-        true
-    }
-}
-
-/// Builder for hardware constraints
-#[derive(Debug)]
-pub struct HardwareConstraintBuilder {
-    constraint: HardwareConstraint,
-}
-
-impl HardwareConstraintBuilder {
-    pub fn new() -> Self {
-        Self {
-            constraint: HardwareConstraint::default(),
-        }
-    }
-
-    pub fn min_ram_mb(mut self, mb: u64) -> Self {
-        self.constraint.min_ram_mb = Some(mb);
-        self
-    }
-
-    pub fn min_vram_mb(mut self, mb: u64) -> Self {
-        self.constraint.min_vram_mb = Some(mb);
-        self
-    }
-
-    pub fn required_os(mut self, os: Vec<String>) -> Self {
-        self.constraint.required_os = Some(os);
-        self
-    }
-
-    pub fn required_gpu_type(mut self, gpu_type: impl Into<String>) -> Self {
-        self.constraint.required_gpu_type = Some(gpu_type.into());
-        self
-    }
-
-    pub fn gpu_required(mut self, required: bool) -> Self {
-        self.constraint.gpu_required = required;
-        self
-    }
-
-    pub fn build(self) -> HardwareConstraint {
-        self.constraint
-    }
-}
-
-/// Adapter descriptor describing an inference backend's capabilities
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Describes the capabilities and constraints of a registered model adapter.
+///
+/// Each adapter declares what modalities, formats, and quantization profiles
+/// it supports. The [`AdapterRegistry`](super::AdapterRegistry) uses this
+/// information to deterministically resolve the best adapter for a given request.
+#[derive(Debug, Clone)]
 pub struct AdapterDescriptor {
-    /// Unique identifier for this adapter
+    /// Unique identifier for this adapter (e.g., "mlx-local", "llama-cpp")
     pub id: String,
+
     /// Human-readable name
     pub name: String,
-    /// Optional description
-    pub description: Option<String>,
-    /// Supported modalities
-    pub supported_modalities: HashSet<Modality>,
-    /// Supported model formats
+
+    /// Modalities this adapter supports
+    pub modalities: HashSet<ModelModality>,
+
+    /// File formats this adapter can load
     pub supported_formats: HashSet<ModelFormat>,
-    /// Supported quantization profiles
-    pub supported_quantizations: Vec<QuantizationProfile>,
-    /// Hardware constraints
-    pub hardware_constraint: HardwareConstraint,
-    /// Priority (higher = preferred when all else equal)
-    pub priority: i32,
-    /// Estimated latency in ms (for scoring)
-    pub estimated_latency_ms: Option<u32>,
-    /// Whether this adapter is experimental
-    pub experimental: bool,
+
+    /// Quantization profiles supported (e.g., "q4_0", "q8_0", "f16").
+    /// An empty set implies no specific quantization constraints (e.g., cloud API).
+    pub supported_quantization: HashSet<String>,
 }
 
 impl AdapterDescriptor {
-    /// Create a new adapter descriptor builder
-    pub fn builder() -> AdapterDescriptorBuilder {
-        AdapterDescriptorBuilder::new()
-    }
-
-    /// Check if this adapter supports the given modality
-    pub fn supports_modality(&self, modality: &Modality) -> bool {
-        self.supported_modalities.contains(modality)
-    }
-
-    /// Check if this adapter supports the given format
-    pub fn supports_format(&self, format: &ModelFormat) -> bool {
-        self.supported_formats
-            .iter()
-            .any(|f| f.is_compatible_with(format))
-    }
-
-    /// Check if this adapter supports the given quantization
-    pub fn supports_quantization(&self, quantization: &str) -> bool {
-        self.supported_quantizations
-            .iter()
-            .any(|q| q.name == quantization)
-    }
-
-    /// Check if this adapter can handle the given hardware profile
-    pub fn supports_hardware(&self, profile: &super::HardwareProfile) -> bool {
-        self.hardware_constraint.is_satisfied_by(profile)
-    }
-}
-
-/// Builder for adapter descriptors
-#[derive(Debug)]
-pub struct AdapterDescriptorBuilder {
-    descriptor: AdapterDescriptor,
-}
-
-impl AdapterDescriptorBuilder {
-    pub fn new() -> Self {
+    /// Creates a new `AdapterDescriptor`.
+    pub fn new(id: impl Into<String>, name: impl Into<String>) -> Self {
         Self {
-            descriptor: AdapterDescriptor {
-                id: String::new(),
-                name: String::new(),
-                description: None,
-                supported_modalities: HashSet::new(),
-                supported_formats: HashSet::new(),
-                supported_quantizations: Vec::new(),
-                hardware_constraint: HardwareConstraint::default(),
-                priority: 0,
-                estimated_latency_ms: None,
-                experimental: false,
-            },
+            id: id.into(),
+            name: name.into(),
+            modalities: HashSet::new(),
+            supported_formats: HashSet::new(),
+            supported_quantization: HashSet::new(),
         }
     }
 
-    pub fn id(mut self, id: impl Into<String>) -> Self {
-        self.descriptor.id = id.into();
+    /// Builder: add a supported modality.
+    pub fn with_modality(mut self, modality: ModelModality) -> Self {
+        self.modalities.insert(modality);
         self
     }
 
-    pub fn name(mut self, name: impl Into<String>) -> Self {
-        self.descriptor.name = name.into();
+    /// Builder: add multiple supported modalities.
+    pub fn with_modalities(mut self, modalities: impl IntoIterator<Item = ModelModality>) -> Self {
+        self.modalities.extend(modalities);
         self
     }
 
-    pub fn description(mut self, description: impl Into<String>) -> Self {
-        self.descriptor.description = Some(description.into());
+    /// Builder: add a supported format.
+    pub fn with_format(mut self, format: ModelFormat) -> Self {
+        self.supported_formats.insert(format);
         self
     }
 
-    pub fn supported_modality(mut self, modality: Modality) -> Self {
-        self.descriptor.supported_modalities.insert(modality);
+    /// Builder: add multiple supported formats.
+    pub fn with_formats(mut self, formats: impl IntoIterator<Item = ModelFormat>) -> Self {
+        self.supported_formats.extend(formats);
         self
     }
 
-    pub fn supported_modalities(mut self, modalities: impl IntoIterator<Item = Modality>) -> Self {
-        self.descriptor.supported_modalities.extend(modalities);
+    /// Builder: add a supported quantization profile string.
+    pub fn with_quantization(mut self, quant: impl Into<String>) -> Self {
+        self.supported_quantization.insert(quant.into());
         self
-    }
-
-    pub fn supported_format(mut self, format: ModelFormat) -> Self {
-        self.descriptor.supported_formats.insert(format);
-        self
-    }
-
-    pub fn supported_formats(mut self, formats: impl IntoIterator<Item = ModelFormat>) -> Self {
-        self.descriptor.supported_formats.extend(formats);
-        self
-    }
-
-    pub fn supported_quantization(mut self, quantization: impl Into<String>) -> Self {
-        self.descriptor
-            .supported_quantizations
-            .push(QuantizationProfile::new(quantization, 0));
-        self
-    }
-
-    pub fn supported_quantizations(mut self, quantizations: Vec<String>) -> Self {
-        self.descriptor.supported_quantizations = quantizations
-            .into_iter()
-            .map(|q| QuantizationProfile::new(q, 0))
-            .collect();
-        self
-    }
-
-    pub fn hardware_constraint(mut self, constraint: HardwareConstraint) -> Self {
-        self.descriptor.hardware_constraint = constraint;
-        self
-    }
-
-    pub fn priority(mut self, priority: i32) -> Self {
-        self.descriptor.priority = priority;
-        self
-    }
-
-    pub fn estimated_latency_ms(mut self, latency_ms: u32) -> Self {
-        self.descriptor.estimated_latency_ms = Some(latency_ms);
-        self
-    }
-
-    pub fn experimental(mut self, experimental: bool) -> Self {
-        self.descriptor.experimental = experimental;
-        self
-    }
-
-    pub fn build(self) -> AdapterDescriptor {
-        if self.descriptor.id.is_empty() {
-            panic!("AdapterDescriptor must have an id");
-        }
-        if self.descriptor.name.is_empty() {
-            panic!("AdapterDescriptor must have a name");
-        }
-        if self.descriptor.supported_modalities.is_empty() {
-            panic!("AdapterDescriptor must have at least one supported modality");
-        }
-        if self.descriptor.supported_formats.is_empty() {
-            panic!("AdapterDescriptor must have at least one supported format");
-        }
-        self.descriptor
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_adapter_descriptor_builder() {
-        let descriptor = AdapterDescriptor::builder()
-            .id("test-adapter")
-            .name("Test Adapter")
-            .description("A test adapter")
-            .supported_modality(Modality::LLM)
-            .supported_format(ModelFormat::Safetensors)
-            .supported_quantization("q4_k")
-            .priority(100)
-            .build();
-
-        assert_eq!(descriptor.id, "test-adapter");
-        assert_eq!(descriptor.name, "Test Adapter");
-        assert!(descriptor.supports_modality(&Modality::LLM));
-        assert!(descriptor.supports_format(&ModelFormat::Safetensors));
-        assert!(descriptor.supports_quantization("q4_k"));
-        assert_eq!(descriptor.priority, 100);
-    }
-
-    #[test]
-    fn test_format_compatibility() {
-        assert!(ModelFormat::GGUF.is_compatible_with(&ModelFormat::GGML));
-        assert!(ModelFormat::GGML.is_compatible_with(&ModelFormat::GGUF));
-        assert!(ModelFormat::Safetensors.is_compatible_with(&ModelFormat::Safetensors));
-        assert!(!ModelFormat::Safetensors.is_compatible_with(&ModelFormat::GGUF));
-    }
-
-    #[test]
-    fn test_modality_display() {
-        assert_eq!(Modality::LLM.to_string(), "llm");
-        assert_eq!(Modality::VLM.to_string(), "vlm");
     }
 }

--- a/crates/mofa-foundation/src/adapter/registry.rs
+++ b/crates/mofa-foundation/src/adapter/registry.rs
@@ -149,8 +149,8 @@ impl AdapterRegistry {
             }
 
             // Step 3: Check quantization support (hard constraint, if specified)
-            if let Some(ref required_quant) = config.required_quantization {
-                if !adapter.supports_quantization(required_quant) {
+            if let Some(ref required_quant) = config.required_quantization
+                && !adapter.supports_quantization(required_quant) {
                     rejections.push(RejectionReason::QuantizationMismatch {
                         required: required_quant.clone(),
                         supported: adapter
@@ -160,7 +160,6 @@ impl AdapterRegistry {
                             .collect(),
                     });
                 }
-            }
 
             // Step 4: Check hardware compatibility (hard constraint)
             if !adapter.supports_hardware(hardware) {
@@ -171,14 +170,13 @@ impl AdapterRegistry {
             }
 
             // Step 5: Check priority threshold (soft constraint)
-            if let Some(min_priority) = config.min_priority {
-                if adapter.priority < min_priority {
+            if let Some(min_priority) = config.min_priority
+                && adapter.priority < min_priority {
                     rejections.push(RejectionReason::PriorityTooLow {
                         required_min_priority: min_priority,
                         adapter_priority: adapter.priority,
                     });
                 }
-            }
 
             // Step 6: Check experimental flag
             if adapter.experimental && !config.allow_experimental {

--- a/crates/mofa-foundation/src/adapter/registry.rs
+++ b/crates/mofa-foundation/src/adapter/registry.rs
@@ -1,436 +1,468 @@
-//! Adapter Registry for runtime model adapter discovery and management
+//! Adapter Registry — runtime discovery and deterministic resolution.
 //!
-//! This module provides the [`AdapterRegistry`] which manages adapter registration,
-//! discovery, and resolution based on model configuration and hardware profiles.
+//! The registry stores [`AdapterDescriptor`]s and resolves the best candidate
+//! for a given [`ModelConfig`] using strict hard-constraint filtering followed
+//! by deterministic tie-breaking (alphabetical by adapter ID).
+//!
+//! # Resolution Algorithm
+//!
+//! 1. **Modality filter** — adapter must support the requested modality.
+//! 2. **Format filter** — adapter must support the requested model format.
+//! 3. **Quantization filter** — if the request specifies a quantization profile,
+//!    the adapter must list it as supported (adapters with an empty quantization
+//!    set are treated as "accepts any").
+//! 4. **Tie-break** — among all surviving candidates, the adapter with the
+//!    lexicographically smallest `id` wins. This guarantees deterministic,
+//!    reproducible resolution regardless of insertion order.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
-use super::config::{HardwareProfile, ModelConfig};
-use super::descriptor::{AdapterDescriptor, Modality, ModelFormat};
-use super::error::{AdapterError, RejectionReason, ResolutionError};
+use super::descriptor::{AdapterDescriptor, ModelFormat, ModelModality};
 
-/// Result of adapter resolution containing the selected adapter and any rejection reasons
-#[derive(Debug)]
-pub struct ResolutionResult {
-    /// The selected adapter
-    pub adapter: AdapterDescriptor,
-    /// Reasons why other candidates were rejected (for debugging/logging)
-    pub rejection_reasons: HashMap<String, Vec<RejectionReason>>,
+/// Configuration describing the model a caller wants to run.
+#[derive(Debug, Clone)]
+pub struct ModelConfig {
+    /// The modality required (e.g., `TextGeneration`)
+    pub modality: ModelModality,
+    /// The file format available on disk (e.g., `Gguf`)
+    pub format: ModelFormat,
+    /// Optional quantization profile (e.g., `"q4_0"`)
+    pub quantization: Option<String>,
 }
 
-/// Registry for managing model adapters
+impl ModelConfig {
+    /// Create a new model configuration.
+    pub fn new(modality: ModelModality, format: ModelFormat) -> Self {
+        Self {
+            modality,
+            format,
+            quantization: None,
+        }
+    }
+
+    /// Builder: set quantization requirement.
+    pub fn with_quantization(mut self, quant: impl Into<String>) -> Self {
+        self.quantization = Some(quant.into());
+        self
+    }
+}
+
+/// Errors produced during adapter resolution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolutionError {
+    /// No adapters are registered at all.
+    EmptyRegistry,
+    /// No adapter supports the requested modality.
+    ModalityNotSupported(ModelModality),
+    /// No adapter supports the requested model format.
+    FormatNotSupported(ModelFormat),
+    /// No adapter supports the requested quantization profile.
+    QuantizationNotSupported(String),
+    /// No adapter passed all hard constraints.
+    NoCompatibleAdapter {
+        modality: ModelModality,
+        format: ModelFormat,
+        quantization: Option<String>,
+    },
+}
+
+impl std::fmt::Display for ResolutionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyRegistry => write!(f, "adapter registry is empty"),
+            Self::ModalityNotSupported(m) => {
+                write!(f, "no adapter supports modality: {}", m)
+            }
+            Self::FormatNotSupported(fmt) => {
+                write!(f, "no adapter supports format: {}", fmt)
+            }
+            Self::QuantizationNotSupported(q) => {
+                write!(f, "no adapter supports quantization: {}", q)
+            }
+            Self::NoCompatibleAdapter {
+                modality,
+                format,
+                quantization,
+            } => {
+                write!(
+                    f,
+                    "no adapter matches all constraints: modality={}, format={}{}",
+                    modality,
+                    format,
+                    quantization
+                        .as_ref()
+                        .map(|q| format!(", quant={}", q))
+                        .unwrap_or_default()
+                )
+            }
+        }
+    }
+}
+
+/// The runtime model-adapter registry.
 ///
-/// The registry provides:
-/// - Register/discover adapters at runtime
-/// - Resolve candidates for a given ModelConfig + HardwareProfile
-/// - Deterministic selection with structured rejection reasons
-#[derive(Debug, Default)]
+/// Adapters are registered with an [`AdapterDescriptor`] and can be looked up
+/// deterministically using [`resolve`](AdapterRegistry::resolve).
+///
+/// # Example
+///
+/// ```
+/// use mofa_foundation::adapter::{
+///     AdapterDescriptor, AdapterRegistry, ModelConfig, ModelModality, ModelFormat,
+/// };
+///
+/// let mut registry = AdapterRegistry::new();
+///
+/// // Register an MLX adapter that handles GGUF text-generation models
+/// let mlx = AdapterDescriptor::new("mlx-local", "MLX Backend")
+///     .with_modality(ModelModality::TextGeneration)
+///     .with_format(ModelFormat::Gguf)
+///     .with_quantization("q4_0");
+///
+/// registry.register(mlx);
+///
+/// let config = ModelConfig::new(ModelModality::TextGeneration, ModelFormat::Gguf);
+/// let result = registry.resolve(&config);
+/// assert!(result.is_ok());
+/// assert_eq!(result.unwrap().id, "mlx-local");
+/// ```
 pub struct AdapterRegistry {
-    adapters: HashMap<String, AdapterDescriptor>,
+    /// BTreeMap ensures iteration is always sorted by adapter ID,
+    /// giving us deterministic resolution for free.
+    adapters: BTreeMap<String, AdapterDescriptor>,
 }
 
 impl AdapterRegistry {
-    /// Create a new empty adapter registry
+    /// Create an empty registry.
     pub fn new() -> Self {
         Self {
-            adapters: HashMap::new(),
+            adapters: BTreeMap::new(),
         }
     }
 
-    /// Register an adapter with the registry
-    ///
-    /// # Errors
-    /// Returns [`AdapterError::AlreadyRegistered`] if an adapter with the same ID already exists
-    pub fn register(&mut self, adapter: AdapterDescriptor) -> Result<(), AdapterError> {
-        let id = adapter.id.clone();
-        if self.adapters.contains_key(&id) {
-            return Err(AdapterError::AlreadyRegistered(id));
-        }
-        self.adapters.insert(id, adapter);
-        Ok(())
+    /// Register an adapter. If an adapter with the same ID already exists,
+    /// it will be replaced.
+    pub fn register(&mut self, descriptor: AdapterDescriptor) {
+        self.adapters.insert(descriptor.id.clone(), descriptor);
     }
 
-    /// Register an adapter, replacing any existing adapter with the same ID
-    pub fn register_or_replace(&mut self, adapter: AdapterDescriptor) {
-        self.adapters.insert(adapter.id.clone(), adapter);
+    /// Remove an adapter by ID. Returns `true` if it was present.
+    pub fn unregister(&mut self, id: &str) -> bool {
+        self.adapters.remove(id).is_some()
     }
 
-    /// Unregister an adapter from the registry
-    ///
-    /// # Errors
-    /// Returns [`AdapterError::NotFound`] if no adapter with the given ID exists
-    pub fn unregister(&mut self, id: &str) -> Result<AdapterDescriptor, AdapterError> {
-        self.adapters
-            .remove(id)
-            .ok_or_else(|| AdapterError::NotFound(id.to_string()))
-    }
-
-    /// Get an adapter by ID
+    /// Get a reference to a registered adapter by ID.
     pub fn get(&self, id: &str) -> Option<&AdapterDescriptor> {
         self.adapters.get(id)
     }
 
-    /// Get all registered adapters
-    pub fn adapters(&self) -> impl Iterator<Item = &AdapterDescriptor> {
-        self.adapters.values()
-    }
-
-    /// Get the number of registered adapters
+    /// Number of registered adapters.
     pub fn len(&self) -> usize {
         self.adapters.len()
     }
 
-    /// Check if the registry is empty
+    /// Whether the registry has no adapters.
     pub fn is_empty(&self) -> bool {
         self.adapters.is_empty()
     }
 
-    /// Resolve the best adapter for the given model configuration and hardware profile
-    ///
-    /// This method performs deterministic resolution with the following steps:
-    /// 1. Filter by modality (hard constraint)
-    /// 2. Filter by format (hard constraint)
-    /// 3. Filter by quantization (hard constraint, if specified)
-    /// 4. Filter by hardware compatibility (hard constraint)
-    /// 5. Filter by priority threshold (soft constraint)
-    /// 6. Filter out experimental adapters unless explicitly allowed
-    /// 7. Select highest priority, then by name for deterministic tie-break
-    ///
-    /// # Errors
-    /// Returns [`ResolutionError::NoCompatibleAdapter`] if no compatible adapter is found
-    pub fn resolve(
-        &self,
-        config: &ModelConfig,
-        hardware: &HardwareProfile,
-    ) -> Result<ResolutionResult, ResolutionError> {
-        self.resolve_with_rejections(config, hardware)
-            .map(|(adapter, reasons)| ResolutionResult {
-                adapter,
-                rejection_reasons: reasons,
-            })
+    /// List all registered adapter IDs.
+    pub fn adapter_ids(&self) -> Vec<&str> {
+        self.adapters.keys().map(|s| s.as_str()).collect()
     }
 
-    /// Resolve adapter with detailed rejection reasons for each candidate
-    fn resolve_with_rejections(
-        &self,
-        config: &ModelConfig,
-        hardware: &HardwareProfile,
-    ) -> Result<(AdapterDescriptor, HashMap<String, Vec<RejectionReason>>), ResolutionError> {
-        let mut candidates: Vec<(AdapterDescriptor, Vec<RejectionReason>)> = Vec::new();
+    /// Resolve the best adapter for the given model configuration.
+    ///
+    /// Uses strict hard-constraint filtering:
+    /// 1. Modality must match.
+    /// 2. Format must match.
+    /// 3. Quantization must match (if specified in config).
+    ///
+    /// Among all passing candidates, the one with the lexicographically
+    /// smallest `id` is returned (deterministic tie-break).
+    pub fn resolve(&self, config: &ModelConfig) -> Result<&AdapterDescriptor, ResolutionError> {
+        if self.adapters.is_empty() {
+            return Err(ResolutionError::EmptyRegistry);
+        }
 
-        for adapter in self.adapters.values() {
-            let mut rejections = Vec::new();
-
-            // Step 1: Check modality support (hard constraint)
-            if !adapter.supports_modality(&config.required_modality) {
-                rejections.push(RejectionReason::ModalityMismatch {
-                    required: config.required_modality.to_string(),
-                    supported: adapter
-                        .supported_modalities
-                        .iter()
-                        .map(|m| m.to_string())
-                        .collect(),
-                });
+        // BTreeMap iterates in sorted key order, so the first match is
+        // already the deterministic winner.
+        for descriptor in self.adapters.values() {
+            if !descriptor.modalities.contains(&config.modality) {
+                continue;
             }
-
-            // Step 2: Check format support (hard constraint)
-            if let Some(ref required_format) = config.required_format {
-                let format = parse_format(required_format);
-                if !adapter.supports_format(&format) {
-                    rejections.push(RejectionReason::FormatMismatch {
-                        required: required_format.clone(),
-                        supported: adapter
-                            .supported_formats
-                            .iter()
-                            .map(|f| f.to_string())
-                            .collect(),
-                    });
+            if !descriptor.supported_formats.contains(&config.format) {
+                continue;
+            }
+            if let Some(ref quant) = config.quantization {
+                // If the adapter has an explicit quantization set,
+                // the requested quant must be in it.
+                // An empty set means "accepts any quantization".
+                if !descriptor.supported_quantization.is_empty()
+                    && !descriptor.supported_quantization.contains(quant)
+                {
+                    continue;
                 }
             }
+            return Ok(descriptor);
+        }
 
-            // Step 3: Check quantization support (hard constraint, if specified)
-            if let Some(ref required_quant) = config.required_quantization {
-                if !adapter.supports_quantization(required_quant) {
-                    rejections.push(RejectionReason::QuantizationMismatch {
-                        required: required_quant.clone(),
-                        supported: adapter
-                            .supported_quantizations
-                            .iter()
-                            .map(|q| q.name.clone())
-                            .collect(),
-                    });
-                }
-            }
+        // No candidate survived all filters — produce a specific error.
+        let has_modality = self
+            .adapters
+            .values()
+            .any(|d| d.modalities.contains(&config.modality));
+        if !has_modality {
+            return Err(ResolutionError::ModalityNotSupported(config.modality));
+        }
 
-            // Step 4: Check hardware compatibility (hard constraint)
-            if !adapter.supports_hardware(hardware) {
-                rejections.push(RejectionReason::HardwareConstraint {
-                    constraint: "hardware_compatibility".to_string(),
-                    reason: "Adapter does not meet hardware requirements".to_string(),
-                });
-            }
+        let has_format = self
+            .adapters
+            .values()
+            .any(|d| d.supported_formats.contains(&config.format));
+        if !has_format {
+            return Err(ResolutionError::FormatNotSupported(config.format));
+        }
 
-            // Step 5: Check priority threshold (soft constraint)
-            if let Some(min_priority) = config.min_priority {
-                if adapter.priority < min_priority {
-                    rejections.push(RejectionReason::PriorityTooLow {
-                        required_min_priority: min_priority,
-                        adapter_priority: adapter.priority,
-                    });
-                }
-            }
-
-            // Step 6: Check experimental flag
-            if adapter.experimental && !config.allow_experimental {
-                rejections.push(RejectionReason::HardwareConstraint {
-                    constraint: "experimental".to_string(),
-                    reason: "Experimental adapter not allowed".to_string(),
-                });
-            }
-
-            // If no hard constraints failed, add as candidate
-            let has_hard_rejection = rejections
-                .iter()
-                .any(|r| r.severity() == super::error::RejectionSeverity::Hard);
-
-            if !has_hard_rejection {
-                candidates.push((adapter.clone(), rejections));
-            } else {
-                // Store rejection reasons for debugging
-                candidates.push((adapter.clone(), rejections));
+        if let Some(ref quant) = config.quantization {
+            let has_quant = self.adapters.values().any(|d| {
+                d.supported_quantization.is_empty() || d.supported_quantization.contains(quant)
+            });
+            if !has_quant {
+                return Err(ResolutionError::QuantizationNotSupported(quant.clone()));
             }
         }
 
-        // Filter to only candidates without hard rejections
-        let valid_candidates: Vec<_> = candidates
-            .iter()
-            .filter(|(_, reasons)| {
-                !reasons
-                    .iter()
-                    .any(|r| r.severity() == super::error::RejectionSeverity::Hard)
-            })
-            .collect();
-
-        if valid_candidates.is_empty() {
-            return Err(ResolutionError::NoCompatibleAdapter);
-        }
-
-        // Sort by priority (descending), then by name (ascending) for deterministic tie-break
-        let mut sorted_candidates: Vec<_> = valid_candidates
-            .iter()
-            .map(|(adapter, reasons)| (adapter, reasons))
-            .collect();
-
-        sorted_candidates.sort_by(|a, b| {
-            let priority_cmp = b.0.priority.cmp(&a.0.priority);
-            if priority_cmp == std::cmp::Ordering::Equal {
-                a.0.name.cmp(&b.0.name)
-            } else {
-                priority_cmp
-            }
-        });
-
-        // Clone the best adapter to avoid borrow issues
-        let best_adapter = sorted_candidates[0].0.clone();
-        let best_adapter_id = best_adapter.id.clone();
-
-        // Collect rejection reasons for all other candidates
-        let rejection_reasons: HashMap<String, Vec<RejectionReason>> = candidates
-            .into_iter()
-            .filter(|(adapter, _)| adapter.id != best_adapter_id)
-            .map(|(adapter, reasons)| (adapter.id, reasons))
-            .collect();
-
-        Ok((best_adapter, rejection_reasons))
-    }
-
-    /// Find all adapters that support a given modality
-    pub fn find_by_modality(
-        &self,
-        modality: &Modality,
-    ) -> impl Iterator<Item = &AdapterDescriptor> {
-        self.adapters
-            .values()
-            .filter(|a| a.supports_modality(modality))
-    }
-
-    /// Find all adapters that support a given format
-    pub fn find_by_format(&self, format: &ModelFormat) -> impl Iterator<Item = &AdapterDescriptor> {
-        self.adapters.values().filter(|a| a.supports_format(format))
-    }
-
-    /// Find all adapters compatible with the given hardware profile
-    pub fn find_compatible(
-        &self,
-        hardware: &HardwareProfile,
-    ) -> impl Iterator<Item = &AdapterDescriptor> {
-        self.adapters
-            .values()
-            .filter(|a| a.supports_hardware(hardware))
+        Err(ResolutionError::NoCompatibleAdapter {
+            modality: config.modality,
+            format: config.format,
+            quantization: config.quantization.clone(),
+        })
     }
 }
 
-/// Parse a format string into a ModelFormat enum
-fn parse_format(format_str: &str) -> ModelFormat {
-    match format_str.to_lowercase().as_str() {
-        "safetensors" => ModelFormat::Safetensors,
-        "gguf" => ModelFormat::GGUF,
-        "pytorch" | "pt" | "ckpt" => ModelFormat::Pytorch,
-        "onnx" => ModelFormat::Onnx,
-        "tensorflow" | "tf" => ModelFormat::Tensorflow,
-        "mlx" => ModelFormat::MLX,
-        "ggml" => ModelFormat::GGML,
-        other => ModelFormat::Custom(other.to_string()),
+impl Default for AdapterRegistry {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::adapter::descriptor::{ModelFormat, ModelModality};
 
-    fn create_test_descriptors() -> Vec<AdapterDescriptor> {
-        vec![
-            AdapterDescriptor::builder()
-                .id("llama-cpp")
-                .name("Llama.cpp Backend")
-                .supported_modality(Modality::LLM)
-                .supported_format(ModelFormat::GGUF)
-                .supported_quantizations(vec!["q4_k".to_string(), "q8_0".to_string()])
-                .priority(100)
-                .build(),
-            AdapterDescriptor::builder()
-                .id("huggingface")
-                .name("HuggingFace Backend")
-                .supported_modality(Modality::LLM)
-                .supported_format(ModelFormat::Safetensors)
-                .supported_quantizations(vec!["bf16".to_string(), "fp16".to_string()])
-                .priority(90)
-                .build(),
-            AdapterDescriptor::builder()
-                .id("mlx-backend")
-                .name("Apple MLX Backend")
-                .supported_modality(Modality::LLM)
-                .supported_modality(Modality::VLM)
-                .supported_format(ModelFormat::MLX)
-                .priority(80)
-                .build(),
-        ]
+    fn mlx_adapter() -> AdapterDescriptor {
+        AdapterDescriptor::new("mlx-local", "MLX Backend")
+            .with_modality(ModelModality::TextGeneration)
+            .with_format(ModelFormat::Gguf)
+            .with_format(ModelFormat::Safetensors)
+            .with_quantization("q4_0")
+            .with_quantization("q8_0")
     }
 
-    #[test]
-    fn test_register_adapter() {
-        let mut registry = AdapterRegistry::new();
-        let adapter = AdapterDescriptor::builder()
-            .id("test")
-            .name("Test")
-            .supported_modality(Modality::LLM)
-            .supported_format(ModelFormat::Safetensors)
-            .build();
-
-        assert!(registry.register(adapter.clone()).is_ok());
-        assert!(registry.register(adapter).is_err()); // Duplicate
+    fn llama_cpp_adapter() -> AdapterDescriptor {
+        AdapterDescriptor::new("llama-cpp", "llama.cpp Backend")
+            .with_modality(ModelModality::TextGeneration)
+            .with_format(ModelFormat::Gguf)
+            .with_quantization("q4_0")
+            .with_quantization("q4_1")
+            .with_quantization("q8_0")
     }
 
+    fn whisper_adapter() -> AdapterDescriptor {
+        AdapterDescriptor::new("whisper-mlx", "Whisper MLX")
+            .with_modality(ModelModality::SpeechToText)
+            .with_format(ModelFormat::Safetensors)
+    }
+
+    fn cloud_adapter() -> AdapterDescriptor {
+        AdapterDescriptor::new("openai-api", "OpenAI API")
+            .with_modality(ModelModality::TextGeneration)
+            .with_modality(ModelModality::Embedding)
+            .with_format(ModelFormat::Safetensors)
+            .with_format(ModelFormat::Gguf)
+    }
+
+    // --- Happy path tests ---
+
     #[test]
-    fn test_resolve_basic() {
+    fn test_resolve_single_adapter() {
         let mut registry = AdapterRegistry::new();
-        for adapter in create_test_descriptors() {
-            registry.register(adapter).unwrap();
-        }
+        registry.register(mlx_adapter());
 
-        let config = ModelConfig::builder()
-            .model_id("llama-3-8b")
-            .required_modality(Modality::LLM)
-            .required_format("gguf")
-            .build();
-
-        let hardware = HardwareProfile::builder()
-            .os("linux")
-            .cpu_family("x86_64")
-            .gpu_available(true)
-            .gpu_type("cuda")
-            .build();
-
-        let result = registry.resolve(&config, &hardware);
+        let config = ModelConfig::new(ModelModality::TextGeneration, ModelFormat::Gguf);
+        let result = registry.resolve(&config);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().adapter.id, "llama-cpp");
+        assert_eq!(result.unwrap().id, "mlx-local");
     }
 
     #[test]
-    fn test_resolve_no_compatible() {
+    fn test_resolve_with_quantization() {
         let mut registry = AdapterRegistry::new();
-        for adapter in create_test_descriptors() {
-            registry.register(adapter).unwrap();
-        }
+        registry.register(mlx_adapter());
 
-        let config = ModelConfig::builder()
-            .model_id("unknown-model")
-            .required_modality(Modality::ASR) // Not supported by any adapter
-            .build();
-
-        let hardware = HardwareProfile::default();
-
-        let result = registry.resolve(&config, &hardware);
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            ResolutionError::NoCompatibleAdapter
-        ));
+        let config = ModelConfig::new(ModelModality::TextGeneration, ModelFormat::Gguf)
+            .with_quantization("q4_0");
+        let result = registry.resolve(&config);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().id, "mlx-local");
     }
 
     #[test]
-    fn test_resolve_deterministic_tie_break() {
+    fn test_deterministic_tiebreak_alphabetical() {
         let mut registry = AdapterRegistry::new();
+        // Register in non-alphabetical order
+        registry.register(mlx_adapter());
+        registry.register(llama_cpp_adapter());
 
-        // Two adapters with same priority
-        registry
-            .register(
-                AdapterDescriptor::builder()
-                    .id("adapter-a")
-                    .name("Adapter A")
-                    .supported_modality(Modality::LLM)
-                    .supported_format(ModelFormat::Safetensors)
-                    .priority(100)
-                    .build(),
-            )
-            .unwrap();
-
-        registry
-            .register(
-                AdapterDescriptor::builder()
-                    .id("adapter-b")
-                    .name("Adapter B")
-                    .supported_modality(Modality::LLM)
-                    .supported_format(ModelFormat::Safetensors)
-                    .priority(100)
-                    .build(),
-            )
-            .unwrap();
-
-        let config = ModelConfig::builder()
-            .model_id("test")
-            .required_modality(Modality::LLM)
-            .required_format("safetensors")
-            .build();
-
-        let hardware = HardwareProfile::default();
-
-        let result = registry.resolve(&config, &hardware).unwrap();
-        // Should select "Adapter A" (alphabetically first due to tie-break)
-        assert_eq!(result.adapter.name, "Adapter A");
+        // Both support TextGeneration + Gguf + q4_0
+        let config = ModelConfig::new(ModelModality::TextGeneration, ModelFormat::Gguf)
+            .with_quantization("q4_0");
+        let result = registry.resolve(&config);
+        assert!(result.is_ok());
+        // "llama-cpp" < "mlx-local" alphabetically
+        assert_eq!(result.unwrap().id, "llama-cpp");
     }
 
     #[test]
-    fn test_find_by_modality() {
+    fn test_resolve_speech_to_text() {
         let mut registry = AdapterRegistry::new();
-        for adapter in create_test_descriptors() {
-            registry.register(adapter).unwrap();
-        }
+        registry.register(mlx_adapter());
+        registry.register(whisper_adapter());
 
-        let llm_adapters: Vec<_> = registry.find_by_modality(&Modality::LLM).collect();
-        assert_eq!(llm_adapters.len(), 3);
+        let config = ModelConfig::new(ModelModality::SpeechToText, ModelFormat::Safetensors);
+        let result = registry.resolve(&config);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().id, "whisper-mlx");
+    }
 
-        let vlm_adapters: Vec<_> = registry.find_by_modality(&Modality::VLM).collect();
-        assert_eq!(vlm_adapters.len(), 1);
+    #[test]
+    fn test_cloud_adapter_accepts_any_quantization() {
+        let mut registry = AdapterRegistry::new();
+        registry.register(cloud_adapter());
+
+        // Cloud adapter has empty quantization set → accepts anything
+        let config = ModelConfig::new(ModelModality::TextGeneration, ModelFormat::Gguf)
+            .with_quantization("q4_0");
+        let result = registry.resolve(&config);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().id, "openai-api");
+    }
+
+    // --- Error path tests ---
+
+    #[test]
+    fn test_empty_registry_error() {
+        let registry = AdapterRegistry::new();
+        let config = ModelConfig::new(ModelModality::TextGeneration, ModelFormat::Gguf);
+        let err = registry.resolve(&config).unwrap_err();
+        assert_eq!(err, ResolutionError::EmptyRegistry);
+    }
+
+    #[test]
+    fn test_modality_not_supported() {
+        let mut registry = AdapterRegistry::new();
+        registry.register(mlx_adapter()); // Only TextGeneration
+
+        let config = ModelConfig::new(ModelModality::SpeechToText, ModelFormat::Gguf);
+        let err = registry.resolve(&config).unwrap_err();
+        assert_eq!(
+            err,
+            ResolutionError::ModalityNotSupported(ModelModality::SpeechToText)
+        );
+    }
+
+    #[test]
+    fn test_format_not_supported() {
+        let mut registry = AdapterRegistry::new();
+        registry.register(mlx_adapter()); // Supports Gguf + Safetensors, not CoreMl
+
+        let config = ModelConfig::new(ModelModality::TextGeneration, ModelFormat::CoreMl);
+        let err = registry.resolve(&config).unwrap_err();
+        assert_eq!(
+            err,
+            ResolutionError::FormatNotSupported(ModelFormat::CoreMl)
+        );
+    }
+
+    #[test]
+    fn test_quantization_not_supported() {
+        let mut registry = AdapterRegistry::new();
+        registry.register(llama_cpp_adapter()); // Supports q4_0, q4_1, q8_0
+
+        let config = ModelConfig::new(ModelModality::TextGeneration, ModelFormat::Gguf)
+            .with_quantization("f16");
+        let err = registry.resolve(&config).unwrap_err();
+        assert_eq!(err, ResolutionError::QuantizationNotSupported("f16".into()));
+    }
+
+    #[test]
+    fn test_no_compatible_adapter_combined() {
+        let mut registry = AdapterRegistry::new();
+        // whisper only supports SpeechToText + Safetensors
+        registry.register(whisper_adapter());
+        // cloud supports TextGeneration + Embedding, Gguf + Safetensors
+        registry.register(cloud_adapter());
+
+        // Request: SpeechToText + Gguf → whisper has modality but wrong format,
+        // cloud has format but wrong modality
+        let config = ModelConfig::new(ModelModality::SpeechToText, ModelFormat::Gguf);
+        let err = registry.resolve(&config).unwrap_err();
+        assert!(matches!(err, ResolutionError::NoCompatibleAdapter { .. }));
+    }
+
+    // --- Registry management tests ---
+
+    #[test]
+    fn test_register_and_unregister() {
+        let mut registry = AdapterRegistry::new();
+        registry.register(mlx_adapter());
+        assert_eq!(registry.len(), 1);
+
+        let removed = registry.unregister("mlx-local");
+        assert!(removed);
+        assert_eq!(registry.len(), 0);
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn test_register_overwrites_existing() {
+        let mut registry = AdapterRegistry::new();
+        registry.register(mlx_adapter());
+
+        // Register a different adapter with the same ID
+        let updated = AdapterDescriptor::new("mlx-local", "MLX Backend v2")
+            .with_modality(ModelModality::VisionLanguage)
+            .with_format(ModelFormat::Safetensors);
+        registry.register(updated);
+
+        assert_eq!(registry.len(), 1);
+        let desc = registry.get("mlx-local").unwrap();
+        assert_eq!(desc.name, "MLX Backend v2");
+        assert!(desc.modalities.contains(&ModelModality::VisionLanguage));
+    }
+
+    #[test]
+    fn test_adapter_ids_sorted() {
+        let mut registry = AdapterRegistry::new();
+        registry.register(mlx_adapter());
+        registry.register(llama_cpp_adapter());
+        registry.register(whisper_adapter());
+
+        let ids = registry.adapter_ids();
+        assert_eq!(ids, vec!["llama-cpp", "mlx-local", "whisper-mlx"]);
+    }
+
+    #[test]
+    fn test_resolution_error_display() {
+        let err = ResolutionError::EmptyRegistry;
+        assert_eq!(format!("{}", err), "adapter registry is empty");
+
+        let err = ResolutionError::ModalityNotSupported(ModelModality::TextToSpeech);
+        assert_eq!(
+            format!("{}", err),
+            "no adapter supports modality: text-to-speech"
+        );
     }
 }

--- a/crates/mofa-foundation/src/agent/components/context_compressor.rs
+++ b/crates/mofa-foundation/src/agent/components/context_compressor.rs
@@ -1072,24 +1072,20 @@ impl ContextCompressor for HierarchicalCompressor {
                             .temperature(0.3)
                             .max_tokens(256);
 
-                    match self.llm.chat(summary_request).await {
-                        Ok(response) => {
-                            if let Some(summary) = response.content() {
-                                let summary_msg = ChatMessage {
-                                    role: msg.role.clone(),
-                                    content: Some(format!("[Compressed] {}", summary)),
-                                    tool_call_id: None,
-                                    tool_calls: None,
-                                };
-                                let summary_tokens = self.count_tokens(&[summary_msg.clone()]);
-                                if current_tokens + summary_tokens <= max_tokens {
-                                    compressed.push(summary_msg);
-                                    current_tokens += summary_tokens;
-                                }
+                    if let Ok(response) = self.llm.chat(summary_request).await
+                        && let Some(summary) = response.content() {
+                            let summary_msg = ChatMessage {
+                                role: msg.role.clone(),
+                                content: Some(format!("[Compressed] {}", summary)),
+                                tool_call_id: None,
+                                tool_calls: None,
+                            };
+                            let summary_tokens = self.count_tokens(&[summary_msg.clone()]);
+                            if current_tokens + summary_tokens <= max_tokens {
+                                compressed.push(summary_msg);
+                                current_tokens += summary_tokens;
                             }
                         }
-                        Err(_) => {}
-                    }
                 }
             }
         }
@@ -1642,7 +1638,7 @@ mod tests {
         // SlidingWindowCompressor with window_size=2 should compress to: 1 system + 2*2 = 5 messages max
         // But token budget might allow more, so just check it's compressed and system is preserved
         assert!(result.len() <= 21);
-        assert!(result.len() >= 1);
+        assert!(!result.is_empty());
         assert_eq!(result[0].role, "system");
     }
 

--- a/crates/mofa-foundation/src/coordination/scheduler.rs
+++ b/crates/mofa-foundation/src/coordination/scheduler.rs
@@ -127,9 +127,9 @@ impl PriorityScheduler {
 
             // 检查是否需要抢占 — 内联以避免死锁
             // Check for preemption — inlined to avoid deadlock
-            if let Some(&load) = agent_load.get(&target_agent) {
-                if load > 0 {
-                    if let Some(tasks_on_agent) = agent_tasks.get(&target_agent) {
+            if let Some(&load) = agent_load.get(&target_agent)
+                && load > 0
+                    && let Some(tasks_on_agent) = agent_tasks.get(&target_agent) {
                         let preemptable_task = tasks_on_agent
                             .iter()
                             .filter(|tid| task_status.get(*tid) == Some(&SchedulingStatus::Running))
@@ -193,8 +193,6 @@ impl PriorityScheduler {
                             }
                         }
                     }
-                }
-            }
 
             // 发送任务给目标智能体
             // Send task to the target agent

--- a/crates/mofa-foundation/src/error_conversions.rs
+++ b/crates/mofa-foundation/src/error_conversions.rs
@@ -82,7 +82,7 @@ mod tests {
             let msg = err.to_string();
             let global: GlobalError = err.into();
             assert_eq!(global.category(), ErrorCategory::LLM);
-            assert!(global.to_string().contains(&msg.split(": ").last().unwrap_or("")));
+            assert!(global.to_string().contains(msg.split(": ").last().unwrap_or("")));
         }
     }
 

--- a/crates/mofa-foundation/src/lib.rs
+++ b/crates/mofa-foundation/src/lib.rs
@@ -9,17 +9,16 @@ pub mod error_conversions;
 // orchestrator module - Model Lifecycle & Allocation
 pub mod orchestrator;
 
+// adapter registry module - runtime model-adapter discovery & resolution
+pub mod adapter;
+
 // hardware discovery module
 pub mod hardware;
 // memory-budgeted scheduler for inference orchestration
 pub mod scheduler;
 
-// adapter registry module - Runtime model adapter discovery
-pub mod adapter;
-
 // inference orchestration module - Unified Inference Routing & Lifecycle
 pub mod inference;
-
 // prompt module
 pub mod prompt;
 

--- a/crates/mofa-foundation/src/lib.rs
+++ b/crates/mofa-foundation/src/lib.rs
@@ -2,7 +2,13 @@
     dead_code,
     unused_imports,
     non_camel_case_types,
-    ambiguous_glob_reexports
+    ambiguous_glob_reexports,
+    clippy::type_complexity,
+    clippy::collapsible_if,
+    clippy::cloned_ref_to_slice_refs,
+    clippy::field_reassign_with_default,
+    clippy::assertions_on_constants,
+    clippy::needless_range_loop
 )]
 // Unified error conversions (GlobalError <-> domain errors)
 pub mod error_conversions;
@@ -56,10 +62,10 @@ pub mod rag;
 // swarm module - Multi-agent swarm orchestration
 pub mod swarm;
 // Structured output: JSON schema validator and agent executor
-pub mod schema_validator;
 pub mod agent_executor;
-pub use schema_validator::{SchemaError, SchemaValidator};
+pub mod schema_validator;
 pub use agent_executor::{AgentExecutor, ExecutorError};
+pub use schema_validator::{SchemaError, SchemaValidator};
 // Security governance - PII redaction, content moderation, prompt guard
 pub mod security;
 

--- a/crates/mofa-foundation/src/llm/anthropic.rs
+++ b/crates/mofa-foundation/src/llm/anthropic.rs
@@ -178,7 +178,7 @@ impl AnthropicProvider {
                                         let data = image_url
                                             .url
                                             .split(',')
-                                            .last()
+                                            .next_back()
                                             .unwrap_or(&image_url.url);
                                         contents.push(serde_json::json!({
                                             "type": "image",
@@ -193,7 +193,7 @@ impl AnthropicProvider {
                                         let media_type =
                                             format!("audio/{}", audio.format.to_lowercase());
                                         let data =
-                                            audio.data.split(',').last().unwrap_or(&audio.data);
+                                            audio.data.split(',').next_back().unwrap_or(&audio.data);
                                         // Some providers/models may not support this block, but this is the standard Anthropics structure if/when supported.
                                         contents.push(serde_json::json!({
                                             "type": "audio",
@@ -208,7 +208,7 @@ impl AnthropicProvider {
                                         let media_type =
                                             format!("video/{}", video.format.to_lowercase());
                                         let data =
-                                            video.data.split(',').last().unwrap_or(&video.data);
+                                            video.data.split(',').next_back().unwrap_or(&video.data);
                                         contents.push(serde_json::json!({
                                             "type": "video",
                                             "source": {

--- a/crates/mofa-foundation/src/llm/google.rs
+++ b/crates/mofa-foundation/src/llm/google.rs
@@ -168,7 +168,7 @@ impl GeminiProvider {
                                         let data = image_url
                                             .url
                                             .split(',')
-                                            .last()
+                                            .next_back()
                                             .unwrap_or(&image_url.url);
                                         gemini_parts.push(serde_json::json!({
                                             "inlineData": {
@@ -181,7 +181,7 @@ impl GeminiProvider {
                                         let mime_type =
                                             format!("audio/{}", audio.format.to_lowercase());
                                         let data =
-                                            audio.data.split(',').last().unwrap_or(&audio.data);
+                                            audio.data.split(',').next_back().unwrap_or(&audio.data);
                                         gemini_parts.push(serde_json::json!({
                                             "inlineData": {
                                                 "mimeType": mime_type,
@@ -193,7 +193,7 @@ impl GeminiProvider {
                                         let mime_type =
                                             format!("video/{}", video.format.to_lowercase());
                                         let data =
-                                            video.data.split(',').last().unwrap_or(&video.data);
+                                            video.data.split(',').next_back().unwrap_or(&video.data);
                                         gemini_parts.push(serde_json::json!({
                                             "inlineData": {
                                                 "mimeType": mime_type,

--- a/crates/mofa-foundation/src/llm/types.rs
+++ b/crates/mofa-foundation/src/llm/types.rs
@@ -1325,7 +1325,7 @@ mod tests {
         // Jitter should keep delay within reasonable bounds
         let delay = strategy.delay(1).as_millis();
         assert!(
-            delay >= 1800 && delay <= 2200,
+            (1800..=2200).contains(&delay),
             "Delay {} out of range",
             delay
         );

--- a/crates/mofa-foundation/src/rag/loaders.rs
+++ b/crates/mofa-foundation/src/rag/loaders.rs
@@ -167,8 +167,8 @@ impl DocumentLoader for MarkdownLoader {
         let mut section_index = 0usize;
 
         for line in content.lines() {
-            if let Some(level) = Self::heading_level(line) {
-                if level <= self.split_level {
+            if let Some(level) = Self::heading_level(line)
+                && level <= self.split_level {
                     // Save previous section
                     if !current_content.trim().is_empty() {
                         let mut metadata = HashMap::new();
@@ -191,7 +191,6 @@ impl DocumentLoader for MarkdownLoader {
                     current_content = format!("{line}\n");
                     continue;
                 }
-            }
 
             current_content.push_str(line);
             current_content.push('\n');
@@ -266,7 +265,7 @@ mod tests {
         let f = write_temp("content");
         let loader = TextLoader::new();
         let docs = loader.load(f.path()).unwrap();
-        assert!(docs[0].metadata.get("source").unwrap().len() > 0);
+        assert!(!docs[0].metadata.get("source").unwrap().is_empty());
     }
 
     #[test]

--- a/crates/mofa-foundation/src/rag/pipeline_adapters.rs
+++ b/crates/mofa-foundation/src/rag/pipeline_adapters.rs
@@ -58,7 +58,7 @@ impl Retriever for InMemoryRetriever {
                 };
 
                 let mut ranked = item.clone();
-                ranked.score = ranked.score + lexical;
+                ranked.score += lexical;
                 ranked
             })
             .collect::<Vec<_>>();

--- a/crates/mofa-foundation/src/rag/recursive_chunker.rs
+++ b/crates/mofa-foundation/src/rag/recursive_chunker.rs
@@ -64,17 +64,11 @@ impl RecursiveChunkConfig {
 /// This produces higher-quality chunks than fixed-size splitting because
 /// it preserves semantic boundaries where possible.
 #[derive(Debug, Clone)]
+#[derive(Default)]
 pub struct RecursiveChunker {
     config: RecursiveChunkConfig,
 }
 
-impl Default for RecursiveChunker {
-    fn default() -> Self {
-        Self {
-            config: RecursiveChunkConfig::default(),
-        }
-    }
-}
 
 impl RecursiveChunker {
     /// Create a new recursive chunker with the given configuration.

--- a/crates/mofa-foundation/src/rag/retrieval.rs
+++ b/crates/mofa-foundation/src/rag/retrieval.rs
@@ -231,11 +231,10 @@ fn pack_context(
         let separator_cost = if parts.is_empty() { 0 } else { SEPARATOR.len() };
         let cost = chunk.text.len() + separator_cost;
 
-        if let Some(budget) = max_chars {
-            if total_chars + cost > budget && !packed.is_empty() {
+        if let Some(budget) = max_chars
+            && total_chars + cost > budget && !packed.is_empty() {
                 break;
             }
-        }
 
         packed.push(chunk.clone());
         parts.push(chunk.text.as_str());

--- a/crates/mofa-foundation/src/security/regex_pii.rs
+++ b/crates/mofa-foundation/src/security/regex_pii.rs
@@ -85,7 +85,7 @@ fn luhn_check(number: &str) -> bool {
         double = !double;
     }
 
-    sum % 10 == 0
+    sum.is_multiple_of(10)
 }
 
 // =============================================================================

--- a/crates/mofa-foundation/src/swarm/config.rs
+++ b/crates/mofa-foundation/src/swarm/config.rs
@@ -78,17 +78,14 @@ impl Default for SLAConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
+#[derive(Default)]
 pub enum HITLMode {
     None,
     Required,
+    #[default]
     Optional,
 }
 
-impl Default for HITLMode {
-    fn default() -> Self {
-        Self::Optional
-    }
-}
 
 // Swarm Result
 /// Result of a swarm orchestration run

--- a/crates/mofa-foundation/src/swarm/dag.rs
+++ b/crates/mofa-foundation/src/swarm/dag.rs
@@ -14,7 +14,9 @@ use mofa_kernel::agent::types::error::{GlobalError, GlobalResult};
 /// Status of an individual subtask in the DAG
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum SubtaskStatus {
+    #[default]
     Pending,
     Ready,
     Running,
@@ -23,11 +25,6 @@ pub enum SubtaskStatus {
     Skipped,
 }
 
-impl Default for SubtaskStatus {
-    fn default() -> Self {
-        Self::Pending
-    }
-}
 
 /// A single subtask node in the DAG
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/mofa-foundation/src/swarm/patterns.rs
+++ b/crates/mofa-foundation/src/swarm/patterns.rs
@@ -8,7 +8,9 @@ use serde::{Deserialize, Serialize};
 /// Coordination pattern for a swarm of agents
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum CoordinationPattern {
+    #[default]
     Sequential,
     Parallel,
     Debate,
@@ -18,11 +20,6 @@ pub enum CoordinationPattern {
     Routing,
 }
 
-impl Default for CoordinationPattern {
-    fn default() -> Self {
-        Self::Sequential
-    }
-}
 
 impl std::fmt::Display for CoordinationPattern {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/mofa-foundation/src/workflow/profiler.rs
+++ b/crates/mofa-foundation/src/workflow/profiler.rs
@@ -107,21 +107,20 @@ impl ExecutionTimeline {
 
     /// End the current node span
     pub fn end_node(&mut self) {
-        if let Some(idx) = self.current_node_span {
-            if let Some(span) = self.node_spans.get_mut(idx) {
+        if let Some(idx) = self.current_node_span
+            && let Some(span) = self.node_spans.get_mut(idx) {
                 let now = DebugEvent::now_ms();
                 span.ended_at_ms = Some(now);
                 span.duration_ms = Some(now.saturating_sub(span.started_at_ms));
             }
-        }
         self.current_node_span = None;
         self.current_tool_span = None;
     }
 
     /// Start recording a tool span within current node
     pub fn start_tool(&mut self, tool_id: String, tool_name: String) {
-        if let Some(idx) = self.current_node_span {
-            if let Some(span) = self.node_spans.get_mut(idx) {
+        if let Some(idx) = self.current_node_span
+            && let Some(span) = self.node_spans.get_mut(idx) {
                 let tool_span = ToolSpan {
                     tool_id,
                     tool_name,
@@ -132,22 +131,18 @@ impl ExecutionTimeline {
                 self.current_tool_span = Some(span.tool_spans.len());
                 span.tool_spans.push(tool_span);
             }
-        }
     }
 
     /// End the current tool span
     pub fn end_tool(&mut self) {
-        if let Some(node_idx) = self.current_node_span {
-            if let Some(span) = self.node_spans.get_mut(node_idx) {
-                if let Some(tool_idx) = self.current_tool_span {
-                    if let Some(tool_span) = span.tool_spans.get_mut(tool_idx) {
+        if let Some(node_idx) = self.current_node_span
+            && let Some(span) = self.node_spans.get_mut(node_idx)
+                && let Some(tool_idx) = self.current_tool_span
+                    && let Some(tool_span) = span.tool_spans.get_mut(tool_idx) {
                         let now = DebugEvent::now_ms();
                         tool_span.ended_at_ms = Some(now);
                         tool_span.duration_ms = Some(now.saturating_sub(tool_span.started_at_ms));
                     }
-                }
-            }
-        }
         self.current_tool_span = None;
     }
 

--- a/crates/mofa-foundation/src/workflow/state.rs
+++ b/crates/mofa-foundation/src/workflow/state.rs
@@ -672,7 +672,7 @@ mod tests {
         let v: WorkflowValue = true.into();
         assert_eq!(v.as_bool(), Some(true));
 
-        let v: WorkflowValue = 3.14f64.into();
-        assert_eq!(v.as_f64(), Some(3.14));
+        let v: WorkflowValue = 42.5f64.into();
+        assert_eq!(v.as_f64(), Some(42.5));
     }
 }

--- a/crates/mofa-foundation/src/workflow/state_graph.rs
+++ b/crates/mofa-foundation/src/workflow/state_graph.rs
@@ -450,9 +450,7 @@ impl<S: GraphState> CompiledGraphImpl<S> {
     /// Get the next node(s) based on the current node and command
     fn get_next_nodes(&self, current_node: &str, command: &Command) -> AgentResult<Vec<String>> {
         match &command.control {
-            ControlFlow::Goto(target) => {
-                Ok(vec![target.clone()])
-            }
+            ControlFlow::Goto(target) => Ok(vec![target.clone()]),
             ControlFlow::Return => {
                 Ok(vec![]) // End execution
             }
@@ -471,6 +469,7 @@ impl<S: GraphState> CompiledGraphImpl<S> {
                             if let Some(target) = routes.get(decision) {
                                 return Ok(vec![target.clone()]);
                             }
+                        }
                         // Priority 2: legacy key-name matching (backward compatible)
                         for update in &command.updates {
                             if let Some(target) = routes.get(&update.key) {
@@ -478,7 +477,8 @@ impl<S: GraphState> CompiledGraphImpl<S> {
                             }
                         }
                         // No route matched — report error instead of silent fallback
-                        let update_keys: Vec<&str> = command.updates.iter().map(|u| u.key.as_str()).collect();
+                        let update_keys: Vec<&str> =
+                            command.updates.iter().map(|u| u.key.as_str()).collect();
                         let route_keys: Vec<&String> = routes.keys().collect();
                         warn!(
                             node_id = current_node,
@@ -691,6 +691,7 @@ impl<S: GraphState + 'static> CompiledGraph<S, serde_json::Value> for CompiledGr
                                     if let Some(target) = routes.get(decision) {
                                         return Ok(vec![target.clone()]);
                                     }
+                                }
                                 // Priority 2: legacy key-name matching (backward compatible)
                                 for update in &command.updates {
                                     if let Some(target) = routes.get(&update.key) {
@@ -1018,8 +1019,8 @@ impl<S: GraphState + 'static> CompiledGraph<S, serde_json::Value> for CompiledGr
 mod tests {
     use super::*;
     use futures::StreamExt;
-    use mofa_kernel::workflow::telemetry::TelemetryEmitter;
     use mofa_kernel::workflow::GraphConfig;
+    use mofa_kernel::workflow::telemetry::TelemetryEmitter;
     use mofa_kernel::workflow::{JsonState, StateGraph};
     use serde_json::json;
     use std::collections::HashMap;
@@ -1522,7 +1523,10 @@ mod tests {
         let compiled = graph.compile().unwrap();
         let result = compiled.invoke(JsonState::new(), None).await;
 
-        assert!(result.is_err(), "invoke should return Err when no conditional route matches");
+        assert!(
+            result.is_err(),
+            "invoke should return Err when no conditional route matches"
+        );
         let err_msg = result.unwrap_err().to_string();
         assert!(
             err_msg.contains("No conditional route matched"),
@@ -1581,6 +1585,9 @@ mod tests {
             }
         }
 
-        assert!(got_error, "stream should emit an error event when no conditional route matches");
+        assert!(
+            got_error,
+            "stream should emit an error event when no conditional route matches"
+        );
     }
 }

--- a/crates/mofa-foundation/src/workflow/state_graph.rs
+++ b/crates/mofa-foundation/src/workflow/state_graph.rs
@@ -471,7 +471,6 @@ impl<S: GraphState> CompiledGraphImpl<S> {
                             if let Some(target) = routes.get(decision) {
                                 return Ok(vec![target.clone()]);
                             }
-                        }
                         // Priority 2: legacy key-name matching (backward compatible)
                         for update in &command.updates {
                             if let Some(target) = routes.get(&update.key) {
@@ -692,7 +691,6 @@ impl<S: GraphState + 'static> CompiledGraph<S, serde_json::Value> for CompiledGr
                                     if let Some(target) = routes.get(decision) {
                                         return Ok(vec![target.clone()]);
                                     }
-                                }
                                 // Priority 2: legacy key-name matching (backward compatible)
                                 for update in &command.updates {
                                     if let Some(target) = routes.get(&update.key) {

--- a/crates/mofa-foundation/src/workflow/state_graph.rs
+++ b/crates/mofa-foundation/src/workflow/state_graph.rs
@@ -465,11 +465,10 @@ impl<S: GraphState> CompiledGraphImpl<S> {
                     Some(EdgeTarget::Parallel(targets)) => Ok(targets.clone()),
                     Some(EdgeTarget::Conditional(routes)) => {
                         // Priority 1: explicit route decision
-                        if let Some(decision) = command.route_value() {
-                            if let Some(target) = routes.get(decision) {
+                        if let Some(decision) = command.route_value()
+                            && let Some(target) = routes.get(decision) {
                                 return Ok(vec![target.clone()]);
                             }
-                        }
                         // Priority 2: legacy key-name matching (backward compatible)
                         for update in &command.updates {
                             if let Some(target) = routes.get(&update.key) {
@@ -687,11 +686,10 @@ impl<S: GraphState + 'static> CompiledGraph<S, serde_json::Value> for CompiledGr
                             Some(EdgeTarget::Parallel(targets)) => Ok(targets.clone()),
                             Some(EdgeTarget::Conditional(routes)) => {
                                 // Priority 1: explicit route decision
-                                if let Some(decision) = command.route_value() {
-                                    if let Some(target) = routes.get(decision) {
+                                if let Some(decision) = command.route_value()
+                                    && let Some(target) = routes.get(decision) {
                                         return Ok(vec![target.clone()]);
                                     }
-                                }
                                 // Priority 2: legacy key-name matching (backward compatible)
                                 for update in &command.updates {
                                     if let Some(target) = routes.get(&update.key) {

--- a/crates/mofa-foundation/tests/rag_streaming_integration.rs
+++ b/crates/mofa-foundation/tests/rag_streaming_integration.rs
@@ -189,7 +189,7 @@ async fn integration_real_llm_streaming() {
         elapsed,
         resp
     );
-    assert!(resp.len() > 0);
+    assert!(!resp.is_empty());
 }
 
 #[tokio::test]
@@ -206,7 +206,7 @@ async fn integration_concurrent_streaming_load() {
         let text = format!("Doc #{} content", i);
         let emb = simple_embedding(&text, dims);
         store
-            .upsert(DocumentChunk::new(&format!("d{}", i), &text, emb))
+            .upsert(DocumentChunk::new(format!("d{}", i), &text, emb))
             .await
             .unwrap();
     }
@@ -254,7 +254,7 @@ async fn integration_large_document_processing_performance() {
         let text = "x".repeat(100);
         let emb = simple_embedding(&text, dims);
         store
-            .upsert(DocumentChunk::new(&format!("d{}", i), &text, emb))
+            .upsert(DocumentChunk::new(format!("d{}", i), &text, emb))
             .await
             .unwrap();
     }
@@ -265,7 +265,7 @@ async fn integration_large_document_processing_performance() {
 
     let start = Instant::now();
     let (_docs, mut s) = pipeline.run_streaming("hello", 5).await.unwrap();
-    while let Some(_) = s.next().await {}
+    while s.next().await.is_some() {}
     let elapsed = start.elapsed();
     println!("processed 1000 docs retrieval+stream in {:?}", elapsed);
     assert!(elapsed.as_secs() < 10);

--- a/crates/mofa-kernel/src/agent/types/error.rs
+++ b/crates/mofa-kernel/src/agent/types/error.rs
@@ -28,7 +28,6 @@ use std::fmt;
 #[non_exhaustive]
 pub enum GlobalError {
     // ---- Core layer errors ----
-
     /// Agent layer error
     #[error("Agent error: {0}")]
     Agent(#[from] AgentError),
@@ -46,7 +45,6 @@ pub enum GlobalError {
     Runtime(String),
 
     // ---- Infrastructure errors ----
-
     /// IO error
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
@@ -60,7 +58,6 @@ pub enum GlobalError {
     Config(String),
 
     // ---- Domain-specific errors ----
-
     /// Persistence / storage error
     #[error("Persistence error: {0}")]
     Persistence(String),
@@ -90,7 +87,6 @@ pub enum GlobalError {
     MessageGraph(String),
 
     // ---- Catch-all ----
-
     /// Other / untyped error
     #[error("Other error: {0}")]
     Other(String),
@@ -422,6 +418,7 @@ impl std::error::Error for ContextualError {
 // ============================================================================
 
 /// Extension trait to attach context to any `Result<T, GlobalError>`
+#[allow(clippy::result_large_err)]
 pub trait WithContext<T> {
     /// Attach context to the error
     fn with_context(self, ctx: ErrorContext) -> Result<T, ContextualError>;

--- a/crates/mofa-kernel/src/llm/types.rs
+++ b/crates/mofa-kernel/src/llm/types.rs
@@ -189,7 +189,6 @@ impl Tool {
         description: impl Into<String>,
         parameters: serde_json::Value,
     ) -> Self {
-        let parameters = parameters;
         Self {
             tool_type: "function".to_string(),
             function: FunctionDefinition {
@@ -230,7 +229,6 @@ pub enum ToolChoice {
 pub struct ToolChoiceFunction {
     pub name: String,
 }
-
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ChatCompletionRequest {
@@ -442,7 +440,6 @@ pub struct EmbeddingResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
-
 pub enum EmbeddingInput {
     Single(String),
     Multiple(Vec<String>),
@@ -549,7 +546,9 @@ mod tests {
         if let Some(MessageContent::Parts(parts)) = &msg.content {
             assert_eq!(parts.len(), 2);
             assert!(matches!(&parts[0], ContentPart::Text { text } if text == "describe this"));
-            assert!(matches!(&parts[1], ContentPart::Image { image_url } if image_url.url == "https://img.example.com/a.png"));
+            assert!(
+                matches!(&parts[1], ContentPart::Image { image_url } if image_url.url == "https://img.example.com/a.png")
+            );
         } else {
             panic!("expected Parts content");
         }
@@ -671,9 +670,7 @@ mod tests {
     fn request_builder_tools_replaces() {
         let t1 = Tool::function("a", "d", json!({}));
         let t2 = Tool::function("b", "d", json!({}));
-        let req = ChatCompletionRequest::new("m")
-            .tool(t1)
-            .tools(vec![t2]);
+        let req = ChatCompletionRequest::new("m").tool(t1).tools(vec![t2]);
         assert_eq!(req.tools.as_ref().unwrap().len(), 1);
         assert_eq!(req.tools.as_ref().unwrap()[0].function.name, "b");
     }
@@ -788,10 +785,7 @@ mod tests {
 
     #[test]
     fn image_detail_serializes_lowercase() {
-        assert_eq!(
-            serde_json::to_string(&ImageDetail::Low).unwrap(),
-            "\"low\""
-        );
+        assert_eq!(serde_json::to_string(&ImageDetail::Low).unwrap(), "\"low\"");
         assert_eq!(
             serde_json::to_string(&ImageDetail::High).unwrap(),
             "\"high\""

--- a/crates/mofa-kernel/src/scheduler.rs
+++ b/crates/mofa-kernel/src/scheduler.rs
@@ -180,7 +180,10 @@ pub struct ScheduleHandle {
 
 impl ScheduleHandle {
     /// Create a new handle (used by `CronScheduler` in foundation).
-    pub fn new(schedule_id: impl Into<String>, cancel_tx: tokio::sync::oneshot::Sender<()>) -> Self {
+    pub fn new(
+        schedule_id: impl Into<String>,
+        cancel_tx: tokio::sync::oneshot::Sender<()>,
+    ) -> Self {
         Self {
             schedule_id: schedule_id.into(),
             cancel_tx,
@@ -244,6 +247,7 @@ pub struct ScheduleInfo {
 ///
 /// Callers that need to be generic over the scheduler backend (e.g. tests using a
 /// `MockScheduler`) depend only on this trait.
+#[allow(async_fn_in_trait)]
 pub trait AgentScheduler: Send + Sync {
     /// Register a new schedule. Returns a [`ScheduleHandle`] that, when dropped or
     /// cancelled, stops the background task.
@@ -253,10 +257,7 @@ pub trait AgentScheduler: Send + Sync {
     /// - [`SchedulerError::AlreadyExists`] — `def.schedule_id` is already registered.
     /// - [`SchedulerError::AgentNotFound`] — the agent is not in the registry.
     /// - [`SchedulerError::InvalidCron`] — the cron expression is syntactically invalid.
-    async fn register(
-        &self,
-        def: ScheduleDefinition,
-    ) -> Result<ScheduleHandle, SchedulerError>;
+    async fn register(&self, def: ScheduleDefinition) -> Result<ScheduleHandle, SchedulerError>;
 
     /// Stop and remove a schedule.
     ///
@@ -522,5 +523,4 @@ mod tests {
         // _rx is still in scope, so the send should succeed
         assert!(handle.cancel());
     }
-
 }

--- a/crates/mofa-kernel/src/security/types.rs
+++ b/crates/mofa-kernel/src/security/types.rs
@@ -46,10 +46,11 @@ impl fmt::Display for SensitiveDataCategory {
 }
 
 /// Strategy for redacting detected sensitive data.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[non_exhaustive]
 pub enum RedactionStrategy {
     /// Mask with asterisks, preserving partial structure (e.g. `j***@example.com`)
+    #[default]
     Mask,
     /// Replace with a deterministic hash prefix (8 hex chars)
     Hash,
@@ -57,12 +58,6 @@ pub enum RedactionStrategy {
     Remove,
     /// Replace with a fixed placeholder string
     Replace(String),
-}
-
-impl Default for RedactionStrategy {
-    fn default() -> Self {
-        Self::Mask
-    }
 }
 
 /// A single match of sensitive data within a text.

--- a/crates/mofa-monitoring/src/dashboard/websocket.rs
+++ b/crates/mofa-monitoring/src/dashboard/websocket.rs
@@ -357,7 +357,7 @@ impl WebSocketHandler {
                     // Messages from direct send
                     Some(msg) = rx.recv() => {
                         let json = serde_json::to_string(&msg).unwrap_or_default();
-                        if sender.send(Message::Text(json.into())).await.is_err() {
+                        if sender.send(Message::Text(json)).await.is_err() {
                             break;
                         }
                     }
@@ -366,7 +366,7 @@ impl WebSocketHandler {
                         match result {
                             Ok(msg) => {
                                 let json = serde_json::to_string(&msg).unwrap_or_default();
-                                if sender.send(Message::Text(json.into())).await.is_err() {
+                                if sender.send(Message::Text(json)).await.is_err() {
                                     break;
                                 }
                             }

--- a/crates/mofa-monitoring/src/tracing/tracer.rs
+++ b/crates/mofa-monitoring/src/tracing/tracer.rs
@@ -15,10 +15,11 @@ use tokio::sync::RwLock;
 
 /// 采样策略
 /// Sampling strategy
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum SamplingStrategy {
     /// 始终采样
     /// Always sample
+    #[default]
     AlwaysOn,
     /// 从不采样
     /// Never sample
@@ -28,20 +29,14 @@ pub enum SamplingStrategy {
     Probabilistic(f64),
     /// 基于速率限制采样
     /// Rate-limiting based sampling
-    RateLimiting { 
+    RateLimiting {
         traces_per_second: u64,
         /// Holds (timestamp_secs << 32) | (count)
-        state: Arc<AtomicU64>
+        state: Arc<AtomicU64>,
     },
     /// 父级决定
     /// Parent-based decision
     ParentBased { root: Box<SamplingStrategy> },
-}
-
-impl Default for SamplingStrategy {
-    fn default() -> Self {
-        SamplingStrategy::AlwaysOn
-    }
 }
 
 impl SamplingStrategy {
@@ -63,17 +58,20 @@ impl SamplingStrategy {
                     .fold(0u64, |acc, &b| acc.wrapping_mul(31).wrapping_add(b as u64));
                 (hash as f64 / u64::MAX as f64) < *probability
             }
-            SamplingStrategy::RateLimiting { traces_per_second, state } => {
+            SamplingStrategy::RateLimiting {
+                traces_per_second,
+                state,
+            } => {
                 let now_secs = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap_or_default()
                     .as_secs();
-                
+
                 let mut current = state.load(Ordering::Relaxed);
                 loop {
                     let current_secs = current >> 32;
                     let current_count = current & 0xFFFFFFFF;
-                    
+
                     let (new_secs, new_count) = if current_secs != now_secs {
                         // New second window
                         (now_secs, 1)
@@ -84,9 +82,14 @@ impl SamplingStrategy {
                         }
                         (current_secs, current_count + 1)
                     };
-                    
+
                     let new_state = (new_secs << 32) | new_count;
-                    match state.compare_exchange_weak(current, new_state, Ordering::SeqCst, Ordering::Relaxed) {
+                    match state.compare_exchange_weak(
+                        current,
+                        new_state,
+                        Ordering::SeqCst,
+                        Ordering::Relaxed,
+                    ) {
                         Ok(_) => return true,
                         Err(v) => current = v,
                     }

--- a/examples/agent_from_database_streaming/src/main.rs
+++ b/examples/agent_from_database_streaming/src/main.rs
@@ -80,7 +80,6 @@
 
 use mofa_sdk::persistence::ChatSession;
 use std::io::Write;
-use std::sync::Arc;
 use futures::StreamExt;
 use mofa_sdk::{llm::{LLMAgentBuilder, Role}, persistence::{PostgresStore, PersistencePlugin}};
 use tracing::{info, Level};
@@ -286,8 +285,8 @@ async fn print_agent_info(agent: &mofa_sdk::llm::LLMAgent) {
     // 获取系统提示词
     // Get system prompt
     let history = agent.history().await;
-    if let Some(system_msg) = history.first() {
-        if matches!(system_msg.role, Role::System) {
+    if let Some(system_msg) = history.first()
+        && matches!(system_msg.role, Role::System) {
             let prompt = system_msg.content.as_ref()
                 .and_then(|c| {
                     if let mofa_sdk::llm::MessageContent::Text(text) = c {
@@ -300,7 +299,6 @@ async fn print_agent_info(agent: &mofa_sdk::llm::LLMAgent) {
             info!("  系统提示词: {}", prompt);
             //   System Prompt: {}
         }
-    }
 
     info!("  当前上下文消息数: {} 条", history.len());
     //   Current context message count: {}

--- a/examples/agent_with_plugins_and_rhai/src/main.rs
+++ b/examples/agent_with_plugins_and_rhai/src/main.rs
@@ -260,7 +260,7 @@ fn execute(llm_response) {
 
     // 创建规则插件
     // Create rules plugin
-    let rules_config = RhaiPluginConfig::new_file("llm_rules", &rules_file.to_path_buf());
+    let rules_config = RhaiPluginConfig::new_file("llm_rules", rules_file);
     let mut rules_plugin = RhaiPlugin::new(rules_config).await?;
 
     let ctx = PluginContext::new("llm_rules_agent");

--- a/examples/cli_agent_logs_demo/src/main.rs
+++ b/examples/cli_agent_logs_demo/src/main.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     fs::create_dir_all(&logs_dir).await?;
 
     let agent_id = "demo-agent";
-    let log_file = logs_dir.join(format!("{}.log", agent_id));
+    let log_file = logs_dir.join(format!("{agent_id}.log"));
 
     println!("1. Creating agent log file: {}", log_file.display());
     
@@ -52,8 +52,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     println!("3. Log file created with content. You can now:");
-    println!("   - View logs: mofa agent logs {}", agent_id);
-    println!("   - Tail logs: mofa agent logs {} --tail", agent_id);
+    println!("   - View logs: mofa agent logs {agent_id}");
+    println!("   - Tail logs: mofa agent logs {agent_id} --tail");
     println!("\n4. Demonstrating log rotation...");
     
     // Simulate log rotation by truncating and writing new content
@@ -79,8 +79,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\nDemo complete!");
     println!("\nTo test the CLI commands:");
     println!("   cd {}", temp.path().display());
-    println!("   mofa agent logs {}  # View all logs", agent_id);
-    println!("   mofa agent logs {} --tail  # Follow logs in real-time", agent_id);
+    println!("   mofa agent logs {agent_id}  # View all logs");
+    println!("   mofa agent logs {agent_id} --tail  # Follow logs in real-time");
 
     // Keep temp dir alive for manual testing
     println!("\nPress Ctrl+C to exit (temp dir will be cleaned up)");

--- a/examples/cli_production_smoke/src/lib.rs
+++ b/examples/cli_production_smoke/src/lib.rs
@@ -72,7 +72,7 @@ impl SmokeEnvironment {
         validate_mofa_bin(&mofa_bin)?;
 
         let temp_dir = TempDir::new().map_err(|e| -> Box<dyn std::error::Error> {
-            format!("Failed to create temp directory for smoke run: {}", e).into()
+            format!("Failed to create temp directory for smoke run: {e}").into()
         })?;
         let xdg_config_home = temp_dir.path().join("xdg-config");
         let xdg_data_home = temp_dir.path().join("xdg-data");
@@ -316,7 +316,7 @@ pub fn smoke_session_lifecycle(env: &SmokeEnvironment, session_id: &str) -> Resu
     let show = env.run(&["session", "show", session_id, "--format", "json"])?;
     expect_ok(&show, "mofa session show --format json")?;
     let shown_json = extract_json_payload(&show).map_err(|e| -> Box<dyn std::error::Error> {
-        format!("Failed to parse session show JSON output: {}", e).into()
+        format!("Failed to parse session show JSON output: {e}").into()
     })?;
     let shown_id = shown_json
         .get("session_id")
@@ -398,13 +398,13 @@ pub fn expect_ok(output: &CommandOutput, label: &str) -> Result<()> {
         return Ok(());
     }
 
-    return Err(format!(
+    Err(format!(
         "{label} failed unexpectedly (cmd: {}).\nstdout:\n{}\nstderr:\n{}",
         output.command_line(),
         output.stdout,
         output.stderr
     )
-    .into());
+    .into())
 }
 
 pub fn expect_fail(output: &CommandOutput, label: &str) -> Result<()> {
@@ -412,13 +412,13 @@ pub fn expect_fail(output: &CommandOutput, label: &str) -> Result<()> {
         return Ok(());
     }
 
-    return Err(format!(
+    Err(format!(
         "{label} succeeded unexpectedly (cmd: {}).\nstdout:\n{}\nstderr:\n{}",
         output.command_line(),
         output.stdout,
         output.stderr
     )
-    .into());
+    .into())
 }
 
 pub fn expect_stdout_contains(output: &CommandOutput, needle: &str, label: &str) -> Result<()> {
@@ -426,11 +426,11 @@ pub fn expect_stdout_contains(output: &CommandOutput, needle: &str, label: &str)
         return Ok(());
     }
 
-    return Err(format!(
+    Err(format!(
         "{label} output did not contain '{needle}'.\nstdout:\n{}\nstderr:\n{}",
         output.stdout, output.stderr
     )
-    .into());
+    .into())
 }
 
 pub fn expect_stdout_not_contains(output: &CommandOutput, needle: &str, label: &str) -> Result<()> {
@@ -438,11 +438,11 @@ pub fn expect_stdout_not_contains(output: &CommandOutput, needle: &str, label: &
         return Ok(());
     }
 
-    return Err(format!(
+    Err(format!(
         "{label} output unexpectedly contained '{needle}'.\nstdout:\n{}\nstderr:\n{}",
         output.stdout, output.stderr
     )
-    .into());
+    .into())
 }
 
 pub fn expect_output_contains(output: &CommandOutput, needle: &str, label: &str) -> Result<()> {
@@ -450,11 +450,11 @@ pub fn expect_output_contains(output: &CommandOutput, needle: &str, label: &str)
         return Ok(());
     }
 
-    return Err(format!(
+    Err(format!(
         "{label} output did not contain '{needle}' in stdout/stderr.\nstdout:\n{}\nstderr:\n{}",
         output.stdout, output.stderr
     )
-    .into());
+    .into())
 }
 
 pub fn expect_output_not_contains(output: &CommandOutput, needle: &str, label: &str) -> Result<()> {
@@ -462,11 +462,11 @@ pub fn expect_output_not_contains(output: &CommandOutput, needle: &str, label: &
         return Ok(());
     }
 
-    return Err(format!(
+    Err(format!(
         "{label} output unexpectedly contained '{needle}' in stdout/stderr.\nstdout:\n{}\nstderr:\n{}",
         output.stdout,
         output.stderr
-    ).into());
+    ).into())
 }
 
 pub fn extract_json_payload(output: &CommandOutput) -> Result<Value> {
@@ -474,17 +474,17 @@ pub fn extract_json_payload(output: &CommandOutput) -> Result<Value> {
         .stdout
         .find('{')
         .ok_or_else(|| -> Box<dyn std::error::Error> {
-            format!("Could not find JSON object in output").into()
+            "Could not find JSON object in output".to_owned().into()
         })?;
     let payload = &output.stdout[start..];
     // Use a streaming deserializer so any trailing text after the JSON object is ignored.
     let mut iter = serde_json::Deserializer::from_str(payload).into_iter::<Value>();
     iter.next()
         .ok_or_else(|| -> Box<dyn std::error::Error> {
-            format!("Empty JSON stream in output").into()
+            "Empty JSON stream in output".to_owned().into()
         })?
         .map_err(|e| -> Box<dyn std::error::Error> {
-            format!("Invalid JSON payload: {}", e).into()
+            format!("Invalid JSON payload: {e}").into()
         })
 }
 
@@ -505,12 +505,12 @@ pub fn resolve_mofa_bin() -> Result<PathBuf> {
         return Ok(fallback);
     }
 
-    return Err(format!(
+    Err(format!(
         "Could not find mofa binary. Build it with `cargo build -p mofa-cli` from repo root, \
          or set MOFA_BIN to the binary path. Expected fallback: {}",
         fallback.display()
     )
-    .into());
+    .into())
 }
 
 fn validate_mofa_bin(path: impl AsRef<Path>) -> Result<PathBuf> {
@@ -519,10 +519,10 @@ fn validate_mofa_bin(path: impl AsRef<Path>) -> Result<PathBuf> {
         return Ok(path.to_path_buf());
     }
 
-    return Err(format!(
+    Err(format!(
         "Could not find mofa binary at '{}'. Build with `cargo build -p mofa-cli` or set MOFA_BIN to a valid binary path.",
         path.display()
-    ).into());
+    ).into())
 }
 
 fn binary_name(base: &str) -> String {
@@ -546,15 +546,14 @@ pub fn workspace_root() -> PathBuf {
     let mut outermost_workspace: Option<PathBuf> = None;
     for ancestor in manifest_dir.ancestors() {
         let cargo_toml = ancestor.join("Cargo.toml");
-        if cargo_toml.is_file() {
-            if let Ok(text) = std::fs::read_to_string(&cargo_toml) {
+        if cargo_toml.is_file()
+            && let Ok(text) = std::fs::read_to_string(&cargo_toml) {
                 // Match only a bare `[workspace]` section header (not inside a comment or
                 // string literal), to avoid false positives from `workspace = true` lines.
                 if text.lines().any(|line| line.trim() == "[workspace]") {
                     outermost_workspace = Some(ancestor.to_path_buf());
                 }
             }
-        }
     }
 
     // Fall back to the original hardcoded depth if the search finds nothing.

--- a/examples/cli_production_smoke/src/main.rs
+++ b/examples/cli_production_smoke/src/main.rs
@@ -27,6 +27,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("All CLI smoke checks passed.");
         Ok(())
     } else {
-        return Err(format!("CLI smoke checks failed").into())
+        Err("CLI smoke checks failed".to_owned().into())
     }
 }

--- a/examples/context_compression/src/main.rs
+++ b/examples/context_compression/src/main.rs
@@ -38,8 +38,8 @@ use tracing::info;
 
 fn make_msg(role: &str, content: &str) -> ChatMessage {
     ChatMessage {
-        role: role.to_string(),
-        content: Some(content.to_string()),
+        role: role.to_owned(),
+        content: Some(content.to_owned()),
         tool_call_id: None,
         tool_calls: None,
     }
@@ -209,7 +209,7 @@ async fn demo_summarizing_compressor() -> Result<(), Box<dyn std::error::Error>>
     use mofa_foundation::llm::openai::{OpenAIConfig, OpenAIProvider};
 
     let base_url = std::env::var("OPENAI_BASE_URL").ok();
-    let model = std::env::var("OPENAI_MODEL").unwrap_or_else(|_| "gpt-4o-mini".to_string());
+    let model = std::env::var("OPENAI_MODEL").unwrap_or_else(|_| "gpt-4o-mini".to_owned());
 
     let mut cfg = OpenAIConfig::new(api_key).with_model(&model);
     if let Some(url) = base_url {

--- a/examples/custom_plugin_install/src/main.rs
+++ b/examples/custom_plugin_install/src/main.rs
@@ -103,10 +103,10 @@ Once installed, the plugin provides HTTP helper functions.
 
     println!("\n   Option B: Package as tar.gz and install from URL");
     println!("   tar -czf {}.tar.gz {}", plugin_name, plugin_dir.display());
-    println!("   mofa plugin install https://example.com/{}.tar.gz", plugin_name);
+    println!("   mofa plugin install https://example.com/{plugin_name}.tar.gz");
 
     println!("\n4. After installation:");
-    println!("   - Plugin will be in ~/.mofa/plugins/{}", plugin_name);
+    println!("   - Plugin will be in ~/.mofa/plugins/{plugin_name}");
     println!("   - Plugin spec will be saved to plugin store");
     println!("   - Use 'mofa plugin list' to verify");
 

--- a/examples/log_rotation_handling/src/main.rs
+++ b/examples/log_rotation_handling/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     fs::create_dir_all(&logs_dir).await?;
 
     let agent_id = "rotating-agent";
-    let log_file = logs_dir.join(format!("{}.log", agent_id));
+    let log_file = logs_dir.join(format!("{agent_id}.log"));
 
     println!("1. Creating initial log file...");
     let mut file = fs::OpenOptions::new()
@@ -55,7 +55,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     drop(file);
 
     // Rotate: move old log and create new one
-    let rotated_log = logs_dir.join(format!("{}.log.1", agent_id));
+    let rotated_log = logs_dir.join(format!("{agent_id}.log.1"));
     fs::rename(&log_file, &rotated_log).await?;
 
     println!("   Moved old log to: {}", rotated_log.display());
@@ -89,7 +89,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("\n5. To test:");
     println!("   # In one terminal, start tailing:");
-    println!("   mofa agent logs {} --tail", agent_id);
+    println!("   mofa agent logs {agent_id} --tail");
     println!("\n   # In another terminal, trigger rotation:");
     println!("   mv {0} {0}.old && touch {0}", log_file.display());
     println!("\n   # The tail command should detect rotation and continue");

--- a/examples/message_graph_executor_runtime/src/main.rs
+++ b/examples/message_graph_executor_runtime/src/main.rs
@@ -29,7 +29,7 @@ fn decode_event_envelope(message: AgentMessage) -> Result<MessageEnvelope, Box<d
         AgentMessage::Event(mofa_kernel::message::AgentEvent::Custom(_, payload)) => {
             serde_json::from_slice(&payload).map_err(|e| format!("failed to decode envelope from event payload: {}", e).into())
         }
-        other => return Err(format!("expected event/custom payload, got {other:?}").into()),
+        other => Err(format!("expected event/custom payload, got {other:?}").into()),
     }
 }
 
@@ -153,7 +153,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map_err(|e| -> Box<dyn std::error::Error> { format!("timed out waiting for fraud target message: {}", e).into() })?
         .map_err(|e| -> Box<dyn std::error::Error> { format!("fraud receiver task failed: {}", e).into() })?
         .map_err(|e| -> Box<dyn std::error::Error> { format!("fraud receive failed: {}", e).into() })?
-        .ok_or_else(|| -> Box<dyn std::error::Error> { format!("fraud receiver got no message").into() })?;
+        .ok_or_else(|| -> Box<dyn std::error::Error> { "fraud receiver got no message".to_string().into() })?;
     let routed = decode_event_envelope(fraud_msg)?;
     println!(
         "fraud target received type='{}' hop_count={}",
@@ -165,7 +165,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map_err(|e| -> Box<dyn std::error::Error> { format!("timed out waiting for stream target message: {}", e).into() })?
         .map_err(|e| -> Box<dyn std::error::Error> { format!("stream receiver task failed: {}", e).into() })?
         .map_err(|e| -> Box<dyn std::error::Error> { format!("stream receive failed: {}", e).into() })?
-        .ok_or_else(|| -> Box<dyn std::error::Error> { format!("stream receiver got no message").into() })?;
+        .ok_or_else(|| -> Box<dyn std::error::Error> { "stream receiver got no message".to_string().into() })?;
     match stream_msg {
         AgentMessage::StreamMessage {
             stream_id,
@@ -201,7 +201,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map_err(|e| -> Box<dyn std::error::Error> { format!("timed out waiting for dlq message: {}", e).into() })?
         .map_err(|e| -> Box<dyn std::error::Error> { format!("dlq receiver task failed: {}", e).into() })?
         .map_err(|e| -> Box<dyn std::error::Error> { format!("dlq receive failed: {}", e).into() })?
-        .ok_or_else(|| -> Box<dyn std::error::Error> { format!("dlq receiver got no message").into() })?;
+        .ok_or_else(|| -> Box<dyn std::error::Error> { "dlq receiver got no message".to_string().into() })?;
     let dlq_envelope = decode_event_envelope(dlq_msg)?;
     let reason = dlq_envelope
         .headers

--- a/examples/monitoring_dashboard/src/main.rs
+++ b/examples/monitoring_dashboard/src/main.rs
@@ -245,7 +245,7 @@ async fn generate_demo_data(collector: Arc<MetricsCollector>) {
         }
 
         // Log progress occasionally
-        if tick % 60 == 0 {
+        if tick.is_multiple_of(60) {
             info!("📊 Demo data tick: {} (agents: {}, workflows: {}, plugins: {}, llm: {})",
                 tick, agents.len(), workflows.len(), plugins.len(), llm_models.len());
         }

--- a/examples/multi_agent_coordination/src/main.rs
+++ b/examples/multi_agent_coordination/src/main.rs
@@ -213,7 +213,7 @@ impl MasterAgent {
         let workers: Vec<_> = workers_map.iter().collect();
 
         if workers.is_empty() {
-            return Err(format!("No workers available").into());
+            return Err("No workers available".to_string().into());
         }
 
         // 构建 worker 列表描述

--- a/examples/rag_pipeline/src/main.rs
+++ b/examples/rag_pipeline/src/main.rs
@@ -30,12 +30,12 @@ use std::sync::Arc;
 /// Generate a simple topic label for a document
 fn get_document_topic(doc_idx: usize) -> String {
     match doc_idx {
-        0 => "architecture".to_string(),
-        1 => "performance".to_string(),
-        2 => "extensibility".to_string(),
-        3 => "deployment".to_string(),
-        4 => "examples".to_string(),
-        _ => "general".to_string(),
+        0 => "architecture".to_owned(),
+        1 => "performance".to_owned(),
+        2 => "extensibility".to_owned(),
+        3 => "deployment".to_owned(),
+        4 => "examples".to_owned(),
+        _ => "general".to_owned(),
     }
 }
 
@@ -81,7 +81,7 @@ impl Retriever for SimpleRetriever {
             .map(|r| ScoredDocument {
                 document: Document::new(r.id, r.text),
                 score: r.score,
-                source: Some("vector_search".to_string()),
+                source: Some("vector_search".to_owned()),
             })
             .collect())
     }
@@ -117,8 +117,7 @@ async fn basic_rag_pipeline() -> Result<(), Box<dyn std::error::Error>> {
     let dimensions = 64;
 
     // Knowledge base: a few paragraphs about MoFA
-    let documents = vec![
-        "MoFA is a modular framework for building AI agents in Rust. It uses a microkernel \
+    let documents = ["MoFA is a modular framework for building AI agents in Rust. It uses a microkernel \
          architecture where the core only defines trait interfaces and concrete implementations \
          are provided by the foundation layer.",
         "The dual plugin system in MoFA supports both compile-time Rust/WASM plugins for \
@@ -129,8 +128,7 @@ async fn basic_rag_pipeline() -> Result<(), Box<dyn std::error::Error>> {
          with five phases: receive ideas, clarify requirements, schedule dispatch, monitor \
          feedback, and acceptance report.",
         "MoFA uses UniFFI for cross-language bindings, allowing agents built in Rust to be \
-         called from Python, Java, Swift, Kotlin, and Go.",
-    ];
+         called from Python, Java, Swift, Kotlin, and Go."];
 
     // Chunk and embed each document
     let chunker = TextChunker::new(ChunkConfig {
@@ -145,8 +143,8 @@ async fn basic_rag_pipeline() -> Result<(), Box<dyn std::error::Error>> {
             let id = format!("doc-{doc_idx}-chunk-{chunk_idx}");
             let embedding = simple_embedding(text, dimensions);
             let chunk = DocumentChunk::new(&id, text.as_str(), embedding)
-                .with_metadata("source", &format!("document_{doc_idx}"))
-                .with_metadata("chunk_index", &chunk_idx.to_string());
+                .with_metadata("source", format!("document_{doc_idx}"))
+                .with_metadata("chunk_index", chunk_idx.to_string());
             all_chunks.push(chunk);
         }
     }
@@ -255,9 +253,9 @@ async fn streaming_rag_pipeline() -> Result<(), Box<dyn std::error::Error>> {
             let id = format!("doc-{doc_idx}-chunk-{chunk_idx}");
             let embedding = simple_embedding(text, dimensions);
             let chunk = DocumentChunk::new(&id, text.as_str(), embedding)
-                .with_metadata("source", &format!("document_{doc_idx}"))
-                .with_metadata("chunk_index", &chunk_idx.to_string())
-                .with_metadata("word_count", &text.split_whitespace().count().to_string())
+                .with_metadata("source", format!("document_{doc_idx}"))
+                .with_metadata("chunk_index", chunk_idx.to_string())
+                .with_metadata("word_count", text.split_whitespace().count().to_string())
                 .with_metadata("topic", get_document_topic(doc_idx));
             all_chunks.push(chunk);
         }
@@ -274,13 +272,11 @@ async fn streaming_rag_pipeline() -> Result<(), Box<dyn std::error::Error>> {
     let pipeline = RagPipeline::new(retriever, reranker, generator);
 
     // Test multiple realistic queries
-    let test_queries = vec![
-        "How does MoFA achieve both performance and extensibility?",
+    let test_queries = ["How does MoFA achieve both performance and extensibility?",
         "What are the different ways agents can coordinate in MoFA?",
         "How does the Secretary Agent pattern work?",
         "What database backends does MoFA support?",
-        "How does MoFA handle cross-language integration?",
-    ];
+        "How does MoFA handle cross-language integration?"];
 
     for (query_idx, query) in test_queries.iter().enumerate() {
         println!("\n--- Test Query {}: \"{}\" ---", query_idx + 1, query);
@@ -297,7 +293,7 @@ async fn streaming_rag_pipeline() -> Result<(), Box<dyn std::error::Error>> {
             println!("  {}. [score: {:.4}] {} ({} words)",
                     i + 1, doc.score,
                     truncate_text(&doc.document.text, 60),
-                    doc.document.metadata.get("word_count").unwrap_or(&"0".to_string()));
+                    doc.document.metadata.get("word_count").unwrap_or(&"0".to_owned()));
         }
 
         println!("\n--- Streaming Generation ---");
@@ -310,7 +306,7 @@ async fn streaming_rag_pipeline() -> Result<(), Box<dyn std::error::Error>> {
         while let Some(chunk_result) = stream.next().await {
             match chunk_result? {
                 mofa_kernel::rag::pipeline::GeneratorChunk::Text(text) => {
-                    print!("{}", text);
+                    print!("{text}");
                     full_response.push_str(&text);
                     chunk_count += 1;
                     total_chars += text.len();
@@ -338,14 +334,14 @@ async fn streaming_rag_pipeline() -> Result<(), Box<dyn std::error::Error>> {
     // Test with empty query
     match pipeline.run_streaming("", 3).await {
         Ok(_) => println!("✓ Empty query handled gracefully"),
-        Err(e) => println!("✗ Empty query failed: {}", e),
+        Err(e) => println!("✗ Empty query failed: {e}"),
     }
 
     // Test with very long query
     let long_query = "What is the relationship between ".repeat(50) + "?";
     match pipeline.run_streaming(&long_query, 3).await {
         Ok((docs, _)) => println!("✓ Long query handled ({} docs retrieved)", docs.len()),
-        Err(e) => println!("✗ Long query failed: {}", e),
+        Err(e) => println!("✗ Long query failed: {e}"),
     }
 
     Ok(())
@@ -359,11 +355,9 @@ async fn streaming_edge_cases_test() -> Result<(), Box<dyn std::error::Error>> {
     let dimensions = 64;
 
     // Minimal knowledge base for edge case testing
-    let documents = vec![
-        "MoFA is a framework for AI agents.",
+    let documents = ["MoFA is a framework for AI agents.",
         "It supports streaming responses.",
-        "Error handling is important.",
-    ];
+        "Error handling is important."];
 
     let chunker = TextChunker::new(ChunkConfig {
         chunk_size: 100,
@@ -400,7 +394,7 @@ async fn streaming_edge_cases_test() -> Result<(), Box<dyn std::error::Error>> {
     ];
 
     for (test_name, query, top_k, description) in test_cases {
-        println!("Testing: {} - {}", test_name, description);
+        println!("Testing: {test_name} - {description}");
 
         match pipeline.run_streaming(query, top_k).await {
             Ok((documents, mut stream)) => {
@@ -421,7 +415,7 @@ async fn streaming_edge_cases_test() -> Result<(), Box<dyn std::error::Error>> {
                             _ => {}
                         },
                         Err(e) => {
-                            println!("  ✗ Stream error: {}", e);
+                            println!("  ✗ Stream error: {e}");
                             stream_success = false;
                             break;
                         }
@@ -429,11 +423,11 @@ async fn streaming_edge_cases_test() -> Result<(), Box<dyn std::error::Error>> {
                 }
 
                 if stream_success {
-                    println!("  ✓ Streaming succeeded: {} chunks, {} characters", chunk_count, total_chars);
+                    println!("  ✓ Streaming succeeded: {chunk_count} chunks, {total_chars} characters");
                 }
             }
             Err(e) => {
-                println!("  ✗ Query failed: {}", e);
+                println!("  ✗ Query failed: {e}");
             }
         }
         println!();
@@ -446,7 +440,7 @@ async fn streaming_edge_cases_test() -> Result<(), Box<dyn std::error::Error>> {
 
     match broken_pipeline.run_streaming("test query", 3).await {
         Ok(_) => println!("  ✗ Expected error but succeeded"),
-        Err(e) => println!("  ✓ Correctly failed with error: {}", e),
+        Err(e) => println!("  ✓ Correctly failed with error: {e}"),
     }
 
     println!("\n✓ Edge cases test completed");
@@ -467,7 +461,7 @@ async fn streaming_memory_test() -> Result<(), Box<dyn std::error::Error>> {
     let mut documents = Vec::new();
     for i in 0..50 {
         documents.push(format!(
-            "Document {}: MoFA is a comprehensive framework for AI agent development. \
+            "Document {i}: MoFA is a comprehensive framework for AI agent development. \
              It provides extensive capabilities for building distributed systems, \
              including advanced coordination patterns, persistence layers, and cross-language \
              interoperability. The framework supports various deployment scenarios from \
@@ -475,8 +469,7 @@ async fn streaming_memory_test() -> Result<(), Box<dyn std::error::Error>> {
              microkernel architecture, dual plugin system, and actor-based concurrency model. \
              Performance optimizations include zero-copy message passing, async I/O operations, \
              and efficient memory management techniques. The framework has been designed \
-             with scalability, reliability, and maintainability as core principles.",
-            i
+             with scalability, reliability, and maintainability as core principles."
         ));
     }
 
@@ -518,14 +511,14 @@ async fn streaming_memory_test() -> Result<(), Box<dyn std::error::Error>> {
     for i in 0..5 {
         let pipeline_clone = pipeline.clone();
         let handle = tokio::spawn(async move {
-            let query = format!("What are the key features of document {}?", i);
+            let query = format!("What are the key features of document {i}?");
             let start = std::time::Instant::now();
 
-            let (docs, mut stream) = pipeline_clone.run_streaming(&query, 3).await.map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { format!("{}", e).into() })?;
+            let (docs, mut stream) = pipeline_clone.run_streaming(&query, 3).await.map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { format!("{e}").into() })?;
             let mut char_count = 0;
 
             while let Some(chunk_result) = stream.next().await {
-                match chunk_result.map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { format!("{}", e).into() })? {
+                match chunk_result.map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { format!("{e}").into() })? {
                     mofa_kernel::rag::pipeline::GeneratorChunk::Text(text) => {
                         char_count += text.len();
                         // Simulate processing time
@@ -550,8 +543,8 @@ async fn streaming_memory_test() -> Result<(), Box<dyn std::error::Error>> {
     for handle in handles {
         let (docs, chars, duration) = match handle.await {
             Ok(Ok(val)) => val,
-            Ok(Err(e)) => return Err(format!("Task error: {}", e).into()),
-            Err(e) => return Err(format!("Join error: {}", e).into()),
+            Ok(Err(e)) => return Err(format!("Task error: {e}").into()),
+            Err(e) => return Err(format!("Join error: {e}").into()),
         };
         total_docs += docs;
         total_chars += chars;
@@ -563,8 +556,8 @@ async fn streaming_memory_test() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     println!("\nConcurrent test results:");
-    println!("  Total documents retrieved: {}", total_docs);
-    println!("  Total characters streamed: {}", total_chars);
+    println!("  Total documents retrieved: {total_docs}");
+    println!("  Total characters streamed: {total_chars}");
     println!("  Max operation time: {:.2}ms", max_duration.as_millis());
     println!("  Average throughput: {:.1} chars/sec",
             total_chars as f64 / max_duration.as_secs_f64());
@@ -598,7 +591,7 @@ async fn streaming_performance_benchmark() -> Result<(), Box<dyn std::error::Err
     let mut documents = Vec::new();
     for i in 0..20 {
         for base_doc in &base_docs {
-            documents.push(format!("{} (variation {})", base_doc, i));
+            documents.push(format!("{base_doc} (variation {i})"));
         }
     }
 
@@ -637,7 +630,7 @@ async fn streaming_performance_benchmark() -> Result<(), Box<dyn std::error::Err
     println!("\nRunning benchmarks...\n");
 
     for (scenario_name, query, top_k) in scenarios {
-        println!("Scenario: {}", scenario_name);
+        println!("Scenario: {scenario_name}");
 
         let mut total_retrieval_time = std::time::Duration::new(0, 0);
         let mut total_streaming_time = std::time::Duration::new(0, 0);
@@ -713,7 +706,7 @@ async fn document_ingestion_demo() -> Result<(), Box<dyn std::error::Error>> {
             let embedding = simple_embedding(text, dimensions);
             let chunk = DocumentChunk::new(&id, text.as_str(), embedding)
                 .with_metadata("filename", *filename)
-                .with_metadata("chunk_index", &i.to_string());
+                .with_metadata("chunk_index", i.to_string());
             chunks.push(chunk);
         }
         total_chunks += chunks.len();
@@ -906,7 +899,7 @@ async fn qdrant_rag_pipeline(qdrant_url: &str) -> Result<(), Box<dyn std::error:
 /// Truncate text to a maximum length with ellipsis.
 fn truncate_text(text: &str, max_len: usize) -> String {
     if text.len() <= max_len {
-        text.to_string()
+        text.to_owned()
     } else {
         format!("{}...", &text[..max_len])
     }

--- a/examples/streaming_persistence/src/main.rs
+++ b/examples/streaming_persistence/src/main.rs
@@ -28,7 +28,7 @@
 use std::io::Write;
 use futures::StreamExt;
 use mofa_sdk::{
-    llm::{LLMResult, Role},
+    llm::LLMResult,
     persistence::quick_agent_with_postgres,
 };
 use tracing::{info, Level};

--- a/examples/tool_routing/src/main.rs
+++ b/examples/tool_routing/src/main.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // 3. 创建Agent并配置工具
     // 3. Create Agent and configure tools
-    let agent = Arc::new(simple_llm_agent(
+    let _agent = Arc::new(simple_llm_agent(
         "multi-task-agent",
         mock_provider.clone(),
         "You are a helpful assistant with access to various tools."
@@ -38,11 +38,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // 4. 创建工具执行器
     // 4. Create tool executor
-    let tool_executor = ExampleToolExecutor::new();
+    let _tool_executor = ExampleToolExecutor::new();
 
     // 5. 创建并添加工具路由插件
     // 5. Create and add tool routing plugin
-    let mut routing_plugin = ToolRoutingPlugin::new();
+    let routing_plugin = ToolRoutingPlugin::new();
     let rule_manager = routing_plugin.rule_manager();
 
     println!("✅ System initialization complete");

--- a/examples/tool_routing/src/tool_executor.rs
+++ b/examples/tool_routing/src/tool_executor.rs
@@ -110,13 +110,13 @@ impl ExampleToolExecutor {
         // For demonstration only, actual projects should use mature math libraries
         use std::str::FromStr;
 
-        let mut chars = expr.chars().peekable();
+        let chars = expr.chars().peekable();
         let mut num_str = String::new();
         let mut result: i64 = 0;
         let mut current_op = '+';
 
-        while let Some(c) = chars.next() {
-            if c.is_digit(10) {
+        for c in chars {
+            if c.is_ascii_digit() {
                 num_str.push(c);
             } else {
                 let num = i64::from_str(&num_str).map_err(|_| ())?;

--- a/examples/workflow_dsl/src/main.rs
+++ b/examples/workflow_dsl/src/main.rs
@@ -11,7 +11,6 @@ use mofa_sdk::workflow::{
 use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::info;
-use tracing_subscriber;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -171,7 +170,7 @@ async fn build_mock_agent(
     // In production, you would configure an actual LLM provider
     let mut builder = LLMAgentBuilder::new()
         .with_id(agent_id)
-        .with_name(&format!("Mock {}", agent_id));
+        .with_name(format!("Mock {}", agent_id));
 
     if let Some(prompt) = &config.system_prompt {
         builder = builder.with_system_prompt(prompt);

--- a/examples/workflow_orchestration/src/main.rs
+++ b/examples/workflow_orchestration/src/main.rs
@@ -818,7 +818,7 @@ async fn run_conditional_llm_workflow() -> Result<(), Box<dyn std::error::Error>
     // 条件分支
     // Conditional branch
     graph.add_node(WorkflowNode::condition("check_route", "Check Classification Result", |_ctx, input| async move {
-        let mut response = input.as_str().unwrap_or("").to_lowercase();
+        let response = input.as_str().unwrap_or("").to_lowercase();
         info!("  [check_route] Classification result: {}", response);
         //   [check_route] Classification result: {}
         response.contains("complex")

--- a/examples/workflow_viz/src/main.rs
+++ b/examples/workflow_viz/src/main.rs
@@ -459,7 +459,7 @@ async fn simulate_execution(
             };
 
             // Random failure chance (~8%)
-            let will_fail = pseudo_rand(node_id) % 13 == 0 && node_type != "start" && node_type != "end";
+            let will_fail = pseudo_rand(node_id).is_multiple_of(13) && node_type != "start" && node_type != "end";
 
             // -- RUNNING --
             {


### PR DESCRIPTION
Closes #333

## Summary

Implements **Phase 1** of the runtime model-adapter registry.

This adds adapter discovery, registration, and deterministic resolution for the inference orchestration pipeline. It sits between the `InferenceOrchestrator` (#390) and the actual backend implementations.

## What's New

### `AdapterDescriptor`
Declares adapter capabilities:
- Supported modalities (`TextGeneration`, `VisionLanguage`, `SpeechToText`, `TextToSpeech`, `Embedding`)
- Supported formats (`Gguf`, `Safetensors`, `PyTorchCheckpoint`, `CoreMl`, `Onnx`)
- Supported quantization profiles (`q4_0`, `q8_0`, `f16`, etc.)

### `AdapterRegistry`
- `BTreeMap`-backed for deterministic iteration order
- Hard-constraint filtering: modality → format → quantization
- Deterministic tie-break: alphabetical by adapter ID
- Structured rejection errors (`ResolutionError`)

### `ModelConfig`
Caller-facing model selection config with builder pattern.

## Resolution Algorithm

1. **Modality filter** — adapter must support the requested modality
2. **Format filter** — adapter must support the requested model format
3. **Quantization filter** — if specified, adapter must list it as supported (empty set = accepts any)
4. **Tie-break** — lexicographically smallest adapter ID wins

No implicit behavior. No hidden fallback paths.

## Files

| File | Lines | Purpose |
|:---|:---|:---|
| `adapter/descriptor.rs` | 133 | Capability types + builder API |
| `adapter/registry.rs` | 460 | Registry + resolution + 14 tests |
| `adapter/mod.rs` | 58 | Module entry + doc-test |
| `lib.rs` | +3 | `pub mod adapter` |

## Tests

- 14 unit tests + 2 doc-tests — all passing
- `cargo clippy` clean
- `cargo fmt` applied

## Related

- #147 — ModelOrchestrator trait
- #221 — Hardware Discovery Service
- #296 — InferenceBackend trait
- #390 — Unified Inference Orchestrator (my PR, consumes this registry)

## What This PR Does NOT Include

- Weighted scoring (Phase 2)
- Metric-aware routing / EWMA (Phase 2)
- Benchmark validation (Phase 2)
