### PR TITLE
[Feature] foundation(tools): implement ToolRegistry::hot_reload_plugin

### DIFF
--- a/crates/mofa-foundation/src/agent/tools/registry.rs
+++ b/crates/mofa-foundation/src/agent/tools/registry.rs
@@ -6,11 +6,13 @@
 
 use async_trait::async_trait;
 use mofa_kernel::agent::components::tool::{
-    Tool, ToolDescriptor, ToolRegistry as ToolRegistryTrait, DynTool, ToolExt,
+    DynTool, Tool, ToolDescriptor, ToolExt, ToolRegistry as ToolRegistryTrait,
 };
-use mofa_kernel::agent::error::{AgentResult, AgentError};
+use mofa_kernel::agent::error::{AgentError, AgentResult};
 use std::collections::HashMap;
 use std::sync::Arc;
+
+type PluginLoader = Arc<dyn Fn(&str) -> AgentResult<Vec<Arc<dyn DynTool>>> + Send + Sync>;
 
 /// 统一工具注册中心
 /// Unified Tool Registry
@@ -55,6 +57,9 @@ pub struct ToolRegistry {
     /// MCP client manager (only used when mcp feature is enabled)
     #[cfg(feature = "mcp")]
     mcp_client: Option<std::sync::Arc<tokio::sync::RwLock<super::mcp::McpClientManager>>>,
+    /// 插件加载器（按路径映射）
+    /// Plugin loaders keyed by plugin path
+    plugin_loaders: HashMap<String, PluginLoader>,
 }
 
 /// 工具来源
@@ -85,6 +90,7 @@ impl ToolRegistry {
             mcp_endpoints: Vec::new(),
             #[cfg(feature = "mcp")]
             mcp_client: None,
+            plugin_loaders: HashMap::new(),
         }
     }
 
@@ -224,14 +230,73 @@ impl ToolRegistry {
         Ok(to_remove)
     }
 
+    /// 注册插件加载器
+    /// Register plugin loader callback for a path
+    pub fn register_plugin_loader<F>(&mut self, path: impl Into<String>, loader: F)
+    where
+        F: Fn(&str) -> AgentResult<Vec<Arc<dyn DynTool>>> + Send + Sync + 'static,
+    {
+        self.plugin_loaders.insert(path.into(), Arc::new(loader));
+    }
+
     /// 热加载插件 (TODO: 实际插件系统实现)
