### PR TITLE
Add explicit route selection for StateGraph

### DIFF
--- a/crates/mofa-foundation/src/workflow/state_graph.rs
+++ b/crates/mofa-foundation/src/workflow/state_graph.rs
@@ -386,6 +386,12 @@ impl<S: GraphState> CompiledGraphImpl<S> {
                     Some(EdgeTarget::Single(target)) => vec![target.clone()],
                     Some(EdgeTarget::Parallel(targets)) => targets.clone(),
                     Some(EdgeTarget::Conditional(routes)) => {
+                        // Priority 1: explicit route decision
+                        if let Some(decision) = command.route_value() {
+                            if let Some(target) = routes.get(decision) {
+                                return vec![target.clone()];
+                            }
+                        }
                         // Find matching route based on state updates
                         for update in &command.updates {
                             if let Some(target) = routes.get(&update.key) {
@@ -546,6 +552,12 @@ impl<S: GraphState + 'static> CompiledGraph<S, serde_json::Value> for CompiledGr
                             Some(EdgeTarget::Single(target)) => vec![target.clone()],
                             Some(EdgeTarget::Parallel(targets)) => targets.clone(),
                             Some(EdgeTarget::Conditional(routes)) => {
+                                // Priority 1: explicit route decision
+                                if let Some(decision) = command.route_value() {
+                                    if let Some(target) = routes.get(decision) {
+                                        return vec![target.clone()];
+                                    }
+                                }
                                 // Find matching route based on state updates
                                 for update in &command.updates {
                                     if let Some(target) = routes.get(&update.key) {
@@ -816,6 +828,7 @@ mod tests {
     use futures::StreamExt;
     use mofa_kernel::workflow::{JsonState, StateGraph};
     use serde_json::json;
+    use std::collections::HashMap;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::time::{Duration, sleep};
 
@@ -837,6 +850,26 @@ mod tests {
                 cmd = cmd.update(update.key.clone(), update.value.clone());
             }
             Ok(cmd.continue_())
+        }
+
+        fn name(&self) -> &str {
+            &self.name
+        }
+    }
+
+    struct StaticCommandNode {
+        name: String,
+        command: Command,
+    }
+
+    #[async_trait]
+    impl NodeFunc<JsonState> for StaticCommandNode {
+        async fn call(
+            &self,
+            _state: &mut JsonState,
+            _ctx: &RuntimeContext,
+        ) -> AgentResult<Command> {
+            Ok(self.command.clone())
         }
 
         fn name(&self) -> &str {
@@ -1058,6 +1091,151 @@ mod tests {
         assert_eq!(
             stream_final_state.get_value("reader_saw_flag"),
             Some(json!(false))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_conditional_routing_prefers_route_value_in_invoke() {
+        let mut graph = StateGraphImpl::<JsonState>::new("route_invoke");
+
+        let mut routes = HashMap::new();
+        routes.insert("approve".to_string(), "approved".to_string());
+        routes.insert("reject".to_string(), "rejected".to_string());
+
+        graph
+            .add_node(
+                "router",
+                Box::new(StaticCommandNode {
+                    name: "router".to_string(),
+                    command: Command::new()
+                        .route("approve")
+                        .update("reject", json!(true))
+                        .continue_(),
+                }),
+            )
+            .add_node(
+                "approved",
+                Box::new(TestNode {
+                    name: "approved".to_string(),
+                    updates: vec![StateUpdate::new("decision", json!("approved"))],
+                }),
+            )
+            .add_node(
+                "rejected",
+                Box::new(TestNode {
+                    name: "rejected".to_string(),
+                    updates: vec![StateUpdate::new("decision", json!("rejected"))],
+                }),
+            )
+            .add_edge(START, "router")
+            .add_conditional_edges("router", routes)
+            .add_edge("approved", END)
+            .add_edge("rejected", END);
+
+        let compiled = graph.compile().unwrap();
+        let final_state = compiled.invoke(JsonState::new(), None).await.unwrap();
+
+        assert_eq!(
+            final_state.get_value::<serde_json::Value>("decision"),
+            Some(json!("approved"))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_conditional_routing_legacy_fallback_when_route_absent() {
+        let mut graph = StateGraphImpl::<JsonState>::new("route_fallback");
+
+        let mut routes = HashMap::new();
+        routes.insert("approve".to_string(), "approved".to_string());
+        routes.insert("reject".to_string(), "rejected".to_string());
+
+        graph
+            .add_node(
+                "router",
+                Box::new(StaticCommandNode {
+                    name: "router".to_string(),
+                    command: Command::new()
+                        .update("reject", json!(true))
+                        .continue_(),
+                }),
+            )
+            .add_node(
+                "approved",
+                Box::new(TestNode {
+                    name: "approved".to_string(),
+                    updates: vec![StateUpdate::new("decision", json!("approved"))],
+                }),
+            )
+            .add_node(
+                "rejected",
+                Box::new(TestNode {
+                    name: "rejected".to_string(),
+                    updates: vec![StateUpdate::new("decision", json!("rejected"))],
+                }),
+            )
+            .add_edge(START, "router")
+            .add_conditional_edges("router", routes)
+            .add_edge("approved", END)
+            .add_edge("rejected", END);
+
+        let compiled = graph.compile().unwrap();
+        let final_state = compiled.invoke(JsonState::new(), None).await.unwrap();
+
+        assert_eq!(
+            final_state.get_value::<serde_json::Value>("decision"),
+            Some(json!("rejected"))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_conditional_routing_stream_respects_route_value() {
+        let mut graph = StateGraphImpl::<JsonState>::new("route_stream");
+
+        let mut routes = HashMap::new();
+        routes.insert("approve".to_string(), "approved".to_string());
+        routes.insert("reject".to_string(), "rejected".to_string());
+
+        graph
+            .add_node(
+                "router",
+                Box::new(StaticCommandNode {
+                    name: "router".to_string(),
+                    command: Command::new().route("approve").continue_(),
+                }),
+            )
+            .add_node(
+                "approved",
+                Box::new(TestNode {
+                    name: "approved".to_string(),
+                    updates: vec![StateUpdate::new("decision", json!("approved"))],
+                }),
+            )
+            .add_node(
+                "rejected",
+                Box::new(TestNode {
+                    name: "rejected".to_string(),
+                    updates: vec![StateUpdate::new("decision", json!("rejected"))],
+                }),
+            )
+            .add_edge(START, "router")
+            .add_conditional_edges("router", routes)
+            .add_edge("approved", END)
+            .add_edge("rejected", END);
+
+        let compiled = graph.compile().unwrap();
+        let mut stream = compiled.stream(JsonState::new(), None);
+
+        let mut final_state = None;
+        while let Some(event) = stream.next().await {
+            if let Ok(StreamEvent::End { final_state: state }) = event {
+                final_state = Some(state);
+            }
+        }
+
+        let final_state = final_state.expect("stream should produce final state");
+        assert_eq!(
+            final_state.get_value::<serde_json::Value>("decision"),
+            Some(json!("approved"))
         );
     }
 }


### PR DESCRIPTION
Closes #554

## Summary
- Add explicit routing support via Command::route(...) with route_value() accessor.
- Conditional edges now resolve in order: explicit route -> legacy key match -> fallback.
- Added invoke and stream tests to confirm routing priority and backward-compatible fallback.

## Scope
- Files: crates/mofa-kernel/src/workflow/command.rs, crates/mofa-foundation/src/workflow/state_graph.rs
- No other subsystems touched.

## Testing
- Not run in this environment. Recommended:
  - cargo test -p mofa-kernel -- workflow::command
  - cargo test -p mofa-foundation -- workflow::state_graph
  - cargo test -p mofa-foundation --test state_graph (if exists)
  - cargo test