### PR TITLE
fix(workflow): add explicit route selection for conditional edges

### DIFF
--- a/crates/mofa-foundation/src/workflow/state_graph.rs
+++ b/crates/mofa-foundation/src/workflow/state_graph.rs
@@ -386,13 +386,19 @@ impl<S: GraphState> CompiledGraphImpl<S> {
                     Some(EdgeTarget::Single(target)) => vec![target.clone()],
                     Some(EdgeTarget::Parallel(targets)) => targets.clone(),
                     Some(EdgeTarget::Conditional(routes)) => {
-                        // Find matching route based on state updates
+                        // Priority 1: explicit route decision
+                        if let Some(decision) = command.route_value() {
+                            if let Some(target) = routes.get(decision) {
+                                return vec![target.clone()];
+                            }
+                        }
+                        // Priority 2: legacy key-name matching (backward compatible)
                         for update in &command.updates {
                             if let Some(target) = routes.get(&update.key) {
                                 return vec![target.clone()];
                             }
                         }
-                        // Default to first route if no match
+                        // Priority 3: fallback to first route
                         routes
                             .values()
                             .next()
@@ -546,13 +552,19 @@ impl<S: GraphState + 'static> CompiledGraph<S, serde_json::Value> for CompiledGr
                             Some(EdgeTarget::Single(target)) => vec![target.clone()],
                             Some(EdgeTarget::Parallel(targets)) => targets.clone(),
                             Some(EdgeTarget::Conditional(routes)) => {
-                                // Find matching route based on state updates
+                                // Priority 1: explicit route decision
+                                if let Some(decision) = command.route_value() {
+                                    if let Some(target) = routes.get(decision) {
+                                        return vec![target.clone()];
+                                    }
+                                }
+                                // Priority 2: legacy key-name matching (backward compatible)
                                 for update in &command.updates {
                                     if let Some(target) = routes.get(&update.key) {
                                         return vec![target.clone()];
                                     }
                                 }
-                                // Default to first route if no match
+                                // Priority 3: fallback to first route
                                 routes
                                     .values()
                                     .next()
@@ -816,6 +828,7 @@ mod tests {
     use futures::StreamExt;
     use mofa_kernel::workflow::{JsonState, StateGraph};
     use serde_json::json;
+    use std::collections::HashMap;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::time::{Duration, sleep};
 
@@ -837,6 +850,27 @@ mod tests {
                 cmd = cmd.update(update.key.clone(), update.value.clone());
             }
             Ok(cmd.continue_())
+        }
+
+        fn name(&self) -> &str {
+            &self.name
+        }
+    }
+
+    /// Test node that returns a fixed Command (used for routing tests)
+    struct StaticCommandNode {
+        name: String,
+        command: Command,
+    }
+
+    #[async_trait]
+    impl NodeFunc<JsonState> for StaticCommandNode {
+        async fn call(
+            &self,
+            _state: &mut JsonState,
+            _ctx: &RuntimeContext,
+        ) -> AgentResult<Command> {
+            Ok(self.command.clone())
         }
 
         fn name(&self) -> &str {
@@ -1058,6 +1092,154 @@ mod tests {
         assert_eq!(
             stream_final_state.get_value("reader_saw_flag"),
             Some(json!(false))
+        );
+    }
+
+    // ── Explicit route selection tests (issue #554) ──
+
+    #[tokio::test]
+    async fn test_conditional_routing_prefers_route_value_in_invoke() {
+        let mut graph = StateGraphImpl::<JsonState>::new("route_invoke");
+
+        let mut routes = HashMap::new();
+        routes.insert("approve".to_string(), "approved".to_string());
+        routes.insert("reject".to_string(), "rejected".to_string());
+
+        graph
+            .add_node(
+                "router",
+                Box::new(StaticCommandNode {
+                    name: "router".to_string(),
+                    // route says "approve", but a key-name update matches "reject".
+                    // The explicit route must win.
+                    command: Command::new()
+                        .route("approve")
+                        .update("reject", json!(true))
+                        .continue_(),
+                }),
+            )
+            .add_node(
+                "approved",
+                Box::new(TestNode {
+                    name: "approved".to_string(),
+                    updates: vec![StateUpdate::new("decision", json!("approved"))],
+                }),
+            )
+            .add_node(
+                "rejected",
+                Box::new(TestNode {
+                    name: "rejected".to_string(),
+                    updates: vec![StateUpdate::new("decision", json!("rejected"))],
+                }),
+            )
+            .add_edge(START, "router")
+            .add_conditional_edges("router", routes)
+            .add_edge("approved", END)
+            .add_edge("rejected", END);
+
+        let compiled = graph.compile().unwrap();
+        let final_state = compiled.invoke(JsonState::new(), None).await.unwrap();
+
+        assert_eq!(
+            final_state.get_value::<serde_json::Value>("decision"),
+            Some(json!("approved"))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_conditional_routing_legacy_fallback_when_route_absent() {
+        let mut graph = StateGraphImpl::<JsonState>::new("route_fallback");
+
+        let mut routes = HashMap::new();
+        routes.insert("approve".to_string(), "approved".to_string());
+        routes.insert("reject".to_string(), "rejected".to_string());
+
+        graph
+            .add_node(
+                "router",
+                Box::new(StaticCommandNode {
+                    name: "router".to_string(),
+                    // No explicit route — should fall back to legacy key matching.
+                    command: Command::new().update("reject", json!(true)).continue_(),
+                }),
+            )
+            .add_node(
+                "approved",
+                Box::new(TestNode {
+                    name: "approved".to_string(),
+                    updates: vec![StateUpdate::new("decision", json!("approved"))],
+                }),
+            )
+            .add_node(
+                "rejected",
+                Box::new(TestNode {
+                    name: "rejected".to_string(),
+                    updates: vec![StateUpdate::new("decision", json!("rejected"))],
+                }),
+            )
+            .add_edge(START, "router")
+            .add_conditional_edges("router", routes)
+            .add_edge("approved", END)
+            .add_edge("rejected", END);
+
+        let compiled = graph.compile().unwrap();
+        let final_state = compiled.invoke(JsonState::new(), None).await.unwrap();
+
+        assert_eq!(
+            final_state.get_value::<serde_json::Value>("decision"),
+            Some(json!("rejected"))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_conditional_routing_stream_respects_route_value() {
+        let mut graph = StateGraphImpl::<JsonState>::new("route_stream");
+
+        let mut routes = HashMap::new();
+        routes.insert("approve".to_string(), "approved".to_string());
+        routes.insert("reject".to_string(), "rejected".to_string());
+
+        graph
+            .add_node(
+                "router",
+                Box::new(StaticCommandNode {
+                    name: "router".to_string(),
+                    command: Command::new().route("approve").continue_(),
+                }),
+            )
+            .add_node(
+                "approved",
+                Box::new(TestNode {
+                    name: "approved".to_string(),
+                    updates: vec![StateUpdate::new("decision", json!("approved"))],
+                }),
+            )
+            .add_node(
+                "rejected",
+                Box::new(TestNode {
+                    name: "rejected".to_string(),
+                    updates: vec![StateUpdate::new("decision", json!("rejected"))],
+                }),
+            )
+            .add_edge(START, "router")
+            .add_conditional_edges("router", routes)
+            .add_edge("approved", END)
+            .add_edge("rejected", END);
+
+        let compiled = graph.compile().unwrap();
+        let mut stream = compiled.stream(JsonState::new(), None);
+
+        let mut final_state = None;
+        while let Some(event) = stream.next().await {
+            if let Ok(StreamEvent::End { final_state: state }) = event {
+                final_state = Some(state);
+            }
+        }
+
+        let final_state = final_state.expect("stream should produce final state");
+        assert_eq!(
+            final_state.get_value::<serde_json::Value>("decision"),
+            Some(json!("approved"))
         );
     }
 }

--- a/crates/mofa-kernel/src/workflow/command.rs
+++ b/crates/mofa-kernel/src/workflow/command.rs
@@ -59,9 +59,12 @@ pub enum ControlFlow<V = Value> {
 /// ]);
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Command<V = Value> {
     /// State updates to apply
     pub updates: Vec<StateUpdate<V>>,
+    /// Optional explicit routing decision for conditional edges
+    pub route: Option<String>,
     /// Control flow directive
     pub control: ControlFlow<V>,
 }
@@ -70,6 +73,7 @@ impl<V> Default for Command<V> {
     fn default() -> Self {
         Self {
             updates: Vec::new(),
+            route: None,
             control: ControlFlow::default(),
         }
     }
@@ -90,6 +94,12 @@ impl<V> Command<V> {
     /// Add multiple state updates
     pub fn updates(mut self, updates: Vec<StateUpdate<V>>) -> Self {
         self.updates.extend(updates);
+        self
+    }
+
+    /// Provide an explicit routing decision for conditional edges
+    pub fn route(mut self, decision: impl Into<String>) -> Self {
+        self.route = Some(decision.into());
         self
     }
 
@@ -115,6 +125,7 @@ impl<V> Command<V> {
     pub fn send(targets: Vec<SendCommand<V>>) -> Self {
         Self {
             updates: Vec::new(),
+            route: None,
             control: ControlFlow::Send(targets),
         }
     }
@@ -150,6 +161,11 @@ impl<V> Command<V> {
             ControlFlow::Goto(target) => Some(target),
             _ => None,
         }
+    }
+
+    /// Get the explicit routing decision if set
+    pub fn route_value(&self) -> Option<&str> {
+        self.route.as_deref()
     }
 }
 
@@ -202,6 +218,17 @@ mod tests {
         assert_eq!(cmd.updates.len(), 2);
         assert_eq!(cmd.updates[0].key, "key1");
         assert_eq!(cmd.goto_target(), Some("next_node"));
+    }
+
+    #[test]
+    fn test_command_route_value() {
+        let cmd = Command::new()
+            .update("status", json!("pending"))
+            .route("approve")
+            .continue_();
+
+        assert_eq!(cmd.route_value(), Some("approve"));
+        assert_eq!(cmd.control, ControlFlow::Continue);
     }
 
     #[test]


### PR DESCRIPTION
Closes #554 
## What

Add explicit value-based routing for conditional edges in `StateGraph`, decoupling routing decisions from state-update key names.

## Why

Conditional edges previously matched against `update.key` names, coupling routing logic to state field naming. This prevented clean decision-based branching where a node wants to route to "approve" without requiring a state key literally named "approve".

## How

- Added `route: Option<String>` to `Command` with builder `.route("...")` and accessor `.route_value()`
- - Marked `Command` with `#[non_exhaustive]` (matching `ControlFlow`'s existing convention) to signal the struct is extensible
- - Updated conditional routing resolution in **both** `invoke()` and `stream()` paths:
-   - Priority 1: explicit `command.route_value()`
-   - Priority 2: legacy `update.key` matching (backward compatible)
-   - Priority 3: fallback to first route
## Backward Compatibility

- `route` defaults to `None` -- existing workflows using key-name matching continue unchanged
- - `#[non_exhaustive]` on `Command` prevents downstream struct-literal construction, which is the standard Rust pattern for extensible public types
## Scope

Only 2 files touched:
- `crates/mofa-kernel/src/workflow/command.rs`
- - `crates/mofa-foundation/src/workflow/state_graph.rs`
## Testing

- `cargo test -p mofa-kernel -- workflow::command` -- **7/7 pass** (1 new)
- - `cargo test -p mofa-foundation -- state_graph` -- **8/8 pass** (3 new):
-   - `test_conditional_routing_prefers_route_value_in_invoke` -- explicit route beats conflicting key match
-   - `test_conditional_routing_legacy_fallback_when_route_absent` -- backward compat
-   - `test_conditional_routing_stream_respects_route_value` -- stream path coverage
- 