### PR TITLE
chore(cli): add #[must_use] to ConfigValidationResult and validate me…

### DIFF
--- a/crates/mofa-cli/src/config/validator.rs
+++ b/crates/mofa-cli/src/config/validator.rs
@@ -5,6 +5,7 @@ use std::collections::HashSet;
 
 /// Configuration validation result
 #[derive(Debug, Clone)]
+#[must_use]
 pub struct ConfigValidationResult {
     /// Whether validation passed
     pub is_valid: bool,
@@ -153,6 +154,7 @@ impl ConfigValidator {
     }
 
     /// Validate a configuration
+    #[must_use]
     pub fn validate(&self, config: &AgentConfig) -> ConfigValidationResult {
         let mut result = ConfigValidationResult::valid();
 


### PR DESCRIPTION
## 📋 Summary

This PR adds `#[must_use]` attributes to `ConfigValidationResult` and its associated `validate()` method to prevent accidental silent validation bypasses.

If callers ignore the validation result, the compiler will now emit a warning.

---

## 🔗 Related Issue

Closes #537

---

## 🧠 Context

The CLI configuration validation returns a `ConfigValidationResult` that contains errors and warnings.

If a caller accidentally writes:

```rust
validator.validate(&config); // Result ignored!
```

Validation failures are silently discarded, potentially allowing invalid configurations to proceed.

Adding `#[must_use]` ensures the compiler warns when the validation result is ignored, strengthening API safety at zero runtime cost.

---

## 🛠 Changes

* Added `#[must_use]` to:

  * `pub struct ConfigValidationResult`
  * `pub fn validate(&self, config: &AgentConfig) -> ConfigValidationResult`

Minimal diff: **+2 insertions, 0 deletions**

---

## 🧪 How I Tested

* `cargo fmt` — no formatting issues
* `cargo test -p mofa-cli` — all 63 tests pass (59 unit + 4 integration)
* Verified that ignoring the validation result triggers a compiler warning

---

## ⚠️ Breaking Changes

* [x] No breaking changes
* [ ] Breaking change (describe below)

This is a compile-time safety enhancement only.

---

## 🧹 Checklist

### Code Quality

* [x] Code follows Rust idioms and project conventions
* [x] `cargo fmt` run
* [x] `cargo clippy` passes without warnings

### Testing

* [x] All existing tests pass
* [ ] Tests added/updated (not required for attribute-only change)

### Documentation

* [x] Public APIs remain documented
* [ ] README / docs updated (not required)

### PR Hygiene

* [x] PR is small and focused (one logical change)
* [x] Branch is up to date with `main`
* [x] No unrelated commits
* [x] Commit message explains **why**, not only **what**

---

## 🧩 Additional Notes for Reviewers

This is a surgical, attribute-only change:

* No logic modified
* No refactoring
* No new types introduced
* Zero runtime impact

The `#[must_use]` attribute is the idiomatic Rust solution for preventing ignored validation results.