### PR TITLE
fix(foundation): make test_protocol_registry actually execute assertions

### DIFF
--- a/crates/mofa-foundation/src/collaboration/types.rs
+++ b/crates/mofa-foundation/src/collaboration/types.rs
@@ -912,16 +912,11 @@ mod tests {
         assert!(json_content.to_text().contains("key"));
     }
 
-    #[test]
-    fn test_protocol_registry() {
+    #[tokio::test]
+    async fn test_protocol_registry() {
         let registry = ProtocolRegistry::new();
-
-        #[tokio::test]
-        async fn test_empty_registry() {
-            let registry = ProtocolRegistry::new();
-            assert_eq!(registry.count().await, 0);
-            assert!(registry.list_names().await.is_empty());
-        }
+        assert_eq!(registry.count().await, 0);
+        assert!(registry.list_names().await.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
Fix [test_protocol_registry](cci:1://file:///Users/rahul/mofa/crates/mofa-foundation/src/collaboration/types.rs:914:4-919:5) so it actually runs its assertions instead of passing vacuously.

## Motivation
The test was marked `#[test]` (synchronous) and contained a nested `async fn test_empty_registry()` decorated with `#[tokio::test]`. The inner function was **never called** — it was only defined and silently dropped. No assertions ever executed, so the test always passed regardless of actual behaviour of [ProtocolRegistry](cci:2://file:///Users/rahul/mofa/crates/mofa-foundation/src/collaboration/types.rs:541:0-543:1).

## Changes
- **[crates/mofa-foundation/src/collaboration/types.rs](cci:7://file:///Users/rahul/mofa/crates/mofa-foundation/src/collaboration/types.rs:0:0-0:0)**: Replaced the synchronous `#[test]` with a `#[tokio::test] async fn` and moved the assertions ([count()](cci:1://file:///Users/rahul/mofa/crates/mofa-foundation/src/collaboration/types.rs:591:4-596:5), [list_names()](cci:1://file:///Users/rahul/mofa/crates/mofa-foundation/src/collaboration/types.rs:584:4-589:5)) directly into the test body, removing the nested uncalled function.

## Related Issues
Closes #371

## Testing
- Ran `cargo test -p mofa-foundation -- test_protocol_registry` — test passes and assertions now execute.
- No production code changes; only test code was modified.

## Checklist
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-features -- -D errors` passes
- [x] `cargo test --workspace --all-features` passes
- [x] `cargo build --examples` succeeds
- [x] `cargo doc --workspace --no-deps --all-features` succeeds
- [x] Architecture layer rules respected (see CONTRIBUTING.md)
- [x] Relevant documentation updated
