### PR TITLE
feat(orchestrator): add Display and Serialize/Deserialize for core types

### DIFF
--- a/crates/mofa-foundation/src/orchestrator/linux_candle.rs
+++ b/crates/mofa-foundation/src/orchestrator/linux_candle.rs
@@ -590,7 +590,7 @@ impl ModelPool {
             }
         }
 
-        Err(OrchestratorError::NoModelForType(format!("{:?}", task)))
+        Err(OrchestratorError::NoModelForType(format!("{}", task)))
     }
 
     /// Apply dynamic precision degradation to the model with the worst LRU score.


### PR DESCRIPTION
## 📋 Summary

This PR improves the core orchestrator types by making them readable in logs and usable for serialization.

Earlier, `ModelType`, `DegradationLevel`, `ModelProviderConfig`, and `PoolStatistics` only derived `Debug`. That caused messy log output (like `Other("whisper-tiny")`) and prevented us from serializing these types for future REST or config support.

This change adds proper `Display` implementations and `serde` support so these types behave like first-class citizens across logging, error handling, and future HTTP/config layers.

## 🔗 Related Issues

Closes #582

---

## 🧠 Context

These types sit at the core of the orchestrator layer, but they were not designed for external-facing usage.

Because they only had `Debug`:

* Error messages were noisy and harder to read.
* Logs were less human-friendly.
* `ModelProviderConfig` and `PoolStatistics` could not be serialized to JSON.

Since `serde` is already available in the workspace, enabling serialization required no new dependencies — just proper derives and clean formatting.

---

## 🛠️ Changes

* Added `Serialize` and `Deserialize` derives to:

  * `ModelType`
  * `DegradationLevel`
  * `ModelProviderConfig`
  * `PoolStatistics`
* Implemented `fmt::Display` for `ModelType` and `DegradationLevel` with clean string mappings (e.g. `Asr → "ASR"`, `Full → "FP32"`).
* Replaced `format!("{:?}", task)` with `format!("{}", task)` in `linux_candle.rs` to use the new `Display` output.
* Added 6 unit tests covering `Display` output and full serde roundtrips.

---

## 🧪 How you Tested

1. Ran `cargo check -p mofa-foundation` — no errors or warnings.
2. Ran `cargo test -p mofa-foundation -- orchestrator` — all tests pass (existing + new).
3. Verified JSON serialize → deserialize → equality roundtrip for all affected types.

---

## ⚠️ Breaking Changes

* [x] No breaking changes
* [ ] Breaking change (describe below)

---

## 🧹 Checklist

### Code Quality

* [x] Code follows Rust idioms and project conventions
* [x] `cargo fmt` run
* [x] `cargo clippy` passes without warnings

### Testing

* [x] Tests added/updated
* [x] `cargo test` passes locally without any error

### Documentation

* [x] Public APIs documented
* [ ] README / docs updated (if needed)

### PR Hygiene

* [x] PR is small and focused (one logical change)
* [x] Branch is up to date with `main`
* [x] No unrelated commits
* [x] Commit messages explain **why**, not only **what**
