### PR TITLE
feat(workflow-viz): Phase 2 — Live Execution Monitoring(websocket)

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -363,6 +363,7 @@ dependencies = [
  "async-trait",
  "axum-core 0.4.5",
  "axum-macros 0.4.2",
+ "base64 0.22.1",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -381,8 +382,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-tungstenite 0.24.0",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
@@ -419,7 +422,7 @@ dependencies = [
  "sha1",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
@@ -7302,6 +7305,18 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.24.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
@@ -7309,7 +7324,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -7687,6 +7702,24 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
 
 [[package]]
 name = "tungstenite"
@@ -9110,6 +9143,8 @@ name = "workflow_viz"
 version = "0.1.0"
 dependencies = [
  "axum 0.7.9",
+ "chrono",
+ "futures",
  "mofa-foundation",
  "serde",
  "serde_json",
@@ -9118,6 +9153,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber 0.3.22",
+ "uuid",
 ]
 
 [[package]]

--- a/examples/workflow_viz/Cargo.toml
+++ b/examples/workflow_viz/Cargo.toml
@@ -10,7 +10,10 @@ serde_json.workspace = true
 serde.workspace = true
 serde_yaml.workspace = true
 tokio.workspace = true
-axum = { workspace = true, features = ["macros"] }
+axum = { workspace = true, features = ["macros", "ws"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tower-http = { version = "0.6", features = ["cors"] }
+uuid.workspace = true
+futures.workspace = true
+chrono.workspace = true

--- a/examples/workflow_viz/src/main.rs
+++ b/examples/workflow_viz/src/main.rs
@@ -1,7 +1,8 @@
-//! Workflow Visualization Web UI
+//! Workflow Visualization Web UI — Phase 2: Live Execution Monitoring
 //!
-//! An axum-based web server that loads YAML workflow definitions and
-//! serves an interactive graph visualization backed by a simple REST API.
+//! An axum-based web server that loads YAML workflow definitions,
+//! serves an interactive graph visualization, and streams live execution
+//! events to connected WebSocket clients.
 //!
 //! Run with:  cargo run -p workflow_viz
 //! Then open: http://127.0.0.1:3030
@@ -10,26 +11,75 @@
 
 use axum::{
     Json,
-    extract::{Path, State},
+    extract::{
+        Path, Query, State,
+        ws::{Message, WebSocket, WebSocketUpgrade},
+    },
     http::{HeaderValue, StatusCode, header},
     response::{Html, IntoResponse, Response},
-    routing::get,
+    routing::{get, post},
 };
+use futures::{SinkExt, StreamExt};
 use mofa_foundation::workflow::dsl::{WorkflowDefinition, WorkflowDslParser};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use tokio::sync::{RwLock, broadcast};
 use tracing::info;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Live execution status for a node
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum NodeStatus {
+    Pending,
+    Running,
+    Completed,
+    Failed,
+}
+
+/// A live execution event broadcast to WebSocket clients
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct NodeEvent {
+    event_type: String,          // "node_status" | "workflow_start" | "workflow_end"
+    node_id: Option<String>,
+    status: Option<NodeStatus>,
+    timestamp_ms: u64,
+    duration_ms: Option<u64>,
+    error: Option<String>,
+    inputs: Option<Value>,
+    outputs: Option<Value>,
+    workflow_id: Option<String>,
+    execution_id: Option<String>,
+}
 
 // ---------------------------------------------------------------------------
 // App state
 // ---------------------------------------------------------------------------
 
-/// Shared state holding parsed workflow definitions.
+/// Shared state holding parsed workflow definitions and live execution state.
 struct AppState {
-    /// workflow‑id → parsed definition
+    /// workflow-id → parsed definition
     definitions: HashMap<String, WorkflowDefinition>,
+    /// Broadcast channel for live events
+    event_tx: broadcast::Sender<NodeEvent>,
+    /// Current node execution states (node_id → status)
+    node_states: Arc<RwLock<HashMap<String, NodeStatusEntry>>>,
+    /// Whether a simulation is currently running
+    sim_running: Arc<RwLock<bool>>,
+}
+
+/// Stored state for a node during/after execution
+#[derive(Debug, Clone, serde::Serialize)]
+struct NodeStatusEntry {
+    status: NodeStatus,
+    duration_ms: Option<u64>,
+    error: Option<String>,
+    inputs: Option<Value>,
+    outputs: Option<Value>,
 }
 
 type SharedState = Arc<RwLock<AppState>>;
@@ -45,10 +95,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         .init();
 
     info!("╔═══════════════════════════════════════════════════╗");
-    info!("║      MoFA Workflow Visualization Server           ║");
+    info!("║   MoFA Workflow Visualization — Live Monitor      ║");
     info!("╚═══════════════════════════════════════════════════╝");
 
-    // Load YAML workflow definitions -----------------------------------------
+    // Load YAML workflow definitions
     let yaml_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../workflow_dsl");
     let mut definitions: HashMap<String, WorkflowDefinition> = HashMap::new();
 
@@ -72,18 +122,29 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     info!("Loaded {} workflow definitions", definitions.len());
 
-    let state: SharedState = Arc::new(RwLock::new(AppState { definitions }));
+    let (event_tx, _) = broadcast::channel::<NodeEvent>(256);
 
-    // Build router -----------------------------------------------------------
+    let state: SharedState = Arc::new(RwLock::new(AppState {
+        definitions,
+        event_tx,
+        node_states: Arc::new(RwLock::new(HashMap::new())),
+        sim_running: Arc::new(RwLock::new(false)),
+    }));
+
+    // Build router
     let app = axum::Router::new()
         // Static frontend
         .route("/", get(serve_index))
         .route("/style.css", get(serve_css))
         .route("/app.js", get(serve_js))
         .route("/logo.png", get(serve_logo))
-        // REST API
+        // REST API — workflows
         .route("/api/workflows", get(list_workflows))
-        .route("/api/workflows/{id}", get(get_workflow))
+        .route("/api/workflows/:id", get(get_workflow))
+        // Live monitoring
+        .route("/ws", get(ws_handler))
+        .route("/api/simulate", post(simulate_execution))
+        .route("/api/execution/state", get(get_execution_state))
         .with_state(state)
         .layer(
             tower_http::cors::CorsLayer::new()
@@ -100,13 +161,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 }
 
 // ---------------------------------------------------------------------------
-// Static file handlers (read from disk for hot-reload during development)
+// Static file handlers
 // ---------------------------------------------------------------------------
 
 fn static_dir() -> std::path::PathBuf {
-    // Resolve relative to the crate root (where Cargo.toml lives)
-    let manifest = std::env::var("CARGO_MANIFEST_DIR")
-        .unwrap_or_else(|_| ".".to_string());
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
     std::path::PathBuf::from(manifest).join("static")
 }
 
@@ -114,11 +173,7 @@ async fn serve_index() -> Response {
     let path = static_dir().join("index.html");
     match tokio::fs::read_to_string(&path).await {
         Ok(body) => Html(body).into_response(),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Error loading index.html: {e}"),
-        )
-            .into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, format!("Error: {e}")).into_response(),
     }
 }
 
@@ -134,7 +189,7 @@ async fn serve_css() -> Response {
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             [(header::CONTENT_TYPE, HeaderValue::from_static("text/css"))],
-            format!("/* Error loading style.css: {e} */"),
+            format!("/* Error: {e} */"),
         )
             .into_response(),
     }
@@ -158,7 +213,7 @@ async fn serve_js() -> Response {
                 header::CONTENT_TYPE,
                 HeaderValue::from_static("application/javascript"),
             )],
