### PR TITLE
fix(kernel): avoid lock-across-await in AgentBus receive_message

### DIFF
--- a/crates/mofa-kernel/src/bus/mod.rs
+++ b/crates/mofa-kernel/src/bus/mod.rs
@@ -154,8 +154,6 @@ impl AgentBus {
         id: &str,
         mode: CommunicationMode,
     ) -> anyhow::Result<Option<AgentMessage>> {
-        let agent_channels = self.agent_channels.read().await;
-
         // 处理广播模式
         // Handle broadcast mode
         if matches!(mode, CommunicationMode::Broadcast) {
@@ -170,11 +168,15 @@ impl AgentBus {
         } else {
             // 处理其他模式
             // Handle other modes
-            let Some(channels) = agent_channels.get(id) else {
-                return Ok(None);
-            };
-            let Some(channel) = channels.get(&mode) else {
-                return Ok(None);
+            let channel = {
+                let agent_channels = self.agent_channels.read().await;
+                let Some(channels) = agent_channels.get(id) else {
+                    return Ok(None);
+                };
+                let Some(channel) = channels.get(&mode) else {
+                    return Ok(None);
+                };
+                channel.clone()
             };
 
             let mut receiver = channel.subscribe();
@@ -197,5 +199,136 @@ impl AgentBus {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::{AgentCapabilities, AgentState};
+    use tokio::time::{Duration, sleep, timeout};
+
+    fn test_agent_metadata(id: &str) -> AgentMetadata {
+        AgentMetadata {
+            id: id.to_string(),
+            name: id.to_string(),
+            description: None,
+            version: None,
+            capabilities: AgentCapabilities::default(),
+            state: AgentState::Ready,
+        }
+    }
+
+    #[tokio::test]
+    async fn receive_message_point_to_point_does_not_block_register_channel() {
+        let bus = AgentBus::new().await.unwrap();
+
+        let receiver = test_agent_metadata("receiver");
+        bus.register_channel(
+            &receiver,
+            CommunicationMode::PointToPoint("sender".to_string()),
+        )
+        .await
+        .unwrap();
+
+        let bus_for_receive = bus.clone();
+        let receive_task = tokio::spawn(async move {
+            bus_for_receive
+                .receive_message(
+                    "receiver",
+                    CommunicationMode::PointToPoint("sender".to_string()),
+                )
+                .await
+        });
+
+        // Give receive_message time to subscribe and park on recv().
+        sleep(Duration::from_millis(50)).await;
+
+        let writer_meta = test_agent_metadata("writer");
+        let register_res = timeout(
+            Duration::from_millis(300),
+            bus.register_channel(
+                &writer_meta,
+                CommunicationMode::PointToPoint("sender".to_string()),
+            ),
+        )
+        .await;
+        assert!(
+            register_res.is_ok(),
+            "register_channel should not be blocked by receive_message"
+        );
+        register_res.unwrap().unwrap();
+
+        bus.send_message(
+            "sender",
+            CommunicationMode::PointToPoint("receiver".to_string()),
+            &AgentMessage::TaskRequest {
+                task_id: "task-1".to_string(),
+                content: "payload".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let received = timeout(Duration::from_secs(1), receive_task)
+            .await
+            .expect("receive task timed out")
+            .expect("receive task join failed")
+            .expect("receive_message returned error");
+        assert!(
+            received.is_some(),
+            "expected one received point-to-point message"
+        );
+    }
+
+    #[tokio::test]
+    async fn receive_message_broadcast_does_not_block_register_channel() {
+        let bus = AgentBus::new().await.unwrap();
+
+        let bus_for_receive = bus.clone();
+        let receive_task = tokio::spawn(async move {
+            bus_for_receive
+                .receive_message("receiver", CommunicationMode::Broadcast)
+                .await
+        });
+
+        // Give receive_message time to subscribe and park on recv().
+        sleep(Duration::from_millis(50)).await;
+
+        let writer_meta = test_agent_metadata("writer");
+        let register_res = timeout(
+            Duration::from_millis(300),
+            bus.register_channel(
+                &writer_meta,
+                CommunicationMode::PointToPoint("sender".to_string()),
+            ),
+        )
+        .await;
+        assert!(
+            register_res.is_ok(),
+            "register_channel should not be blocked by broadcast receive_message"
+        );
+        register_res.unwrap().unwrap();
+
+        bus.send_message(
+            "sender",
+            CommunicationMode::Broadcast,
+            &AgentMessage::TaskRequest {
+                task_id: "task-2".to_string(),
+                content: "payload".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let received = timeout(Duration::from_secs(1), receive_task)
+            .await
+            .expect("receive task timed out")
+            .expect("receive task join failed")
+            .expect("receive_message returned error");
+        assert!(
+            received.is_some(),
+            "expected one received broadcast message"
+        );
     }
 }


### PR DESCRIPTION
## Summary
Fixes lock-across-await in `AgentBus::receive_message` by ensuring `agent_channels` read guards are dropped before `recv().await`.

Closes #428.

## Root Cause
`receive_message` acquired `self.agent_channels.read().await` and then awaited on `receiver.recv().await`, keeping a read guard alive across an async suspension point. That can block concurrent writers (`register_channel`) when receives wait for messages.

## Changes
- Refactored `receive_message` in `crates/mofa-kernel/src/bus/mod.rs`:
  - `Broadcast` path no longer touches `agent_channels` lock.
  - Non-broadcast path clones the channel handle under a short read lock scope, drops the lock, then awaits `recv()`.
- Added regression tests:
  - `receive_message_point_to_point_does_not_block_register_channel`
  - `receive_message_broadcast_does_not_block_register_channel`

## Validation
```bash
cargo test -p mofa-kernel receive_message_
cargo test -p mofa-kernel
```
Both new tests pass, and full `mofa-kernel` tests pass.

## Note
`cargo clippy -p mofa-kernel --all-targets -- -D warnings` currently fails due to an existing unrelated deprecated API usage in `crates/mofa-kernel/src/error.rs`.
