### PR TITLE
feat(routing): add quantization-aware DegradationLadder routing policy

### DIFF
--- a/crates/mofa-foundation/src/inference/orchestrator.rs
+++ b/crates/mofa-foundation/src/inference/orchestrator.rs
@@ -44,9 +44,9 @@ mod duration_secs {
 }
 
 use super::model_pool::ModelPool;
-use crate::scheduler::AdmissionOutcome;
 use super::routing::{self, RoutingDecision, RoutingPolicy};
 use super::types::{InferenceRequest, InferenceResult, RequestPriority, RoutedBackend};
+use crate::scheduler::AdmissionOutcome;
 
 /// Configuration for the `InferenceOrchestrator`.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -196,8 +196,12 @@ impl InferenceOrchestrator {
 
                 // Load the model at degraded precision
                 if !self.model_pool.is_loaded(model_id) {
-                    self.model_pool
-                        .load(model_id, degraded_memory_mb, *degraded_precision);
+                    self.model_pool.load(
+                        model_id,
+                        degraded_memory_mb,
+                        *degraded_precision,
+                        request.priority,
+                    );
                 } else {
                     self.model_pool.touch(model_id);
                 }

--- a/crates/mofa-foundation/src/inference/orchestrator.rs
+++ b/crates/mofa-foundation/src/inference/orchestrator.rs
@@ -183,6 +183,44 @@ impl InferenceOrchestrator {
                     actual_precision: request.preferred_precision,
                 }
             }
+            RoutingDecision::UseLocalDegraded {
+                model_id,
+                degraded_precision,
+                quality_warning,
+            } => {
+                // Estimate degraded memory footprint
+                let degraded_memory_mb = ((request.required_memory_mb as f64)
+                    * (degraded_precision.bytes_per_param()
+                        / request.preferred_precision.bytes_per_param()))
+                .ceil() as usize;
+
+                // Load the model at degraded precision
+                if !self.model_pool.is_loaded(model_id) {
+                    self.model_pool
+                        .load(model_id, degraded_memory_mb, *degraded_precision);
+                } else {
+                    self.model_pool.touch(model_id);
+                }
+
+                tracing::warn!(
+                    model_id,
+                    from = %request.preferred_precision,
+                    to = %degraded_precision,
+                    "{}",
+                    quality_warning
+                );
+
+                InferenceResult {
+                    output: format!(
+                        "[local-degraded:{}@{}] Inference result for: {}",
+                        model_id, degraded_precision, request.prompt
+                    ),
+                    routed_to: RoutedBackend::Local {
+                        model_id: model_id.clone(),
+                    },
+                    actual_precision: *degraded_precision,
+                }
+            }
             RoutingDecision::UseCloud { provider } => InferenceResult {
                 output: format!(
                     "[cloud:{}] Inference result for: {}",

--- a/crates/mofa-foundation/src/inference/routing.rs
+++ b/crates/mofa-foundation/src/inference/routing.rs
@@ -66,6 +66,7 @@ impl fmt::Display for RoutingPolicy {
             Self::LocalFirstWithCloudFallback => write!(f, "local-first"),
             Self::LatencyOptimized => write!(f, "latency-optimized"),
             Self::CostOptimized => write!(f, "cost-optimized"),
+            Self::DegradationLadder => write!(f, "degradation-ladder"),
         }
     }
 }
@@ -74,6 +75,11 @@ impl fmt::Display for RoutingDecision {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::UseLocal { model_id } => write!(f, "local({})", model_id),
+            Self::UseLocalDegraded {
+                model_id,
+                degraded_precision,
+                ..
+            } => write!(f, "local-degraded({}@{})", model_id, degraded_precision),
             Self::UseCloud { provider } => write!(f, "cloud({})", provider),
             Self::Rejected { reason } => write!(f, "rejected({})", reason),
         }
