### PR TITLE
fix(search): avoid duplicate remote calls in default mode

### DIFF
--- a/mofa/commands/search.py
+++ b/mofa/commands/search.py
@@ -216,6 +216,7 @@ def register_search_commands(cli_group):
 
         # Both local and remote (default)
         local_matches = [name for name in local_agents if keyword_lower in name.lower()]
+        remote_matches = []
 
         if local_matches:
             click.echo(f"Local agents matching '{keyword}' ({len(local_matches)}):")
@@ -242,14 +243,8 @@ def register_search_commands(cli_group):
         except Exception as e:
             click.echo(f"\nError searching remote agents: {e}", err=True)
 
-        if not local_matches:
-            try:
-                hub = HubClient()
-                remote_matches = hub.search_agents(keyword)
-                if not remote_matches:
-                    click.echo(f"No agents found matching '{keyword}'")
-            except:
-                pass
+        if not local_matches and not remote_matches:
+            click.echo(f"No agents found matching '{keyword}'")
 
     @search.command()
     @click.argument("keyword", required=True)
@@ -299,6 +294,7 @@ def register_search_commands(cli_group):
 
         # Both local and remote (default)
         local_matches = [name for name in local_flows if keyword_lower in name.lower()]
+        remote_matches = []
 
         if local_matches:
             click.echo(f"Local flows matching '{keyword}' ({len(local_matches)}):")
@@ -325,11 +321,5 @@ def register_search_commands(cli_group):
         except Exception as e:
             click.echo(f"\nError searching remote flows: {e}", err=True)
 
-        if not local_matches:
-            try:
-                hub = HubClient()
-                remote_matches = hub.search_flows(keyword)
-                if not remote_matches:
-                    click.echo(f"No flows found matching '{keyword}'")
-            except:
-                pass
+        if not local_matches and not remote_matches:
+            click.echo(f"No flows found matching '{keyword}'")

--- a/tests/test_search_commands.py
+++ b/tests/test_search_commands.py
@@ -1,0 +1,59 @@
+import unittest
+from unittest.mock import patch
+
+import click
+from click.testing import CliRunner
+
+from mofa.commands.search import register_search_commands
+
+
+def build_cli():
+    @click.group()
+    def cli():
+        pass
+
+    register_search_commands(cli)
+    return cli
+
+
+class FakeHubClient:
+    agent_calls = 0
+    flow_calls = 0
+
+    def search_agents(self, keyword):
+        FakeHubClient.agent_calls += 1
+        return []
+
+    def search_flows(self, keyword):
+        FakeHubClient.flow_calls += 1
+        return []
+
+
+class SearchCommandTests(unittest.TestCase):
+    def setUp(self):
+        FakeHubClient.agent_calls = 0
+        FakeHubClient.flow_calls = 0
+        self.cli = build_cli()
+        self.runner = CliRunner()
+
+    def test_agent_default_search_calls_remote_once(self):
+        with patch("mofa.commands.search.get_subdirectories", return_value=[]), \
+             patch("mofa.commands.search.HubClient", FakeHubClient):
+            result = self.runner.invoke(self.cli, ["search", "agent", "demo"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(FakeHubClient.agent_calls, 1)
+        self.assertIn("No agents found matching 'demo'", result.output)
+
+    def test_flow_default_search_calls_remote_once(self):
+        with patch("mofa.commands.search.get_subdirectories", return_value=[]), \
+             patch("mofa.commands.search.HubClient", FakeHubClient):
+            result = self.runner.invoke(self.cli, ["search", "flow", "demo"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(FakeHubClient.flow_calls, 1)
+        self.assertIn("No flows found matching 'demo'", result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
Default search mode (local + remote) called remote hub search twice when local results were empty.

## Root Cause
No-result messaging logic executed a second remote request instead of reusing the initial response.

## Changes
- Reused first remote response for no-match checks
- Removed duplicate remote API calls in default mode
- Added tests asserting a single remote call for agents and flows search paths

## Test Plan
- `python3 -m unittest discover -s tests -p 'test_search_commands.py' -v`

## Risk / Impact
Low risk with measurable efficiency improvement (fewer network calls).

Closes #477
