### PR TITLE
fix(mofa-cli): make PersistedStore::save() atomic via write-then-rename

### DIFF
--- a/crates/mofa-cli/Cargo.toml
+++ b/crates/mofa-cli/Cargo.toml
@@ -50,6 +50,9 @@ indicatif = "0.17"
 comfy-table = "7"
 dirs-next = "2"
 
+# Atomic file writes
+tempfile = "3"
+
 # Process management
 nix = { version = "0.29", features = ["process", "signal"] }
 
@@ -69,7 +72,6 @@ tokio-stream = "0.1"
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"
-tempfile = "3"
 
 [features]
 default = []

--- a/crates/mofa-cli/src/store.rs
+++ b/crates/mofa-cli/src/store.rs
@@ -1,10 +1,84 @@
 //! Generic file-based persisted store for CLI state.
+//!
+//! Uses atomic write-then-rename to guarantee crash safety:
+//! data is first written to a temporary file in the same directory,
+//! `fsync`'d to disk, then atomically renamed to the target path.
+//! On POSIX systems, `rename(2)` within the same filesystem is atomic.
 
 use serde::Serialize;
 use serde::de::DeserializeOwned;
+use std::fmt;
 use std::fs;
+use std::io::Write;
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
+use tempfile::NamedTempFile;
+use tracing::warn;
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/// Errors that can occur during [`PersistedStore`] operations.
+#[derive(Debug)]
+pub enum StoreError {
+    /// Failed to create the store directory.
+    CreateDir { path: PathBuf, source: std::io::Error },
+    /// JSON serialization failed.
+    Serialize(serde_json::Error),
+    /// JSON deserialization failed.
+    Deserialize { path: PathBuf, source: serde_json::Error },
+    /// An I/O operation on a specific path failed.
+    Io { path: PathBuf, source: std::io::Error },
+    /// An I/O operation without a specific path (e.g. temp file creation).
+    IoRaw(std::io::Error),
+    /// Atomic rename of the temp file to the target path failed.
+    Persist { path: PathBuf, source: std::io::Error },
+}
+
+impl fmt::Display for StoreError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CreateDir { path, source } => {
+                write!(f, "failed to create store directory {}: {source}", path.display())
+            }
+            Self::Serialize(e) => write!(f, "failed to serialize store entry: {e}"),
+            Self::Deserialize { path, source } => {
+                write!(f, "failed to deserialize store entry {}: {source}", path.display())
+            }
+            Self::Io { path, source } => {
+                write!(f, "I/O error on {}: {source}", path.display())
+            }
+            Self::IoRaw(e) => write!(f, "I/O error: {e}"),
+            Self::Persist { path, source } => {
+                write!(f, "failed to atomically persist {}: {source}", path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for StoreError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::CreateDir { source, .. } => Some(source),
+            Self::Serialize(e) => Some(e),
+            Self::Deserialize { source, .. } => Some(source),
+            Self::Io { source, .. } => Some(source),
+            Self::IoRaw(e) => Some(e),
+            Self::Persist { source, .. } => Some(source),
+        }
+    }
+}
+
+impl From<serde_json::Error> for StoreError {
+    fn from(e: serde_json::Error) -> Self {
+        Self::Serialize(e)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
 
 pub struct PersistedStore<T> {
     dir: PathBuf,
@@ -12,39 +86,87 @@ pub struct PersistedStore<T> {
 }
 
 impl<T: Serialize + DeserializeOwned> PersistedStore<T> {
-    pub fn new(dir: impl AsRef<Path>) -> anyhow::Result<Self> {
+    pub fn new(dir: impl AsRef<Path>) -> Result<Self, StoreError> {
         let dir = dir.as_ref().to_path_buf();
-        fs::create_dir_all(&dir)?;
+        fs::create_dir_all(&dir).map_err(|e| StoreError::CreateDir {
+            path: dir.clone(),
+            source: e,
+        })?;
         Ok(Self {
             dir,
             _phantom: PhantomData,
         })
     }
 
-    pub fn save(&self, id: &str, item: &T) -> anyhow::Result<()> {
-        let path = self.path_for(id);
+    /// Persist `item` under the given `id`.
+    ///
+    /// Uses an atomic write strategy:
+    /// 1. Serialize to a temporary file in the **same directory** (ensures same filesystem).
+    /// 2. `fsync` the temp file so bytes are durable on disk.
+    /// 3. Atomically rename the temp file to the final path.
+    ///
+    /// If the process crashes at any point before the rename completes,
+    /// the previous version of the file (if any) remains intact.
+    pub fn save(&self, id: &str, item: &T) -> Result<(), StoreError> {
+        let target = self.path_for(id);
         let payload = serde_json::to_vec_pretty(item)?;
-        fs::write(path, payload)?;
+
+        // Create temp file in the same directory so rename is guaranteed
+        // to be a same-filesystem atomic operation.
+        let mut tmp = NamedTempFile::new_in(&self.dir)
+            .map_err(StoreError::IoRaw)?;
+
+        tmp.write_all(&payload)
+            .map_err(StoreError::IoRaw)?;
+
+        // Flush userspace buffers and fsync to ensure durability before rename.
+        tmp.as_file().sync_all()
+            .map_err(StoreError::IoRaw)?;
+
+        // Atomically replace the target file.
+        // `persist` calls `rename(2)` on POSIX — atomic within the same filesystem.
+        tmp.persist(&target)
+            .map_err(|e| StoreError::Persist {
+                path: target,
+                source: e.error,
+            })?;
+
         Ok(())
     }
 
-    pub fn get(&self, id: &str) -> anyhow::Result<Option<T>> {
+    pub fn get(&self, id: &str) -> Result<Option<T>, StoreError> {
         let path = self.path_for(id);
         if !path.exists() {
             return Ok(None);
         }
 
-        let payload = fs::read(path)?;
-        let item = serde_json::from_slice(&payload)?;
+        let payload = fs::read(&path).map_err(|e| StoreError::Io {
+            path: path.clone(),
+            source: e,
+        })?;
+        let item = serde_json::from_slice(&payload).map_err(|e| StoreError::Deserialize {
+            path,
+            source: e,
+        })?;
         Ok(Some(item))
     }
 
-    pub fn list(&self) -> anyhow::Result<Vec<(String, T)>> {
+    /// List all stored entries.
+    ///
+    /// Individual corrupt or unreadable files are logged and skipped rather than
+    /// aborting the entire listing — a single bad file should not break the CLI.
+    pub fn list(&self) -> Result<Vec<(String, T)>, StoreError> {
         let mut items = Vec::new();
 
-        for entry in fs::read_dir(&self.dir)? {
-            let entry = entry?;
+        let entries = fs::read_dir(&self.dir).map_err(|e| StoreError::Io {
+            path: self.dir.clone(),
+            source: e,
+        })?;
+
+        for entry in entries {
+            let entry = entry.map_err(StoreError::IoRaw)?;
             let path = entry.path();
+
             if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
                 continue;
             }
@@ -54,22 +176,31 @@ impl<T: Serialize + DeserializeOwned> PersistedStore<T> {
                 None => continue,
             };
 
-            let payload = fs::read(path)?;
-            let item = serde_json::from_slice(&payload)?;
-            items.push((id, item));
+            match fs::read(&path).and_then(|payload| {
+                serde_json::from_slice::<T>(&payload)
+                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+            }) {
+                Ok(item) => items.push((id, item)),
+                Err(e) => {
+                    warn!(path = %path.display(), error = %e, "skipping corrupt store entry");
+                }
+            }
         }
 
         items.sort_by(|a, b| a.0.cmp(&b.0));
         Ok(items)
     }
 
-    pub fn delete(&self, id: &str) -> anyhow::Result<bool> {
+    pub fn delete(&self, id: &str) -> Result<bool, StoreError> {
         let path = self.path_for(id);
         if !path.exists() {
             return Ok(false);
         }
 
-        fs::remove_file(path)?;
+        fs::remove_file(&path).map_err(|e| StoreError::Io {
+            path,
+            source: e,
+        })?;
         Ok(true)
     }
 
@@ -158,6 +289,31 @@ mod tests {
     }
 
     #[test]
+    fn test_list_skips_corrupt_files() {
+        let temp = TempDir::new().unwrap();
+        let store = PersistedStore::<TestEntry>::new(temp.path()).unwrap();
+
+        // Write a valid entry.
+        store
+            .save(
+                "good",
+                &TestEntry {
+                    name: "good".to_string(),
+                    value: 1,
+                },
+            )
+            .unwrap();
+
+        // Manually write a corrupt JSON file.
+        fs::write(temp.path().join("bad.json"), b"NOT VALID JSON {{{").unwrap();
+
+        // list() should return only the valid entry, not abort.
+        let items = store.list().unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].0, "good");
+    }
+
+    #[test]
     fn test_delete() {
         let temp = TempDir::new().unwrap();
         let store = PersistedStore::<TestEntry>::new(temp.path()).unwrap();
@@ -210,6 +366,61 @@ mod tests {
         let loaded = store.get("k").unwrap().unwrap();
         assert_eq!(loaded.name, "new");
         assert_eq!(loaded.value, 2);
+    }
+
+    #[test]
+    fn test_overwrite_preserves_original_on_failure() {
+        // Simulate the guarantee: if a second save were to fail after
+        // writing the original, the original data must still be intact.
+        let temp = TempDir::new().unwrap();
+        let store = PersistedStore::<TestEntry>::new(temp.path()).unwrap();
+
+        let original = TestEntry {
+            name: "original".to_string(),
+            value: 42,
+        };
+        store.save("item", &original).unwrap();
+
+        // Verify original is readable.
+        let loaded = store.get("item").unwrap().unwrap();
+        assert_eq!(loaded, original);
+
+        // Write a second version — the atomic rename ensures no partial state.
+        let updated = TestEntry {
+            name: "updated".to_string(),
+            value: 99,
+        };
+        store.save("item", &updated).unwrap();
+        let loaded = store.get("item").unwrap().unwrap();
+        assert_eq!(loaded, updated);
+    }
+
+    #[test]
+    fn test_save_leaves_no_temp_files() {
+        let temp = TempDir::new().unwrap();
+        let store = PersistedStore::<TestEntry>::new(temp.path()).unwrap();
+
+        store
+            .save(
+                "clean",
+                &TestEntry {
+                    name: "clean".to_string(),
+                    value: 1,
+                },
+            )
+            .unwrap();
+
+        // After a successful save, the only file in the directory should
+        // be the final .json — no leftover temp files.
+        let files: Vec<_> = fs::read_dir(temp.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            files[0].path().file_name().unwrap().to_str().unwrap(),
+            "clean.json"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 📋 Summary

`PersistedStore::save()` in `mofa-cli` was not crash-safe: it called `fs::write()` directly on the target path, which truncates the file before writing. A process crash between those two kernel operations left the file empty or partially written — permanently corrupting persisted agent, plugin, or tool state with no recovery path.

This PR makes all writes atomic using a write-then-rename strategy, fixes `list()` to tolerate corrupt files without aborting, and replaces the `anyhow::Result` return types with a typed `StoreError` enum.

---

## 🔗 Related Issues

Closes #505 

---

## 🧠 Context

All three CLI-level persistent stores (agent store, plugin store, tool store) delegate to `PersistedStore<T>`, which backs `~/.local/share/mofa/` (or platform equivalent). Every `mofa agent create`, `mofa plugin install`, and similar write command goes through `save()`.

The old implementation:
```rust
fs::write(path, payload)?  // truncate → write: crash window exists here
```

On POSIX, `fs::write` is not atomic. The OS truncates the target file to zero bytes first, then writes. Any crash (OOM-kill, power loss, `SIGKILL`) between those steps destroys the stored record. There is no atomic fallback — the file is gone.

Additionally, `list()` used `?` when reading individual files, meaning a single pre-existing corrupt `.json` file (e.g. from a previous bad write) would abort the entire `mofa agent list` or `mofa plugin list` command, leaving the user unable to inspect any state.

---

## 🛠️ Changes

- **`save()` — atomic write-then-rename**: serialize into a `NamedTempFile` created in the same directory (guaranteeing same filesystem), `fsync` before rename, then atomically replace the target via `NamedTempFile::persist()` (`rename(2)` on POSIX). The previous file version is fully intact if anything fails before the rename commits.
- **`list()` — corrupt-file resilience**: individual unreadable or malformed files are now logged via `tracing::warn!` and skipped rather than propagating an error that aborts the entire listing.
- **Typed `StoreError` enum**: replaces bare `anyhow::Result` returns with a structured error type carrying path context and a proper `source()` chain, making errors debuggable and matchable by callers.
- **`Cargo.toml`**: `tempfile` promoted from `[dev-dependencies]` to `[dependencies]` since it is now used in production code.

---

## 🧪 How you Tested

1. Run the store unit tests:
   ```
   cargo test -p mofa-cli -- store
   ```
   All 11 tests pass, including three new ones:
   - `test_list_skips_corrupt_files` — verifies a corrupt `.json` file is skipped, not fatal
   - `test_save_leaves_no_temp_files` — verifies no temp files leak after a successful save
   - `test_overwrite_preserves_original_on_failure` — documents the atomicity guarantee on overwrite

2. Run clippy:
   ```
   cargo clippy -p mofa-cli -- -W clippy::all
   ```
   Zero warnings.

3. Run `cargo fmt` and verify no formatting changes.

---

## 📸 Screenshots / Logs (if applicable)

```
running 11 tests
test store::tests::test_delete ... ok
test store::tests::test_delete_nonexistent_returns_false ... ok
test store::tests::test_get_returns_none_for_missing ... ok
test store::tests::test_list_returns_all ... ok
test store::tests::test_list_skips_corrupt_files ... ok
test store::tests::test_overwrite ... ok
test store::tests::test_overwrite_preserves_original_on_failure ... ok
test store::tests::test_save_and_get ... ok
test store::tests::test_save_leaves_no_temp_files ... ok
test store::tests::test_survives_new_instance ... ok
test context::tests::test_agent_store_persists_across_context_instances ... ok
test result: ok. 11 passed; 0 failed; 0 ignored
```

---

## ⚠️ Breaking Changes

- [ ] No breaking changes
- [x] Breaking change (describe below)

`PersistedStore::new/save/get/list/delete` now return `Result<_, StoreError>` instead of `anyhow::Result`. Callers using `?` in `anyhow::Result` contexts are unaffected (`StoreError` implements `std::error::Error` so anyhow's blanket `From` converts it automatically). Direct `match` on the error type will need to use `StoreError` variants.

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [x] Public APIs documented
- [ ] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---

## 🚀 Deployment Notes (if applicable)

No migrations or config changes. Existing `.json` state files written by previous versions are fully compatible — the new code only changes how writes are performed, not the file format.

---

## 🧩 Additional Notes for Reviewers

The key invariant: `NamedTempFile::new_in(&self.dir)` places the temp file on the same filesystem as the target, which is required for `rename(2)` to be atomic. If the temp file were created in `/tmp` (a different mount), the rename would silently fall back to a copy+delete, losing the atomicity guarantee. The `new_in` call is intentional.
