### PR TITLE
fix(run-flow): avoid global dora kills during startup cleanup

### DIFF
--- a/mofa/commands/run_flow.py
+++ b/mofa/commands/run_flow.py
@@ -455,6 +455,13 @@ def build_env(base_env: dict, venv_info: dict):
     return env
 
 
+def cleanup_existing_dora_processes():
+    """Best-effort cleanup for Dora daemon state without global process killing."""
+    click.echo("Cleaning up existing dora daemon state...")
+    destroy_dora_daemon()
+    time.sleep(1)
+
+
 def run_flow(dataflow_file: str, vibe_test_mode: bool = False, detach: bool = False, no_terminal: bool = False):
     """Execute a dataflow from the given YAML file.
 
@@ -534,18 +541,8 @@ def run_flow(dataflow_file: str, vibe_test_mode: bool = False, detach: bool = Fa
         click.echo("Please ensure dora-rs is installed correctly.")
         return
 
-    # Clean up any existing dora processes to avoid conflicts
-    click.echo("Cleaning up existing dora processes...")
-    try:
-        subprocess.run(["pkill", "-f", "dora"], capture_output=True, check=False)
-    except FileNotFoundError:
-        # pkill might not be available on all systems, try alternative
-        try:
-            subprocess.run(["killall", "dora"], capture_output=True, check=False)
-        except FileNotFoundError:
-            # If neither pkill nor killall is available, skip cleanup
-            pass
-    time.sleep(1)
+    # Clean up existing Dora daemon state before starting a new run.
+    cleanup_existing_dora_processes()
 
     env_info = None
     run_env = os.environ.copy()

--- a/tests/test_run_flow_cleanup.py
+++ b/tests/test_run_flow_cleanup.py
@@ -1,0 +1,32 @@
+import unittest
+import sys
+import types
+from unittest.mock import patch
+
+# run_flow imports read.py, which imports pandas at module import time.
+# Stub pandas so this unit test can run in minimal environments.
+if "pandas" not in sys.modules:
+    fake_pandas = types.ModuleType("pandas")
+    fake_pandas.ExcelFile = object
+    fake_pandas.read_excel = lambda *args, **kwargs: None
+    sys.modules["pandas"] = fake_pandas
+if "toml" not in sys.modules:
+    fake_toml = types.ModuleType("toml")
+    fake_toml.dump = lambda *args, **kwargs: None
+    sys.modules["toml"] = fake_toml
+
+from mofa.commands import run_flow as run_flow_module
+
+
+class RunFlowCleanupTests(unittest.TestCase):
+    def test_cleanup_uses_destroy_daemon_only(self):
+        with patch("mofa.commands.run_flow.destroy_dora_daemon") as destroy_mock, \
+             patch("mofa.commands.run_flow.time.sleep") as sleep_mock:
+            run_flow_module.cleanup_existing_dora_processes()
+
+        destroy_mock.assert_called_once()
+        sleep_mock.assert_called_once_with(1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
`mofa run-flow` used global process-kill commands (`pkill -f dora` / `killall dora`) during startup cleanup, which can terminate unrelated Dora processes.

## Root Cause
Cleanup logic was not scoped to the MoFA-managed daemon lifecycle.

## Changes
- Replaced global kill patterns with scoped cleanup via existing daemon-management helpers
- Limited cleanup to the targeted MoFA daemon process flow
- Added unit coverage for cleanup call path behavior

## Test Plan
- `python3 -m unittest discover -s tests -p 'test_run_flow_cleanup.py' -v`

## Risk / Impact
Medium operational improvement, low code risk. Prevents accidental termination of unrelated workloads.

Closes #474
