### PR TITLE
chore(cli): add #[must_use] to ConfigValidator::validate()

### DIFF
--- a/crates/mofa-cli/src/config/validator.rs
+++ b/crates/mofa-cli/src/config/validator.rs
@@ -153,6 +153,7 @@ impl ConfigValidator {
     }
 
     /// Validate a configuration
+    #[must_use]
     pub fn validate(&self, config: &AgentConfig) -> ConfigValidationResult {
         let mut result = ConfigValidationResult::valid();
 


### PR DESCRIPTION
## 📋 Summary

Add `#[must_use]` to `ConfigValidator::validate()` so the compiler warns when its return value is silently discarded. Ignoring a `ConfigValidationResult` means validation errors go unnoticed — this attribute catches that mistake at compile time.

## 🔗 Related Issues

Closes #543

---

## 🧠 Context

`ConfigValidator::validate()` returns a `ConfigValidationResult` containing any errors or warnings found during config validation. If a caller writes `validator.validate(&config);` without inspecting the result, all validation findings are silently dropped. Adding `#[must_use]` makes Rust emit a warning in this case, enforcing correct usage at the API level.

---

## 🛠️ Changes

- Added `#[must_use]` attribute to `ConfigValidator::validate(&self, config: &AgentConfig) -> ConfigValidationResult`

---

## 🧪 How you Tested

1. `cargo check -p mofa-cli` — compiles with zero errors
2. `cargo test -p mofa-cli` — 82 tests passed, 0 failed
3. `cargo clippy -p mofa-cli` — no new warnings introduced
4. `git diff upstream/main` — confirms exactly 1 file changed, 1 insertion, 0 deletions

---

## 📸 Screenshots / Logs (if applicable)

---

## ⚠️ Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (describe below)

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [ ] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [ ] Public APIs documented
- [ ] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---

## 🚀 Deployment Notes (if applicable)

None — attribute-only change with no runtime impact.

---

## 🧩 Additional Notes for Reviewers

Single-line attribute addition. The branch is based on `upstream/main`. No logic, formatting, or visibility changes.