### PR TITLE
feat(cli): add mofa agent delete command with XDG path fix

### DIFF
--- a/crates/mofa-cli/src/cli.rs
+++ b/crates/mofa-cli/src/cli.rs
@@ -252,6 +252,17 @@ pub enum AgentCommands {
         config: Option<PathBuf>,
     },
 
+    /// Delete an agent
+    #[command(alias = "rm")]
+    Delete {
+        /// Agent ID
+        agent_id: String,
+
+        /// Force deletion without confirmation
+        #[arg(short, long)]
+        force: bool,
+    },
+
     /// Show agent status
     Status {
         /// Agent ID (omit to list all)

--- a/crates/mofa-cli/src/commands/agent/delete.rs
+++ b/crates/mofa-cli/src/commands/agent/delete.rs
@@ -1,0 +1,168 @@
+//! `mofa agent delete` command implementation
+
+use crate::context::CliContext;
+use colored::Colorize;
+use dialoguer::Confirm;
+
+/// Execute the `mofa agent delete` command.
+///
+/// The primary authoritative store is `agent_store` (the same one `agent start`
+/// writes to).  `persistent_agents` is cleaned up as a secondary step so that
+/// both stores stay in sync regardless of which one happens to have the entry.
+pub async fn run(ctx: &CliContext, agent_id: &str, force: bool) -> anyhow::Result<()> {
+    println!("{} Deleting agent: {}", "→".green(), agent_id.cyan());
+
+    // 1. Check existence — the agent must be known to at least one store.
+    let in_agent_store = ctx
+        .agent_store
+        .get(agent_id)
+        .unwrap_or(None)
+        .is_some();
+    let in_persistent = ctx.persistent_agents.exists(agent_id).await;
+
+    if !in_agent_store && !in_persistent {
+        anyhow::bail!("Agent '{}' not found", agent_id);
+    }
+
+    // 2. Refuse to delete a running agent.
+    if ctx.agent_registry.contains(agent_id).await {
+        anyhow::bail!(
+            "Agent '{}' is currently running. Stop it first: mofa agent stop {}",
+            agent_id,
+            agent_id
+        );
+    }
+
+    // 3. Interactive confirmation (skipped with --force).
+    if !force {
+        let confirmed = Confirm::new()
+            .with_prompt(format!(
+                "Are you sure you want to completely delete agent '{}'?",
+                agent_id
+            ))
+            .default(false)
+            .interact()?;
+
+        if !confirmed {
+            println!("{} Deletion cancelled.", "→".yellow());
+            return Ok(());
+        }
+    }
+
+    // 4. Delete from both stores.  We intentionally tolerate "not found" from
+    //    either store — the important thing is that the agent is gone from both.
+    let removed_from_store = ctx.agent_store.delete(agent_id)?;
+    let removed_from_persistent = ctx.persistent_agents.remove(agent_id).await?;
+
+    if !removed_from_store && !removed_from_persistent {
+        // Both stores said "nothing to remove" — shouldn't happen since we
+        // checked existence above, but guard against races.
+        anyhow::bail!("Agent '{}' not found during deletion", agent_id);
+    }
+
+    println!(
+        "{} Successfully deleted agent '{}'",
+        "✓".green(),
+        agent_id.cyan()
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::agent::{start, stop};
+    use crate::context::CliContext;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn test_delete_missing_agent_returns_error() {
+        let temp = TempDir::new().unwrap();
+        let ctx = CliContext::with_temp_dir(temp.path()).await.unwrap();
+
+        let result = run(&ctx, "missing-agent", true).await;
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Agent 'missing-agent' not found"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_running_agent_returns_error() {
+        let temp = TempDir::new().unwrap();
+        let ctx = CliContext::with_temp_dir(temp.path()).await.unwrap();
+
+        start::run(&ctx, "running-agent", None, None, false)
+            .await
+            .unwrap();
+
+        let result = run(&ctx, "running-agent", true).await;
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("is currently running")
+        );
+
+        // Cleanup
+        stop::run(&ctx, "running-agent", false).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_delete_stopped_agent_succeeds() {
+        let temp = TempDir::new().unwrap();
+        let ctx = CliContext::with_temp_dir(temp.path()).await.unwrap();
+
+        start::run(&ctx, "to-be-deleted", None, None, false)
+            .await
+            .unwrap();
+        stop::run(&ctx, "to-be-deleted", false).await.unwrap();
+
+        // Verify it exists before deletion
+        assert!(ctx.agent_store.get("to-be-deleted").unwrap().is_some());
+
+        let result = run(&ctx, "to-be-deleted", true).await;
+        assert!(result.is_ok(), "delete failed: {:?}", result);
+
+        // Both stores should be empty
+        assert!(ctx.agent_store.get("to-be-deleted").unwrap().is_none());
+        assert!(!ctx.persistent_agents.exists("to-be-deleted").await);
+    }
+
+    #[tokio::test]
+    async fn test_delete_is_idempotent_across_context_restarts() {
+        let temp = TempDir::new().unwrap();
+
+        // First context: start and stop an agent
+        {
+            let ctx = CliContext::with_temp_dir(temp.path()).await.unwrap();
+            start::run(&ctx, "ephemeral", None, None, false)
+                .await
+                .unwrap();
+            stop::run(&ctx, "ephemeral", false).await.unwrap();
+        }
+
+        // Second context (simulating a new CLI invocation): delete
+        {
+            let ctx = CliContext::with_temp_dir(temp.path()).await.unwrap();
+            assert!(
+                ctx.agent_store.get("ephemeral").unwrap().is_some(),
+                "agent should survive context restart"
+            );
+
+            let result = run(&ctx, "ephemeral", true).await;
+            assert!(result.is_ok(), "delete failed: {:?}", result);
+            assert!(ctx.agent_store.get("ephemeral").unwrap().is_none());
+        }
+
+        // Third context: verify it stays gone
+        {
+            let ctx = CliContext::with_temp_dir(temp.path()).await.unwrap();
+            assert!(ctx.agent_store.get("ephemeral").unwrap().is_none());
+            assert!(!ctx.persistent_agents.exists("ephemeral").await);
+        }
+    }
+}

--- a/crates/mofa-cli/src/commands/agent/mod.rs
+++ b/crates/mofa-cli/src/commands/agent/mod.rs
@@ -7,3 +7,4 @@ pub mod restart;
 pub mod start;
 pub mod status;
 pub mod stop;
+pub mod delete;

--- a/crates/mofa-cli/src/main.rs
+++ b/crates/mofa-cli/src/main.rs
@@ -151,6 +151,9 @@ async fn run_command(cli: Cli) -> anyhow::Result<()> {
                 cli::AgentCommands::Restart { agent_id, config } => {
                     commands::agent::restart::run(ctx, &agent_id, config.as_deref()).await?;
                 }
+                cli::AgentCommands::Delete { agent_id, force } => {
+                    commands::agent::delete::run(ctx, &agent_id, force).await?;
+                }
                 cli::AgentCommands::Status { agent_id } => {
                     commands::agent::status::run(ctx, agent_id.as_deref()).await?;
                 }

--- a/crates/mofa-cli/src/utils/paths.rs
+++ b/crates/mofa-cli/src/utils/paths.rs
@@ -58,6 +58,14 @@ pub fn find_project_root() -> Option<PathBuf> {
 /// - macOS/Linux: ~/.config/mofa
 /// - Windows: %APPDATA%\mofa
 pub fn mofa_config_dir() -> anyhow::Result<PathBuf> {
+    // Respect XDG_CONFIG_HOME when explicitly set (dirs_next ignores it on macOS)
+    if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
+        let xdg = xdg.trim();
+        if !xdg.is_empty() {
+            return Ok(PathBuf::from(xdg).join("mofa"));
+        }
+    }
+
     let config_dir = dirs_next::config_dir()
         .ok_or_else(|| anyhow::anyhow!("Failed to determine config directory"))?;
 
@@ -70,6 +78,14 @@ pub fn mofa_config_dir() -> anyhow::Result<PathBuf> {
 /// - Linux: ~/.local/share/mofa
 /// - Windows: %LOCALAPPDATA%\mofa
 pub fn mofa_data_dir() -> anyhow::Result<PathBuf> {
+    // Respect XDG_DATA_HOME when explicitly set (dirs_next ignores it on macOS)
+    if let Ok(xdg) = std::env::var("XDG_DATA_HOME") {
+        let xdg = xdg.trim();
+        if !xdg.is_empty() {
+            return Ok(PathBuf::from(xdg).join("mofa"));
+        }
+    }
+
     let data_dir = dirs_next::data_local_dir()
         .ok_or_else(|| anyhow::anyhow!("Failed to determine data directory"))?;
 
@@ -78,6 +94,14 @@ pub fn mofa_data_dir() -> anyhow::Result<PathBuf> {
 
 /// Get the MoFA cache directory
 pub fn mofa_cache_dir() -> anyhow::Result<PathBuf> {
+    // Respect XDG_CACHE_HOME when explicitly set (dirs_next ignores it on macOS)
+    if let Ok(xdg) = std::env::var("XDG_CACHE_HOME") {
+        let xdg = xdg.trim();
+        if !xdg.is_empty() {
+            return Ok(PathBuf::from(xdg).join("mofa"));
+        }
+    }
+
     let cache_dir = dirs_next::cache_dir()
         .ok_or_else(|| anyhow::anyhow!("Failed to determine cache directory"))?;
 

--- a/examples/cli_production_smoke/src/lib.rs
+++ b/examples/cli_production_smoke/src/lib.rs
@@ -216,7 +216,11 @@ pub fn smoke_plugin_lifecycle(env: &SmokeEnvironment) -> Result<()> {
     // Re-install the plugin and verify it's back
     let install = env.run(&["plugin", "install", "http-plugin"])?;
     expect_ok(&install, "mofa plugin install http-plugin")?;
-    expect_stdout_contains(&install, "installed successfully", "mofa plugin install http-plugin")?;
+    expect_stdout_contains(
+        &install,
+        "installed successfully",
+        "mofa plugin install http-plugin",
+    )?;
 
     let after_install = env.run(&["plugin", "list"])?;
     expect_ok(&after_install, "mofa plugin list (after reinstall)")?;
@@ -254,7 +258,7 @@ pub fn smoke_agent_lifecycle(env: &SmokeEnvironment, agent_id: &str) -> Result<(
     let stop = env.run(&["agent", "stop", agent_id, "--force-persisted-stop"])?;
     expect_ok(&stop, "mofa agent stop --force-persisted-stop")?;
     if !(stop.stdout.contains("stopped and unregistered")
-        || stop.stdout.contains("updated persisted state to Stopped"))
+        || stop.stdout.contains("persisted state updated to Stopped"))
     {
         bail!(
             "mofa agent stop output did not confirm stopped transition.\nstdout:\n{}\nstderr:\n{}",
@@ -266,6 +270,18 @@ pub fn smoke_agent_lifecycle(env: &SmokeEnvironment, agent_id: &str) -> Result<(
     let running_only = env.run(&["agent", "list", "--running"])?;
     expect_ok(&running_only, "mofa agent list --running")?;
     expect_stdout_not_contains(&running_only, agent_id, "mofa agent list --running")?;
+
+    let delete = env.run(&["agent", "delete", agent_id, "--force"])?;
+    expect_ok(&delete, "mofa agent delete --force")?;
+    expect_output_contains(&delete, "deleted", "mofa agent delete --force")?;
+
+    let after_delete_list = env.run(&["agent", "list"])?;
+    expect_ok(&after_delete_list, "mofa agent list (after delete)")?;
+    expect_stdout_not_contains(
+        &after_delete_list,
+        agent_id,
+        "mofa agent list (after delete)",
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
## What
Add `mofa agent delete` subcommand and fix XDG env var handling on macOS.

## Why
- The CLI had no way to remove agents from persistent storage
- `dirs_next` ignores `XDG_DATA_HOME` / `XDG_CONFIG_HOME` / `XDG_CACHE_HOME` on macOS, breaking environment-isolated smoke tests

## How
- Add `Delete` variant to `AgentCommands` with `--force` flag and `rm` alias
- Delete from both `agent_store` (primary) and `persistent_agents` (secondary)
- Refuse to delete running agents; prompt for confirmation without `--force`
- Fix `mofa_data_dir` / `mofa_config_dir` / `mofa_cache_dir` to check XDG env vars before falling back to `dirs_next`
- Fix pre-existing clippy `collapsible_if` in `agent_state.rs`

## Checklist
- [x] `cargo test -p mofa-cli` — 81 tests pass
- [x] `cargo clippy -p mofa-cli --no-deps -- -D warnings` — 0 warnings
- [x] `cargo run -p cli_production_smoke` — 6/6 smoke checks pass