-    /// Hot reload plugin (TODO: actual implementation)
-    pub async fn hot_reload_plugin(&mut self, _path: &str) -> AgentResult<Vec<String>> {
-        // TODO: 实际插件热加载实现
-        // TODO: actual hot reload implementation
-        Err(mofa_kernel::agent::error::AgentError::Other(
-            "Plugin hot reloading is not yet implemented".to_string(),
-        ))
+    /// Hot reload plugin
+    pub async fn hot_reload_plugin(&mut self, path: &str) -> AgentResult<Vec<String>> {
+        let loader = self.plugin_loaders.get(path).cloned().ok_or_else(|| {
+            AgentError::NotFound(format!("Plugin loader not registered for path: {path}"))
+        })?;
+
+        let tools_backup = self.tools.clone();
+        let sources_backup = self.sources.clone();
+
+        let to_remove: Vec<String> = self
+            .sources
+            .iter()
+            .filter_map(|(name, source)| {
+                if let ToolSource::Plugin { path: plugin_path } = source
+                    && plugin_path == path
+                {
+                    return Some(name.clone());
+                }
+                None
+            })
+            .collect();
+
+        for name in to_remove {
+            self.tools.remove(&name);
+            self.sources.remove(&name);
+        }
+
+        let loaded_tools = match loader(path) {
+            Ok(tools) => tools,
+            Err(err) => {
+                self.tools = tools_backup;
+                self.sources = sources_backup;
+                return Err(err);
+            }
+        };
+
+        let mut reloaded_names = Vec::new();
+        for tool in loaded_tools {
+            let name = tool.name().to_string();
+            if self.sources.contains_key(&name) {
+                self.tools = tools_backup;
+                self.sources = sources_backup;
+                return Err(AgentError::RegistrationFailed(format!(
+                    "Tool '{name}' already exists and cannot be replaced during plugin hot reload",
+                )));
+            }
+
+            self.register_with_source(
+                tool,
+                ToolSource::Plugin {
+                    path: path.to_string(),
+                },
+            )?;
+            reloaded_names.push(name);
+        }
+
+        Ok(reloaded_names)
     }
 
     /// 获取工具来源
@@ -374,5 +439,137 @@ impl<'a> ToolSearcher<'a> {
             .filter(|tool| tool.metadata().is_dangerous || tool.requires_confirmation())
             .map(|tool| ToolDescriptor::from_dyn_tool(tool.as_ref()))
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mofa_kernel::agent::components::tool::{ToolInput, ToolResult};
+    use mofa_kernel::agent::context::AgentContext;
+
+    struct TestTool {
+        name: &'static str,
+    }
+
+    impl TestTool {
+        fn new(name: &'static str) -> Self {
+            Self { name }
+        }
+    }
+
+    #[async_trait]
+    impl Tool for TestTool {
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn description(&self) -> &str {
+            "test tool"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({
+                "type": "object",
+                "properties": {}
+            })
+        }
+
+        async fn execute(
+            &self,
+            _input: ToolInput<serde_json::Value>,
+            _ctx: &AgentContext,
+        ) -> ToolResult<serde_json::Value> {
+            ToolResult::success(serde_json::json!({"ok": true}))
+        }
+    }
+
+    #[tokio::test]
+    async fn hot_reload_plugin_replaces_existing_plugin_tools() {
+        let mut registry = ToolRegistry::new();
+        let path = "/plugins/sample.rhai";
+
+        registry
+            .register_with_source(
+                TestTool::new("old_plugin_tool").into_dynamic(),
+                ToolSource::Plugin {
+                    path: path.to_string(),
+                },
+            )
+            .unwrap();
+        registry
+            .register_with_source(
+                TestTool::new("keep_dynamic").into_dynamic(),
+                ToolSource::Dynamic,
+            )
+            .unwrap();
+
+        registry.register_plugin_loader(path, |_plugin_path| {
+            Ok(vec![
+                TestTool::new("new_plugin_tool_a").into_dynamic(),
+                TestTool::new("new_plugin_tool_b").into_dynamic(),
+            ])
+        });
+
+        let reloaded = registry.hot_reload_plugin(path).await.unwrap();
+        assert_eq!(reloaded.len(), 2);
+        assert!(reloaded.iter().any(|n| n == "new_plugin_tool_a"));
+        assert!(reloaded.iter().any(|n| n == "new_plugin_tool_b"));
+
+        assert!(!registry.contains("old_plugin_tool"));
+        assert!(registry.contains("keep_dynamic"));
+        assert!(registry.contains("new_plugin_tool_a"));
+        assert!(registry.contains("new_plugin_tool_b"));
+
+        assert!(matches!(
+            registry.get_source("new_plugin_tool_a"),
+            Some(ToolSource::Plugin { path: p }) if p == path
+        ));
+    }
+
+    #[tokio::test]
+    async fn hot_reload_plugin_rolls_back_on_loader_error() {
+        let mut registry = ToolRegistry::new();
+        let path = "/plugins/fail.rhai";
+
+        registry
+            .register_with_source(
+                TestTool::new("existing_plugin_tool").into_dynamic(),
+                ToolSource::Plugin {
+                    path: path.to_string(),
+                },
+            )
+            .unwrap();
+
+        registry.register_plugin_loader(path, |_plugin_path| {
+            Err(AgentError::Other(
+                "simulated plugin load failure".to_string(),
+            ))
+        });
+
+        let err = registry
+            .hot_reload_plugin(path)
+            .await
+            .expect_err("reload should fail");
+        assert!(err.to_string().contains("simulated plugin load failure"));
+
+        assert!(registry.contains("existing_plugin_tool"));
+        assert!(matches!(
+            registry.get_source("existing_plugin_tool"),
+            Some(ToolSource::Plugin { path: p }) if p == path
+        ));
+    }
+
+    #[tokio::test]
+    async fn hot_reload_plugin_fails_without_registered_loader() {
+        let mut registry = ToolRegistry::new();
+        let path = "/plugins/missing_loader.rhai";
+
+        let err = registry
+            .hot_reload_plugin(path)
+            .await
+            .expect_err("reload should fail");
+        assert!(matches!(err, AgentError::NotFound(_)));
+        assert!(err.to_string().contains("Plugin loader not registered"));
     }
 }

--- a/crates/mofa-foundation/src/workflow/state_graph.rs
+++ b/crates/mofa-foundation/src/workflow/state_graph.rs
@@ -875,10 +875,7 @@ mod tests {
     #[async_trait]
     impl NodeFunc<JsonState> for FlagReaderNode {
         async fn call(&self, state: &mut JsonState, _ctx: &RuntimeContext) -> AgentResult<Command> {
-            let saw_flag = state
-                .get_value("flag")
-                .and_then(|v: Value| v.as_bool())
-                .unwrap_or(false);
+            let saw_flag = state.get_value::<bool>("flag").unwrap_or(false);
             Ok(Command::new()
                 .update("reader_saw_flag", json!(saw_flag))
                 .continue_())
@@ -1048,7 +1045,7 @@ mod tests {
         assert_eq!(final_state.get_value("reader_saw_flag"), Some(json!(false)));
 
         let mut stream = compiled.stream(JsonState::new(), None);
-        let mut stream_final_state = None;
+        let mut stream_final_state: Option<JsonState> = None;
         while let Some(event) = stream.next().await {
             if let StreamEvent::End { final_state } = event.unwrap() {
                 stream_final_state = Some(final_state);


### PR DESCRIPTION
## 📋 Summary

Implement `ToolRegistry::hot_reload_plugin` with rollback-safe behavior and add focused tests for success/failure cases.

## 🔗 Related Issues

Closes #490

Related to #491

---

## 🧠 Context

`hot_reload_plugin` was a stub. Plugin workflows need deterministic reloading with source bookkeeping and safe rollback on errors.

---

## 🛠️ Changes

- Added plugin loader registry (`register_plugin_loader`) keyed by plugin path.
- Implemented `hot_reload_plugin` to remove old plugin tools, load replacements, and rollback on load/collision failure.
- Added async tests for successful replace, rollback on loader error, and missing-loader failure.

---

## 🧪 How you Tested

1. `cargo test -p mofa-foundation hot_reload_plugin -- --nocapture`
2. `cargo clippy -p mofa-foundation --all-targets -- -D warnings`
3. Verified source mapping for reloaded tools remains `ToolSource::Plugin { path }`.

---

## 📸 Screenshots / Logs (if applicable)

- Hot-reload tests: 3 passed.
- Clippy note: `-D warnings` currently fails due pre-existing unrelated warnings in other `mofa-foundation` test modules.

---

## ⚠️ Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (describe below)

If breaking:

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [ ] `cargo clippy` passes without warnings

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [ ] Public APIs documented
- [ ] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**


---

## 🧩 Additional Notes for Reviewers

This PR introduces a callback-based loader seam to keep hot-reload testable without coupling to a specific plugin runtime.
