### PR TITLE
fix(foundation): preserve multi-step branch pipelines

### DIFF
--- a/crates/mofa-foundation/src/llm/pipeline.rs
+++ b/crates/mofa-foundation/src/llm/pipeline.rs
@@ -73,8 +73,8 @@ enum PipelineStep {
     /// Conditional Branch
     Branch {
         condition: Arc<dyn Fn(&str) -> bool + Send + Sync>,
-        if_true: Box<PipelineStep>,
-        if_false: Box<PipelineStep>,
+        if_true: Vec<PipelineStep>,
+        if_false: Vec<PipelineStep>,
     },
     /// 尝试恢复（如果失败则使用默认值）
     /// Try Recovery (use default value on failure)
@@ -220,31 +220,10 @@ impl Pipeline {
     where
         F: Fn(&str) -> bool + Send + Sync + 'static,
     {
-        // 将子流水线转换为单个步骤
-        // Convert sub-pipeline into a single step
-        let true_step = if if_true.steps.is_empty() {
-            PipelineStep::Identity
-        } else if if_true.steps.len() == 1 {
-            if_true.steps.into_iter().next().unwrap()
-        } else {
-            // 多步骤情况，需要嵌套
-            // Multi-step case, requires nesting
-            PipelineStep::Identity // 简化处理
-            // Simplified handling
-        };
-
-        let false_step = if if_false.steps.is_empty() {
-            PipelineStep::Identity
-        } else if if_false.steps.len() == 1 {
-            if_false.steps.into_iter().next().unwrap()
-        } else {
-            PipelineStep::Identity
-        };
-
         self.steps.push(PipelineStep::Branch {
             condition: Arc::new(condition),
-            if_true: Box::new(true_step),
-            if_false: Box::new(false_step),
+            if_true: if_true.steps,
+            if_false: if_false.steps,
         });
         self
     }
@@ -329,11 +308,14 @@ impl Pipeline {
                     if_true,
                     if_false,
                 } => {
-                    if condition(&input) {
-                        Self::execute_step(if_true, input).await
-                    } else {
-                        Self::execute_step(if_false, input).await
+                    let selected_steps = if condition(&input) { if_true } else { if_false };
+                    let mut current = input;
+
+                    for step in selected_steps {
+                        current = Self::execute_step(step, current).await?;
                     }
+
+                    Ok(current)
                 }
 
                 PipelineStep::TryRecover { step, default } => {
@@ -597,5 +579,37 @@ mod tests {
             .map(|s| s.to_lowercase());
 
         assert_eq!(pipeline.steps.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_branch_multistep_true_runs_all_steps() {
+        let pipeline = Pipeline::new().branch(
+            |_| true,
+            Pipeline::new()
+                .map(|s| format!("{s}-A"))
+                .map(|s| format!("{s}-B")),
+            Pipeline::new()
+                .map(|s| format!("{s}-C"))
+                .map(|s| format!("{s}-D")),
+        );
+
+        let out = pipeline.run("x").await.expect("pipeline should run");
+        assert_eq!(out, "x-A-B");
+    }
+
+    #[tokio::test]
+    async fn test_branch_multistep_false_runs_all_steps() {
+        let pipeline = Pipeline::new().branch(
+            |_| false,
+            Pipeline::new()
+                .map(|s| format!("{s}-A"))
+                .map(|s| format!("{s}-B")),
+            Pipeline::new()
+                .map(|s| format!("{s}-C"))
+                .map(|s| format!("{s}-D")),
+        );
+
+        let out = pipeline.run("x").await.expect("pipeline should run");
+        assert_eq!(out, "x-C-D");
     }
 }


### PR DESCRIPTION
## Summary
Fixes `Pipeline::branch(...)` so multi-step `if_true`/`if_false` branches are preserved and executed, instead of collapsing to `Identity`.

## Motivation
Issue #578 reported that branch pipelines with more than one step were silently dropped, producing incorrect outputs for valid conditional flows.

## Changes
- Updated `PipelineStep::Branch` in `mofa-foundation` to store full branch step sequences.
- Removed the multi-step simplification fallback to `PipelineStep::Identity` in `branch(...)`.
- Updated branch execution to run all steps of the selected branch sequentially.
- Added regression tests:
  - `llm::pipeline::tests::test_branch_multistep_true_runs_all_steps`
  - `llm::pipeline::tests::test_branch_multistep_false_runs_all_steps`

## Related Issues
Closes #578

## Testing
- `cargo test -p mofa-foundation branch_multistep -- --nocapture`

## Checklist
- [x] `cargo test -p mofa-foundation branch_multistep -- --nocapture` passes
- [x] Architecture layer rules respected (see CONTRIBUTING.md)
