### PR TITLE
chore(kernel): add #[must_use] to public builder build() methods

### DIFF
--- a/crates/mofa-cli/src/output/table.rs
+++ b/crates/mofa-cli/src/output/table.rs
@@ -32,6 +32,7 @@ impl TableBuilder {
     }
 
     /// Build the table
+    #[must_use]
     pub fn build(self) -> Table {
         Table {
             inner: {

--- a/crates/mofa-extra/src/rhai/rules.rs
+++ b/crates/mofa-extra/src/rhai/rules.rs
@@ -990,6 +990,7 @@ impl RuleBuilder {
         self
     }
 
+    #[must_use]
     pub fn build(self) -> RuleDefinition {
         self.rule
     }

--- a/crates/mofa-extra/src/rhai/tools.rs
+++ b/crates/mofa-extra/src/rhai/tools.rs
@@ -809,6 +809,7 @@ impl ToolBuilder {
         self
     }
 
+    #[must_use]
     pub fn build(self) -> ScriptToolDefinition {
         self.definition
     }

--- a/crates/mofa-foundation/src/llm/agent.rs
+++ b/crates/mofa-foundation/src/llm/agent.rs
@@ -2772,6 +2772,7 @@ impl LLMAgentBuilder {
     /// # Panics
     /// 如果未设置 provider 则 panic
     /// Panics if the provider is not set
+    #[must_use]
     pub fn build(self) -> LLMAgent {
         let provider = self
             .provider

--- a/crates/mofa-foundation/src/llm/agent_workflow.rs
+++ b/crates/mofa-foundation/src/llm/agent_workflow.rs
@@ -988,6 +988,7 @@ impl AgentWorkflowBuilder {
 
     /// 构建工作流
     /// Build the workflow
+    #[must_use]
     pub fn build(self) -> AgentWorkflow {
         // 构建邻接表
         // Build adjacency list

--- a/crates/mofa-foundation/src/llm/multi_agent.rs
+++ b/crates/mofa-foundation/src/llm/multi_agent.rs
@@ -465,6 +465,7 @@ impl AgentTeamBuilder {
 
     /// 构建团队
     /// Build team
+    #[must_use]
     pub fn build(self) -> AgentTeam {
         let member_map: HashMap<String, usize> = self
             .members

--- a/crates/mofa-foundation/src/orchestrator/pipeline.rs
+++ b/crates/mofa-foundation/src/orchestrator/pipeline.rs
@@ -209,6 +209,7 @@ impl PipelineBuilder {
     }
 
     /// Build the configured pipeline
+    #[must_use]
     pub fn build(self) -> InferencePipeline {
         InferencePipeline {
             stages: self.stages,

--- a/crates/mofa-foundation/src/secretary/core.rs
+++ b/crates/mofa-foundation/src/secretary/core.rs
@@ -497,6 +497,7 @@ where
 
     /// 构建秘书核心
     /// Build secretary core
+    #[must_use]
     pub fn build(self) -> SecretaryCore<B> {
         SecretaryCore::with_config(self.behavior, self.config)
     }

--- a/crates/mofa-foundation/src/secretary/default/behavior.rs
+++ b/crates/mofa-foundation/src/secretary/default/behavior.rs
@@ -791,6 +791,7 @@ impl DefaultSecretaryBuilder {
 
     /// 构建秘书行为
     /// Build secretary behavior
+    #[must_use]
     pub fn build(self) -> DefaultSecretaryBehavior {
         let mut behavior = DefaultSecretaryBehavior::new(self.config);
 

--- a/crates/mofa-foundation/src/workflow/builder.rs
+++ b/crates/mofa-foundation/src/workflow/builder.rs
@@ -388,6 +388,7 @@ impl WorkflowBuilder {
 
     /// 构建工作流图
     /// Build workflow graph
+    #[must_use]
     pub fn build(self) -> WorkflowGraph {
         self.graph
     }

--- a/crates/mofa-kernel/src/agent/capabilities.rs
+++ b/crates/mofa-kernel/src/agent/capabilities.rs
@@ -330,6 +330,7 @@ impl AgentCapabilitiesBuilder {
 
     /// 构建能力描述
     /// Build the capability description
+    #[must_use]
     pub fn build(self) -> AgentCapabilities {
         self.capabilities
     }
@@ -532,6 +533,7 @@ impl AgentRequirementsBuilder {
 
     /// 构建需求描述
     /// Build the requirements description
+    #[must_use]
     pub fn build(self) -> AgentRequirements {
         self.requirements
     }

--- a/crates/mofa-kernel/src/agent/secretary/context.rs
+++ b/crates/mofa-kernel/src/agent/secretary/context.rs
@@ -180,6 +180,7 @@ impl<State> SecretaryContextBuilder<State> {
 
     /// 构建上下文
     /// Builds the context
+    #[must_use]
     pub fn build(self) -> SecretaryContext<State> {
         SecretaryContext {
             state: self.state,

--- a/crates/mofa-kernel/src/agent/types/event.rs
+++ b/crates/mofa-kernel/src/agent/types/event.rs
@@ -185,6 +185,7 @@ impl EventBuilder {
 
     /// 构建事件
     /// Build event
+    #[must_use]
     pub fn build(self) -> GlobalEvent {
         self.event
     }

--- a/crates/mofa-runtime/src/dora_adapter/runtime.rs
+++ b/crates/mofa-runtime/src/dora_adapter/runtime.rs
@@ -546,6 +546,7 @@ impl DoraRuntimeBuilder {
 
     /// 构建运行时
     /// Build runtime
+    #[must_use]
     pub fn build(self) -> DoraRuntime {
         DoraRuntime::new(self.config)
     }


### PR DESCRIPTION
## 📋 Summary

Add `#[must_use]` attributes to public `build()` methods on builder types across the workspace. Ignoring the return value of a builder's `build()` method is always a bug — the constructed object would be silently discarded. This PR makes the compiler catch that mistake at compile time.

---

## 🔗 Related Issues

Closes #545 

---

## 🧠 Context

Builder patterns throughout MoFA consume `self` and return a fully constructed object. If a caller writes `builder.build();` without binding the result, the built object is immediately dropped — a silent logic error. Rust's `#[must_use]` attribute turns this into a compiler warning, catching the mistake early.

Only methods that return a concrete, non-Result object are annotated. Methods returning `Result` are excluded because `Result` already carries `#[must_use]`.

---

## 🛠️ Changes

- Added `#[must_use]` to 15 public `build(self)` methods across mofa-kernel, mofa-foundation, mofa-runtime, mofa-cli, and mofa-extra
- No logic, formatting, or signature changes
- Diff: **14 files changed, 15 insertions(+), 0 deletions**

---

## 🧪 How you Tested

1. `cargo check` — compiles successfully
2. `cargo test -p mofa-kernel -p mofa-foundation -p mofa-cli -p mofa-extra` — all tests pass
3. `cargo clippy -p mofa-kernel -p mofa-foundation -p mofa-cli -p mofa-extra -p mofa-runtime` — no new warnings

---

## ⚠️ Breaking Changes

- [x] No breaking changes

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms
- [x] `cargo fmt` run
- [x] `cargo clippy` passes

### Testing
- [x] All tests pass

### PR Hygiene
- [x] PR is small and focused
- [x] Branch up to date with main

---

## 🧩 Additional Notes for Reviewers

- Methods returning `Result`/`LLMResult`/`PromptResult` were excluded (already have `#[must_use]`)
- `CustomToolBuilder::build()` excluded (returning `None` is valid non-error outcome)
- Zero runtime impact