-            format!("// Error loading app.js: {e}"),
+            format!("// Error: {e}"),
         )
             .into_response(),
     }
@@ -173,22 +228,17 @@ async fn serve_logo() -> Response {
             body,
         )
             .into_response(),
-        Err(e) => (
-            StatusCode::NOT_FOUND,
-            format!("Logo not found: {e}"),
-        )
-            .into_response(),
+        Err(e) => (StatusCode::NOT_FOUND, format!("Logo not found: {e}")).into_response(),
     }
 }
 
 // ---------------------------------------------------------------------------
-// REST API handlers
+// REST API — Workflow handlers
 // ---------------------------------------------------------------------------
 
-/// GET /api/workflows — list all loaded workflows (sorted by ID for deterministic order)
+/// GET /api/workflows
 async fn list_workflows(State(state): State<SharedState>) -> Json<Value> {
     let s = state.read().await;
-    // Collect definitions into a vector and sort by ID for deterministic ordering
     let mut defs: Vec<&WorkflowDefinition> = s.definitions.values().collect();
     defs.sort_by(|a, b| a.metadata.id.cmp(&b.metadata.id));
     let items: Vec<Value> = defs
@@ -206,7 +256,7 @@ async fn list_workflows(State(state): State<SharedState>) -> Json<Value> {
     Json(json!({ "workflows": items }))
 }
 
-/// GET /api/workflows/{id} — return graph JSON for a single workflow
+/// GET /api/workflows/{id}
 async fn get_workflow(
     State(state): State<SharedState>,
     Path(id): Path<String>,
@@ -217,8 +267,362 @@ async fn get_workflow(
 }
 
 // ---------------------------------------------------------------------------
+// WebSocket handler
+// ---------------------------------------------------------------------------
+
+/// GET /ws — upgrade to WebSocket for live event streaming
+async fn ws_handler(
+    ws: WebSocketUpgrade,
+    State(state): State<SharedState>,
+) -> impl IntoResponse {
+    ws.on_upgrade(|socket| handle_ws(socket, state))
+}
+
+async fn handle_ws(socket: WebSocket, state: SharedState) {
+    let (mut sender, mut receiver) = socket.split();
+
+    // Subscribe to broadcast
+    let mut rx = {
+        let s = state.read().await;
+        s.event_tx.subscribe()
+    };
+
+    info!("WebSocket client connected");
+
+    // Send current state snapshot as initial catch-up
+    {
+        let s = state.read().await;
+        let states = s.node_states.read().await;
+        if !states.is_empty() {
+            let snapshot = json!({
+                "event_type": "state_snapshot",
+                "states": &*states,
+            });
+            let _ = sender.send(Message::Text(snapshot.to_string().into())).await;
+        }
+    }
+
+    // Forward broadcast events to client
+    let send_task = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                result = rx.recv() => {
+                    match result {
+                        Ok(event) => {
+                            let json = serde_json::to_string(&event).unwrap_or_default();
+                            if sender.send(Message::Text(json.into())).await.is_err() {
+                                break;
+                            }
+                        }
+                        Err(broadcast::error::RecvError::Lagged(n)) => {
+                            tracing::debug!("WS client lagged {n} events");
+                        }
+                        Err(broadcast::error::RecvError::Closed) => break,
+                    }
+                }
+                _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
+                    // Heartbeat ping
+                    let hb = json!({"event_type": "heartbeat", "timestamp_ms": now_ms()});
+                    if sender.send(Message::Text(hb.to_string().into())).await.is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    });
+
+    // Receive side — just consume pings/pongs and detect close
+    let recv_task = tokio::spawn(async move {
+        while let Some(result) = receiver.next().await {
+            match result {
+                Ok(Message::Close(_)) | Err(_) => break,
+                _ => {} // ignore all client messages
+            }
+        }
+    });
+
+    tokio::select! {
+        _ = send_task => {}
+        _ = recv_task => {}
+    }
+
+    info!("WebSocket client disconnected");
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/execution/state — for reconnection catch-up
+// ---------------------------------------------------------------------------
+
+async fn get_execution_state(State(state): State<SharedState>) -> Json<Value> {
+    let s = state.read().await;
+    let states = s.node_states.read().await;
+    let sim_running = *s.sim_running.read().await;
+    Json(json!({
+        "states": &*states,
+        "sim_running": sim_running,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/simulate — synthetic execution
+// ---------------------------------------------------------------------------
+
+#[derive(serde::Deserialize)]
+struct SimParams {
+    workflow_id: String,
+}
+
+async fn simulate_execution(
+    State(state): State<SharedState>,
+    Query(params): Query<SimParams>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    // Get the workflow definition and atomically check-and-set sim_running
+    let (def_json, event_tx, node_states_arc, sim_running_arc) = {
+        let s = state.read().await;
+
+        // Atomic check-and-set under the same write lock to prevent races
+        {
+            let mut running = s.sim_running.write().await;
+            if *running {
+                return Err((StatusCode::CONFLICT, Json(json!({"error": "Simulation already running"}))));
+            }
+            *running = true;
+        }
+
+        let def = s.definitions.get(&params.workflow_id)
+            .ok_or((StatusCode::NOT_FOUND, Json(json!({"error": "Workflow not found"}))))?;
+        (
+            definition_to_json(def),
+            s.event_tx.clone(),
+            s.node_states.clone(),
+            s.sim_running.clone(),
+        )
+    };
+
+    let execution_id = uuid::Uuid::new_v4().to_string();
+    let workflow_id = params.workflow_id.clone();
+
+    // Compute topological order
+    let nodes = def_json["nodes"].as_array().cloned().unwrap_or_default();
+    let edges = def_json["edges"].as_array().cloned().unwrap_or_default();
+    let order = topo_order(&nodes, &edges);
+
+    // Reset node states to pending
+    {
+        let mut states = node_states_arc.write().await;
+        states.clear();
+        for node_id in &order {
+            states.insert(node_id.clone(), NodeStatusEntry {
+                status: NodeStatus::Pending,
+                duration_ms: None,
+                error: None,
+                inputs: None,
+                outputs: None,
+            });
+        }
+    }
+
+    info!("  ▶ Starting simulation of '{}' ({} nodes)", workflow_id, order.len());
+
+    // Broadcast workflow start
+    let _ = event_tx.send(NodeEvent {
+        event_type: "workflow_start".to_string(),
+        node_id: None,
+        status: None,
+        timestamp_ms: now_ms(),
+        duration_ms: None,
+        error: None,
+        inputs: None,
+        outputs: None,
+        workflow_id: Some(workflow_id.clone()),
+        execution_id: Some(execution_id.clone()),
+    });
+
+    // Spawn background task to walk nodes
+    let wf_id = workflow_id.clone();
+    let exec_id = execution_id.clone();
+    tokio::spawn(async move {
+        for node_id in &order {
+            let node_meta = nodes.iter()
+                .find(|n| n["id"].as_str() == Some(node_id))
+                .cloned()
+                .unwrap_or(json!({}));
+            let node_type = node_meta["type"].as_str().unwrap_or("task");
+
+            // Determine duration based on node type
+            let duration_ms: u64 = match node_type {
+                "start" | "end" => 150 + pseudo_rand(node_id) % 100,
+                "condition" => 200 + pseudo_rand(node_id) % 200,
+                "parallel" | "join" => 400 + pseudo_rand(node_id) % 300,
+                "loop" => 600 + pseudo_rand(node_id) % 500,
+                _ => 300 + pseudo_rand(node_id) % 500,
+            };
+
+            // Random failure chance (~8%)
+            let will_fail = pseudo_rand(node_id) % 13 == 0 && node_type != "start" && node_type != "end";
+
+            // -- RUNNING --
+            {
+                let mut states = node_states_arc.write().await;
+                if let Some(entry) = states.get_mut(node_id) {
+                    entry.status = NodeStatus::Running;
+                    entry.inputs = Some(json!({
+                        "triggered_by": "simulation",
+                        "node_type": node_type,
+                    }));
+                }
+            }
+            let _ = event_tx.send(NodeEvent {
+                event_type: "node_status".to_string(),
+                node_id: Some(node_id.clone()),
+                status: Some(NodeStatus::Running),
+                timestamp_ms: now_ms(),
+                duration_ms: None,
+                error: None,
+                inputs: Some(json!({"triggered_by": "simulation", "node_type": node_type})),
+                outputs: None,
+                workflow_id: None,
+                execution_id: None,
+            });
+
+            // Simulate execution time
+            tokio::time::sleep(std::time::Duration::from_millis(duration_ms)).await;
+
+            // -- COMPLETED or FAILED --
+            let (final_status, error) = if will_fail {
+                (NodeStatus::Failed, Some(format!("Simulated error in node '{}'", node_id)))
+            } else {
+                (NodeStatus::Completed, None)
+            };
+
+            let outputs = if final_status == NodeStatus::Completed {
+                Some(json!({
+                    "result": format!("Output from {}", node_id),
+                    "processed_items": pseudo_rand(node_id) % 100 + 1,
+                }))
+            } else {
+                None
+            };
+
+            {
+                let mut states = node_states_arc.write().await;
+                if let Some(entry) = states.get_mut(node_id) {
+                    entry.status = final_status;
+                    entry.duration_ms = Some(duration_ms);
+                    entry.error = error.clone();
+                    entry.outputs = outputs.clone();
+                }
+            }
+
+            let _ = event_tx.send(NodeEvent {
+                event_type: "node_status".to_string(),
+                node_id: Some(node_id.clone()),
+                status: Some(final_status),
+                timestamp_ms: now_ms(),
+                duration_ms: Some(duration_ms),
+                error: error.clone(),
+                inputs: None,
+                outputs: outputs.clone(),
+                workflow_id: None,
+                execution_id: None,
+            });
+
+            // If a node fails, stop the simulation
+            if will_fail {
+                info!("  ✗ Node '{}' failed — stopping simulation", node_id);
+                break;
+            }
+        }
+
+        // Broadcast workflow end
+        let _ = event_tx.send(NodeEvent {
+            event_type: "workflow_end".to_string(),
+            node_id: None,
+            status: None,
+            timestamp_ms: now_ms(),
+            duration_ms: None,
+            error: None,
+            inputs: None,
+            outputs: None,
+            workflow_id: Some(wf_id.clone()),
+            execution_id: Some(exec_id),
+        });
+
+        *sim_running_arc.write().await = false;
+        info!("  ✓ Simulation of '{}' complete", wf_id);
+    });
+
+    Ok(Json(json!({
+        "execution_id": execution_id,
+        "workflow_id": workflow_id,
+        "status": "started",
+    })))
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+fn now_ms() -> u64 {
+    chrono::Utc::now().timestamp_millis() as u64
+}
+
+/// Deterministic pseudo-random from a string (for consistent simulation behaviour)
+fn pseudo_rand(s: &str) -> u64 {
+    let mut h: u64 = 5381;
+    for b in s.bytes() {
+        h = h.wrapping_mul(33).wrapping_add(b as u64);
+    }
+    h
+}
+
+/// Topological order via Kahn's BFS
+fn topo_order(nodes: &[Value], edges: &[Value]) -> Vec<String> {
+    let mut adj: HashMap<String, Vec<String>> = HashMap::new();
+    let mut in_deg: HashMap<String, usize> = HashMap::new();
+    for n in nodes {
+        let id = n["id"].as_str().unwrap_or("").to_string();
+        adj.entry(id.clone()).or_default();
+        in_deg.entry(id).or_insert(0);
+    }
+    for e in edges {
+        let from = e["from"].as_str().unwrap_or("").to_string();
+        let to = e["to"].as_str().unwrap_or("").to_string();
+        adj.entry(from.clone()).or_default().push(to.clone());
+        *in_deg.entry(to).or_insert(0) += 1;
+    }
+
+    let mut queue: Vec<String> = in_deg.iter()
+        .filter(|&(_, &d)| d == 0)
+        .map(|(id, _)| id.clone())
+        .collect();
+    queue.sort();
+    let mut order = Vec::new();
+    let mut qi = 0;
+    while qi < queue.len() {
+        let cur = queue[qi].clone();
+        qi += 1;
+        order.push(cur.clone());
+        if let Some(nexts) = adj.get(&cur) {
+            for nx in nexts {
+                if let Some(d) = in_deg.get_mut(nx) {
+                    *d -= 1;
+                    if *d == 0 {
+                        queue.push(nx.clone());
+                    }
+                }
+            }
+        }
+    }
+    // Remaining nodes
+    for n in nodes {
+        let id = n["id"].as_str().unwrap_or("").to_string();
+        if !order.contains(&id) {
+            order.push(id);
+        }
+    }
+    order
+}
 
 /// Convert a parsed `WorkflowDefinition` into the graph JSON structure
 /// expected by the frontend, without needing real agent instances.
@@ -267,10 +671,7 @@ fn definition_to_json(def: &WorkflowDefinition) -> Value {
             })
         })
         .collect();
-    // Sort nodes by ID for deterministic JSON output
-    nodes.sort_by(|a, b| {
-        a["id"].as_str().unwrap_or("").cmp(b["id"].as_str().unwrap_or(""))
-    });
+    nodes.sort_by(|a, b| a["id"].as_str().unwrap_or("").cmp(b["id"].as_str().unwrap_or("")));
 
     let mut edges: Vec<Value> = def
         .edges
@@ -289,7 +690,6 @@ fn definition_to_json(def: &WorkflowDefinition) -> Value {
             })
         })
         .collect();
