### PR TITLE
fix(vibe): save API key to project env path

### DIFF
--- a/mofa/commands/vibe.py
+++ b/mofa/commands/vibe.py
@@ -118,7 +118,7 @@ def _check_and_setup_api_key():
 
             # Ask if they want to save it
             if click.confirm("\nSave to .env file?", default=True):
-                env_file = os.path.join(os.getcwd(), '.env')
+                env_file = _get_env_file_path()
 
                 # Append to .env or create new one
                 with open(env_file, 'a') as f:

--- a/tests/test_vibe_api_key_path.py
+++ b/tests/test_vibe_api_key_path.py
@@ -1,0 +1,27 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import mofa.commands.vibe as vibe_module
+
+
+class VibeApiKeyPathTests(unittest.TestCase):
+    def test_api_key_save_uses_project_env_path(self):
+        with tempfile.TemporaryDirectory() as td:
+            env_path = Path(td) / ".env"
+
+            with patch.dict("os.environ", {}, clear=True), \
+                 patch("mofa.commands.vibe._get_env_file_path", return_value=str(env_path)), \
+                 patch("mofa.commands.vibe.click.confirm", side_effect=[True, True]), \
+                 patch("mofa.commands.vibe.click.prompt", return_value="sk-test-123"):
+                api_key = vibe_module._check_and_setup_api_key()
+
+            self.assertEqual(api_key, "sk-test-123")
+            self.assertTrue(env_path.exists())
+            content = env_path.read_text()
+            self.assertIn("OPENAI_API_KEY=sk-test-123", content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
`mofa vibe` API-key setup wrote to `os.getcwd()/.env`, which can store secrets outside the intended project location.

## Root Cause
The command used current working directory instead of the project env-path helper.

## Changes
- Use `_get_env_file_path()` for API-key persistence
- Preserve existing setup UX while ensuring project-scoped writes
- Added regression test validating target env file path

## Test Plan
- `python3 -m unittest discover -s tests -p 'test_vibe_api_key_path.py' -v`

## Risk / Impact
Low risk, security/operational improvement by avoiding accidental secret writes.

Closes #476
