### PR TITLE
refactor: remove anyhow from all lib crates, use typed errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4931,7 +4931,6 @@ dependencies = [
 name = "mofa-extra"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "regex",
  "rhai",
@@ -4966,7 +4965,6 @@ dependencies = [
 name = "mofa-foundation"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-openai",
  "async-trait",
  "base64 0.22.1",
@@ -5006,7 +5004,6 @@ dependencies = [
 name = "mofa-kernel"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "base64 0.22.1",
  "bincode 1.3.3",
@@ -5033,7 +5030,6 @@ version = "0.1.0"
 name = "mofa-monitoring"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "axum 0.8.8",
  "chrono",
@@ -5063,7 +5059,6 @@ dependencies = [
 name = "mofa-plugins"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "backoff",
  "chrono",
@@ -5104,7 +5099,6 @@ dependencies = [
 name = "mofa-runtime"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "bincode 1.3.3",
  "chrono",
@@ -5135,7 +5129,6 @@ dependencies = [
 name = "mofa-sdk"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "mofa-extra",
  "mofa-foundation",

--- a/crates/mofa-extra/Cargo.toml
+++ b/crates/mofa-extra/Cargo.toml
@@ -31,7 +31,6 @@ tokio = { workspace = true }
 async-trait = { workspace = true }
 
 # Error handling
-anyhow = { workspace = true }
 thiserror = { workspace = true }
 
 # Utilities

--- a/crates/mofa-extra/src/rhai/error.rs
+++ b/crates/mofa-extra/src/rhai/error.rs
@@ -1,0 +1,54 @@
+//! Typed errors for the Rhai scripting subsystem.
+//!
+//! Rhai engine, tool, workflow, and rule operations.
+
+use thiserror::Error;
+
+/// Errors that can occur in the Rhai scripting subsystem.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum RhaiError {
+    /// Script compilation failed.
+    #[error("Compile error: {0}")]
+    CompileError(String),
+
+    /// Script execution failed at runtime.
+    #[error("Execution error: {0}")]
+    ExecutionError(String),
+
+    /// An I/O error (e.g. reading a script file).
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// A (de)serialization error.
+    #[error("Serialization error: {0}")]
+    Serialization(String),
+
+    /// Validation of input/parameters failed.
+    #[error("Validation error: {0}")]
+    ValidationError(String),
+
+    /// A requested resource was not found.
+    #[error("Not found: {0}")]
+    NotFound(String),
+
+    /// Catch-all.
+    #[error("{0}")]
+    Other(String),
+}
+
+/// Convenience result alias for the Rhai subsystem.
+pub type RhaiResult<T> = Result<T, RhaiError>;
+
+// Conversion helpers
+impl From<serde_json::Error> for RhaiError {
+    fn from(err: serde_json::Error) -> Self {
+        RhaiError::Serialization(err.to_string())
+    }
+}
+
+impl From<serde_yaml::Error> for RhaiError {
+    fn from(err: serde_yaml::Error) -> Self {
+        RhaiError::Serialization(err.to_string())
+    }
+}

--- a/crates/mofa-extra/src/rhai/mod.rs
+++ b/crates/mofa-extra/src/rhai/mod.rs
@@ -15,11 +15,13 @@
 //! 5. Hot-reload script support
 
 pub mod engine;
+pub mod error;
 pub mod rules;
 pub mod tools;
 pub mod workflow;
 
 pub use engine::*;
+pub use error::*;
 pub use rules::*;
 pub use tools::*;
 pub use workflow::*;

--- a/crates/mofa-foundation/Cargo.toml
+++ b/crates/mofa-foundation/Cargo.toml
@@ -39,7 +39,6 @@ uuid.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 futures.workspace = true
-anyhow.workspace = true
 tokio-stream = { workspace = true }
 tracing.workspace = true
 rand.workspace = true

--- a/crates/mofa-foundation/src/config.rs
+++ b/crates/mofa-foundation/src/config.rs
@@ -34,6 +34,7 @@
 //!   default_timeout_secs: 30
 //! ```
 
+use mofa_kernel::agent::types::error::{GlobalError, GlobalResult};
 use mofa_kernel::config::{from_str, load_config};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -200,14 +201,14 @@ impl Default for RuntimeConfig {
 impl AgentYamlConfig {
     /// 从文件加载配置 (自动检测格式)
     /// Load config from file (auto-detect format)
-    pub fn from_file(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+    pub fn from_file(path: impl AsRef<Path>) -> GlobalResult<Self> {
         let path_str = path.as_ref().to_string_lossy().to_string();
-        load_config(&path_str).map_err(|e| anyhow::anyhow!("Failed to load config: {}", e))
+        load_config(&path_str).map_err(|e| GlobalError::Other(format!("Failed to load config: {}", e)))
     }
 
     /// 从字符串解析配置 (指定格式)
     /// Parse config from string (specified format)
-    pub fn from_str_with_format(content: &str, format: &str) -> anyhow::Result<Self> {
+    pub fn from_str_with_format(content: &str, format: &str) -> GlobalResult<Self> {
         use config::FileFormat;
 
         let file_format = match format.to_lowercase().as_str() {
@@ -217,15 +218,15 @@ impl AgentYamlConfig {
             "ini" => FileFormat::Ini,
             "ron" => FileFormat::Ron,
             "json5" => FileFormat::Json5,
-            _ => return Err(anyhow::anyhow!("Unsupported config format: {}", format)),
+            _ => return Err(GlobalError::Other(format!("Unsupported config format: {}", format))),
         };
 
-        from_str(content, file_format).map_err(|e| anyhow::anyhow!("Failed to parse config: {}", e))
+        from_str(content, file_format).map_err(|e| GlobalError::Other(format!("Failed to parse config: {}", e)))
     }
 
     /// 从字符串解析配置 (自动检测为 YAML)
     /// Parse config from string (defaults to YAML)
-    pub fn parse(content: &str) -> anyhow::Result<Self> {
+    pub fn parse(content: &str) -> GlobalResult<Self> {
         Self::from_str_with_format(content, "yaml")
     }
 }

--- a/crates/mofa-foundation/src/coordination/mod.rs
+++ b/crates/mofa-foundation/src/coordination/mod.rs
@@ -1,3 +1,4 @@
+use mofa_kernel::agent::types::error::{GlobalError, GlobalResult};
 mod scheduler;
 use mofa_kernel::message::{AgentMessage, TaskRequest, TaskStatus};
 use mofa_kernel::{AgentBus, CommunicationMode};
@@ -49,7 +50,7 @@ impl AgentCoordinator {
 
     /// 注册智能体角色（如 "master"/"worker"/"data_provider"）
     /// Register agent roles (e.g., "master"/"worker"/"data_provider")
-    pub async fn register_role(&self, agent_id: &str, role: &str) -> anyhow::Result<()> {
+    pub async fn register_role(&self, agent_id: &str, role: &str) -> GlobalResult<()> {
         let mut role_map = self.role_mapping.write().await;
         role_map
             .entry(role.to_string())
@@ -60,7 +61,7 @@ impl AgentCoordinator {
 
     /// 执行协同任务：根据策略自动分配任务给对应角色的智能体
     /// Execute coordination task: auto-assign tasks based on strategy and roles
-    pub async fn coordinate_task(&self, task_msg: &AgentMessage) -> anyhow::Result<()> {
+    pub async fn coordinate_task(&self, task_msg: &AgentMessage) -> GlobalResult<()> {
         match &self.strategy {
             CoordinationStrategy::MasterSlave => self.master_slave_coordinate(task_msg).await,
             CoordinationStrategy::Pipeline => self.pipeline_coordinate(task_msg).await,
@@ -70,31 +71,31 @@ impl AgentCoordinator {
 
     /// 对外暴露的接口：提交带优先级的任务
     /// Public interface: Submit tasks with priority levels
-    pub async fn submit_priority_task(&self, task: TaskRequest) -> anyhow::Result<()> {
+    pub async fn submit_priority_task(&self, task: TaskRequest) -> GlobalResult<()> {
         self.scheduler.submit_task(task).await
     }
 
     /// 主从模式协同逻辑（核心示例）
     /// Master-Slave coordination logic (Core example)
-    async fn master_slave_coordinate(&self, task_msg: &AgentMessage) -> anyhow::Result<()> {
+    async fn master_slave_coordinate(&self, task_msg: &AgentMessage) -> GlobalResult<()> {
         let role_map = self.role_mapping.read().await;
         // 1. 获取主智能体（负责任务分配）
         // 1. Get the Master agent (responsible for task distribution)
         let masters = role_map
             .get("master")
-            .ok_or_else(|| anyhow::anyhow!("No master agent registered"))?;
+            .ok_or_else(|| GlobalError::Other("No master agent registered".to_string()))?;
         let master_id = &masters[0];
         // 2. 获取所有 worker 智能体（负责执行任务）
         // 2. Get all worker agents (responsible for task execution)
         let workers = role_map
             .get("worker")
-            .ok_or_else(|| anyhow::anyhow!("No worker agents registered"))?;
+            .ok_or_else(|| GlobalError::Other("No worker agents registered".to_string()))?;
 
         // 3. 主智能体广播任务给所有 worker
         // 3. Master agent broadcasts the task to all workers
         self.bus
             .send_message(master_id, CommunicationMode::Broadcast, task_msg)
-            .await?;
+            .await.map_err(|e| GlobalError::Other(e.to_string()))?;
 
         // 4. 跟踪任务状态（简化示例）
         // 4. Track task status (Simplified example)
@@ -109,7 +110,7 @@ impl AgentCoordinator {
 
     /// 流水线模式协同逻辑（任务串行传递）
     /// Pipeline coordination logic (Serial task transmission)
-    async fn pipeline_coordinate(&self, task_msg: &AgentMessage) -> anyhow::Result<()> {
+    async fn pipeline_coordinate(&self, task_msg: &AgentMessage) -> GlobalResult<()> {
         let role_map = self.role_mapping.read().await;
         // 按流水线阶段顺序获取角色（如 "stage1_extract" → "stage2_process" → "stage3_output"）
         // Get roles by pipeline sequence (e.g., "stage1_extract" -> "stage2_process" -> "stage3_output")
@@ -119,7 +120,7 @@ impl AgentCoordinator {
         for stage in stages {
             let agents = role_map
                 .get(stage)
-                .ok_or_else(|| anyhow::anyhow!("No agent for stage {}", stage))?;
+                .ok_or_else(|| GlobalError::Other(format!("No agent for stage {}", stage)))?;
             let agent_id = &agents[0];
             // 传递上一阶段输出作为当前阶段输入
             // Pass the output of the previous stage as current stage input
@@ -138,7 +139,7 @@ impl AgentCoordinator {
                     CommunicationMode::PointToPoint(agent_id.to_string()),
                     &current_msg,
                 )
-                .await?;
+                .await.map_err(|e| GlobalError::Other(e.to_string()))?;
             // 接收当前阶段输出（简化示例）
             // Receive current stage output (Simplified example)
             if let Some(AgentMessage::TaskResponse { result, .. }) = self
@@ -147,7 +148,8 @@ impl AgentCoordinator {
                     agent_id,
                     CommunicationMode::PointToPoint("coordinator".to_string()),
                 )
-                .await?
+                .await
+                .map_err(|e| GlobalError::Other(e.to_string()))?
             {
                 last_output = Some(result);
             }

--- a/crates/mofa-foundation/src/coordination/scheduler.rs
+++ b/crates/mofa-foundation/src/coordination/scheduler.rs
@@ -1,3 +1,4 @@
+use mofa_kernel::agent::types::error::{GlobalError, GlobalResult};
 use mofa_kernel::message::{AgentEvent, AgentMessage, SchedulingStatus, TaskPriority, TaskRequest};
 use mofa_kernel::{AgentBus, CommunicationMode};
 use std::collections::{BinaryHeap, HashMap};
@@ -59,7 +60,7 @@ impl PriorityScheduler {
 
     /// 1. 提交任务到优先级队列
     /// 1. Submit task to the priority queue
-    pub async fn submit_task(&self, task: TaskRequest) -> anyhow::Result<()> {
+    pub async fn submit_task(&self, task: TaskRequest) -> GlobalResult<()> {
         let priority_task = PriorityTask {
             priority: task.priority.clone(),
             task: task.clone(),
@@ -76,13 +77,13 @@ impl PriorityScheduler {
             .insert(task.task_id, SchedulingStatus::Pending);
         // 提交后立即触发调度
         // Trigger scheduling immediately after submission
-        self.schedule().await?;
+        self.schedule().await.map_err(|e| GlobalError::Other(e.to_string()))?;
         Ok(())
     }
 
     /// 2. 核心调度逻辑：选高优先级任务 + 选负载最低的智能体
     /// 2. Core logic: select high-priority task + select lowest-load agent
-    pub async fn schedule(&self) -> anyhow::Result<()> {
+    pub async fn schedule(&self) -> GlobalResult<()> {
         let mut task_queue = self.task_queue.write().await;
         let mut agent_load = self.agent_load.write().await;
         let mut task_status = self.task_status.write().await;
@@ -100,7 +101,7 @@ impl PriorityScheduler {
 
             // 选择负载最低的可用智能体（同角色内）
             // Select the available agent with the lowest load (within the same role)
-            let target_agent = self.select_low_load_agent("worker").await?;
+            let target_agent = self.select_low_load_agent("worker").await.map_err(|e| GlobalError::Other(e.to_string()))?;
             if target_agent.is_empty() {
                 // 无可用智能体，重新入队
                 // No agent available, re-enqueue the task
@@ -111,7 +112,7 @@ impl PriorityScheduler {
 
             // 检查是否需要抢占：如果目标智能体有低优先级任务在运行
             // Check for preemption: if the target agent has low-priority tasks running
-            self.preempt_low_priority_task(&target_agent, &task).await?;
+            self.preempt_low_priority_task(&target_agent, &task).await.map_err(|e| GlobalError::Other(e.to_string()))?;
 
             // 发送任务给目标智能体
             // Send task to the target agent
@@ -126,7 +127,7 @@ impl PriorityScheduler {
                     CommunicationMode::PointToPoint(target_agent.clone()),
                     &task_msg,
                 )
-                .await?;
+                .await.map_err(|e| GlobalError::Other(e.to_string()))?;
 
             // 更新状态和负载
             // Update task status and agent loa
@@ -142,11 +143,11 @@ impl PriorityScheduler {
 
     /// 3. 负载均衡：选择同角色内负载最低的智能体
     /// 3. Load balancing: select the lowest-load agent within the same role
-    async fn select_low_load_agent(&self, role: &str) -> anyhow::Result<Vec<String>> {
+    async fn select_low_load_agent(&self, role: &str) -> GlobalResult<Vec<String>> {
         let role_map = self.role_mapping.read().await;
         let agents = role_map
             .get(role)
-            .ok_or_else(|| anyhow::anyhow!("No agent for role: {}", role))?;
+            .ok_or_else(|| GlobalError::Other(format!("No agent for role: {}", role)))?;
         let agent_load = self.agent_load.read().await;
 
         // 按负载升序排序，取负载最低的
@@ -162,7 +163,7 @@ impl PriorityScheduler {
         &self,
         agent_id: &str,
         high_priority_task: &TaskRequest,
-    ) -> anyhow::Result<()> {
+    ) -> GlobalResult<()> {
         // 简化实现：直接发送抢占事件
         // Simplified implementation: directly send a preemption event
         let agent_load = self.agent_load.read().await;
@@ -206,7 +207,7 @@ impl PriorityScheduler {
                         CommunicationMode::PointToPoint(agent_id.to_string()),
                         &preempt_msg,
                     )
-                    .await?;
+                    .await.map_err(|e| GlobalError::Other(e.to_string()))?;
             }
         }
         Ok(())
@@ -214,7 +215,7 @@ impl PriorityScheduler {
 
     /// 5. 任务完成后更新状态和负载
     /// 5. Update status and load upon task completion
-    pub async fn on_task_completed(&self, agent_id: &str, task_id: &str) -> anyhow::Result<()> {
+    pub async fn on_task_completed(&self, agent_id: &str, task_id: &str) -> GlobalResult<()> {
         let mut agent_load = self.agent_load.write().await;
         let mut task_status = self.task_status.write().await;
         let mut agent_tasks = self.agent_tasks.write().await;
@@ -231,7 +232,7 @@ impl PriorityScheduler {
 
         // 任务完成后再次触发调度，处理队列中的下一个任务
         // Trigger scheduling again after completion to handle the next task
-        self.schedule().await?;
+        self.schedule().await.map_err(|e| GlobalError::Other(e.to_string()))?;
         Ok(())
     }
 }

--- a/crates/mofa-foundation/src/llm/agent.rs
+++ b/crates/mofa-foundation/src/llm/agent.rs
@@ -13,7 +13,7 @@
 //! use mofa_sdk::llm::LLMAgentBuilder;
 //!
 //! #[tokio::main]
-//! async fn main() -> anyhow::Result<()> {
+//! async fn main() -> GlobalResult<()> {
 //!     let agent = LLMAgentBuilder::from_env()?
 //!         .with_id("my-llm-agent")
 //!         .with_system_prompt("You are a helpful assistant.")
@@ -25,6 +25,7 @@
 //! }
 //! ```
 
+use mofa_kernel::agent::types::error::{GlobalError, GlobalResult};
 use super::client::{ChatSession, LLMClient};
 use super::provider::{ChatStream, LLMProvider};
 use super::tool_executor::ToolExecutor;
@@ -2547,7 +2548,7 @@ impl LLMAgentBuilder {
     /// use std::sync::Arc;
     /// use uuid::Uuid;
     ///
-    /// # async fn example() -> anyhow::Result<()> {
+    /// # async fn example() -> GlobalResult<()> {
     /// let store = Arc::new(PostgresStore::connect("postgres://localhost/mofa").await?);
     /// let user_id = Uuid::now_v7();
     /// let tenant_id = Uuid::now_v7();

--- a/crates/mofa-foundation/src/llm/agent_loop.rs
+++ b/crates/mofa-foundation/src/llm/agent_loop.rs
@@ -15,12 +15,12 @@ use crate::llm::types::{
     ChatCompletionRequest, ChatMessage, ContentPart, ImageUrl, LLMResult, MessageContent, Role,
     Tool,
 };
-use anyhow::Result;
+use mofa_kernel::agent::types::error::{GlobalError, GlobalResult};
 use std::collections::HashMap;
 use std::path::Path;
 
 /// Type alias for tool handler function in SimpleToolExecutor
-pub type SimpleToolHandler = Box<dyn Fn(&str) -> Result<String> + Send + Sync>;
+pub type SimpleToolHandler = Box<dyn Fn(&str) -> GlobalResult<String> + Send + Sync>;
 use std::sync::Arc;
 
 /// Configuration for the agent loop
@@ -93,7 +93,7 @@ impl AgentLoop {
         context: Vec<ChatMessage>,
         content: &str,
         media: Option<Vec<String>>,
-    ) -> Result<String> {
+    ) -> GlobalResult<String> {
         self.process_with_options(context, content, media, None)
             .await
     }
@@ -105,7 +105,7 @@ impl AgentLoop {
         content: &str,
         media: Option<Vec<String>>,
         model: &str,
-    ) -> Result<String> {
+    ) -> GlobalResult<String> {
         self.process_with_options(context, content, media, Some(model))
             .await
     }
@@ -117,7 +117,7 @@ impl AgentLoop {
         content: &str,
         media: Option<Vec<String>>,
         model: Option<&str>,
-    ) -> Result<String> {
+    ) -> GlobalResult<String> {
         // Build user message with optional media
         let user_msg = if let Some(media_paths) = media {
             if !media_paths.is_empty() {
@@ -136,7 +136,7 @@ impl AgentLoop {
             .tools
             .available_tools()
             .await
-            .map_err(|e| anyhow::anyhow!(e))?;
+            .map_err(|e| GlobalError::Other(e.to_string()))?;
 
         // Run the agent loop
         self.run_agent_loop(context, &tools, model).await
@@ -150,7 +150,7 @@ impl AgentLoop {
         content: &str,
         media: Option<Vec<String>>,
         model: Option<&str>,
-    ) -> Result<String> {
+    ) -> GlobalResult<String> {
         let context = context_builder
             .build_messages(history, content, media)
             .await?;
@@ -159,7 +159,7 @@ impl AgentLoop {
             .tools
             .available_tools()
             .await
-            .map_err(|e| anyhow::anyhow!(e))?;
+            .map_err(|e| GlobalError::Other(e.to_string()))?;
 
         self.run_agent_loop(context, &tools, model).await
     }
@@ -176,7 +176,7 @@ impl AgentLoop {
         media: Option<Vec<String>>,
         context_builder: Option<&AgentContextBuilder>,
         model: Option<&str>,
-    ) -> Result<String> {
+    ) -> GlobalResult<String> {
         let history = session.messages().to_vec();
 
         let context = if let Some(builder) = context_builder {
@@ -202,7 +202,7 @@ impl AgentLoop {
             .tools
             .available_tools()
             .await
-            .map_err(|e| anyhow::anyhow!(e))?;
+            .map_err(|e| GlobalError::Other(e.to_string()))?;
 
         let response = self.run_agent_loop(context, &tools, model).await?;
 
@@ -229,7 +229,7 @@ impl AgentLoop {
         mut messages: Vec<ChatMessage>,
         tools: &[Tool],
         model: Option<&str>,
-    ) -> Result<String> {
+    ) -> GlobalResult<String> {
         let model = model.unwrap_or(&self.config.default_model);
 
         for _iteration in 0..self.config.max_tool_iterations {
@@ -244,7 +244,7 @@ impl AgentLoop {
             }
 
             // Call LLM
-            let response = self.provider.chat(request).await?;
+            let response = self.provider.chat(request).await.map_err(|e| GlobalError::Other(e.to_string()))?;
 
             // Check for tool calls
             if let Some(tool_calls) = response.tool_calls()
@@ -296,7 +296,7 @@ impl AgentLoop {
     }
 
     /// Build a vision message with images
-    fn build_vision_message(text: &str, image_paths: &[String]) -> Result<ChatMessage> {
+    fn build_vision_message(text: &str, image_paths: &[String]) -> GlobalResult<ChatMessage> {
         let mut parts = vec![ContentPart::Text {
             text: text.to_string(),
         }];
@@ -316,14 +316,14 @@ impl AgentLoop {
     }
 
     /// Encode an image file as a data URL
-    fn encode_image_data_url(path: &Path) -> Result<ImageUrl> {
+    fn encode_image_data_url(path: &Path) -> GlobalResult<ImageUrl> {
         use base64::Engine;
         use base64::engine::general_purpose::STANDARD_NO_PAD;
         use std::fs;
 
         let bytes = fs::read(path)?;
         let mime_type = infer::get_from_path(path)?
-            .ok_or_else(|| anyhow::anyhow!("Unknown MIME type for: {:?}", path))?
+            .ok_or_else(|| GlobalError::Other(format!("Unknown MIME type for: {:?}", path)))?
             .mime_type()
             .to_string();
 
@@ -374,7 +374,7 @@ impl AgentLoopRunner {
     }
 
     /// Run the loop with optional media inputs.
-    pub async fn run(&mut self, content: &str, media: Option<Vec<String>>) -> Result<String> {
+    pub async fn run(&mut self, content: &str, media: Option<Vec<String>>) -> GlobalResult<String> {
         if let Some(session) = self.session.as_mut() {
             let builder = self.context_builder.as_ref();
             return self
@@ -416,7 +416,7 @@ impl SimpleToolExecutor {
 
     pub fn register<F>(&mut self, name: impl Into<String>, handler: F) -> &mut Self
     where
-        F: Fn(&str) -> Result<String> + Send + Sync + 'static,
+        F: Fn(&str) -> GlobalResult<String> + Send + Sync + 'static,
     {
         self.tools.insert(name.into(), Box::new(handler));
         self

--- a/crates/mofa-foundation/src/llm/context.rs
+++ b/crates/mofa-foundation/src/llm/context.rs
@@ -7,7 +7,7 @@
 //! - Vision message support
 
 use crate::llm::types::{ChatMessage, ContentPart, ImageUrl, MessageContent, Role};
-use anyhow::Result;
+use mofa_kernel::agent::types::error::{GlobalError, GlobalResult};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -129,7 +129,7 @@ impl AgentContextBuilder {
     }
 
     /// Build system prompt from bootstrap files
-    pub async fn build_system_prompt(&self) -> Result<String> {
+    pub async fn build_system_prompt(&self) -> GlobalResult<String> {
         // Check cache
         {
             let cached = self.cached_prompt.read().await;
@@ -190,7 +190,7 @@ The following skills extend your capabilities. To use a skill, read its document
         history: Vec<ChatMessage>,
         current: &str,
         media: Option<Vec<String>>,
-    ) -> Result<Vec<ChatMessage>> {
+    ) -> GlobalResult<Vec<ChatMessage>> {
         let mut messages = Vec::new();
 
         // System prompt
@@ -223,7 +223,7 @@ The following skills extend your capabilities. To use a skill, read its document
         current: &str,
         media: Option<Vec<String>>,
         skill_names: Option<&[String]>,
-    ) -> Result<Vec<ChatMessage>> {
+    ) -> GlobalResult<Vec<ChatMessage>> {
         let mut messages = Vec::new();
 
         // Build system prompt with optional skills
@@ -273,7 +273,7 @@ The following skills extend your capabilities. To use a skill, read its document
     }
 
     /// Build a vision message with images
-    fn build_vision_message(text: &str, image_paths: &[String]) -> Result<ChatMessage> {
+    fn build_vision_message(text: &str, image_paths: &[String]) -> GlobalResult<ChatMessage> {
         let mut parts = vec![ContentPart::Text {
             text: text.to_string(),
         }];
@@ -293,14 +293,14 @@ The following skills extend your capabilities. To use a skill, read its document
     }
 
     /// Encode an image file as a data URL
-    fn encode_image_data_url(path: &Path) -> Result<ImageUrl> {
+    fn encode_image_data_url(path: &Path) -> GlobalResult<ImageUrl> {
         use base64::Engine;
         use base64::engine::general_purpose::STANDARD_NO_PAD;
         use std::fs;
 
         let bytes = fs::read(path)?;
         let mime_type = infer::get_from_path(path)?
-            .ok_or_else(|| anyhow::anyhow!("Unknown MIME type for: {:?}", path))?
+            .ok_or_else(|| GlobalError::Other(format!("Unknown MIME type for: {:?}", path)))?
             .mime_type()
             .to_string();
 
@@ -311,9 +311,9 @@ The following skills extend your capabilities. To use a skill, read its document
     }
 
     /// Load a file's content
-    fn load_file(path: &Path) -> Result<String> {
+    fn load_file(path: &Path) -> GlobalResult<String> {
         std::fs::read_to_string(path)
-            .map_err(|e| anyhow::anyhow!("Failed to read {:?}: {}", path, e))
+            .map_err(|e| GlobalError::Other(format!("Failed to read {:?}: {}", path, e)))
     }
 
     /// Get the workspace path

--- a/crates/mofa-foundation/src/llm/plugin.rs
+++ b/crates/mofa-foundation/src/llm/plugin.rs
@@ -183,7 +183,7 @@ impl AgentPlugin for LLMPlugin {
         // Health check
         self.provider.health_check().await.map_err(|e| {
             self.state = PluginState::Error(e.to_string());
-            anyhow::anyhow!("LLM health check failed: {}", e)
+            mofa_kernel::plugin::PluginError::InitFailed(format!("LLM health check failed: {}", e))
         })?;
 
         Ok(())
@@ -209,7 +209,7 @@ impl AgentPlugin for LLMPlugin {
         // Simple mode: treat input directly as a user message
         self.ask(&input)
             .await
-            .map_err(|e| anyhow::anyhow!("LLM execution failed: {}", e))
+            .map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("LLM execution failed: {}", e)))
     }
 
     fn stats(&self) -> HashMap<String, serde_json::Value> {

--- a/crates/mofa-foundation/src/persistence/plugin.rs
+++ b/crates/mofa-foundation/src/persistence/plugin.rs
@@ -4,6 +4,7 @@
 //! 提供与 LLMAgent 集成的持久化功能
 //! Provides persistence functionality integrated with LLMAgent
 
+use mofa_kernel::agent::types::error::{GlobalError, GlobalResult};
 use super::entities::*;
 use super::traits::*;
 use crate::llm::types::LLMResponseMetadata;
@@ -188,7 +189,7 @@ where
 /// use mofa_sdk::llm::LLMAgentBuilder;
 /// use uuid::Uuid;
 ///
-/// # async fn example() -> anyhow::Result<()> {
+/// # async fn example() -> GlobalResult<()> {
 /// let store = PostgresStore::connect("postgres://localhost/mofa").await?;
 /// let user_id = Uuid::now_v7();
 /// let tenant_id = Uuid::now_v7();

--- a/crates/mofa-foundation/src/secretary/core.rs
+++ b/crates/mofa-foundation/src/secretary/core.rs
@@ -16,6 +16,7 @@
 //! - 连接抽象：支持多种连接方式（通道、WebSocket 等）
 //! - Connection abstraction: supports multiple connection methods (Channels, WebSocket, etc.)
 
+use mofa_kernel::agent::types::error::{GlobalError, GlobalResult};
 use tokio::sync::mpsc;
 
 // 使用 mofa-kernel 的核心抽象
@@ -266,7 +267,7 @@ where
     pub async fn start<C>(
         self,
         connection: C,
-    ) -> (SecretaryHandle, tokio::task::JoinHandle<anyhow::Result<()>>)
+    ) -> (SecretaryHandle, tokio::task::JoinHandle<GlobalResult<()>>)
     where
         C: UserConnection<Input = B::Input, Output = B::Output> + 'static,
     {
@@ -284,7 +285,7 @@ where
 
     /// 同步启动秘书（阻塞当前任务）
     /// Start secretary synchronously (blocking current task)
-    pub async fn run<C>(self, connection: C) -> anyhow::Result<()>
+    pub async fn run<C>(self, connection: C) -> GlobalResult<()>
     where
         C: UserConnection<Input = B::Input, Output = B::Output> + 'static,
     {
@@ -300,7 +301,7 @@ where
         connection: C,
         handle: SecretaryHandle,
         mut stop_rx: mpsc::Receiver<()>,
-    ) -> anyhow::Result<()>
+    ) -> GlobalResult<()>
     where
         C: UserConnection<Input = B::Input, Output = B::Output>,
     {

--- a/crates/mofa-foundation/src/secretary/default/clarifier.rs
+++ b/crates/mofa-foundation/src/secretary/default/clarifier.rs
@@ -1,6 +1,7 @@
 //! 需求澄清器 - 阶段2: 澄清需求，转换为项目文档
 //! Requirement Clarifier - Phase 2: Clarify requirements and convert to project documents
 
+use mofa_kernel::agent::types::error::{GlobalError, GlobalResult};
 use super::types::*;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -312,7 +313,7 @@ impl RequirementClarifier {
         session: &mut ClarificationSession,
         question_id: &str,
         answer: &str,
-    ) -> anyhow::Result<()> {
+    ) -> GlobalResult<()> {
         let idx = session
             .pending_questions
             .iter()
@@ -325,7 +326,7 @@ impl RequirementClarifier {
                 .push((question, answer.to_string()));
             Ok(())
         } else {
-            Err(anyhow::anyhow!("Question not found: {}", question_id))
+            Err(GlobalError::Other(format!("Question not found: {}", question_id)))
         }
     }
 
@@ -334,7 +335,7 @@ impl RequirementClarifier {
     pub async fn finalize_requirement(
         &self,
         session: &mut ClarificationSession,
-    ) -> anyhow::Result<ProjectRequirement> {
+    ) -> GlobalResult<ProjectRequirement> {
         let requirement = self.synthesize_requirement(session).await?;
         session.clarified_requirement = Some(requirement.clone());
         Ok(requirement)
@@ -343,7 +344,7 @@ impl RequirementClarifier {
     async fn synthesize_requirement(
         &self,
         session: &ClarificationSession,
-    ) -> anyhow::Result<ProjectRequirement> {
+    ) -> GlobalResult<ProjectRequirement> {
         let mut acceptance_criteria = Vec::new();
         for (question, answer) in &session.answered_questions {
             if question.id == "acceptance" {
@@ -454,7 +455,7 @@ impl RequirementClarifier {
         &self,
         todo_id: &str,
         raw_idea: &str,
-    ) -> anyhow::Result<ProjectRequirement> {
+    ) -> GlobalResult<ProjectRequirement> {
         let mut session = self.start_session(todo_id, raw_idea).await;
 
         let pending = session.pending_questions.clone();

--- a/crates/mofa-foundation/src/secretary/mod.rs
+++ b/crates/mofa-foundation/src/secretary/mod.rs
@@ -63,7 +63,7 @@
 //!         &self,
 //!         input: Self::Input,
 //!         ctx: &mut SecretaryContext<Self::State>,
-//!     ) -> anyhow::Result<Vec<Self::Output>> {
+//!     ) -> GlobalResult<Vec<Self::Output>> {
 //!         // 自定义处理逻辑
 //!         // Custom processing logic
 //!     }
@@ -79,6 +79,7 @@
 // Implementation Modules
 // =============================================================================
 
+use mofa_kernel::agent::types::error::{GlobalError, GlobalResult};
 mod agent_router;
 mod connection;
 mod core;

--- a/crates/mofa-foundation/src/secretary/monitoring/plugin.rs
+++ b/crates/mofa-foundation/src/secretary/monitoring/plugin.rs
@@ -155,7 +155,7 @@ impl AgentPlugin for BaseEventResponsePlugin {
 
         // Check if we can handle this event
         if !self.can_handle(&event) {
-            return Err(anyhow::anyhow!("Cannot handle this event type"));
+            return Err(mofa_kernel::plugin::PluginError::ExecutionFailed("Cannot handle this event type".into()));
         }
 
         // Handle the event
@@ -163,7 +163,7 @@ impl AgentPlugin for BaseEventResponsePlugin {
         let processed_event = self.handle_event(event).await?;
 
         // Return the result as JSON
-        processed_event.to_json().map_err(|e| anyhow::anyhow!(e))
+        processed_event.to_json().map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(e.to_string()))
     }
 
     fn stats(&self) -> HashMap<String, serde_json::Value> {

--- a/crates/mofa-kernel/Cargo.toml
+++ b/crates/mofa-kernel/Cargo.toml
@@ -21,7 +21,6 @@ serde_json.workspace = true
 serde_yaml = { workspace = true, optional = true }
 tokio.workspace = true
 bincode.workspace = true
-anyhow.workspace = true
 thiserror.workspace = true
 error-stack.workspace = true
 uuid = {workspace = true,features = ["serde", "v4"]}

--- a/crates/mofa-kernel/src/agent/error.rs
+++ b/crates/mofa-kernel/src/agent/error.rs
@@ -179,8 +179,26 @@ impl From<serde_json::Error> for AgentError {
     }
 }
 
-impl From<anyhow::Error> for AgentError {
-    fn from(err: anyhow::Error) -> Self {
+impl From<crate::plugin::PluginError> for AgentError {
+    fn from(err: crate::plugin::PluginError) -> Self {
+        AgentError::Internal(err.to_string())
+    }
+}
+
+impl From<crate::bus::BusError> for AgentError {
+    fn from(err: crate::bus::BusError) -> Self {
+        AgentError::Internal(err.to_string())
+    }
+}
+
+impl From<crate::agent::secretary::ConnectionError> for AgentError {
+    fn from(err: crate::agent::secretary::ConnectionError) -> Self {
+        AgentError::Internal(err.to_string())
+    }
+}
+
+impl From<crate::agent::secretary::SecretaryError> for AgentError {
+    fn from(err: crate::agent::secretary::SecretaryError) -> Self {
         AgentError::Internal(err.to_string())
     }
 }

--- a/crates/mofa-kernel/src/agent/secretary/error.rs
+++ b/crates/mofa-kernel/src/agent/secretary/error.rs
@@ -1,0 +1,69 @@
+//! Typed errors for the secretary and connection sub-systems.
+
+use thiserror::Error;
+
+// Connection Errors
+/// Errors that can occur on the user-connection layer.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ConnectionError {
+    /// The connection has been closed (gracefully or otherwise).
+    #[error("Connection closed")]
+    Closed,
+
+    /// A connection-level timeout expired.
+    #[error("Connection timeout")]
+    Timeout,
+
+    /// Sending a message to the remote peer failed.
+    #[error("Send failed: {0}")]
+    SendFailed(String),
+
+    /// Receiving a message from the remote peer failed.
+    #[error("Receive failed: {0}")]
+    ReceiveFailed(String),
+
+    /// An underlying I/O error.
+    #[error("I/O error: {source}")]
+    Io {
+        #[from]
+        source: std::io::Error,
+    },
+
+    /// A (de)serialization error at the connection boundary.
+    #[error("Serialization error: {0}")]
+    Serialization(String),
+
+    /// Catch-all for errors that don't fit the above categories.
+    #[error("{0}")]
+    Other(String),
+}
+
+// Secretary Errors
+/// Errors that can occur in the secretary behaviour layer.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum SecretaryError {
+    /// An error occurred while handling user input.
+    #[error("Input handling failed: {0}")]
+    InputHandlingFailed(String),
+
+    /// An error propagated from the connection layer.
+    #[error("Connection error: {source}")]
+    Connection {
+        #[from]
+        source: ConnectionError,
+    },
+
+    /// A workflow orchestration step failed.
+    #[error("Workflow error: {0}")]
+    WorkflowFailed(String),
+
+    /// A single phase within a workflow failed.
+    #[error("Phase error: {0}")]
+    PhaseFailed(String),
+
+    /// Catch-all for errors that don't fit the above categories.
+    #[error("{0}")]
+    Other(String),
+}

--- a/crates/mofa-kernel/src/agent/secretary/mod.rs
+++ b/crates/mofa-kernel/src/agent/secretary/mod.rs
@@ -63,12 +63,14 @@
 
 mod connection;
 mod context;
+pub mod error;
 mod traits;
 
 // 核心导出
 // Core exports
 pub use connection::{ConnectionFactory, UserConnection};
 pub use context::{SecretaryContext, SecretaryContextBuilder, SharedSecretaryContext};
+pub use error::{ConnectionError, SecretaryError};
 pub use traits::{
     EventListener, InputHandler, Middleware, PhaseHandler, PhaseResult, SecretaryBehavior,
     SecretaryEvent, SecretaryInput, SecretaryOutput, WorkflowOrchestrator, WorkflowResult,

--- a/crates/mofa-kernel/src/agent/secretary/traits.rs
+++ b/crates/mofa-kernel/src/agent/secretary/traits.rs
@@ -18,6 +18,7 @@
 //! - [`WorkflowOrchestrator`][]: 编排多阶段工作流
 //! - [`WorkflowOrchestrator`][]: Orchestrates multi-phase workflows
 
+use super::error::SecretaryError;
 use async_trait::async_trait;
 use serde::{Serialize, de::DeserializeOwned};
 use std::fmt::Debug;
@@ -180,7 +181,7 @@ pub trait SecretaryBehavior: Send + Sync {
         &self,
         input: Self::Input,
         ctx: &mut super::context::SecretaryContext<Self::State>,
-    ) -> anyhow::Result<Vec<Self::Output>>;
+    ) -> Result<Vec<Self::Output>, SecretaryError>;
 
     /// 欢迎消息
     /// Welcome message
@@ -213,7 +214,7 @@ pub trait SecretaryBehavior: Send + Sync {
     async fn periodic_check(
         &self,
         _ctx: &mut super::context::SecretaryContext<Self::State>,
-    ) -> anyhow::Result<Vec<Self::Output>> {
+    ) -> Result<Vec<Self::Output>, SecretaryError> {
         Ok(vec![])
     }
 
@@ -225,7 +226,7 @@ pub trait SecretaryBehavior: Send + Sync {
     async fn on_disconnect(
         &self,
         _ctx: &mut super::context::SecretaryContext<Self::State>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), SecretaryError> {
         Ok(())
     }
 
@@ -236,7 +237,7 @@ pub trait SecretaryBehavior: Send + Sync {
     /// Called to generate an error response when an error occurs during input processing.
     /// 默认实现返回 `None`，表示不向用户发送错误消息。
     /// Default implementation returns `None`, meaning no error message is sent to the user.
-    fn handle_error(&self, _error: &anyhow::Error) -> Option<Self::Output> {
+    fn handle_error(&self, _error: &SecretaryError) -> Option<Self::Output> {
         None
     }
 }
@@ -280,7 +281,7 @@ where
         &self,
         input: Input,
         ctx: &mut super::context::SecretaryContext<State>,
-    ) -> anyhow::Result<PhaseResult<Output>>;
+    ) -> Result<PhaseResult<Output>, SecretaryError>;
 
     /// 是否可以跳过此阶段
     /// Whether this phase can be skipped
@@ -342,7 +343,7 @@ where
         &self,
         input: Input,
         ctx: &mut super::context::SecretaryContext<State>,
-    ) -> anyhow::Result<WorkflowResult<Output>>;
+    ) -> Result<WorkflowResult<Output>, SecretaryError>;
 }
 
 /// 工作流执行结果
@@ -395,7 +396,7 @@ where
         &self,
         input: Input,
         ctx: &mut super::context::SecretaryContext<State>,
-    ) -> anyhow::Result<Vec<Output>>;
+    ) -> Result<Vec<Output>, SecretaryError>;
 }
 
 // =============================================================================

--- a/crates/mofa-kernel/src/agent/types/error.rs
+++ b/crates/mofa-kernel/src/agent/types/error.rs
@@ -184,12 +184,6 @@ pub type GlobalResult<T> = Result<T, GlobalError>;
 // Conversion from other error types
 // ============================================================================
 
-impl From<anyhow::Error> for GlobalError {
-    fn from(err: anyhow::Error) -> Self {
-        Self::Other(err.to_string())
-    }
-}
-
 impl From<String> for GlobalError {
     fn from(s: String) -> Self {
         Self::Other(s)

--- a/crates/mofa-kernel/src/bus/error.rs
+++ b/crates/mofa-kernel/src/bus/error.rs
@@ -1,0 +1,24 @@
+//! Typed errors for the agent communication bus.
+
+use thiserror::Error;
+
+/// Errors that can occur on the agent communication bus.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum BusError {
+    /// The target channel was not found for an agent.
+    #[error("Channel not found for agent: {0}")]
+    ChannelNotFound(String),
+
+    /// The target agent has not been registered on the bus.
+    #[error("Agent not registered: {0}")]
+    AgentNotRegistered(String),
+
+    /// Sending a message through a bus channel failed.
+    #[error("Send failed: {0}")]
+    SendFailed(String),
+
+    /// A serialization or deserialization error occurred.
+    #[error("Serialization error: {0}")]
+    Serialization(String),
+}

--- a/crates/mofa-kernel/src/error.rs
+++ b/crates/mofa-kernel/src/error.rs
@@ -53,6 +53,22 @@ pub enum KernelError {
     /// An internal / untyped error described by a message string.
     #[error("{0}")]
     Internal(String),
+
+    /// A plugin sub-system error.
+    #[error("Plugin error: {0}")]
+    Plugin(#[from] crate::plugin::PluginError),
+
+    /// A bus communication error.
+    #[error("Bus error: {0}")]
+    Bus(#[from] crate::bus::BusError),
+
+    /// A connection-layer error.
+    #[error("Connection error: {0}")]
+    Connection(#[from] crate::agent::secretary::ConnectionError),
+
+    /// A secretary-layer error.
+    #[error("Secretary error: {0}")]
+    Secretary(#[from] crate::agent::secretary::SecretaryError),
 }
 
 impl From<crate::agent::types::error::GlobalError> for KernelError {

--- a/crates/mofa-kernel/src/plugin/error.rs
+++ b/crates/mofa-kernel/src/plugin/error.rs
@@ -1,0 +1,51 @@
+//! Typed errors for the plugin sub-system.
+
+use thiserror::Error;
+
+/// Errors that can occur during plugin lifecycle operations.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum PluginError {
+    /// Plugin failed during the `load` phase.
+    #[error("Plugin load failed: {0}")]
+    LoadFailed(String),
+
+    /// Plugin failed during initialisation.
+    #[error("Plugin initialization failed: {0}")]
+    InitFailed(String),
+
+    /// Plugin execution (`execute`) returned an error.
+    #[error("Plugin execution failed: {0}")]
+    ExecutionFailed(String),
+
+    /// An operation was attempted while the plugin was in an incompatible state.
+    #[error("Plugin not in valid state: expected {expected}, got {actual}")]
+    InvalidState {
+        /// The state(s) that were expected.
+        expected: String,
+        /// The state the plugin was actually in.
+        actual: String,
+    },
+
+    /// Plugin configuration is invalid or missing.
+    #[error("Plugin configuration error: {0}")]
+    ConfigError(String),
+
+    /// An I/O error surfaced during a plugin operation.
+    #[error("Plugin I/O error: {source}")]
+    Io {
+        #[from]
+        source: std::io::Error,
+    },
+
+    /// A (de)serialization error surfaced during a plugin operation.
+    #[error("Plugin serialization error: {source}")]
+    Serialization {
+        #[from]
+        source: serde_json::Error,
+    },
+
+    /// Catch-all for errors that don't fit the above categories.
+    #[error("{0}")]
+    Other(String),
+}

--- a/crates/mofa-kernel/src/plugin/mod.rs
+++ b/crates/mofa-kernel/src/plugin/mod.rs
@@ -4,9 +4,11 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-/// 插件执行结果
-/// Plugin execution result
-pub type PluginResult<T> = anyhow::Result<T>;
+pub mod error;
+pub use error::PluginError;
+
+/// Plugin execution result type using the typed [`PluginError`].
+pub type PluginResult<T> = Result<T, PluginError>;
 
 // ============================================================================
 // 热加载相关定义 (Hot-reload related definitions)
@@ -530,11 +532,11 @@ impl PluginContext {
 
     /// 发送插件事件
     /// Emit plugin event
-    pub async fn emit_event(&self, event: PluginEvent) -> anyhow::Result<()> {
+    pub async fn emit_event(&self, event: PluginEvent) -> PluginResult<()> {
         if let Some(ref tx) = self.event_tx {
             tx.send(event)
                 .await
-                .map_err(|e| anyhow::anyhow!("Failed to send event: {}", e))?;
+                .map_err(|e| PluginError::Other(format!("Failed to send event: {}", e)))?;
         }
         Ok(())
     }

--- a/crates/mofa-monitoring/Cargo.toml
+++ b/crates/mofa-monitoring/Cargo.toml
@@ -26,7 +26,6 @@ async-trait.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
-anyhow.workspace = true
 tracing.workspace = true
 uuid = { workspace = true, features = ["serde", "v4"] }
 chrono.workspace = true

--- a/crates/mofa-plugins/Cargo.toml
+++ b/crates/mofa-plugins/Cargo.toml
@@ -21,7 +21,6 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 tokio.workspace = true
 tokio-stream = { workspace = true }
-anyhow.workspace = true
 thiserror.workspace = true
 parking_lot.workspace = true
 notify.workspace = true

--- a/crates/mofa-plugins/src/hot_reload/manager.rs
+++ b/crates/mofa-plugins/src/hot_reload/manager.rs
@@ -850,7 +850,7 @@ impl HotReloadManager {
         let mut plugins = self.loaded_plugins.write().await;
         let entry = plugins
             .get_mut(plugin_id)
-            .ok_or_else(|| anyhow::anyhow!("Plugin {} not found", plugin_id))?;
+            .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Plugin {} not found", plugin_id)))?;
 
         entry.plugin.plugin_mut().execute(input).await
     }

--- a/crates/mofa-plugins/src/lib.rs
+++ b/crates/mofa-plugins/src/lib.rs
@@ -25,8 +25,8 @@ pub mod tts;
 pub mod wasm_runtime;
 
 pub use mofa_kernel::{
-    AgentPlugin, PluginConfig, PluginContext, PluginEvent, PluginMetadata, PluginResult,
-    PluginState, PluginType,
+    AgentPlugin, PluginConfig, PluginContext, PluginError, PluginEvent, PluginMetadata,
+    PluginResult, PluginState, PluginType,
 };
 use serde::{Deserialize, Serialize};
 use std::any::Any;
@@ -255,7 +255,7 @@ impl LLMPlugin {
         let client = self
             .client
             .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("LLM client not initialized"))?;
+            .ok_or_else(|| PluginError::InitFailed("LLM client not initialized".into()))?;
         self.call_count += 1;
         client.chat(messages).await
     }
@@ -266,7 +266,7 @@ impl LLMPlugin {
         let client = self
             .client
             .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("LLM client not initialized"))?;
+            .ok_or_else(|| PluginError::InitFailed("LLM client not initialized".into()))?;
         client.embedding(text).await
     }
 }
@@ -333,7 +333,7 @@ impl AgentPlugin for LLMPlugin {
         let client = self
             .client
             .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("LLM client not initialized"))?;
+            .ok_or_else(|| PluginError::InitFailed("LLM client not initialized".into()))?;
         self.call_count += 1;
         client.generate(&input).await
     }
@@ -500,7 +500,7 @@ impl ToolPlugin {
         let tool = self
             .tools
             .get(&call.name)
-            .ok_or_else(|| anyhow::anyhow!("Tool not found: {}", call.name))?;
+            .ok_or_else(|| PluginError::ExecutionFailed(format!("Tool not found: {}", call.name)))?;
 
         // 验证参数
         // Validate arguments
@@ -578,10 +578,10 @@ impl AgentPlugin for ToolPlugin {
         // 解析输入为工具调用
         // Parse input as tool call
         let call: ToolCall = serde_json::from_str(&input)
-            .map_err(|e| anyhow::anyhow!("Invalid tool call format: {}", e))?;
+            .map_err(|e| PluginError::ExecutionFailed(format!("Invalid tool call format: {}", e)))?;
         let result = self.call_tool(call).await?;
         serde_json::to_string(&result)
-            .map_err(|e| anyhow::anyhow!("Failed to serialize result: {}", e))
+            .map_err(|e| PluginError::ExecutionFailed(format!("Failed to serialize result: {}", e)))
     }
 
     fn stats(&self) -> HashMap<String, serde_json::Value> {
@@ -729,7 +729,7 @@ impl StoragePlugin {
         let backend = self
             .backend
             .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("Storage backend not initialized"))?;
+            .ok_or_else(|| PluginError::InitFailed("Storage backend not initialized".into()))?;
         self.read_count += 1;
         backend.get(key).await
     }
@@ -740,7 +740,7 @@ impl StoragePlugin {
         let backend = self
             .backend
             .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("Storage backend not initialized"))?;
+            .ok_or_else(|| PluginError::InitFailed("Storage backend not initialized".into()))?;
         self.write_count += 1;
         backend.set(key, value).await
     }
@@ -751,7 +751,7 @@ impl StoragePlugin {
         let backend = self
             .backend
             .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("Storage backend not initialized"))?;
+            .ok_or_else(|| PluginError::InitFailed("Storage backend not initialized".into()))?;
         self.write_count += 1;
         backend.delete(key).await
     }
@@ -831,8 +831,8 @@ impl AgentPlugin for StoragePlugin {
                 let deleted = self.delete(key).await?;
                 Ok(if deleted { "1" } else { "0" }.to_string())
             }
-            _ => Err(anyhow::anyhow!(
-                "Invalid command. Use: get <key>, set <key> <value>, delete <key>"
+            _ => Err(PluginError::ExecutionFailed(
+                "Invalid command. Use: get <key>, set <key> <value>, delete <key>".into(),
             )),
         }
     }
@@ -1044,14 +1044,16 @@ impl AgentPlugin for MemoryPlugin {
             ["search", query] => {
                 let results = self.retrieve(query, 5);
                 let contents: Vec<&str> = results.iter().map(|m| m.content.as_str()).collect();
-                Ok(serde_json::to_string(&contents)?)
+                let json = serde_json::to_string(&contents)
+                    .map_err(|e| PluginError::ExecutionFailed(e.to_string()))?;
+                Ok(json)
             }
             ["count"] => Ok(self.memories.len().to_string()),
             ["clear"] => {
                 self.clear();
                 Ok("Cleared".to_string())
             }
-            _ => Err(anyhow::anyhow!("Invalid command")),
+            _ => Err(PluginError::ExecutionFailed("Invalid command".into())),
         }
     }
 
@@ -1148,7 +1150,7 @@ impl PluginManager {
         let mut plugins = self.plugins.write().await;
 
         if plugins.contains_key(&plugin_id) {
-            return Err(anyhow::anyhow!("Plugin {} already registered", plugin_id));
+            return Err(PluginError::Other(format!("Plugin {} already registered", plugin_id)));
         }
 
         let entry = PluginEntry {
@@ -1305,7 +1307,7 @@ impl PluginManager {
         let mut plugins = self.plugins.write().await;
         let entry = plugins
             .get_mut(plugin_id)
-            .ok_or_else(|| anyhow::anyhow!("Plugin {} not found", plugin_id))?;
+            .ok_or_else(|| PluginError::Other(format!("Plugin {} not found", plugin_id)))?;
         entry.plugin.execute(input).await
     }
 

--- a/crates/mofa-plugins/src/rhai_runtime/function_calling.rs
+++ b/crates/mofa-plugins/src/rhai_runtime/function_calling.rs
@@ -212,7 +212,7 @@ impl FunctionCallingAdapter {
         self.engine
             .compile_and_cache(&self.script_id, "function_calling_script", script_content)
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to compile script '{}': {}", self.script_id, e))
+            .map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Failed to compile script '{}': {}", self.script_id, e)))
     }
 }
 

--- a/crates/mofa-plugins/src/rhai_runtime/plugin.rs
+++ b/crates/mofa-plugins/src/rhai_runtime/plugin.rs
@@ -460,13 +460,13 @@ impl RhaiPlugin {
     async fn execute_script(&self, input: String) -> PluginResult<String> {
         // Create context with input
         let mut context = ScriptContext::new();
-        context = context.with_variable("input", input.clone())?;
+        context = context.with_variable("input", input.clone()).map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(e.to_string()))?;
 
         // Compile and cache the script (idempotent when already cached)
         let script_id = format!("{}_exec", self.id);
         self.engine
             .compile_and_cache(&script_id, "execute", &self.cached_content)
-            .await?;
+            .await.map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(e.to_string()))?;
 
         // Try to call the execute function with the input
         match self
@@ -484,7 +484,7 @@ impl RhaiPlugin {
                     "Rhai plugin {} executed successfully via call_function",
                     self.id
                 );
-                Ok(serde_json::to_string_pretty(&result)?)
+                Ok(serde_json::to_string_pretty(&result).map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(e.to_string()))?)
             }
             Err(e) => {
                 warn!(
@@ -493,16 +493,16 @@ impl RhaiPlugin {
                 );
 
                 // Fallback: execute the whole script directly
-                let result = self.engine.execute(&self.cached_content, &context).await?;
+                let result = self.engine.execute(&self.cached_content, &context).await.map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(e.to_string()))?;
 
                 if !result.success {
-                    return Err(anyhow::anyhow!(
+                    return Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!(
                         "Script execution failed: {:?}",
                         result.error
-                    ));
+                    )));
                 }
 
-                Ok(serde_json::to_string_pretty(&result.value)?)
+                Ok(serde_json::to_string_pretty(&result.value).map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(e.to_string()))?)
             }
         }
     }
@@ -593,7 +593,8 @@ impl AgentPlugin for RhaiPlugin {
         *self.plugin_context.write().await = Some(ctx.clone());
 
         // Extract metadata from script
-        self.extract_metadata().await?;
+        self.extract_metadata().await
+            .map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(e.to_string()))?;
 
         let mut state = self.state.write().await;
         *state = RhaiPluginState::Loaded;
@@ -603,7 +604,7 @@ impl AgentPlugin for RhaiPlugin {
     async fn init_plugin(&mut self) -> PluginResult<()> {
         let mut state = self.state.write().await;
         if *state != RhaiPluginState::Loaded {
-            return Err(anyhow::anyhow!("Plugin not loaded"));
+            return Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Plugin not loaded")));
         }
 
         *state = RhaiPluginState::Initializing;
@@ -627,7 +628,7 @@ impl AgentPlugin for RhaiPlugin {
     async fn start(&mut self) -> PluginResult<()> {
         let mut state = self.state.write().await;
         if *state != RhaiPluginState::Running && *state != RhaiPluginState::Paused {
-            return Err(anyhow::anyhow!("Plugin not ready to start"));
+            return Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Plugin not ready to start")));
         }
 
         // Call start function if exists
@@ -647,7 +648,7 @@ impl AgentPlugin for RhaiPlugin {
     async fn stop(&mut self) -> PluginResult<()> {
         let mut state = self.state.write().await;
         if *state != RhaiPluginState::Running {
-            return Err(anyhow::anyhow!("Plugin not running"));
+            return Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Plugin not running")));
         }
 
         // Call stop function if exists
@@ -685,7 +686,7 @@ impl AgentPlugin for RhaiPlugin {
         {
             let state = self.state.read().await;
             if *state != RhaiPluginState::Running {
-                return Err(anyhow::anyhow!("Plugin not running"));
+                return Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Plugin not running")));
             }
         }
 

--- a/crates/mofa-plugins/src/rhai_runtime/types.rs
+++ b/crates/mofa-plugins/src/rhai_runtime/types.rs
@@ -2,7 +2,6 @@
 //!
 //! Type definitions for Rhai runtime plugins
 
-use anyhow::Result;
 use rhai::Dynamic;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -70,7 +69,7 @@ impl PluginMetadata {
     }
 
     /// Load metadata from Rhai global variables
-    pub fn from_rhai_vars(_vars: &HashMap<String, Dynamic>) -> Result<Self> {
+    pub fn from_rhai_vars(_vars: &HashMap<String, Dynamic>) -> RhaiPluginResult<Self> {
         // Simplified for now - will implement properly later
         Ok(Self::default())
     }
@@ -113,7 +112,13 @@ pub enum RhaiPluginError {
 
     /// Other error
     #[error("Other: {0}")]
-    Other(#[from] anyhow::Error),
+    Other(String),
+}
+
+impl From<mofa_extra::rhai::RhaiError> for RhaiPluginError {
+    fn from(err: mofa_extra::rhai::RhaiError) -> Self {
+        RhaiPluginError::RhaiError(err.to_string())
+    }
 }
 
 /// Rhai plugin result type

--- a/crates/mofa-plugins/src/skill/disclosure.rs
+++ b/crates/mofa-plugins/src/skill/disclosure.rs
@@ -103,7 +103,7 @@ impl DisclosureController {
     ///
     /// 按优先级从多个目录扫描，先找到的优先
     /// Scan multiple directories by priority; the first match takes precedence
-    pub fn scan_metadata(&mut self) -> anyhow::Result<usize> {
+    pub fn scan_metadata(&mut self) -> mofa_kernel::plugin::PluginResult<usize> {
         let mut count = 0;
 
         for skills_dir in &self.search_dirs {

--- a/crates/mofa-plugins/src/skill/parser.rs
+++ b/crates/mofa-plugins/src/skill/parser.rs
@@ -2,7 +2,7 @@
 //! SKILL.md file parser
 
 use crate::skill::metadata::SkillMetadata;
-use anyhow::Result;
+use mofa_kernel::plugin::{PluginError, PluginResult};
 use regex::Regex;
 use std::fs;
 use std::path::Path;
@@ -14,7 +14,7 @@ pub struct SkillParser;
 impl SkillParser {
     /// 解析 YAML frontmatter
     /// Parse YAML frontmatter
-    pub fn parse_frontmatter(content: &str) -> Result<(SkillMetadata, String)> {
+    pub fn parse_frontmatter(content: &str) -> PluginResult<(SkillMetadata, String)> {
         // Use [\s\S]*? instead of .*? to match newlines in YAML content
         let frontmatter_regex = Regex::new(r"^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$").unwrap();
 
@@ -22,19 +22,28 @@ impl SkillParser {
             let yaml = &caps[1];
             let markdown = &caps[2];
 
-            let metadata: SkillMetadata = serde_yaml::from_str(yaml)
-                .map_err(|e| anyhow::anyhow!("Failed to parse YAML frontmatter: {}", e))?;
+            let metadata: SkillMetadata = serde_yaml::from_str(yaml).map_err(|e| {
+                mofa_kernel::plugin::PluginError::ExecutionFailed(format!(
+                    "Failed to parse YAML frontmatter: {}",
+                    e
+                ))
+            })?;
 
             Ok((metadata, markdown.to_string()))
         } else {
-            anyhow::bail!("SKILL.md must start with YAML frontmatter")
+            Err(PluginError::ExecutionFailed(
+                "SKILL.md must start with YAML frontmatter".to_string(),
+            ))
         }
     }
 
     /// 从 SKILL.md 文件解析元数据
     /// Parse metadata from SKILL.md file
-    pub fn parse_from_file(skill_md_path: impl AsRef<Path>) -> Result<(SkillMetadata, String)> {
-        let content = fs::read_to_string(skill_md_path.as_ref())?;
+    pub fn parse_from_file(
+        skill_md_path: impl AsRef<Path>,
+    ) -> PluginResult<(SkillMetadata, String)> {
+        let content = fs::read_to_string(skill_md_path.as_ref())
+            .map_err(|e| PluginError::Other(e.to_string()))?;
         Self::parse_frontmatter(&content)
     }
 }

--- a/crates/mofa-plugins/src/tool/adapter.rs
+++ b/crates/mofa-plugins/src/tool/adapter.rs
@@ -108,7 +108,7 @@ impl AgentPlugin for ToolPluginAdapter {
     async fn execute(&mut self, input: String) -> PluginResult<String> {
         // Parse the input as ToolInput
         let tool_input: ToolInput = serde_json::from_str(&input)
-            .map_err(|e| anyhow::anyhow!("Failed to parse tool input: {}", e))?;
+            .map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Failed to parse tool input: {}", e)))?;
 
         // Execute the tool with a minimal context
         let ctx = mofa_kernel::agent::context::AgentContext::new("tool-execution");

--- a/crates/mofa-plugins/src/tools/calculator.rs
+++ b/crates/mofa-plugins/src/tools/calculator.rs
@@ -53,49 +53,49 @@ impl ToolExecutor for CalculatorTool {
     async fn execute(&self, arguments: serde_json::Value) -> PluginResult<serde_json::Value> {
         let operation = arguments["operation"]
             .as_str()
-            .ok_or_else(|| anyhow::anyhow!("Operation is required"))?;
+            .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Operation is required")))?;
         let a = arguments["a"]
             .as_f64()
-            .ok_or_else(|| anyhow::anyhow!("Operand 'a' is required"))?;
+            .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Operand 'a' is required")))?;
 
         let result = match operation {
             "add" => {
                 let b = arguments["b"]
                     .as_f64()
-                    .ok_or_else(|| anyhow::anyhow!("Operand 'b' is required for add"))?;
+                    .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Operand 'b' is required for add")))?;
                 a + b
             }
             "subtract" => {
                 let b = arguments["b"]
                     .as_f64()
-                    .ok_or_else(|| anyhow::anyhow!("Operand 'b' is required for subtract"))?;
+                    .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Operand 'b' is required for subtract")))?;
                 a - b
             }
             "multiply" => {
                 let b = arguments["b"]
                     .as_f64()
-                    .ok_or_else(|| anyhow::anyhow!("Operand 'b' is required for multiply"))?;
+                    .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Operand 'b' is required for multiply")))?;
                 a * b
             }
             "divide" => {
                 let b = arguments["b"]
                     .as_f64()
-                    .ok_or_else(|| anyhow::anyhow!("Operand 'b' is required for divide"))?;
+                    .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Operand 'b' is required for divide")))?;
                 if b == 0.0 {
-                    return Err(anyhow::anyhow!("Division by zero"));
+                    return Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Division by zero")));
                 }
                 a / b
             }
             "power" => {
                 let b = arguments["b"]
                     .as_f64()
-                    .ok_or_else(|| anyhow::anyhow!("Operand 'b' is required for power"))?;
+                    .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Operand 'b' is required for power")))?;
                 a.powf(b)
             }
             "sqrt" => {
                 if a < 0.0 {
-                    return Err(anyhow::anyhow!(
-                        "Cannot compute square root of negative number"
+                    return Err(mofa_kernel::plugin::PluginError::ExecutionFailed(
+                        "Cannot compute square root of negative number".into(),
                     ));
                 }
                 a.sqrt()
@@ -112,7 +112,7 @@ impl ToolExecutor for CalculatorTool {
             "floor" => a.floor(),
             "ceil" => a.ceil(),
             "round" => a.round(),
-            _ => return Err(anyhow::anyhow!("Unknown operation: {}", operation)),
+            _ => return Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Unknown operation: {}", operation))),
         };
 
         Ok(json!({

--- a/crates/mofa-plugins/src/tools/datetime.rs
+++ b/crates/mofa-plugins/src/tools/datetime.rs
@@ -66,7 +66,7 @@ impl ToolExecutor for DateTimeTool {
     async fn execute(&self, arguments: serde_json::Value) -> PluginResult<serde_json::Value> {
         let operation = arguments["operation"]
             .as_str()
-            .ok_or_else(|| anyhow::anyhow!("Operation is required"))?;
+            .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Operation is required")))?;
 
         match operation {
             "now" => {
@@ -83,7 +83,7 @@ impl ToolExecutor for DateTimeTool {
             "format" => {
                 let timestamp = arguments["timestamp"]
                     .as_i64()
-                    .ok_or_else(|| anyhow::anyhow!("Timestamp is required for format operation"))?;
+                    .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Timestamp is required for format operation")))?;
                 let format = arguments["format"].as_str().unwrap_or("%Y-%m-%d %H:%M:%S");
                 let timezone = arguments["timezone"].as_str().unwrap_or("UTC");
 
@@ -103,12 +103,12 @@ impl ToolExecutor for DateTimeTool {
                         "formatted": f,
                         "timestamp": timestamp
                     })),
-                    None => Err(anyhow::anyhow!("Invalid timestamp")),
+                    None => Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Invalid timestamp"))),
                 }
             }
             "parse" => {
                 let date_string = arguments["date_string"].as_str().ok_or_else(|| {
-                    anyhow::anyhow!("date_string is required for parse operation")
+                    mofa_kernel::plugin::PluginError::ExecutionFailed(format!("date_string is required for parse operation"))
                 })?;
 
                 // Try RFC3339 first
@@ -129,17 +129,17 @@ impl ToolExecutor for DateTimeTool {
                     }));
                 }
 
-                Err(anyhow::anyhow!(
+                Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!(
                     "Could not parse date string: {}",
                     date_string
-                ))
+                )))
             }
             "add" => {
                 let timestamp = arguments["timestamp"]
                     .as_i64()
                     .unwrap_or_else(|| Utc::now().timestamp());
                 let duration = arguments["duration_seconds"].as_i64().ok_or_else(|| {
-                    anyhow::anyhow!("duration_seconds is required for add operation")
+                    mofa_kernel::plugin::PluginError::ExecutionFailed(format!("duration_seconds is required for add operation"))
                 })?;
 
                 let new_timestamp = timestamp + duration;
@@ -151,16 +151,16 @@ impl ToolExecutor for DateTimeTool {
                         "new_timestamp": new_timestamp,
                         "utc": dt.to_rfc3339()
                     })),
-                    None => Err(anyhow::anyhow!("Invalid resulting timestamp")),
+                    None => Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Invalid resulting timestamp"))),
                 }
             }
             "diff" => {
                 let ts1 = arguments["timestamp1"]
                     .as_i64()
-                    .ok_or_else(|| anyhow::anyhow!("timestamp1 is required for diff operation"))?;
+                    .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("timestamp1 is required for diff operation")))?;
                 let ts2 = arguments["timestamp2"]
                     .as_i64()
-                    .ok_or_else(|| anyhow::anyhow!("timestamp2 is required for diff operation"))?;
+                    .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("timestamp2 is required for diff operation")))?;
 
                 let diff = ts2 - ts1;
                 let days = diff / 86400;
@@ -173,7 +173,7 @@ impl ToolExecutor for DateTimeTool {
                     "diff_human": format!("{}d {}h {}m {}s", days, hours, minutes, seconds)
                 }))
             }
-            _ => Err(anyhow::anyhow!("Unknown operation: {}", operation)),
+            _ => Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Unknown operation: {}", operation))),
         }
     }
 }

--- a/crates/mofa-plugins/src/tools/filesystem.rs
+++ b/crates/mofa-plugins/src/tools/filesystem.rs
@@ -75,16 +75,16 @@ impl ToolExecutor for FileSystemTool {
     async fn execute(&self, arguments: serde_json::Value) -> PluginResult<serde_json::Value> {
         let operation = arguments["operation"]
             .as_str()
-            .ok_or_else(|| anyhow::anyhow!("Operation is required"))?;
+            .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Operation is required")))?;
         let path = arguments["path"]
             .as_str()
-            .ok_or_else(|| anyhow::anyhow!("Path is required"))?;
+            .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Path is required")))?;
 
         if !self.is_path_allowed(path) {
-            return Err(anyhow::anyhow!(
+            return Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!(
                 "Access denied: path '{}' is not in allowed paths",
                 path
-            ));
+            )));
         }
 
         match operation {
@@ -107,7 +107,7 @@ impl ToolExecutor for FileSystemTool {
             "write" => {
                 let content = arguments["content"]
                     .as_str()
-                    .ok_or_else(|| anyhow::anyhow!("Content is required for write operation"))?;
+                    .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Content is required for write operation")))?;
                 fs::write(path, content).await?;
                 Ok(json!({
                     "success": true,
@@ -157,7 +157,7 @@ impl ToolExecutor for FileSystemTool {
                     "message": format!("Created directory {}", path)
                 }))
             }
-            _ => Err(anyhow::anyhow!("Unknown operation: {}", operation)),
+            _ => Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Unknown operation: {}", operation))),
         }
     }
 }

--- a/crates/mofa-plugins/src/tools/http.rs
+++ b/crates/mofa-plugins/src/tools/http.rs
@@ -141,14 +141,14 @@ impl ToolExecutor for HttpRequestTool {
         let method = arguments["method"].as_str().unwrap_or("GET");
         let url = arguments["url"]
             .as_str()
-            .ok_or_else(|| anyhow::anyhow!("URL is required"))?;
+            .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("URL is required")))?;
 
         // Validate URL to prevent SSRF attacks
         if !Self::is_url_allowed(url) {
-            return Err(anyhow::anyhow!(
+            return Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!(
                 "Access denied: URL '{}' targets a blocked address (private/internal network or disallowed scheme)",
                 url
-            ));
+            )));
         }
 
         let mut request = match method {
@@ -156,7 +156,7 @@ impl ToolExecutor for HttpRequestTool {
             "POST" => self.client.post(url),
             "PUT" => self.client.put(url),
             "DELETE" => self.client.delete(url),
-            _ => return Err(anyhow::anyhow!("Unsupported HTTP method: {}", method)),
+            _ => return Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Unsupported HTTP method: {}", method))),
         };
 
         // Add headers if provided
@@ -173,7 +173,8 @@ impl ToolExecutor for HttpRequestTool {
             request = request.body(body.to_string());
         }
 
-        let response = request.send().await?;
+        let response = request.send().await
+            .map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(e.to_string()))?;
         let status = response.status().as_u16();
         let headers: std::collections::HashMap<String, String> = response
             .headers()
@@ -181,7 +182,8 @@ impl ToolExecutor for HttpRequestTool {
             .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
             .collect();
 
-        let body = response.text().await?;
+        let body = response.text().await
+            .map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(e.to_string()))?;
 
         // Truncate body if too long
         let truncated_body = if body.len() > 5000 {

--- a/crates/mofa-plugins/src/tools/json.rs
+++ b/crates/mofa-plugins/src/tools/json.rs
@@ -90,17 +90,17 @@ impl JsonTool {
                     obj.insert(part.to_string(), new_value);
                     return Ok(());
                 }
-                return Err(anyhow::anyhow!("Cannot set value at path"));
+                return Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Cannot set value at path")));
             } else {
                 // Navigate to next level
                 if let Ok(index) = part.parse::<usize>() {
                     current = current
                         .get_mut(index)
-                        .ok_or_else(|| anyhow::anyhow!("Invalid path"))?;
+                        .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Invalid path")))?;
                 } else {
                     current = current
                         .get_mut(*part)
-                        .ok_or_else(|| anyhow::anyhow!("Invalid path"))?;
+                        .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Invalid path")))?;
                 }
             }
         }
@@ -118,13 +118,13 @@ impl ToolExecutor for JsonTool {
     async fn execute(&self, arguments: serde_json::Value) -> PluginResult<serde_json::Value> {
         let operation = arguments["operation"]
             .as_str()
-            .ok_or_else(|| anyhow::anyhow!("Operation is required"))?;
+            .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Operation is required")))?;
 
         match operation {
             "parse" => {
                 let data = arguments["data"]
                     .as_str()
-                    .ok_or_else(|| anyhow::anyhow!("String data is required for parse"))?;
+                    .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("String data is required for parse")))?;
                 let parsed: serde_json::Value = serde_json::from_str(data)?;
                 Ok(json!({
                     "success": true,
@@ -150,7 +150,7 @@ impl ToolExecutor for JsonTool {
             "get" => {
                 let path = arguments["path"]
                     .as_str()
-                    .ok_or_else(|| anyhow::anyhow!("Path is required for get operation"))?;
+                    .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Path is required for get operation")))?;
                 let data = &arguments["data"];
                 let result = Self::get_by_path(data, path);
                 Ok(json!({
@@ -161,10 +161,10 @@ impl ToolExecutor for JsonTool {
             "set" => {
                 let path = arguments["path"]
                     .as_str()
-                    .ok_or_else(|| anyhow::anyhow!("Path is required for set operation"))?;
+                    .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Path is required for set operation")))?;
                 let value = arguments
                     .get("value")
-                    .ok_or_else(|| anyhow::anyhow!("Value is required for set operation"))?
+                    .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Value is required for set operation")))?
                     .clone();
                 let mut data = arguments["data"].clone();
                 Self::set_by_path(&mut data, path, value)?;
@@ -176,11 +176,11 @@ impl ToolExecutor for JsonTool {
             "merge" => {
                 let mut data = arguments["data"]
                     .as_object()
-                    .ok_or_else(|| anyhow::anyhow!("Data must be an object for merge"))?
+                    .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Data must be an object for merge")))?
                     .clone();
                 let other = arguments["other"]
                     .as_object()
-                    .ok_or_else(|| anyhow::anyhow!("Other must be an object for merge"))?;
+                    .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Other must be an object for merge")))?;
                 for (k, v) in other {
                     data.insert(k.clone(), v.clone());
                 }
@@ -192,7 +192,7 @@ impl ToolExecutor for JsonTool {
             "keys" => {
                 let data = arguments["data"]
                     .as_object()
-                    .ok_or_else(|| anyhow::anyhow!("Data must be an object for keys"))?;
+                    .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Data must be an object for keys")))?;
                 let keys: Vec<&String> = data.keys().collect();
                 Ok(json!({
                     "success": true,
@@ -202,14 +202,14 @@ impl ToolExecutor for JsonTool {
             "values" => {
                 let data = arguments["data"]
                     .as_object()
-                    .ok_or_else(|| anyhow::anyhow!("Data must be an object for values"))?;
+                    .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Data must be an object for values")))?;
                 let values: Vec<&serde_json::Value> = data.values().collect();
                 Ok(json!({
                     "success": true,
                     "result": values
                 }))
             }
-            _ => Err(anyhow::anyhow!("Unknown operation: {}", operation)),
+            _ => Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Unknown operation: {}", operation))),
         }
     }
 }

--- a/crates/mofa-plugins/src/tools/medical_knowledge.rs
+++ b/crates/mofa-plugins/src/tools/medical_knowledge.rs
@@ -133,7 +133,7 @@ impl ToolExecutor for MedicalKnowledgeTool {
     async fn execute(&self, arguments: serde_json::Value) -> PluginResult<serde_json::Value> {
         let action = arguments["action"]
             .as_str()
-            .ok_or_else(|| anyhow::anyhow!("Action is required"))?;
+            .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Action is required")))?;
 
         match action {
             // 注入知识（支持JSON数据或文件路径）
@@ -148,8 +148,8 @@ impl ToolExecutor for MedicalKnowledgeTool {
                     // Inject from file
                     self.load_knowledge_from_file(file_path).await?
                 } else {
-                    return Err(anyhow::anyhow!(
-                        "Either knowledge JSON or file_path must be provided for inject_knowledge"
+                    return Err(mofa_kernel::plugin::PluginError::ExecutionFailed(
+                        "Either knowledge JSON or file_path must be provided for inject_knowledge".into(),
                     ));
                 };
 
@@ -178,7 +178,7 @@ impl ToolExecutor for MedicalKnowledgeTool {
             // Query diagnosis criteria
             "query_diagnosis" => {
                 let disease = arguments["disease"].as_str().ok_or_else(|| {
-                    anyhow::anyhow!("Disease name is required for query_diagnosis")
+                    mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Disease name is required for query_diagnosis"))
                 })?;
 
                 let knowledge = self.knowledge.read().unwrap();
@@ -201,7 +201,7 @@ impl ToolExecutor for MedicalKnowledgeTool {
             // Query treatment plan
             "query_treatment" => {
                 let disease = arguments["disease"].as_str().ok_or_else(|| {
-                    anyhow::anyhow!("Disease name is required for query_treatment")
+                    mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Disease name is required for query_treatment"))
                 })?;
 
                 let knowledge = self.knowledge.read().unwrap();
@@ -255,7 +255,7 @@ impl ToolExecutor for MedicalKnowledgeTool {
                 }))
             }
 
-            _ => Err(anyhow::anyhow!("Unsupported action: {}", action)),
+            _ => Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Unsupported action: {}", action))),
         }
     }
 }

--- a/crates/mofa-plugins/src/tools/response_optimizer.rs
+++ b/crates/mofa-plugins/src/tools/response_optimizer.rs
@@ -117,12 +117,12 @@ impl ToolExecutor for ResponseOptimizerTool {
     async fn execute(&self, arguments: serde_json::Value) -> PluginResult<serde_json::Value> {
         let action = arguments["action"]
             .as_str()
-            .ok_or_else(|| anyhow::anyhow!("Action is required"))?;
+            .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Action is required")))?;
 
         match action {
             "record_feedback" => {
                 let feedback_type = arguments["feedback_type"].as_str().ok_or_else(|| {
-                    anyhow::anyhow!("feedback_type is required for record_feedback")
+                    mofa_kernel::plugin::PluginError::ExecutionFailed(format!("feedback_type is required for record_feedback"))
                 })?;
 
                 let feedback_content = arguments["feedback_content"].as_str().unwrap_or("");
@@ -168,7 +168,7 @@ impl ToolExecutor for ResponseOptimizerTool {
                     "message": "Feedback stats reset successfully"
                 }))
             }
-            _ => Err(anyhow::anyhow!("Unknown action: {}", action)),
+            _ => Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Unknown action: {}", action))),
         }
     }
 }

--- a/crates/mofa-plugins/src/tools/rhai.rs
+++ b/crates/mofa-plugins/src/tools/rhai.rs
@@ -12,7 +12,8 @@ pub struct RhaiScriptTool {
 impl RhaiScriptTool {
     pub fn new() -> PluginResult<Self> {
         let config = ScriptEngineConfig::default();
-        let engine = RhaiScriptEngine::new(config)?;
+        let engine = RhaiScriptEngine::new(config)
+            .map_err(|e| mofa_kernel::plugin::PluginError::InitFailed(e.to_string()))?;
         Ok(Self {
             definition: ToolDefinition {
                 name: "rhai_script".to_string(),
@@ -48,7 +49,7 @@ impl ToolExecutor for RhaiScriptTool {
     async fn execute(&self, arguments: serde_json::Value) -> PluginResult<serde_json::Value> {
         let script = arguments["script"]
             .as_str()
-            .ok_or_else(|| anyhow::anyhow!("Script is required"))?;
+            .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed("Script is required".into()))?;
 
         let mut context = ScriptContext::new();
 
@@ -56,29 +57,31 @@ impl ToolExecutor for RhaiScriptTool {
         if let Some(vars) = arguments.get("variables").and_then(|v| v.as_object()) {
             for (key, value) in vars {
                 // Convert JSON values to Rhai-compatible types
+                let me = |e: mofa_extra::rhai::RhaiError| mofa_kernel::plugin::PluginError::ExecutionFailed(e.to_string());
                 match value {
                     serde_json::Value::Number(n) => {
                         if let Some(i) = n.as_i64() {
-                            context = context.with_variable(key, i)?;
+                            context = context.with_variable(key, i).map_err(me)?;
                         } else if let Some(f) = n.as_f64() {
-                            context = context.with_variable(key, f)?;
+                            context = context.with_variable(key, f).map_err(me)?;
                         }
                     }
                     serde_json::Value::String(s) => {
-                        context = context.with_variable(key, s.clone())?;
+                        context = context.with_variable(key, s.clone()).map_err(me)?;
                     }
                     serde_json::Value::Bool(b) => {
-                        context = context.with_variable(key, *b)?;
+                        context = context.with_variable(key, *b).map_err(me)?;
                     }
                     _ => {
                         // For complex types, pass as JSON string
-                        context = context.with_variable(key, value.to_string())?;
+                        context = context.with_variable(key, value.to_string()).map_err(me)?;
                     }
                 }
             }
         }
 
-        let result = self.engine.execute(script, &context).await?;
+        let result = self.engine.execute(script, &context).await
+            .map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(e.to_string()))?;
 
         Ok(json!({
             "success": true,

--- a/crates/mofa-plugins/src/tools/shell.rs
+++ b/crates/mofa-plugins/src/tools/shell.rs
@@ -78,14 +78,14 @@ impl ToolExecutor for ShellCommandTool {
     async fn execute(&self, arguments: serde_json::Value) -> PluginResult<serde_json::Value> {
         let command = arguments["command"]
             .as_str()
-            .ok_or_else(|| anyhow::anyhow!("Command is required"))?;
+            .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Command is required")))?;
 
         if !self.is_command_allowed(command) {
-            return Err(anyhow::anyhow!(
+            return Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!(
                 "Command '{}' is not in the allowed commands list. Allowed: {:?}",
                 command,
                 self.allowed_commands
-            ));
+            )));
         }
 
         let args: Vec<String> = arguments

--- a/crates/mofa-plugins/src/tts.rs
+++ b/crates/mofa-plugins/src/tts.rs
@@ -300,12 +300,12 @@ pub fn play_audio(audio_data: Vec<u8>) -> PluginResult<()> {
 
     let cursor = Cursor::new(audio_data);
     let (_stream, stream_handle) = OutputStream::try_default()
-        .map_err(|e| anyhow::anyhow!("Failed to get audio output: {}", e))?;
+        .map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Failed to get audio output: {}", e)))?;
     let sink = Sink::try_new(&stream_handle)
-        .map_err(|e| anyhow::anyhow!("Failed to create sink: {}", e))?;
+        .map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Failed to create sink: {}", e)))?;
 
     let source =
-        Decoder::new(cursor).map_err(|e| anyhow::anyhow!("Failed to decode audio: {}", e))?;
+        Decoder::new(cursor).map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Failed to decode audio: {}", e)))?;
     sink.append(source);
     sink.sleep_until_end();
 
@@ -339,7 +339,7 @@ pub fn play_audio(audio_data: Vec<u8>) -> PluginResult<()> {
 pub async fn play_audio_async(audio_data: Vec<u8>) -> PluginResult<()> {
     tokio::task::spawn_blocking(move || play_audio(audio_data))
         .await
-        .map_err(|e| anyhow::anyhow!("Playback task failed: {}", e))?
+        .map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Playback task failed: {}", e)))?
 }
 
 // ============================================================================
@@ -444,7 +444,7 @@ impl TTSPlugin {
         let engine = self
             .engine
             .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("TTS engine not initialized"))?;
+            .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("TTS engine not initialized")))?;
 
         self.synthesis_count += 1;
         self.total_chars_synthesized += text.len() as u64;
@@ -460,7 +460,7 @@ impl TTSPlugin {
         let engine = self
             .engine
             .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("TTS engine not initialized"))?;
+            .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("TTS engine not initialized")))?;
 
         self.synthesis_count += 1;
         self.total_chars_synthesized += text.len() as u64;
@@ -478,7 +478,7 @@ impl TTSPlugin {
         let engine = self
             .engine
             .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("TTS engine not initialized"))?;
+            .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("TTS engine not initialized")))?;
 
         self.synthesis_count += 1;
         self.total_chars_synthesized += text.len() as u64;
@@ -511,7 +511,7 @@ impl TTSPlugin {
         let engine = self
             .engine
             .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("TTS engine not initialized"))?;
+            .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("TTS engine not initialized")))?;
 
         self.synthesis_count += 1;
         self.total_chars_synthesized += text.len() as u64;
@@ -525,7 +525,7 @@ impl TTSPlugin {
                 return kokoro
                     .synthesize_stream_f32(text, voice, callback)
                     .await
-                    .map_err(|e| anyhow::anyhow!("F32 streaming failed: {}", e));
+                    .map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("F32 streaming failed: {}", e)));
             }
         }
 
@@ -552,7 +552,7 @@ impl TTSPlugin {
         let engine = self
             .engine
             .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("TTS engine not initialized"))?;
+            .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("TTS engine not initialized")))?;
         engine.list_voices().await
     }
 
@@ -644,7 +644,7 @@ impl AgentPlugin for TTSPlugin {
         let cache_dir = self.config.cache_dir.as_ref().map(std::path::PathBuf::from);
         self.model_cache = Some(
             cache::ModelCache::new(cache_dir)
-                .map_err(|e| anyhow::anyhow!("Failed to initialize model cache: {}", e))?,
+                .map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Failed to initialize model cache: {}", e)))?,
         );
 
         // Initialize Hugging Face client
@@ -661,12 +661,12 @@ impl AgentPlugin for TTSPlugin {
         let cache = self
             .model_cache
             .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("Model cache not initialized"))?;
+            .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Model cache not initialized")))?;
 
         let hf_client = self
             .hf_client
             .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("HF client not initialized"))?;
+            .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("HF client not initialized")))?;
 
         // Check if model exists in cache
         let model_exists = cache.exists(&self.config.model_url).await;
@@ -696,15 +696,15 @@ impl AgentPlugin for TTSPlugin {
             hf_client
                 .download_model(download_config, cache)
                 .await
-                .map_err(|e| anyhow::anyhow!("Failed to download model: {}", e))?;
+                .map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Failed to download model: {}", e)))?;
         } else if !model_exists {
             // Auto-download disabled, fail with clear error
-            return Err(anyhow::anyhow!(
+            return Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!(
                 "Model '{}' not found in cache and auto_download is disabled. \
                 Please enable auto_download or manually download the model to: {:?}",
                 self.config.model_url,
                 cache.model_path(&self.config.model_url)
-            ));
+            )));
         }
 
         // Validate cached model
@@ -712,11 +712,11 @@ impl AgentPlugin for TTSPlugin {
             && !cache
                 .validate(&self.config.model_url, Some(expected_checksum))
                 .await
-                .map_err(|e| anyhow::anyhow!("Failed to validate model: {}", e))?
+                .map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Failed to validate model: {}", e)))?
         {
-            return Err(anyhow::anyhow!(
+            return Err(mofa_kernel::plugin::PluginError::ExecutionFailed(
                 "Model validation failed. The cached model may be corrupted. \
-                    Try deleting the cache and re-downloading."
+                    Try deleting the cache and re-downloading.".into(),
             ));
         }
 
@@ -734,7 +734,7 @@ impl AgentPlugin for TTSPlugin {
 
                 let model_path_str = model_path
                     .to_str()
-                    .ok_or_else(|| anyhow::anyhow!("Invalid model path"))?;
+                    .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Invalid model path")))?;
 
                 info!(
                     "Initializing Kokoro TTS engine with model: {}, voices: {}",
@@ -747,12 +747,12 @@ impl AgentPlugin for TTSPlugin {
                         info!("Kokoro TTS engine initialized successfully");
                     }
                     Err(e) => {
-                        return Err(anyhow::anyhow!(
+                        return Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!(
                             "Failed to initialize Kokoro engine (model: {}, voices: {}): {}",
                             model_path_str,
                             voice_path,
                             e
-                        ));
+                        )));
                     }
                 }
             }
@@ -791,13 +791,13 @@ impl AgentPlugin for TTSPlugin {
     async fn execute(&mut self, input: String) -> PluginResult<String> {
         // Parse input as JSON command
         let command: TTSCommand = serde_json::from_str(&input)
-            .map_err(|e| anyhow::anyhow!("Invalid TTS command format: {}", e))?;
+            .map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Invalid TTS command format: {}", e)))?;
 
         match command.action.as_str() {
             "speak" | "synthesize" => {
                 let text = command
                     .text
-                    .ok_or_else(|| anyhow::anyhow!("Missing 'text' parameter"))?;
+                    .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Missing 'text' parameter")))?;
 
                 if command.play.unwrap_or(true) {
                     self.synthesize_and_play(&text).await?;
@@ -811,22 +811,24 @@ impl AgentPlugin for TTSPlugin {
             }
             "list_voices" => {
                 let voices = self.list_voices().await?;
-                let json = serde_json::to_string(&voices)?;
+                let json = serde_json::to_string(&voices)
+                    .map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(e.to_string()))?;
                 Ok(json)
             }
             "set_voice" => {
                 let voice = command
                     .voice
-                    .ok_or_else(|| anyhow::anyhow!("Missing 'voice' parameter"))?;
+                    .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Missing 'voice' parameter")))?;
                 self.set_default_voice(&voice);
                 Ok(format!("Default voice set to: {}", voice))
             }
             "stats" => {
                 let stats = self.stats();
-                let json = serde_json::to_string(&stats)?;
+                let json = serde_json::to_string(&stats)
+                    .map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(e.to_string()))?;
                 Ok(json)
             }
-            _ => Err(anyhow::anyhow!("Unknown action: {}", command.action)),
+            _ => Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Unknown action: {}", command.action))),
         }
     }
 
@@ -920,7 +922,7 @@ impl ToolExecutor for TextToSpeechTool {
         let text = arguments
             .get("text")
             .and_then(|v| v.as_str())
-            .ok_or_else(|| anyhow::anyhow!("Missing 'text' parameter"))?;
+            .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Missing 'text' parameter")))?;
 
         let voice = arguments.get("voice").and_then(|v| v.as_str());
         let play = arguments
@@ -944,7 +946,8 @@ impl ToolExecutor for TextToSpeechTool {
             }
         };
 
-        let input = serde_json::to_string(&command)?;
+        let input = serde_json::to_string(&command)
+            .map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(e.to_string()))?;
         Ok(serde_json::json!({
             "success": true,
             "message": format!("TTS command prepared for: {}", text),
@@ -954,10 +957,10 @@ impl ToolExecutor for TextToSpeechTool {
 
     fn validate(&self, arguments: &serde_json::Value) -> PluginResult<()> {
         if !arguments.is_object() {
-            return Err(anyhow::anyhow!("Arguments must be an object"));
+            return Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Arguments must be an object")));
         }
         if arguments.get("text").and_then(|v| v.as_str()).is_none() {
-            return Err(anyhow::anyhow!("Missing required parameter: text"));
+            return Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Missing required parameter: text")));
         }
         Ok(())
     }

--- a/crates/mofa-plugins/src/tts/kokoro_wrapper.rs
+++ b/crates/mofa-plugins/src/tts/kokoro_wrapper.rs
@@ -83,7 +83,7 @@
 //! ```
 
 use super::{TTSEngine, VoiceInfo};
-use futures::StreamExt;
+use mofa_kernel::plugin::{PluginError, PluginResult};use futures::StreamExt;
 pub use kokoro_tts::{KokoroTts, SynthSink, SynthStream, Voice};
 use std::path::Path;
 use std::sync::Arc;
@@ -131,7 +131,7 @@ impl KokoroTTS {
     ///
     /// # Errors
     /// Returns an error if model initialization fails
-    pub async fn new(model_path: &str, voice_path: &str) -> Result<Self, anyhow::Error> {
+    pub async fn new(model_path: &str, voice_path: &str) -> PluginResult<Self> {
         info!(
             "Initializing Kokoro TTS with model: {}, voices: {}",
             model_path, voice_path
@@ -139,13 +139,13 @@ impl KokoroTTS {
 
         // Validate file paths exist
         if !Path::new(model_path).exists() {
-            return Err(anyhow::anyhow!(
+            return Err(PluginError::Other(format!(
                 "Kokoro model file not found: {}",
                 model_path
             ));
         }
         if !Path::new(voice_path).exists() {
-            return Err(anyhow::anyhow!(
+            return Err(PluginError::Other(format!(
                 "Kokoro voices file not found: {}",
                 voice_path
             ));
@@ -154,7 +154,7 @@ impl KokoroTTS {
         // Initialize Kokoro TTS
         let tts = KokoroTts::new(model_path, voice_path)
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to initialize Kokoro TTS: {:?}", e))?;
+            .map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Failed to initialize Kokoro TTS: {:?}", e)))?;
 
         let model_lower = model_path.to_ascii_lowercase();
         let is_v11_model = model_lower.contains("v1.1") || model_lower.contains("v11");
@@ -231,7 +231,7 @@ impl KokoroTTS {
     pub async fn create_stream(
         &self,
         voice: &str,
-    ) -> Result<(SynthSink<String>, SynthStream), anyhow::Error> {
+    ) -> PluginResult<(SynthSink<String>, SynthStream)> {
         let voice_enum = self.resolve_voice(voice);
         let (sink, stream) = self.tts.stream::<String>(voice_enum);
         Ok((sink, stream))
@@ -259,7 +259,7 @@ impl KokoroTTS {
         text: &str,
         voice: &str,
         callback: Box<dyn Fn(Vec<f32>) + Send + Sync>,
-    ) -> Result<(), anyhow::Error> {
+    ) -> PluginResult<()> {
         debug!(
             "[KokoroTTS] F32 stream synthesizing with voice '{}': {}",
             voice, text
@@ -273,7 +273,7 @@ impl KokoroTTS {
         // Submit text for synthesis
         sink.synth(text.to_string())
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to submit text for f32 streaming: {:?}", e))?;
+            .map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Failed to submit text for f32 streaming: {:?}", e)))?;
 
         // Process audio chunks and call callback for each chunk
         while let Some((audio_f32, _took)) = stream.next().await {
@@ -318,7 +318,7 @@ impl TTSEngine for KokoroTTS {
     /// let audio = kokoro.synthesize("Hello world", "default").await?;
     /// println!("Audio size: {} bytes", audio.len());
     /// ```
-    async fn synthesize(&self, text: &str, voice: &str) -> Result<Vec<u8>, anyhow::Error> {
+    async fn synthesize(&self, text: &str, voice: &str) -> PluginResult<Vec<u8>> {
         debug!(
             "[KokoroTTS] Synthesizing text with voice '{}': {}",
             voice, text
@@ -332,7 +332,7 @@ impl TTSEngine for KokoroTTS {
         // Submit text for synthesis using the synth method
         sink.synth(text.to_string())
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to submit text for synthesis: {:?}", e))?;
+            .map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Failed to submit text for synthesis: {:?}", e)))?;
 
         // Collect all audio chunks
         let mut audio = Vec::new();
@@ -410,7 +410,7 @@ impl TTSEngine for KokoroTTS {
         text: &str,
         voice: &str,
         callback: Box<dyn Fn(Vec<u8>) + Send + Sync>,
-    ) -> Result<(), anyhow::Error> {
+    ) -> PluginResult<()> {
         debug!(
             "[KokoroTTS] Stream synthesizing text with voice '{}': {}",
             voice, text
@@ -423,7 +423,7 @@ impl TTSEngine for KokoroTTS {
 
         // Submit text for synthesis
         sink.synth(text.to_string()).await.map_err(|e| {
-            anyhow::anyhow!("Failed to submit text for streaming synthesis: {:?}", e)
+            mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Failed to submit text for streaming synthesis: {:?}", e))
         })?;
 
         // Process audio chunks and call callback for each chunk
@@ -451,7 +451,7 @@ impl TTSEngine for KokoroTTS {
     }
 
     /// List available voices
-    async fn list_voices(&self) -> Result<Vec<VoiceInfo>, anyhow::Error> {
+    async fn list_voices(&self) -> PluginResult<Vec<VoiceInfo>> {
         let voices = vec![
             VoiceInfo::new("default", "默认女声 (Default Female)", "zh-CN"),
             VoiceInfo::new("zh_female", "中文女声1 (Chinese Female 1)", "zh-CN"),

--- a/crates/mofa-plugins/src/tts/kokoro_wrapper.rs
+++ b/crates/mofa-plugins/src/tts/kokoro_wrapper.rs
@@ -142,13 +142,13 @@ impl KokoroTTS {
             return Err(PluginError::Other(format!(
                 "Kokoro model file not found: {}",
                 model_path
-            ));
+            )));
         }
         if !Path::new(voice_path).exists() {
             return Err(PluginError::Other(format!(
                 "Kokoro voices file not found: {}",
                 voice_path
-            ));
+            )));
         }
 
         // Initialize Kokoro TTS

--- a/crates/mofa-runtime/Cargo.toml
+++ b/crates/mofa-runtime/Cargo.toml
@@ -20,7 +20,6 @@ serde.workspace = true
 serde_json.workspace = true
 bincode.workspace = true
 tokio.workspace = true
-anyhow.workspace = true
 tracing.workspace = true
 flume.workspace = true
 uuid.workspace = true

--- a/crates/mofa-runtime/src/dora_adapter/error.rs
+++ b/crates/mofa-runtime/src/dora_adapter/error.rs
@@ -83,12 +83,6 @@ impl From<tokio::sync::broadcast::error::SendError<Vec<u8>>> for DoraError {
     }
 }
 
-impl From<anyhow::Error> for DoraError {
-    fn from(err: anyhow::Error) -> Self {
-        DoraError::Internal(err.to_string())
-    }
-}
-
 /// dora-rs 适配层结果类型
 /// Result type for the dora-rs adapter layer
 pub type DoraResult<T> = Result<T, DoraError>;

--- a/crates/mofa-runtime/src/lib.rs
+++ b/crates/mofa-runtime/src/lib.rs
@@ -1,3 +1,4 @@
+use mofa_kernel::agent::types::error::{GlobalError, GlobalResult};
 #[cfg(feature = "monitoring")]
 pub use mofa_monitoring::*;
 
@@ -264,7 +265,7 @@ impl AgentBuilder {
     /// 使用提供的 MoFAAgent 实现构建简单运行时（非 dora 模式）
     /// Builds simple runtime with MoFAAgent implementation (non-dora mode)
     #[cfg(not(feature = "dora"))]
-    pub async fn with_agent<A: MoFAAgent>(self, agent: A) -> anyhow::Result<SimpleAgentRuntime<A>> {
+    pub async fn with_agent<A: MoFAAgent>(self, agent: A) -> GlobalResult<SimpleAgentRuntime<A>> {
         let metadata = self.build_metadata();
         let config = self.build_config();
         let interrupt = AgentInterrupt::new();
@@ -294,7 +295,7 @@ impl AgentBuilder {
     pub async fn build_and_start<A: MoFAAgent>(
         self,
         agent: A,
-    ) -> anyhow::Result<SimpleAgentRuntime<A>> {
+    ) -> GlobalResult<SimpleAgentRuntime<A>> {
         let mut runtime = self.with_agent(agent).await?;
         runtime.start().await?;
         Ok(runtime)
@@ -554,16 +555,16 @@ impl<A: MoFAAgent> SimpleAgentRuntime<A> {
 
     /// 初始化插件
     /// Initializes plugins
-    pub async fn init_plugins(&mut self) -> anyhow::Result<()> {
+    pub async fn init_plugins(&mut self) -> GlobalResult<()> {
         for plugin in &mut self.plugins {
-            plugin.init_plugin().await?;
+            plugin.init_plugin().await.map_err(|e| GlobalError::Other(e.to_string()))?;
         }
         Ok(())
     }
 
     /// 启动运行时
     /// Starts the runtime
-    pub async fn start(&mut self) -> anyhow::Result<()> {
+    pub async fn start(&mut self) -> GlobalResult<()> {
         // 创建 CoreAgentContext
         // Create CoreAgentContext
         let context = mofa_kernel::agent::AgentContext::new(self.metadata.id.clone());
@@ -580,7 +581,7 @@ impl<A: MoFAAgent> SimpleAgentRuntime<A> {
 
     /// 处理单个事件
     /// Processes a single event
-    pub async fn handle_event(&mut self, event: AgentEvent) -> anyhow::Result<()> {
+    pub async fn handle_event(&mut self, event: AgentEvent) -> GlobalResult<()> {
         // 检查中断 - 注意：MoFAAgent 没有 on_interrupt 方法
         // Check interrupt - Note: MoFAAgent lacks on_interrupt method
         // 中断处理需要由 Agent 内部自行处理或通过 AgentMessaging 扩展
@@ -616,13 +617,13 @@ impl<A: MoFAAgent> SimpleAgentRuntime<A> {
 
     /// 运行事件循环（使用内部事件接收器）
     /// Runs event loop (using internal event receiver)
-    pub async fn run(&mut self) -> anyhow::Result<()> {
+    pub async fn run(&mut self) -> GlobalResult<()> {
         // 获取内部事件接收器
         // Get internal event receiver
         let event_rx = self
             .event_rx
             .take()
-            .ok_or_else(|| anyhow::anyhow!("Event receiver already taken"))?;
+            .ok_or_else(|| GlobalError::Other("Event receiver already taken".to_string()))?;
 
         self.run_with_receiver(event_rx).await
     }
@@ -632,7 +633,7 @@ impl<A: MoFAAgent> SimpleAgentRuntime<A> {
     pub async fn run_with_receiver(
         &mut self,
         mut event_rx: tokio::sync::mpsc::Receiver<AgentEvent>,
-    ) -> anyhow::Result<()> {
+    ) -> GlobalResult<()> {
         loop {
             // 检查中断
             // Check for interrupts
@@ -674,7 +675,7 @@ impl<A: MoFAAgent> SimpleAgentRuntime<A> {
 
     /// 停止运行时
     /// Stops the runtime
-    pub async fn stop(&mut self) -> anyhow::Result<()> {
+    pub async fn stop(&mut self) -> GlobalResult<()> {
         self.interrupt.trigger();
         self.agent.shutdown().await?;
         ::tracing::info!("SimpleAgentRuntime {} stopped", self.metadata.id);
@@ -767,7 +768,7 @@ impl SimpleMessageBus {
 
     /// 发送点对点消息
     /// Send point-to-point message
-    pub async fn send_to(&self, target_id: &str, event: AgentEvent) -> anyhow::Result<()> {
+    pub async fn send_to(&self, target_id: &str, event: AgentEvent) -> GlobalResult<()> {
         let senders = {
             let subs = self.subscribers.read().await;
             subs.get(target_id).cloned().unwrap_or_default()
@@ -781,7 +782,7 @@ impl SimpleMessageBus {
 
     /// 广播消息给所有智能体
     /// Broadcast message to all agents
-    pub async fn broadcast(&self, event: AgentEvent) -> anyhow::Result<()> {
+    pub async fn broadcast(&self, event: AgentEvent) -> GlobalResult<()> {
         let senders = {
             let subs = self.subscribers.read().await;
             subs.values()
@@ -797,7 +798,7 @@ impl SimpleMessageBus {
 
     /// 发布到主题
     /// Publish to a topic
-    pub async fn publish(&self, topic: &str, event: AgentEvent) -> anyhow::Result<()> {
+    pub async fn publish(&self, topic: &str, event: AgentEvent) -> GlobalResult<()> {
         let agent_ids = {
             let topics = self.topic_subscribers.read().await;
             topics.get(topic).cloned().unwrap_or_default()
@@ -835,11 +836,11 @@ impl SimpleMessageBus {
         stream_id: &str,
         stream_type: StreamType,
         metadata: HashMap<String, String>,
-    ) -> anyhow::Result<()> {
+    ) -> GlobalResult<()> {
         {
             let mut streams = self.streams.write().await;
             if streams.contains_key(stream_id) {
-                return Err(anyhow::anyhow!("Stream {} already exists", stream_id));
+                return Err(GlobalError::Other(format!("Stream {} already exists", stream_id)));
             }
 
             // 创建流信息
@@ -868,7 +869,7 @@ impl SimpleMessageBus {
 
     /// 关闭流
     /// Close a stream
-    pub async fn close_stream(&self, stream_id: &str, reason: &str) -> anyhow::Result<()> {
+    pub async fn close_stream(&self, stream_id: &str, reason: &str) -> GlobalResult<()> {
         let subscribers = {
             let mut streams = self.streams.write().await;
             streams
@@ -910,7 +911,7 @@ impl SimpleMessageBus {
 
     /// 订阅流
     /// Subscribe to a stream
-    pub async fn subscribe_stream(&self, agent_id: &str, stream_id: &str) -> anyhow::Result<()> {
+    pub async fn subscribe_stream(&self, agent_id: &str, stream_id: &str) -> GlobalResult<()> {
         let should_broadcast = {
             let mut streams = self.streams.write().await;
             if let Some(stream_info) = streams.get_mut(stream_id) {
@@ -941,7 +942,7 @@ impl SimpleMessageBus {
 
     /// 取消订阅流
     /// Unsubscribe from a stream
-    pub async fn unsubscribe_stream(&self, agent_id: &str, stream_id: &str) -> anyhow::Result<()> {
+    pub async fn unsubscribe_stream(&self, agent_id: &str, stream_id: &str) -> GlobalResult<()> {
         let should_broadcast = {
             let mut streams = self.streams.write().await;
             if let Some(stream_info) = streams.get_mut(stream_id) {
@@ -976,7 +977,7 @@ impl SimpleMessageBus {
         &self,
         stream_id: &str,
         message: Vec<u8>,
-    ) -> anyhow::Result<()> {
+    ) -> GlobalResult<()> {
         let stream_delivery = {
             let mut streams = self.streams.write().await;
             if let Some(stream_info) = streams.get_mut(stream_id) {
@@ -1031,7 +1032,7 @@ impl SimpleMessageBus {
 
     /// 暂停流
     /// Pause a stream
-    pub async fn pause_stream(&self, stream_id: &str) -> anyhow::Result<()> {
+    pub async fn pause_stream(&self, stream_id: &str) -> GlobalResult<()> {
         let mut streams = self.streams.write().await;
         if let Some(stream_info) = streams.get_mut(stream_id) {
             stream_info.is_paused = true;
@@ -1041,7 +1042,7 @@ impl SimpleMessageBus {
 
     /// 恢复流
     /// Resume a stream
-    pub async fn resume_stream(&self, stream_id: &str) -> anyhow::Result<()> {
+    pub async fn resume_stream(&self, stream_id: &str) -> GlobalResult<()> {
         let mut streams = self.streams.write().await;
         if let Some(stream_info) = streams.get_mut(stream_id) {
             stream_info.is_paused = false;
@@ -1051,7 +1052,7 @@ impl SimpleMessageBus {
 
     /// 获取流信息
     /// Get stream information
-    pub async fn get_stream_info(&self, stream_id: &str) -> anyhow::Result<Option<StreamInfo>> {
+    pub async fn get_stream_info(&self, stream_id: &str) -> GlobalResult<Option<StreamInfo>> {
         let streams = self.streams.read().await;
         Ok(streams.get(stream_id).cloned())
     }
@@ -1083,7 +1084,7 @@ impl SimpleRuntime {
         metadata: AgentMetadata,
         config: AgentConfig,
         role: &str,
-    ) -> anyhow::Result<tokio::sync::mpsc::Receiver<AgentEvent>> {
+    ) -> GlobalResult<tokio::sync::mpsc::Receiver<AgentEvent>> {
         let agent_id = metadata.id.clone();
         let (tx, rx) = tokio::sync::mpsc::channel(100);
 
@@ -1131,25 +1132,25 @@ impl SimpleRuntime {
 
     /// 发送消息给指定智能体
     /// Send message to a specific agent
-    pub async fn send_to_agent(&self, target_id: &str, event: AgentEvent) -> anyhow::Result<()> {
+    pub async fn send_to_agent(&self, target_id: &str, event: AgentEvent) -> GlobalResult<()> {
         self.message_bus.send_to(target_id, event).await
     }
 
     /// 广播消息给所有智能体
     /// Broadcast message to all agents
-    pub async fn broadcast(&self, event: AgentEvent) -> anyhow::Result<()> {
+    pub async fn broadcast(&self, event: AgentEvent) -> GlobalResult<()> {
         self.message_bus.broadcast(event).await
     }
 
     /// 发布到主题
     /// Publish to a topic
-    pub async fn publish_to_topic(&self, topic: &str, event: AgentEvent) -> anyhow::Result<()> {
+    pub async fn publish_to_topic(&self, topic: &str, event: AgentEvent) -> GlobalResult<()> {
         self.message_bus.publish(topic, event).await
     }
 
     /// 订阅主题
     /// Subscribe to a topic
-    pub async fn subscribe_topic(&self, agent_id: &str, topic: &str) -> anyhow::Result<()> {
+    pub async fn subscribe_topic(&self, agent_id: &str, topic: &str) -> GlobalResult<()> {
         self.message_bus.subscribe(agent_id, topic).await;
         Ok(())
     }
@@ -1167,7 +1168,7 @@ impl SimpleRuntime {
         stream_id: &str,
         stream_type: StreamType,
         metadata: std::collections::HashMap<String, String>,
-    ) -> anyhow::Result<()> {
+    ) -> GlobalResult<()> {
         self.message_bus
             .create_stream(stream_id, stream_type, metadata)
             .await
@@ -1175,19 +1176,19 @@ impl SimpleRuntime {
 
     /// 关闭流
     /// Close stream
-    pub async fn close_stream(&self, stream_id: &str, reason: &str) -> anyhow::Result<()> {
+    pub async fn close_stream(&self, stream_id: &str, reason: &str) -> GlobalResult<()> {
         self.message_bus.close_stream(stream_id, reason).await
     }
 
     /// 订阅流
     /// Subscribe to stream
-    pub async fn subscribe_stream(&self, agent_id: &str, stream_id: &str) -> anyhow::Result<()> {
+    pub async fn subscribe_stream(&self, agent_id: &str, stream_id: &str) -> GlobalResult<()> {
         self.message_bus.subscribe_stream(agent_id, stream_id).await
     }
 
     /// 取消订阅流
     /// Unsubscribe from stream
-    pub async fn unsubscribe_stream(&self, agent_id: &str, stream_id: &str) -> anyhow::Result<()> {
+    pub async fn unsubscribe_stream(&self, agent_id: &str, stream_id: &str) -> GlobalResult<()> {
         self.message_bus
             .unsubscribe_stream(agent_id, stream_id)
             .await
@@ -1199,7 +1200,7 @@ impl SimpleRuntime {
         &self,
         stream_id: &str,
         message: Vec<u8>,
-    ) -> anyhow::Result<()> {
+    ) -> GlobalResult<()> {
         self.message_bus
             .send_stream_message(stream_id, message)
             .await
@@ -1207,25 +1208,25 @@ impl SimpleRuntime {
 
     /// 暂停流
     /// Pause stream
-    pub async fn pause_stream(&self, stream_id: &str) -> anyhow::Result<()> {
+    pub async fn pause_stream(&self, stream_id: &str) -> GlobalResult<()> {
         self.message_bus.pause_stream(stream_id).await
     }
 
     /// 恢复流
     /// Resume stream
-    pub async fn resume_stream(&self, stream_id: &str) -> anyhow::Result<()> {
+    pub async fn resume_stream(&self, stream_id: &str) -> GlobalResult<()> {
         self.message_bus.resume_stream(stream_id).await
     }
 
     /// 获取流信息
     /// Get stream info
-    pub async fn get_stream_info(&self, stream_id: &str) -> anyhow::Result<Option<StreamInfo>> {
+    pub async fn get_stream_info(&self, stream_id: &str) -> GlobalResult<Option<StreamInfo>> {
         self.message_bus.get_stream_info(stream_id).await
     }
 
     /// 停止所有智能体
     /// Stop all agents
-    pub async fn stop_all(&self) -> anyhow::Result<()> {
+    pub async fn stop_all(&self) -> GlobalResult<()> {
         self.message_bus.broadcast(AgentEvent::Shutdown).await?;
         ::tracing::info!("SimpleRuntime stopped");
         Ok(())

--- a/crates/mofa-sdk/Cargo.toml
+++ b/crates/mofa-sdk/Cargo.toml
@@ -42,7 +42,6 @@ mofa-monitoring = { path = "../mofa-monitoring", version = "0.1", optional = tru
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "mysql", "sqlite", "uuid", "chrono", "json"], optional = true }
 async-trait = "0.1"
 tokio = { version = "1", features = ["full"] }
-anyhow.workspace = true
 uuid.workspace = true
 tracing.workspace = true
 serde_json.workspace = true

--- a/crates/mofa-sdk/src/lib.rs
+++ b/crates/mofa-sdk/src/lib.rs
@@ -43,7 +43,7 @@
 //! }
 //!
 //! #[tokio::main]
-//! async fn main() -> anyhow::Result<()> {
+//! async fn main() -> GlobalResult<()> {
 //!     let outputs = run_agents(MyAgent, vec![AgentInput::text("Hello")]).await?;
 //!     println!("{}", outputs[0].to_text());
 //!     Ok(())
@@ -623,7 +623,7 @@ pub mod secretary {
     //! use std::sync::Arc;
     //!
     //! #[tokio::main]
-    //! async fn main() -> anyhow::Result<()> {
+    //! async fn main() -> GlobalResult<()> {
     //!     // 1. 创建秘书Agent
     //!     // 1. Create Secretary Agent
     //!     let mut backend_agent = AgentInfo::new("backend_agent", "后端Agent");
@@ -695,7 +695,7 @@ pub mod secretary {
     //! impl LLMProvider for MyLLMProvider {
     //!     fn name(&self) -> &str { "my-llm" }
     //!
-    //!     async fn chat(&self, messages: Vec<ChatMessage>) -> anyhow::Result<String> {
+    //!     async fn chat(&self, messages: Vec<ChatMessage>) -> GlobalResult<String> {
     //!         // 调用你的LLM API
     //!         // Call your LLM API
     //!         Ok("LLM响应".to_string())
@@ -760,7 +760,7 @@ pub mod collaboration {
     //! use std::sync::Arc;
     //!
     //! #[tokio::main]
-    //! async fn main() -> anyhow::Result<()> {
+    //! async fn main() -> GlobalResult<()> {
     //!     let manager = LLMDrivenCollaborationManager::new("agent_001");
     //!
     //!     // 注册标准协议

--- a/crates/mofa-sdk/src/skills/manager.rs
+++ b/crates/mofa-sdk/src/skills/manager.rs
@@ -3,6 +3,7 @@
 
 use super::{DisclosureController, RequirementCheck, SkillMetadata};
 use std::path::{Path, PathBuf};
+use mofa_kernel::agent::types::error::{GlobalError, GlobalResult};
 
 /// Skills Manager - SDK 层统一 API
 /// Skills Manager - SDK Layer Unified API
@@ -30,14 +31,14 @@ impl SkillsManager {
     ///
     /// let manager = SkillsManager::new("./skills").unwrap();
     /// ```
-    pub fn new(skills_dir: impl AsRef<Path>) -> anyhow::Result<Self> {
+    pub fn new(skills_dir: impl AsRef<Path>) -> GlobalResult<Self> {
         let skills_dir = skills_dir.as_ref();
 
         // 不要求目录必须存在（支持空目录）
         // Directory existence not required (supports empty directories)
         let mut controller = DisclosureController::new(skills_dir);
         if skills_dir.exists() {
-            controller.scan_metadata()?;
+            controller.scan_metadata().map_err(|e| GlobalError::Other(e.to_string()))?;
         }
 
         Ok(Self { controller })
@@ -64,7 +65,7 @@ impl SkillsManager {
     ///     let manager = SkillsManager::with_search_dirs(vec![workspace_skills, builtin]).unwrap();
     /// }
     /// ```
-    pub fn with_search_dirs(search_dirs: Vec<PathBuf>) -> anyhow::Result<Self> {
+    pub fn with_search_dirs(search_dirs: Vec<PathBuf>) -> GlobalResult<Self> {
         let controller = DisclosureController::with_search_dirs(search_dirs);
         let mut manager = Self { controller };
         manager.rescan()?;
@@ -309,13 +310,13 @@ impl SkillsManager {
 
     /// 重新扫描 Skills 目录
     /// Rescan Skills directory
-    pub fn rescan(&mut self) -> anyhow::Result<usize> {
-        self.controller.scan_metadata()
+    pub fn rescan(&mut self) -> GlobalResult<usize> {
+        self.controller.scan_metadata().map_err(|e| GlobalError::Other(e.to_string()))
     }
 
     /// 重新扫描 Skills 目录（异步版本）
     /// Rescan Skills directory (Async version)
-    pub async fn rescan_async(&mut self) -> anyhow::Result<usize> {
+    pub async fn rescan_async(&mut self) -> GlobalResult<usize> {
         self.rescan()
     }
 

--- a/crates/mofa-sdk/src/skills/mod.rs
+++ b/crates/mofa-sdk/src/skills/mod.rs
@@ -21,6 +21,7 @@ pub use mofa_plugins::skill::{
     SkillRequirements, SkillState, SkillVersion,
 };
 
+use mofa_kernel::agent::types::error::GlobalResult;
 use std::path::PathBuf;
 
 /// Skills 管理器构建器
@@ -62,13 +63,13 @@ impl SkillsManagerBuilder {
 
     /// 构建 SkillsManager
     /// Build SkillsManager
-    pub fn build(&self) -> anyhow::Result<SkillsManager> {
+    pub fn build(&self) -> GlobalResult<SkillsManager> {
         SkillsManager::new(&self.search_dirs[0])
     }
 
     /// 构建支持多目录的 SkillsManager
     /// Build SkillsManager with multi-directory support
-    pub fn build_multi(&self) -> anyhow::Result<SkillsManager> {
+    pub fn build_multi(&self) -> GlobalResult<SkillsManager> {
         if self.search_dirs.len() == 1 {
             SkillsManager::new(&self.search_dirs[0])
         } else {
@@ -79,6 +80,6 @@ impl SkillsManagerBuilder {
 
 /// 便捷函数：从目录创建 SkillsManager
 /// Convenience function: Create SkillsManager from a directory
-pub fn from_dir(skills_dir: impl AsRef<std::path::Path>) -> anyhow::Result<SkillsManager> {
+pub fn from_dir(skills_dir: impl AsRef<std::path::Path>) -> GlobalResult<SkillsManager> {
     SkillsManager::new(skills_dir)
 }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4025,7 +4025,6 @@ dependencies = [
 name = "mofa-extra"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "regex",
  "rhai",
@@ -4042,7 +4041,6 @@ dependencies = [
 name = "mofa-foundation"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-openai",
  "async-trait",
  "base64 0.22.1",
@@ -4080,7 +4078,6 @@ dependencies = [
 name = "mofa-kernel"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "base64 0.22.1",
  "bincode 1.3.3",
@@ -4102,7 +4099,6 @@ dependencies = [
 name = "mofa-monitoring"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "axum 0.8.8",
  "chrono",
@@ -4129,7 +4125,6 @@ dependencies = [
 name = "mofa-plugins"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "backoff",
  "chrono",
@@ -4169,7 +4164,6 @@ dependencies = [
 name = "mofa-runtime"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "bincode 1.3.3",
  "chrono",
@@ -4195,7 +4189,6 @@ dependencies = [
 name = "mofa-sdk"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "mofa-extra",
  "mofa-foundation",

--- a/examples/hitl_secretary/src/main.rs
+++ b/examples/hitl_secretary/src/main.rs
@@ -20,6 +20,7 @@ use mofa_sdk::secretary::{
     DispatchStrategy, LLMProvider, QueryType, ReportType, SecretaryCommand,
     SecretaryCore, TodoPriority, TodoStatus,
 };
+use mofa_sdk::kernel::GlobalResult;
 use std::io::{BufRead, Write};
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -37,7 +38,7 @@ impl LLMProvider for MockLLMProvider {
         "mock-llm"
     }
 
-    async fn chat(&self, messages: Vec<ChatMessage>) -> anyhow::Result<String> {
+    async fn chat(&self, messages: Vec<ChatMessage>) -> GlobalResult<String> {
         // 简单的mock响应，实际项目中调用真实LLM API
         // Simple mock response; call real LLM APIs in actual projects
         let last_message = messages.last().map(|m| m.content.as_str()).unwrap_or("");

--- a/examples/secretary_agent/src/llm_integration.rs
+++ b/examples/secretary_agent/src/llm_integration.rs
@@ -1,6 +1,7 @@
 // 为了演示，我们实现一个简单的模拟LLM提供者
 // For demonstration, we implement a simple mock LLM provider
 use mofa_sdk::secretary::{ChatMessage, LLMProvider, ModelInfo};
+use mofa_sdk::kernel::GlobalResult;
 use std::sync::Arc;
 use tracing::info;
 
@@ -25,7 +26,7 @@ impl LLMProvider for MockLLMProvider {
         "mock-llm"
     }
 
-    async fn chat(&self, messages: Vec<ChatMessage>) -> anyhow::Result<String> {
+    async fn chat(&self, messages: Vec<ChatMessage>) -> GlobalResult<String> {
         // 模拟LLM响应，实际上这里应该调用真实的LLM API
         // Mock LLM response, in practice this should call a real LLM API
         info!("模拟LLM接收消息: {:?}", messages);
@@ -36,7 +37,7 @@ impl LLMProvider for MockLLMProvider {
         if last_message.content.contains("用户需求") {
             // 模拟需求分析的JSON响应
             // Mock requirement analysis JSON response
-            Ok(r#"{
+            return Ok(r#"{
                 "title": "用户管理系统开发",
                 "description": "开发一个包含注册、登录、权限管理功能的用户管理系统",
                 "acceptance_criteria": ["用户可以成功注册", "用户可以登录", "权限可以正确分配", "系统稳定可靠"],
@@ -77,7 +78,7 @@ impl LLMProvider for MockLLMProvider {
         } else if last_message.content.contains("分析用户需求") {
             // 模拟需求分析的JSON响应
             // Mock requirement analysis JSON response
-            Ok(r#"{
+            return Ok(r#"{
                 "core_objective": "开发一个功能完整的用户管理系统",
                 "functional_requirements": ["注册", "登录", "权限管理", "密码重置"],
                 "constraints": ["支持1000并发", "数据加密传输"],
@@ -87,7 +88,7 @@ impl LLMProvider for MockLLMProvider {
         } else {
             // 默认响应 - 对于需求澄清场景，我们也需要返回JSON格式
             // Default response - For requirement clarification scenarios, we also need to return JSON format
-            Ok(r#"{
+            return Ok(r#"{
                 "title": "默认需求",
                 "description": "默认需求描述",
                 "acceptance_criteria": ["功能按预期工作"],


### PR DESCRIPTION
## 📋 Summary

Replace all `anyhow` usage across MoFA's library crates with idiomatic, typed error handling using `thiserror`. This improves error specificity, enables callers to match on concrete failure modes, and eliminates an unnecessary runtime dependency from all library crates.

Closes #552 
---

## 🧠 Context

`anyhow` is designed for application-level error handling where you don't need callers to match on specific error variants. In a library/framework like MoFA, typed errors are preferred because:

- Downstream consumers can pattern-match on specific failures
- Error provenance is explicit at compile time
- IDE tooling and documentation benefit from concrete types
- It reduces the dependency footprint of all library crates

---

## 🛠️ Changes

- **`mofa-kernel`**: Removed `From<anyhow::Error> for GlobalError`; errors already covered by `GlobalError`, `PluginError`, `BusError`, `ConnectionError`, `SecretaryError`
- **`mofa-extra`**: Introduced `RhaiError`/`RhaiResult` for Rhai engine, tool, workflow, and rule operations
- **`mofa-plugins`**: Replaced `anyhow` in TTS submodules (`cache.rs`, `model_downloader.rs`, `kokoro_wrapper.rs`) and skill parser with `PluginError`/`PluginResult`
- **`mofa-foundation`**: Converted ~137 occurrences across secretary, LLM, collaboration, coordination, and persistence subsystems to use `GlobalError`/`GlobalResult`
- **`mofa-runtime`**: Converted `builder.rs` and `lib.rs`; removed `From<anyhow::Error> for DoraError`; added explicit `.map_err()` for cross-crate error conversions
- **`mofa-sdk`**: Converted skills manager to use `GlobalResult` with explicit `PluginError → GlobalError` mapping
- **`mofa-monitoring`**: Removed unused `anyhow` dependency
- **Cargo.toml cleanup**: Removed `anyhow` from all 7 library crate `Cargo.toml` files; only `mofa-cli` retains it as an application binary

---

## 🧪 How you Tested

1. `cargo check --workspace` — passes with zero errors
2. `grep -rn 'anyhow' crates/mofa-{kernel,extra,plugins,foundation,runtime,sdk,monitoring}/src/ --include='*.rs'` — only doc comments remain (no functional references)
3. `grep -rn 'anyhow' crates/*/Cargo.toml` — only `mofa-cli/Cargo.toml` retains it

---

## 📸 Screenshots / Logs (if applicable)

```
$ cargo check --workspace
    Finished `dev` profile [unoptimized + debuginfo] target(s)
```

---

## ⚠️ Breaking Changes

- [x] Breaking change (describe below)

**`From<anyhow::Error>` impls removed from `GlobalError` and `DoraError`.**  
Any downstream code relying on `anyhow::Error` auto-converting into these types via `?` will need to add explicit `.map_err()` calls. This is intentional — implicit `anyhow` conversions masked error origins.

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [ ] `cargo fmt` run
- [ ] `cargo clippy` passes without warnings

### Testing
- [ ] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [x] Public APIs documented
- [ ] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [ ] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---

## 🚀 Deployment Notes (if applicable)

No migrations, config changes, or env var changes required.

---

## 🧩 Additional Notes for Reviewers

- Cross-crate error conversions (e.g., `PluginError → GlobalError`, `LLMError → GlobalError`, `BusError → GlobalError`) use explicit `.map_err(|e| GlobalError::Other(e.to_string()))` rather than blanket `From` impls — this keeps error boundaries visible
- `mofa-cli` retains `anyhow` as it is an application binary, though it will be migrated in a follow-up
- The new error enums (`RhaiError`, `PluginError`, `BusError`, `ConnectionError`, `SecretaryError`) are all `#[non_exhaustive]` for forward compatibility