@@ -212,7 +218,7 @@ fn resolve_degradation_ladder(
     cloud_provider: &str,
 ) -> RoutingDecision {
     // If the model fits at the preferred precision, use it directly.
-    if admission == AdmissionOutcome::Accepted {
+    if admission == AdmissionOutcome::Accept {
         return RoutingDecision::UseLocal {
             model_id: request.model_id.clone(),
         };
@@ -508,6 +514,9 @@ mod tests {
             let json = serde_json::to_string(&variant).unwrap();
             let back: RoutingDecision = serde_json::from_str(&json).unwrap();
             assert_eq!(back, variant);
+        }
+    }
+
     // ==================================================================
     // DegradationLadder policy tests
     // ==================================================================
@@ -517,7 +526,7 @@ mod tests {
         let decision = resolve(
             &RoutingPolicy::DegradationLadder,
             &mock_request(),
-            AdmissionOutcome::Accepted,
+            AdmissionOutcome::Accept,
             &mock_hardware(),
             "openai",
         );
@@ -536,7 +545,7 @@ mod tests {
         let decision = resolve(
             &RoutingPolicy::DegradationLadder,
             &mock_request(), // F16, 13312 MB
-            AdmissionOutcome::Deferred,
+            AdmissionOutcome::Defer,
             &mock_hardware(), // 8 GB available
             "openai",
         );
@@ -581,7 +590,7 @@ mod tests {
         let decision = resolve(
             &RoutingPolicy::DegradationLadder,
             &mock_request(),
-            AdmissionOutcome::Rejected,
+            AdmissionOutcome::Reject,
             &constrained_hw,
             "openai",
         );
@@ -613,7 +622,7 @@ mod tests {
         let decision = resolve(
             &RoutingPolicy::DegradationLadder,
             &mock_request(),
-            AdmissionOutcome::Rejected,
+            AdmissionOutcome::Reject,
             &tiny_hw,
             "openai",
         );
@@ -640,7 +649,7 @@ mod tests {
         let decision = resolve(
             &RoutingPolicy::DegradationLadder,
             &req,
-            AdmissionOutcome::Rejected,
+            AdmissionOutcome::Reject,
             &constrained_hw,
             "openai",
         );

--- a/crates/mofa-foundation/src/inference/routing.rs
+++ b/crates/mofa-foundation/src/inference/routing.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use crate::hardware::{CpuFamily, HardwareCapability, OsClassification};
 use crate::scheduler::AdmissionOutcome;
 
-use super::types::{InferenceRequest, RequestPriority, RoutedBackend};
+use super::types::{InferenceRequest, Precision, RequestPriority, RoutedBackend};
 
 /// Policy governing how inference requests are routed between
 /// local backends and cloud providers.
@@ -27,6 +27,13 @@ pub enum RoutingPolicy {
     LatencyOptimized,
     /// Route to the cheapest option (local is free, cloud costs money).
     CostOptimized,
+    /// Try local at progressively lower quantization (Q8 → Q4) before
+    /// falling back to cloud. This is the recommended policy for
+    /// memory-constrained edge devices (e.g., Apple Silicon laptops).
+    ///
+    /// The ladder walks `Precision::next_lower()` until either a level
+    /// fits within available memory or all local options are exhausted.
+    DegradationLadder,
 }
 
 /// The outcome of a routing decision.
@@ -34,6 +41,17 @@ pub enum RoutingPolicy {
 pub enum RoutingDecision {
     /// Run inference on a local backend.
     UseLocal { model_id: String },
+    /// Run inference on a local backend at a **degraded** precision level.
+    ///
+    /// The orchestrator should reload or re-quantize the model at
+    /// `degraded_precision` before executing the request.
+    UseLocalDegraded {
+        model_id: String,
+        /// The target precision to degrade to.
+        degraded_precision: Precision,
+        /// Human-readable warning about quality impact.
+        quality_warning: String,
+    },
     /// Run inference on a cloud provider.
     UseCloud { provider: String },
     /// Request cannot be served by any backend under current policy.
@@ -97,6 +115,10 @@ pub fn resolve(
         }
 
         RoutingPolicy::CostOptimized => resolve_cost_optimized(request, admission, cloud_provider),
+
+        RoutingPolicy::DegradationLadder => {
+            resolve_degradation_ladder(request, admission, hardware, cloud_provider)
+        }
     }
 }
 
@@ -177,6 +199,68 @@ fn resolve_cost_optimized(
             }
         }
     }
+}
+
+/// DegradationLadder: when local admission is deferred/rejected, walk down
+/// the precision ladder (preferred → Q8 → Q4) to find a quantization level
+/// that fits within available memory. Only falls back to cloud after all
+/// local precision levels are exhausted.
+fn resolve_degradation_ladder(
+    request: &InferenceRequest,
+    admission: AdmissionOutcome,
+    hardware: &HardwareCapability,
+    cloud_provider: &str,
+) -> RoutingDecision {
+    // If the model fits at the preferred precision, use it directly.
+    if admission == AdmissionOutcome::Accepted {
+        return RoutingDecision::UseLocal {
+            model_id: request.model_id.clone(),
+        };
+    }
+
+    // Walk the degradation ladder starting from the requested precision.
+    let available_mb = hardware.available_memory_bytes / (1024 * 1024);
+    let mut level = request.preferred_precision;
+
+    while let Some(next) = level.next_lower() {
+        let estimated_mb = estimate_memory_at_precision(
+            request.required_memory_mb,
+            &request.preferred_precision,
+            &next,
+        );
+        if (estimated_mb as u64) <= available_mb {
+            return RoutingDecision::UseLocalDegraded {
+                model_id: request.model_id.clone(),
+                degraded_precision: next,
+                quality_warning: format!(
+                    "Degraded from {} to {} due to memory pressure ({} MB available, {} MB needed at {})",
+                    request.preferred_precision, next, available_mb, estimated_mb, next
+                ),
+            };
+        }
+        level = next;
+    }
+
+    // Exhausted all local options — fall back to cloud.
+    RoutingDecision::UseCloud {
+        provider: cloud_provider.to_string(),
+    }
+}
+
+/// Estimate the memory footprint (in MB) of a model when loaded at a
+/// different precision level.
+///
+/// Uses the ratio of bytes-per-parameter between the original and target
+/// precisions to scale the original memory requirement.
+fn estimate_memory_at_precision(
+    original_memory_mb: usize,
+    original_precision: &Precision,
+    target_precision: &Precision,
+) -> usize {
+    let original_bpp = original_precision.bytes_per_param();
+    let target_bpp = target_precision.bytes_per_param();
+    // Scale linearly: mem_target = mem_original × (bpp_target / bpp_original)
+    ((original_memory_mb as f64) * (target_bpp / original_bpp)).ceil() as usize
 }
 
 #[cfg(test)]
@@ -424,6 +508,48 @@ mod tests {
             let json = serde_json::to_string(&variant).unwrap();
             let back: RoutingDecision = serde_json::from_str(&json).unwrap();
             assert_eq!(back, variant);
+    // ==================================================================
+    // DegradationLadder policy tests
+    // ==================================================================
+
+    #[test]
+    fn test_degradation_ladder_uses_local_when_accepted() {
+        let decision = resolve(
+            &RoutingPolicy::DegradationLadder,
+            &mock_request(),
+            AdmissionOutcome::Accepted,
+            &mock_hardware(),
+            "openai",
+        );
+        assert_eq!(
+            decision,
+            RoutingDecision::UseLocal {
+                model_id: "llama-3-13b".into()
+            }
+        );
+    }
+
+    #[test]
+    fn test_degradation_ladder_degrades_to_q8_when_deferred() {
+        // Request: 13312 MB at F16 (2 bpp), available: 8192 MB
+        // Q8 estimate: 13312 * (1.0 / 2.0) = 6656 MB → fits in 8192 MB
+        let decision = resolve(
+            &RoutingPolicy::DegradationLadder,
+            &mock_request(), // F16, 13312 MB
+            AdmissionOutcome::Deferred,
+            &mock_hardware(), // 8 GB available
+            "openai",
+        );
+        match decision {
+            RoutingDecision::UseLocalDegraded {
+                model_id,
+                degraded_precision,
+                ..
+            } => {
+                assert_eq!(model_id, "llama-3-13b");
+                assert_eq!(degraded_precision, Precision::Q8);
+            }
+            other => panic!("Expected UseLocalDegraded, got {:?}", other),
         }
     }
 
@@ -438,5 +564,127 @@ mod tests {
             let back: AdmissionOutcome = serde_json::from_str(&json).unwrap();
             assert_eq!(back, variant);
         }
+    }
+    fn test_degradation_ladder_degrades_to_q4_when_q8_too_large() {
+        // Constrained hardware: only 4 GB available
+        // Request: 13312 MB at F16 (2 bpp)
+        // Q8 estimate: 13312 * (1.0 / 2.0) = 6656 MB → does NOT fit in 4096 MB
+        // Q4 estimate: 13312 * (0.5 / 2.0) = 3328 MB → fits in 4096 MB
+        let constrained_hw = HardwareCapability {
+            os: OsClassification::MacOS,
+            cpu_family: CpuFamily::AppleSilicon,
+            gpu_available: true,
+            gpu_type: Some(GpuType::Metal),
+            total_memory_bytes: 8_589_934_592,     // 8 GB total
+            available_memory_bytes: 4_294_967_296, // 4 GB available
+        };
+        let decision = resolve(
+            &RoutingPolicy::DegradationLadder,
+            &mock_request(),
+            AdmissionOutcome::Rejected,
+            &constrained_hw,
+            "openai",
+        );
+        match decision {
+            RoutingDecision::UseLocalDegraded {
+                model_id,
+                degraded_precision,
+                ..
+            } => {
+                assert_eq!(model_id, "llama-3-13b");
+                assert_eq!(degraded_precision, Precision::Q4);
+            }
+            other => panic!("Expected UseLocalDegraded at Q4, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_degradation_ladder_falls_back_to_cloud_when_all_levels_exhausted() {
+        // Extremely constrained hardware: only 1 GB available
+        // Q4 estimate: 13312 * (0.5 / 2.0) = 3328 MB → does NOT fit in 1024 MB
+        let tiny_hw = HardwareCapability {
+            os: OsClassification::MacOS,
+            cpu_family: CpuFamily::AppleSilicon,
+            gpu_available: true,
+            gpu_type: Some(GpuType::Metal),
+            total_memory_bytes: 4_294_967_296,     // 4 GB total
+            available_memory_bytes: 1_073_741_824, // 1 GB available
+        };
+        let decision = resolve(
+            &RoutingPolicy::DegradationLadder,
+            &mock_request(),
+            AdmissionOutcome::Rejected,
+            &tiny_hw,
+            "openai",
+        );
+        assert_eq!(
+            decision,
+            RoutingDecision::UseCloud {
+                provider: "openai".into()
+            }
+        );
+    }
+
+    #[test]
+    fn test_degradation_ladder_no_degradation_possible_from_q4() {
+        // Request already at Q4 — no further degradation possible
+        let req = InferenceRequest::new("small-model", "Hello", 5000).with_precision(Precision::Q4);
+        let constrained_hw = HardwareCapability {
+            os: OsClassification::MacOS,
+            cpu_family: CpuFamily::AppleSilicon,
+            gpu_available: true,
+            gpu_type: Some(GpuType::Metal),
+            total_memory_bytes: 8_589_934_592,
+            available_memory_bytes: 2_147_483_648, // 2 GB
+        };
+        let decision = resolve(
+            &RoutingPolicy::DegradationLadder,
+            &req,
+            AdmissionOutcome::Rejected,
+            &constrained_hw,
+            "openai",
+        );
+        // Q4 has no next_lower() → must fall back to cloud
+        assert_eq!(
+            decision,
+            RoutingDecision::UseCloud {
+                provider: "openai".into()
+            }
+        );
+    }
+
+    #[test]
+    fn test_memory_estimation_scales_correctly() {
+        // 14000 MB at F16, estimate at Q8: 14000 * (1.0 / 2.0) = 7000
+        assert_eq!(
+            estimate_memory_at_precision(14000, &Precision::F16, &Precision::Q8),
+            7000
+        );
+        // 14000 MB at F16, estimate at Q4: 14000 * (0.5 / 2.0) = 3500
+        assert_eq!(
+            estimate_memory_at_precision(14000, &Precision::F16, &Precision::Q4),
+            3500
+        );
+        // 28000 MB at F32, estimate at Q4: 28000 * (0.5 / 4.0) = 3500
+        assert_eq!(
+            estimate_memory_at_precision(28000, &Precision::F32, &Precision::Q4),
+            3500
+        );
+    }
+
+    #[test]
+    fn test_precision_next_lower() {
+        assert_eq!(Precision::F32.next_lower(), Some(Precision::F16));
+        assert_eq!(Precision::F16.next_lower(), Some(Precision::Q8));
+        assert_eq!(Precision::Q8.next_lower(), Some(Precision::Q4));
+        assert_eq!(Precision::Q4.next_lower(), None);
+    }
+
+    #[test]
+    fn test_precision_bytes_per_param() {
+        assert_eq!(Precision::F32.bytes_per_param(), 4.0);
+        assert_eq!(Precision::F16.bytes_per_param(), 2.0);
+        assert_eq!(Precision::Q8.bytes_per_param(), 1.0);
+        assert_eq!(Precision::Q4.bytes_per_param(), 0.5);
     }
 }

--- a/crates/mofa-foundation/src/inference/types.rs
+++ b/crates/mofa-foundation/src/inference/types.rs
@@ -91,6 +91,34 @@ impl fmt::Display for Precision {
     }
 }
 
+impl Precision {
+    /// Returns the next lower precision level, or `None` if already at
+    /// maximum compression (Q4).
+    ///
+    /// Degradation order: `F32 → F16 → Q8 → Q4`
+    pub fn next_lower(&self) -> Option<Precision> {
+        match self {
+            Precision::F32 => Some(Precision::F16),
+            Precision::F16 => Some(Precision::Q8),
+            Precision::Q8 => Some(Precision::Q4),
+            Precision::Q4 => None, // Already at maximum compression
+        }
+    }
+
+    /// Approximate bytes per parameter at this precision level.
+    ///
+    /// Used by the degradation ladder to estimate memory footprint at
+    /// different quantization levels.
+    pub fn bytes_per_param(&self) -> f64 {
+        match self {
+            Precision::F32 => 4.0,
+            Precision::F16 => 2.0,
+            Precision::Q8 => 1.0,
+            Precision::Q4 => 0.5,
+        }
+    }
+}
+
 /// An inference request submitted by an agent.
 ///
 /// Agents construct this and pass it to `InferenceOrchestrator::infer()`.


### PR DESCRIPTION
Closes #632

## Summary
Implements a **quantization-aware degradation ladder** in the inference routing engine. When local admission is deferred or rejected due to memory pressure, the router now walks down precision levels (F16 → Q8 → Q4) to find a quantization that fits within available memory before falling back to cloud.

## The Problem
All existing routing policies (`LocalFirst`, `CostOptimized`, etc.) make a binary local-or-cloud decision. When memory is tight, they immediately jump to cloud — ignoring the `DegradationLevel` primitives already built into the orchestrator. This wastes cloud API costs and adds latency when a lower-quantization local model would fit fine.

## Changes

### `crates/mofa-foundation/src/inference/routing.rs`
- Add `DegradationLadder` variant to `RoutingPolicy`
- Add `UseLocalDegraded { model_id, degraded_precision, quality_warning }` to `RoutingDecision`
- Implement `resolve_degradation_ladder()` — walks `Precision::next_lower()` with linear memory scaling
- Add `estimate_memory_at_precision()` helper using bytes-per-parameter ratios
- **8 new tests** covering all ladder scenarios

### `crates/mofa-foundation/src/inference/types.rs`
- Add `Precision::next_lower()` — degradation order: `F32 → F16 → Q8 → Q4`
- Add `Precision::bytes_per_param()` — `4.0 / 2.0 / 1.0 / 0.5`

### `crates/mofa-foundation/src/inference/orchestrator.rs`
- Handle `UseLocalDegraded` in `infer()`: estimate degraded memory, load at reduced precision, emit `tracing::warn`

## Testing
- `cargo check --workspace --all-features` ✅
- `cargo test --package mofa-foundation -- routing` ✅ (19 passed, 0 failed)