-    // Sort edges by (from, to) for deterministic JSON output
     edges.sort_by(|a, b| {
         let af = a["from"].as_str().unwrap_or("");
         let bf = b["from"].as_str().unwrap_or("");
@@ -298,7 +698,6 @@ fn definition_to_json(def: &WorkflowDefinition) -> Value {
         })
     });
 
-    // Derive start_node / end_nodes from the definitions
     let start_node = def.nodes.iter().find_map(|n| {
         if matches!(n, NodeDefinition::Start { .. }) {
             Some(n.id().to_string())

--- a/examples/workflow_viz/static/index.html
+++ b/examples/workflow_viz/static/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>MoFA — Workflow Visualizer</title>
-  <meta name="description" content="Interactive workflow graph visualization for MoFA agent orchestration framework" />
+  <meta name="description" content="Interactive workflow graph visualization with live execution monitoring" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link
     href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap"
@@ -21,7 +21,7 @@
         <img src="/logo.png" alt="MoFA" class="logo-img" />
         <div class="logo-text">
           <span>MoFA</span>
-          <small>Workflow Viz</small>
+          <small>Live Monitor</small>
         </div>
       </div>
     </div>
@@ -45,15 +45,17 @@
         <kbd>-</kbd><span>Zoom out</span>
         <kbd>0</kbd><span>Fit view</span>
         <kbd>/</kbd><span>Search</span>
-        <kbd>S</kbd><span>Simulate</span>
+        <kbd>X</kbd><span>Execute</span>
         <kbd>E</kbd><span>Export SVG</span>
+        <kbd>A</kbd><span>Auto-pan</span>
+        <kbd>L</kbd><span>Toggle log</span>
         <kbd>Esc</kbd><span>Close panel</span>
       </div>
     </div>
 
     <div class="sidebar-footer">
-      <span class="status-dot"></span>
-      <span id="status-text">Connecting…</span>
+      <span id="ws-dot" class="status-dot disconnected"></span>
+      <span id="ws-status">Disconnected</span>
     </div>
   </aside>
 
@@ -62,7 +64,6 @@
     <!-- toolbar -->
     <div id="toolbar">
       <span id="graph-title">Select a workflow</span>
-      <!-- stats bar -->
       <div id="stats-bar" class="hidden">
         <span class="stat"><b id="stat-nodes">0</b> nodes</span>
         <span class="stat-sep">·</span>
@@ -71,8 +72,10 @@
         <span class="stat"><b id="stat-layers">0</b> layers</span>
       </div>
       <div class="toolbar-actions">
-        <button id="btn-simulate" title="Simulate execution (S)">▶ Simulate</button>
+        <button id="btn-execute" title="Execute workflow (X)">▶ Execute</button>
         <button id="btn-export" title="Export SVG (E)">⤓ Export</button>
+        <span class="toolbar-divider"></span>
+        <button id="btn-autopan" title="Auto-pan to active node (A)" class="btn-toggle">⊕ Auto-pan</button>
         <span class="toolbar-divider"></span>
         <button id="btn-zoom-in" title="Zoom in (+)">＋</button>
         <span id="zoom-pct" class="zoom-pct">100%</span>
@@ -85,7 +88,6 @@
     <div id="canvas-wrap">
       <svg id="canvas" xmlns="http://www.w3.org/2000/svg">
         <defs>
-          <!-- arrow markers -->
           <marker id="arrow" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto"
             markerUnits="strokeWidth">
             <polygon points="0 0, 10 3.5, 0 7" fill="#c0c4cc" />
@@ -102,7 +104,6 @@
             markerUnits="strokeWidth">
             <polygon points="0 0, 10 3.5, 0 7" fill="#3498DB" />
           </marker>
-          <!-- glow filters -->
           <filter id="glow">
             <feGaussianBlur stdDeviation="3" result="blur" />
             <feMerge>
@@ -124,15 +125,14 @@
         <g id="graph-group"></g>
       </svg>
       <!-- minimap -->
-      <div id="minimap">
-        <canvas id="minimap-canvas" width="180" height="120"></canvas>
+      <div id="minimap"><canvas id="minimap-canvas" width="180" height="120"></canvas>
         <div id="minimap-viewport"></div>
       </div>
       <!-- empty state -->
       <div id="empty-state">
         <div class="empty-icon">⬡</div>
         <p>Select a workflow from the sidebar to visualize its graph.</p>
-        <p class="empty-hint">Press <kbd>/</kbd> to search nodes in the current workflow</p>
+        <p class="empty-hint">Press <kbd>/</kbd> to search, <kbd>X</kbd> to execute</p>
       </div>
       <!-- loading overlay -->
       <div id="loading-overlay" class="hidden">
@@ -140,9 +140,24 @@
         <p>Loading graph…</p>
       </div>
     </div>
+
+    <!-- ── Execution Log Panel ── -->
+    <div id="exec-log" class="exec-log collapsed">
+      <div class="exec-log-header">
+        <button id="log-toggle" class="log-toggle-btn">Execution Log</button>
+        <div class="log-filters">
+          <button class="log-filter active" data-filter="all">All</button>
+          <button class="log-filter" data-filter="running">Running</button>
+          <button class="log-filter" data-filter="completed">Completed</button>
+          <button class="log-filter" data-filter="failed">Failed</button>
+        </div>
+        <button id="log-clear" class="log-clear-btn">Clear</button>
+      </div>
+      <ul id="log-list" class="log-list"></ul>
+    </div>
   </main>
 
-  <!-- ── detail panel ── -->
+  <!-- ── detail panel (inspector) ── -->
   <aside id="detail-panel" class="hidden">
     <button id="detail-close" title="Close (Esc)">✕</button>
     <h2 id="detail-title">Node</h2>

--- a/examples/workflow_viz/static/style.css
+++ b/examples/workflow_viz/static/style.css
@@ -883,3 +883,301 @@ kbd {
 .edge-line {
   animation: fade-in .3s ease-out both;
 }
+
+/* ================================================================
+   Phase 2: Live Execution Monitoring
+   ================================================================ */
+
+/* ── Connection status ── */
+.status-dot.connected {
+  background: var(--teal);
+  box-shadow: 0 0 4px var(--teal);
+}
+
+.status-dot.reconnecting {
+  background: var(--gold);
+  box-shadow: 0 0 4px var(--gold);
+  animation: reconnect-pulse 1s infinite;
+}
+
+.status-dot.disconnected {
+  background: var(--coral);
+  box-shadow: 0 0 4px var(--coral);
+}
+
+@keyframes reconnect-pulse {
+
+  0%,
+  100% {
+    opacity: 1
+  }
+
+  50% {
+    opacity: .3
+  }
+}
+
+/* ── Execute button ── */
+#btn-execute {
+  background: var(--teal-dim);
+  color: var(--teal);
+  border-color: rgba(26, 188, 156, .25);
+  font-weight: 600;
+}
+
+#btn-execute:hover {
+  background: rgba(26, 188, 156, .15);
+}
+
+#btn-execute.running {
+  background: var(--coral-dim);
+  color: var(--coral);
+  border-color: rgba(231, 76, 60, .25);
+  animation: sim-pulse 1s ease-in-out infinite;
+}
+
+/* ── Auto-pan toggle ── */
+.btn-toggle {
+  transition: all var(--transition);
+}
+
+.btn-toggle.active {
+  background: var(--blue-dim) !important;
+  color: var(--blue) !important;
+  border-color: rgba(52, 152, 219, .3) !important;
+}
+
+/* ── Node execution states ── */
+.node-group.status-running .node-shape {
+  stroke: var(--teal) !important;
+  stroke-width: 3px !important;
+  filter: url(#glow-strong);
+  animation: exec-pulse 1.2s ease-in-out infinite;
+}
+
+.node-group.status-completed .node-shape {
+  stroke: var(--blue) !important;
+  stroke-width: 2.5px !important;
+  filter: url(#drop-shadow);
+}
+
+.node-group.status-failed .node-shape {
+  stroke: var(--coral) !important;
+  stroke-width: 3px !important;
+  filter: url(#glow);
+}
+
+.node-group.status-pending {
+  opacity: 0.5;
+  transition: opacity .3s;
+}
+
+.node-group.status-running,
+.node-group.status-completed,
+.node-group.status-failed {
+  opacity: 1;
+  transition: opacity .3s;
+}
+
+@keyframes exec-pulse {
+
+  0%,
+  100% {
+    stroke-width: 2.5px;
+  }
+
+  50% {
+    stroke-width: 4px;
+  }
+}
+
+/* Status badge overlay */
+.node-status-badge {
+  font-family: var(--mono);
+  font-size: 8px;
+  font-weight: 700;
+  text-anchor: end;
+  dominant-baseline: hanging;
+  pointer-events: none;
+}
+
+/* Duration badge */
+.node-duration-badge {
+  font-family: var(--mono);
+  font-size: 7.5px;
+  font-weight: 600;
+  fill: var(--text-muted);
+  text-anchor: middle;
+  dominant-baseline: hanging;
+  pointer-events: none;
+}
+
+/* ── Execution Log Panel ── */
+.exec-log {
+  flex-shrink: 0;
+  background: var(--bg-toolbar);
+  border-top: 1px solid var(--border);
+  transition: height .3s ease;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.exec-log.collapsed {
+  height: 32px;
+}
+
+.exec-log.expanded {
+  height: 220px;
+}
+
+.exec-log-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 14px;
+  height: 32px;
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.log-toggle-btn {
+  background: none;
+  border: none;
+  font-family: var(--font);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 2px 0;
+}
+
+.log-toggle-btn:hover {
+  color: var(--text-primary);
+}
+
+.exec-log.collapsed .log-toggle-btn::before {
+  content: '▼ ';
+}
+
+.exec-log.expanded .log-toggle-btn::before {
+  content: '▲ ';
+}
+
+.log-toggle-btn::before {
+  content: '';
+}
+
+.log-filters {
+  display: flex;
+  gap: 4px;
+  margin-left: auto;
+}
+
+.log-filter {
+  height: 22px;
+  padding: 0 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: #fff;
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 600;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.log-filter:hover {
+  border-color: var(--blue);
+  color: var(--blue);
+}
+
+.log-filter.active {
+  background: var(--blue-dim);
+  border-color: rgba(52, 152, 219, .3);
+  color: var(--blue);
+}
+
+.log-clear-btn {
+  height: 22px;
+  padding: 0 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: #fff;
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 600;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.log-clear-btn:hover {
+  border-color: var(--coral);
+  color: var(--coral);
+}
+
+.log-list {
+  list-style: none;
+  overflow-y: auto;
+  flex: 1;
+  padding: 4px 0;
+  font-size: 11px;
+  font-family: var(--mono);
+}
+
+.log-list li {
+  padding: 3px 14px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  transition: background var(--transition);
+  border-bottom: 1px solid rgba(0, 0, 0, .02);
+}
+
+.log-list li:hover {
+  background: var(--bg-hover);
+}
+
+.log-list li.hidden {
+  display: none;
+}
+
+.log-time {
+  color: var(--text-faint);
+  font-size: 10px;
+  white-space: nowrap;
+}
+
+.log-node {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.log-arrow {
+  color: var(--text-faint);
+}
+
+.log-status {
+  font-weight: 600;
+  font-size: 10px;
+}
+
+.log-status.running {
+  color: var(--teal);
+}
+
+.log-status.completed {
+  color: var(--blue);
+}
+
+.log-status.failed {
+  color: var(--coral);
+}
+
+.log-dur {
+  color: var(--text-muted);
+  font-size: 10px;
+  margin-left: auto;
+}


### PR DESCRIPTION
<img width="1939" height="1004" alt="image" src="https://github.com/user-attachments/assets/0831c471-cfb8-4b21-bfe6-136026e179b1" />
<img width="781" height="159" alt="image" src="https://github.com/user-attachments/assets/1f15a363-54eb-42d2-a168-4acabcf0c67c" />

<html><head></head><body><h2>Summary</h2>
<p>Adds real-time WebSocket execution monitoring to the workflow visualizer.
Nodes update live with status colors, duration badges, and a filterable
execution log.</p>
<p>Depends on: #520</p>
<hr>
<h2>Changes</h2>
<h3>Backend (<code>main.rs</code>)</h3>
<ul>
<li><code>GET /ws</code> — WebSocket endpoint with <code>tokio::sync::broadcast</code>, 30s heartbeat,
and state snapshot on connect for reconnecting clients</li>
<li><code>POST /api/simulate</code> — topo-walk with realistic delays (150–800ms) and ~8%
random failure chance</li>
<li><code>GET /api/execution/state</code> — catch-up endpoint returning current node states</li>
<li>New types: <code>NodeEvent</code>, <code>NodeStatus</code> (<code>Pending</code> / <code>Running</code> / <code>Completed</code> / <code>Failed</code>)</li>
</ul>
<h3>Frontend</h3>
<ul>
<li>WebSocket client with exponential backoff reconnection (1s → 10s)</li>
<li>Node status animations: green pulse → blue glow → red border → dimmed</li>
<li>Duration badges on completed nodes</li>
<li>Execution log: collapsible, filterable by status, click-to-pan, capped at 500 entries</li>
<li>Inspector v2: collapsible JSON trees for inputs/outputs, inline error display</li>
<li>Connection indicator: Connected / Reconnecting / Disconnected</li>
<li>Keyboard shortcuts: <code>X</code> Execute · <code>A</code> Auto-pan · <code>L</code> Toggle log · <code>Esc</code> Close panel</li>
</ul>
<hr>
<h2>How to Test</h2>
<pre><code class="language-bash">cd examples &amp;&amp; cargo run -p workflow_viz
# Open http://127.0.0.1:3030
</code></pre>
<ol>
<li>Select a workflow → click <strong>Execute</strong> → watch nodes pulse green then blue</li>
<li>Press <code>L</code> for the execution log, <code>A</code> to enable auto-pan</li>
<li>Let a run reach a failure — confirm the node turns red and simulation stops</li>
<li>Reconnect (close/reopen tab) — confirm state is restored from catch-up endpoint</li>
</ol>
<hr>
<h2>Verification</h2>
<pre><code class="language-bash">$ curl -s -X POST 'localhost:3030/api/simulate?workflow_id=customer_support'
{"execution_id":"a711b410-...","status":"started","workflow_id":"customer_support"}

$ curl -s localhost:3030/api/execution/state | jq '.states | keys'
["classify","end","handle_billing","handle_general","handle_technical","route","start"]
</code></pre>
<pre><code>INFO  Starting simulation of 'customer_support' (7 nodes)
INFO  Node 'route' failed — stopping simulation
INFO  Simulation of 'customer_support' complete
</code></pre>
<p><code>cargo check -p workflow_viz</code> — 0 errors, 0 warnings</p>
<hr>
<h2>Files Changed</h2>

File | Change
-- | --
examples/Cargo.toml | Added workflow_viz to workspace
examples/workflow_viz/Cargo.toml | New deps: axum[ws], uuid, futures, chrono
examples/workflow_viz/src/main.rs | WS handler, broadcast, simulate, catch-up (731 lines)
examples/workflow_viz/static/app.js | WS client, live updates, log, inspector v2 (745 lines)
examples/workflow_viz/static/index.html | Execution UI elements
examples/workflow_viz/static/style.css | Status animations, log panel


<hr>
<h2>Breaking Changes</h2>
<ul>
<li>[x] No breaking changes</li>
<li>[ ] Breaking change (describe below)</li>
</ul>
<p>Phase 1 static rendering is unchanged. All additions are new endpoints and
frontend behavior.</p>
<hr>
<h2>Checklist</h2>
<ul>
<li>[x] <code>cargo check -p workflow_viz</code> passes with 0 errors, 0 warnings</li>
<li>[x] Happy path, failure path, and reconnect manually verified</li>
<li>[x] PR is scoped to Phase 2 only — no unrelated changes</li>
<li>[x] Commit message explains <strong>why</strong>, not just <strong>what</strong></li>
</ul>
<hr>
<h2>Notes for Reviewers</h2>
<ul>
<li><strong>Broadcast backpressure</strong>: slow WebSocket clients will drop events rather
than queue them — intentional for a visualizer, but worth confirming.</li>
<li><strong>Hardcoded simulation params</strong>: the 8% failure rate and delay range are
fixed. Flag if these should be configurable.</li>
</ul></body></html>