### PR TITLE
feat(cli): Add `mofa plugin new` command with interactive template generator

### DIFF
--- a/crates/mofa-cli/Cargo.toml
+++ b/crates/mofa-cli/Cargo.toml
@@ -51,6 +51,7 @@ dialoguer = "0.11"
 indicatif = "0.17"
 comfy-table = "7"
 dirs-next = "2"
+tera = "1.19"
 
 # Process management
 nix = { version = "0.29", features = ["process", "signal"] }

--- a/crates/mofa-cli/src/cli.rs
+++ b/crates/mofa-cli/src/cli.rs
@@ -341,6 +341,12 @@ pub enum ConfigValueCommands {
 /// Plugin management subcommands
 #[derive(Subcommand)]
 pub enum PluginCommands {
+    /// Create a new plugin project interactively
+    New {
+        /// Optional name of the plugin (will prompt if not provided)
+        name: Option<String>,
+    },
+
     /// List plugins
     List {
         /// Show installed plugins only

--- a/crates/mofa-cli/src/commands/plugin/mod.rs
+++ b/crates/mofa-cli/src/commands/plugin/mod.rs
@@ -3,5 +3,6 @@
 pub mod info;
 pub mod install;
 pub mod list;
-pub mod uninstall;
+pub mod new;
 pub mod repository;
+pub mod uninstall;

--- a/crates/mofa-cli/src/commands/plugin/new.rs
+++ b/crates/mofa-cli/src/commands/plugin/new.rs
@@ -1,0 +1,210 @@
+use crate::error::CliError;
+use clap::ValueEnum;
+use colored::Colorize;
+use dialoguer::{theme::ColorfulTheme, Input, Select};
+use std::fs;
+use std::path::{Path, PathBuf};
+use serde::Serialize;
+use tera::{Context, Tera};
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum PluginTemplate {
+    SimpleTool,
+    Middleware,
+    LlmProvider,
+    Custom,
+}
+
+impl std::fmt::Display for PluginTemplate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PluginTemplate::SimpleTool => write!(f, "Simple Tool"),
+            PluginTemplate::Middleware => write!(f, "Middleware"),
+            PluginTemplate::LlmProvider => write!(f, "LLM Provider"),
+            PluginTemplate::Custom => write!(f, "Custom (Empty)"),
+        }
+    }
+}
+
+pub async fn run(name: Option<&str>) -> Result<(), CliError> {
+    let theme = ColorfulTheme::default();
+
+    // 1. Prompt for Name
+    let plugin_name = match name {
+        Some(n) => n.to_string(),
+        None => Input::with_theme(&theme)
+            .with_prompt("Plugin name (e.g. my-awesome-plugin)")
+            .interact_text()
+            .map_err(|e| CliError::Other(format!("Prompt failed: {}", e)))?,
+    };
+
+    // Normalize hyphen/underscore for rust crate names
+    let crate_name = plugin_name.replace("-", "_");
+    
+    // 2. Prompt for Description
+    let description: String = Input::with_theme(&theme)
+        .with_prompt("Short description")
+        .default("A MoFA plugin".into())
+        .interact_text()
+        .map_err(|e| CliError::Other(format!("Prompt failed: {}", e)))?;
+
+    // 3. Prompt for Author
+    let author: String = Input::with_theme(&theme)
+        .with_prompt("Author")
+        .default("Anonymous".into())
+        .interact_text()
+        .map_err(|e| CliError::Other(format!("Prompt failed: {}", e)))?;
+
+    // 4. Prompt for Template Type
+    let templates = &[
+        PluginTemplate::SimpleTool,
+        PluginTemplate::Middleware,
+        PluginTemplate::LlmProvider,
+        PluginTemplate::Custom,
+    ];
+    let selection = Select::with_theme(&theme)
+        .with_prompt("Select a starting template")
+        .default(0)
+        .items(&templates[..])
+        .interact()
+        .map_err(|e| CliError::Other(format!("Prompt failed: {}", e)))?;
+
+    let selected_template = templates[selection];
+
+    println!(
+        "\n🚀 Scaffolding new plugin {} ({})...",
+        plugin_name.cyan().bold(),
+        selected_template.to_string().yellow()
+    );
+
+    let target_dir = std::env::current_dir()?.join(&plugin_name);
+
+    if target_dir.exists() {
+        return Err(CliError::Other(format!(
+            "Directory '{}' already exists. Aborting.",
+            target_dir.display()
+        )));
+    }
+
+    generate_scaffold(&target_dir, &plugin_name, &crate_name, &description, &author, selected_template)?;
+
+    println!(
+        "✅ Successfully created plugin in {}!",
+        target_dir.display().to_string().green()
+    );
+    
+    // Attempt auto-adding to workspace
+    let added_to_workspace = add_to_workspace_if_present(&target_dir)?;
+    if added_to_workspace {
+        println!("ℹ️  Added `{}` to the adjacent workspace Cargo.toml", plugin_name.cyan());
+    }
+
+    println!("\nNext steps:");
+    println!("  cd {}", plugin_name);
+    println!("  cargo check");
+
+    Ok(())
+}
+
+fn generate_scaffold(
+    target: &Path,
+    plugin_name: &str,
+    crate_name: &str,
+    description: &str,
+    author: &str,
+    template: PluginTemplate,
+) -> Result<(), CliError> {
+    fs::create_dir_all(target)?;
+    fs::create_dir_all(target.join("src"))?;
+    fs::create_dir_all(target.join("tests"))?;
+
+    let mut tera = Tera::default();
+    let mut ctx = Context::new();
+    ctx.insert("plugin_name", plugin_name);
+    ctx.insert("crate_name", crate_name);
+    ctx.insert("description", description);
+    ctx.insert("author", author);
+    ctx.insert("template_type", &format!("{:?}", template));
+
+    // Define all templates
+    tera.add_raw_template("Cargo.toml", include_str!("../../templates/Cargo.toml.tera"))
+        .map_err(|e| CliError::Other(e.to_string()))?;
+    tera.add_raw_template("lib.rs", include_str!("../../templates/lib.rs.tera"))
+        .map_err(|e| CliError::Other(e.to_string()))?;
+    tera.add_raw_template("config.rs", include_str!("../../templates/config.rs.tera"))
+        .map_err(|e| CliError::Other(e.to_string()))?;
+    tera.add_raw_template("handler.rs", include_str!("../../templates/handler.rs.tera"))
+        .map_err(|e| CliError::Other(e.to_string()))?;
+    tera.add_raw_template("integration.rs", include_str!("../../templates/integration.rs.tera"))
+        .map_err(|e| CliError::Other(e.to_string()))?;
+    tera.add_raw_template("README.md", include_str!("../../templates/README.md.tera"))
+        .map_err(|e| CliError::Other(e.to_string()))?;
+
+    // Render & write
+    let cargo_toml = tera.render("Cargo.toml", &ctx).map_err(|e| CliError::Other(e.to_string()))?;
+    fs::write(target.join("Cargo.toml"), cargo_toml)?;
+
+    let lib_rs = tera.render("lib.rs", &ctx).map_err(|e| CliError::Other(e.to_string()))?;
+    fs::write(target.join("src/lib.rs"), lib_rs)?;
+
+    let config_rs = tera.render("config.rs", &ctx).map_err(|e| CliError::Other(e.to_string()))?;
+    fs::write(target.join("src/config.rs"), config_rs)?;
+
+    let handler_rs = tera.render("handler.rs", &ctx).map_err(|e| CliError::Other(e.to_string()))?;
+    fs::write(target.join("src/handler.rs"), handler_rs)?;
+
+    let integration_rs = tera.render("integration.rs", &ctx).map_err(|e| CliError::Other(e.to_string()))?;
+    fs::write(target.join("tests/integration.rs"), integration_rs)?;
+
+    let readme = tera.render("README.md", &ctx).map_err(|e| CliError::Other(e.to_string()))?;
+    fs::write(target.join("README.md"), readme)?;
+
+    Ok(())
+}
+
+fn add_to_workspace_if_present(target_dir: &Path) -> Result<bool, CliError> {
+    // Try to find a workspace Cargo.toml at the parent level
+    let mut current = target_dir.parent();
+    
+    // Typical heuristics: We usually execute from root workspace or nested once
+    // For safety, just check exactly one parent.
+    if let Some(parent) = current {
+        let parent_cargo = parent.join("Cargo.toml");
+        if parent_cargo.exists() {
+            let content = fs::read_to_string(&parent_cargo)?;
+            // Rudimentary check for workspace members array
+            if content.contains("[workspace]") && content.contains("members = [") {
+                // If it isn't already there...
+                let plugin_name = target_dir.file_name().unwrap_or_default().to_string_lossy();
+                if !content.contains(&format!("\"{}\"", plugin_name)) && !content.contains(&format!("'{}'", plugin_name)) {
+                    // Try to inject it at the end of members
+                    if let Some(members_start) = content.find("members = [") {
+                        let members_end = content[members_start..].find("]").map(|m| m + members_start);
+                        if let Some(end_idx) = members_end {
+                            // Extract inner array, add ours, reform
+                            let inner = &content[members_start + 11..end_idx];
+                            let new_content = if inner.trim().is_empty() {
+                                format!("{}members = [\n    \"{}\"\n]{}", &content[..members_start], plugin_name, &content[end_idx+1..])
+                            } else {
+                                // Find last entry
+                                let last_quote = inner.rfind('"').or_else(|| inner.rfind('\''));
+                                if let Some(q) = last_quote {
+                                    let absolute_q = members_start + 11 + q;
+                                    format!("{}\",\n    \"{}\"{}", &content[..absolute_q], plugin_name, &content[absolute_q+1..])
+                                } else {
+                                    content.clone() // fallback
+                                }
+                            };
+                            
+                            // To perfectly preserve user formatting, let's do a naive replace
+                            fs::write(parent_cargo, new_content)?;
+                            return Ok(true);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    Ok(false)
+}

--- a/crates/mofa-cli/src/main.rs
+++ b/crates/mofa-cli/src/main.rs
@@ -208,6 +208,9 @@ async fn run_command(cli: Cli) -> Result<(), CliError> {
         Some(Commands::Plugin { action }) => {
             let ctx = ctx.as_ref().unwrap();
             match action {
+                cli::PluginCommands::New { name } => {
+                    commands::plugin::new::run(name.as_deref()).await?;
+                }
                 cli::PluginCommands::List {
                     installed,
                     available,

--- a/crates/mofa-cli/src/templates/Cargo.toml.tera
+++ b/crates/mofa-cli/src/templates/Cargo.toml.tera
@@ -1,0 +1,17 @@
+[package]
+name = "{{ crate_name }}"
+version = "0.1.0"
+edition = "2021"
+description = "{{ description }}"
+{% if author != "" %}authors = ["{{ author }}"]{% endif %}
+
+[dependencies]
+mofa-kernel = { path = "../crates/mofa-kernel", version = "0.1" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+async-trait = "0.1"
+anyhow = "1.0"
+
+[dev-dependencies]
+tokio = { version = "1.37", features = ["macros", "rt-multi-thread"] }
+mofa-foundation = { path = "../crates/mofa-foundation", version = "0.1" }

--- a/crates/mofa-cli/src/templates/README.md.tera
+++ b/crates/mofa-cli/src/templates/README.md.tera
@@ -1,0 +1,25 @@
+# {{ plugin_name }}
+
+{{ description }}
+
+## Features
+- Implements `AgentPlugin` trait from `mofa-kernel`
+- Fully async ready
+- Template type: {{ template_type }}
+
+## Getting Started
+
+To compile your plugin, run:
+```sh
+cargo build
+```
+
+To run your tests:
+```sh
+cargo test
+```
+
+## Adding to MoFA
+If this is within a MoFA workspace, it will be automatically available for your Agents to load via `config.yml`.
+
+> scaffolded with `mofa plugin new`

--- a/crates/mofa-cli/src/templates/config.rs.tera
+++ b/crates/mofa-cli/src/templates/config.rs.tera
@@ -1,0 +1,17 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginConfig {
+    pub enabled: bool,
+    // Add specific configurations here
+    pub custom_value: String,
+}
+
+impl Default for PluginConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            custom_value: "example-value".into(),
+        }
+    }
+}

--- a/crates/mofa-cli/src/templates/handler.rs.tera
+++ b/crates/mofa-cli/src/templates/handler.rs.tera
@@ -1,0 +1,10 @@
+use serde_json::Value;
+
+pub async fn handle_request(input: Value) -> anyhow::Result<Value> {
+    // Process your input here
+    let greeting = format!("Received input: {}", input);
+    Ok(serde_json::json!({
+        "status": "success",
+        "message": greeting
+    }))
+}

--- a/crates/mofa-cli/src/templates/integration.rs.tera
+++ b/crates/mofa-cli/src/templates/integration.rs.tera
@@ -1,0 +1,20 @@
+#[cfg(test)]
+mod tests {
+    use {{ crate_name }}::{{ plugin_name | title | replace(from="-", to="") }}Plugin;
+    use mofa_kernel::plugin::AgentPlugin;
+
+    #[tokio::test]
+    async fn test_plugin_init() {
+        let mut plugin = {{ plugin_name | title | replace(from="-", to="") }}Plugin::default();
+        let result = plugin.init_plugin().await;
+        assert!(result.is_ok(), "Plugin should initialize successfully");
+    }
+
+    #[test]
+    fn test_plugin_metadata() {
+        let plugin = {{ plugin_name | title | replace(from="-", to="") }}Plugin::default();
+        let metadata = plugin.metadata();
+        assert_eq!(metadata.id, "{{ crate_name }}");
+        assert_eq!(metadata.description, "{{ description }}");
+    }
+}

--- a/crates/mofa-cli/src/templates/lib.rs.tera
+++ b/crates/mofa-cli/src/templates/lib.rs.tera
@@ -1,0 +1,97 @@
+#![allow(dead_code)]
+
+pub mod config;
+pub mod handler;
+
+use mofa_kernel::plugin::{AgentPlugin, PluginContext, PluginError, PluginMetadata, PluginState, PluginType, PluginResult};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::any::Any;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct {{ plugin_name | title | replace(from="-", to="") }}Plugin {
+    metadata: PluginMetadata,
+    state: PluginState,
+    config: config::PluginConfig,
+}
+
+impl {{ plugin_name | title | replace(from="-", to="") }}Plugin {
+    pub fn new() -> Self {
+        let mut metadata = PluginMetadata::new(
+            "{{ crate_name }}",
+            "{{ plugin_name | title | replace(from="-", to=" ") }}",
+            PluginType::Tool, // or Custom
+        );
+        metadata.description = "{{ description }}".to_string();
+        
+        Self {
+            metadata,
+            state: PluginState::Unloaded,
+            config: config::PluginConfig::default(),
+        }
+    }
+}
+
+impl Default for {{ plugin_name | title | replace(from="-", to="") }}Plugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl AgentPlugin for {{ plugin_name | title | replace(from="-", to="") }}Plugin {
+    fn metadata(&self) -> &PluginMetadata {
+        &self.metadata
+    }
+
+    fn state(&self) -> PluginState {
+        self.state.clone()
+    }
+
+    async fn load(&mut self, _ctx: &PluginContext) -> PluginResult<()> {
+        self.state = PluginState::Loaded;
+        Ok(())
+    }
+
+    async fn init_plugin(&mut self) -> PluginResult<()> {
+        // Initialization logic here
+        Ok(())
+    }
+
+    async fn start(&mut self) -> PluginResult<()> {
+        self.state = PluginState::Running;
+        Ok(())
+    }
+
+    async fn stop(&mut self) -> PluginResult<()> {
+        self.state = PluginState::Loaded;
+        Ok(())
+    }
+
+    async fn unload(&mut self) -> PluginResult<()> {
+        self.state = PluginState::Unloaded;
+        Ok(())
+    }
+
+    async fn execute(&mut self, input: String) -> PluginResult<String> {
+        let val: serde_json::Value = serde_json::from_str(&input)
+            .map_err(|e| PluginError::Other(e.to_string()))?;
+            
+        let result = handler::handle_request(val).await
+            .map_err(|e| PluginError::Other(e.to_string()))?;
+            
+        Ok(result.to_string())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
+}


### PR DESCRIPTION
## Summary
Creating a new MoFA plugin requires manual boilerplate: setting up `Cargo.toml`, `src/lib.rs`, trait implementations, and test stubs. This PR adds a `mofa plugin new <name>` command that generates a complete, compilable plugin scaffold to encourage new contributors.

Resolves #639

## Changes
- **Interactive Prompting**: Fully automated command-line wizard using the `dialoguer` crate, requesting Plugin Name, Description, Author, and Template Type.
- **Tera Templating**: Predefined plugin configurations (`Cargo.toml`, `config.rs`, `lib.rs`, `handler.rs`, `tests/integration.rs`, and `README.md`) are embedded within the CLI using `tera` string generation for rapid instantiation.
- **Workspace Integration**: The CLI auto-detects if run within the MoFA codebase and automatically updates the workspace `Cargo.toml` `members` array to ensure immediate CI integration.

## Testing & Verification
- Simulated interactive input during `cargo run -p mofa-cli -- plugin new my-test-plugin`.
- Verified the generated plugin compiles with `cargo check` and correctly points to relative `../crates/..` dependencies.
- Verified that `cargo test` successfully runs the generated `integration.rs` test stubs ensuring the scaffold properly implements `AgentPlugin` logic from `mofa-kernel`.
