### PR TITLE
feat(workflow): Add `dry-run` mode to validate workflows without execution

### DIFF
--- a/crates/mofa-cli/src/cli.rs
+++ b/crates/mofa-cli/src/cli.rs
@@ -78,6 +78,10 @@ pub enum Commands {
         /// Enable dora runtime
         #[arg(long)]
         dora: bool,
+
+        /// Validate workflow without executing (dry run)
+        #[arg(long)]
+        dry_run: bool,
     },
 
     /// Run a dora dataflow

--- a/crates/mofa-cli/src/commands/run.rs
+++ b/crates/mofa-cli/src/commands/run.rs
@@ -4,7 +4,11 @@ use crate::CliError;
 use colored::Colorize;
 
 /// Execute the `mofa run` command
-pub fn run(config: &std::path::Path, _dora: bool) -> Result<(), CliError> {
+pub fn run(config: &std::path::Path, _dora: bool, dry_run: bool) -> Result<(), CliError> {
+    if dry_run {
+        return run_dry_run(config);
+    }
+
     println!(
         "{} Running agent with config: {}",
         "→".green(),
@@ -24,6 +28,135 @@ pub fn run(config: &std::path::Path, _dora: bool) -> Result<(), CliError> {
     }
 
     Ok(())
+}
+
+/// Validate a workflow definition without executing it
+fn run_dry_run(config: &std::path::Path) -> Result<(), CliError> {
+    use mofa_foundation::workflow::dsl::WorkflowDslParser;
+    use mofa_foundation::workflow::validator::WorkflowValidator;
+    use mofa_foundation::workflow::{WorkflowGraph, WorkflowNode, EdgeConfig};
+
+    println!(
+        "{} Dry-run: validating workflow {}",
+        "→".cyan(),
+        config.display()
+    );
+
+    // 1. Parse the DSL file
+    let definition = WorkflowDslParser::from_file(config).map_err(|e| {
+        CliError::Other(format!("Failed to parse workflow file: {}", e))
+    })?;
+
+    // 2. Build a lightweight WorkflowGraph from the definition
+    //    We construct the graph manually from the parsed definition
+    //    without requiring an agent registry (dry-run doesn't need real agents).
+    let mut graph = WorkflowGraph::new(
+        &definition.metadata.id,
+        &definition.metadata.name,
+    );
+
+    for node_def in &definition.nodes {
+        use mofa_foundation::workflow::dsl::NodeDefinition;
+        match node_def {
+            NodeDefinition::Start { id, .. } => {
+                graph.add_node(WorkflowNode::start(id));
+            }
+            NodeDefinition::End { id, .. } => {
+                graph.add_node(WorkflowNode::end(id));
+            }
+            NodeDefinition::Task { id, name, .. } => {
+                graph.add_node(WorkflowNode::task(id, name, |_ctx, input| async move { Ok(input) }));
+            }
+            NodeDefinition::LlmAgent { id, name, .. } => {
+                graph.add_node(WorkflowNode::task(id, name, |_ctx, input| async move { Ok(input) }));
+            }
+            NodeDefinition::Condition { id, name, .. } => {
+                graph.add_node(WorkflowNode::task(id, name, |_ctx, input| async move { Ok(input) }));
+            }
+            NodeDefinition::Parallel { id, name, .. } => {
+                graph.add_node(WorkflowNode::task(id, name, |_ctx, input| async move { Ok(input) }));
+            }
+            NodeDefinition::Join { id, name, wait_for, .. } => {
+                let refs: Vec<&str> = wait_for.iter().map(|s| s.as_str()).collect();
+                graph.add_node(WorkflowNode::join(id, name, refs));
+            }
+            NodeDefinition::Loop { id, name, .. } => {
+                graph.add_node(WorkflowNode::task(id, name, |_ctx, input| async move { Ok(input) }));
+            }
+            NodeDefinition::Transform { id, name, .. } => {
+                graph.add_node(WorkflowNode::task(id, name, |_ctx, input| async move { Ok(input) }));
+            }
+            NodeDefinition::SubWorkflow { id, name, workflow_id, .. } => {
+                graph.add_node(WorkflowNode::sub_workflow(id, name, workflow_id));
+            }
+            NodeDefinition::Wait { id, name, event_type, .. } => {
+                graph.add_node(WorkflowNode::wait(id, name, event_type));
+            }
+        }
+    }
+
+    for edge in &definition.edges {
+        use mofa_foundation::workflow::EdgeConfig;
+        if let Some(ref condition) = edge.condition {
+            graph.add_edge(EdgeConfig::conditional(&edge.from, &edge.to, condition));
+        } else {
+            graph.add_edge(EdgeConfig::new(&edge.from, &edge.to));
+        }
+    }
+
+    // 3. Run the validator
+    let report = WorkflowValidator::validate(&graph);
+
+    // 4. Print the report
+    println!();
+    println!(
+        "  {} Graph structure: {} nodes, {} edges",
+        if report.stats.start_nodes > 0 { "✓".green().to_string() } else { "✗".red().to_string() },
+        report.stats.total_nodes,
+        report.stats.total_edges,
+    );
+
+    println!(
+        "  {} Start node present",
+        if report.stats.start_nodes > 0 { "✓".green().to_string() } else { "✗".red().to_string() },
+    );
+
+    println!(
+        "  {} End node(s) present",
+        if report.stats.end_nodes > 0 { "✓".green().to_string() } else { "✗".red().to_string() },
+    );
+
+    let has_cycle_error = report.issues.iter().any(|i| {
+        i.severity == mofa_foundation::workflow::Severity::Error && i.message.contains("cycle")
+    });
+    println!(
+        "  {} No unintentional cycles",
+        if !has_cycle_error { "✓".green().to_string() } else { "✗".red().to_string() },
+    );
+
+    // Print individual issues
+    for issue in &report.issues {
+        let icon = match issue.severity {
+            mofa_foundation::workflow::Severity::Error => "✗".red().to_string(),
+            mofa_foundation::workflow::Severity::Warning => "⚠".yellow().to_string(),
+        };
+        let node_ctx = issue.node_id.as_deref().unwrap_or("global");
+        println!("  {} [{}] {}", icon, node_ctx, issue.message);
+    }
+
+    println!();
+    if report.is_valid() {
+        println!("{} Workflow validation passed!", "✓".green());
+        Ok(())
+    } else {
+        let err_count = report.errors().count();
+        println!(
+            "{} Workflow validation failed with {} error(s).",
+            "✗".red(),
+            err_count
+        );
+        Err(CliError::Other("Workflow validation failed".to_string()))
+    }
 }
 
 /// Execute the `mofa dataflow` command (requires dora feature)

--- a/crates/mofa-cli/src/main.rs
+++ b/crates/mofa-cli/src/main.rs
@@ -87,8 +87,8 @@ async fn run_command(cli: Cli) -> Result<(), CliError> {
             commands::build::run(release, features.as_deref())?;
         }
 
-        Some(Commands::Run { config, dora }) => {
-            commands::run::run(&config, dora)?;
+        Some(Commands::Run { config, dora, dry_run }) => {
+            commands::run::run(&config, dora, dry_run)?;
         }
 
         #[cfg(feature = "dora")]

--- a/crates/mofa-foundation/src/workflow/executor.rs
+++ b/crates/mofa-foundation/src/workflow/executor.rs
@@ -178,6 +178,17 @@ impl WorkflowExecutor {
         workflows.insert(id.to_string(), Arc::new(graph));
     }
 
+    /// 验证工作流 (Dry Run)
+    /// Validate workflow statically without running
+    pub async fn validate(&self, graph: &WorkflowGraph) -> Result<(), crate::workflow::validator::ValidationReport> {
+        let report = crate::workflow::validator::WorkflowValidator::validate(graph);
+        if report.is_valid() {
+            Ok(())
+        } else {
+            Err(report)
+        }
+    }
+
     /// 发送执行事件
     /// Emit execution event
     async fn emit_event(&self, event: ExecutionEvent) {

--- a/crates/mofa-foundation/src/workflow/mod.rs
+++ b/crates/mofa-foundation/src/workflow/mod.rs
@@ -48,6 +48,7 @@ pub mod session_recorder;
 mod state;
 mod state_graph;
 pub mod telemetry;
+pub mod validator;
 
 pub mod dsl;
 
@@ -79,3 +80,4 @@ pub use session_recorder::InMemorySessionRecorder;
 pub use state::*;
 pub use state_graph::{CompiledGraphImpl, StateGraphImpl};
 pub use telemetry::{ChannelTelemetryEmitter, RecordingTelemetryEmitter};
+pub use validator::{ValidationReport, WorkflowValidator, ValidationIssue, Severity};

--- a/crates/mofa-foundation/src/workflow/validator.rs
+++ b/crates/mofa-foundation/src/workflow/validator.rs
@@ -1,0 +1,220 @@
+use super::graph::{EdgeConfig, EdgeType, WorkflowGraph};
+use super::node::{NodeType, WorkflowNode};
+use std::collections::{HashMap, HashSet};
+
+/// Validation error severity levels
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Severity {
+    Warning,
+    Error,
+}
+
+/// A specific validation issue found in the workflow graph
+#[derive(Debug, Clone)]
+pub struct ValidationIssue {
+    pub severity: Severity,
+    pub node_id: Option<String>,
+    pub message: String,
+}
+
+impl ValidationIssue {
+    pub fn error(node_id: Option<String>, message: impl Into<String>) -> Self {
+        Self {
+            severity: Severity::Error,
+            node_id,
+            message: message.into(),
+        }
+    }
+
+    pub fn warning(node_id: Option<String>, message: impl Into<String>) -> Self {
+        Self {
+            severity: Severity::Warning,
+            node_id,
+            message: message.into(),
+        }
+    }
+}
+
+/// Statistics about the validated graph
+#[derive(Debug, Clone, Default)]
+pub struct GraphStats {
+    pub total_nodes: usize,
+    pub total_edges: usize,
+    pub start_nodes: usize,
+    pub end_nodes: usize,
+}
+
+/// The final report produced by examining a workflow graph
+#[derive(Debug, Clone)]
+pub struct ValidationReport {
+    pub issues: Vec<ValidationIssue>,
+    pub stats: GraphStats,
+}
+
+impl ValidationReport {
+    pub fn new() -> Self {
+        Self {
+            issues: Vec::new(),
+            stats: GraphStats::default(),
+        }
+    }
+
+    pub fn is_valid(&self) -> bool {
+        !self.issues.iter().any(|i| i.severity == Severity::Error)
+    }
+
+    pub fn errors(&self) -> impl Iterator<Item = &ValidationIssue> {
+        self.issues.iter().filter(|i| i.severity == Severity::Error)
+    }
+
+    pub fn warnings(&self) -> impl Iterator<Item = &ValidationIssue> {
+        self.issues.iter().filter(|i| i.severity == Severity::Warning)
+    }
+}
+
+/// Engine to validate a `WorkflowGraph` statically
+pub struct WorkflowValidator;
+
+impl WorkflowValidator {
+    /// Validate the given graph without executing it
+    pub fn validate(graph: &WorkflowGraph) -> ValidationReport {
+        let mut report = ValidationReport::new();
+
+        report.stats.total_nodes = graph.node_count();
+        report.stats.total_edges = graph.edge_count();
+
+        // 1. Structural Validation
+        Self::validate_structure(graph, &mut report);
+
+        // 2. Connectivity Validation  
+        Self::validate_connectivity(graph, &mut report);
+
+        // 3. Cycle Detection in Normal loops
+        // The graph inherently checks for cycles via topological_sort internally,
+        // but we want to map those specifically if they aren't explicit `Loop` nodes.
+        Self::validate_cycles(graph, &mut report);
+
+        report
+    }
+
+    fn validate_structure(graph: &WorkflowGraph, report: &mut ValidationReport) {
+        let start_node = graph.start_node();
+        let end_nodes = graph.end_nodes();
+
+        report.stats.start_nodes = if start_node.is_some() { 1 } else { 0 };
+        report.stats.end_nodes = end_nodes.len();
+
+        if start_node.is_none() {
+            report.issues.push(ValidationIssue::error(
+                None,
+                "Workflow has no Start node.",
+            ));
+        }
+
+        if end_nodes.is_empty() {
+            report.issues.push(ValidationIssue::error(
+                None,
+                "Workflow has no End node.",
+            ));
+        }
+        
+        // Ensure starting point has no incoming edges
+        if let Some(start) = start_node {
+            if !graph.get_incoming_edges(start).is_empty() {
+                report.issues.push(ValidationIssue::warning(
+                    Some(start.to_string()),
+                    "Start node should typically not have incoming edges.",
+                ));
+            }
+        }
+    }
+
+    fn validate_connectivity(graph: &WorkflowGraph, report: &mut ValidationReport) {
+        let node_ids = graph.node_ids();
+
+        for node_id in &node_ids {
+            let outgoing = graph.get_outgoing_edges(node_id);
+            let incoming = graph.get_incoming_edges(node_id);
+            let node = graph.get_node(node_id).unwrap();
+
+            // All edges must point to existing nodes (The core graph enforces this partially, but good to assert)
+            for edge in outgoing {
+                if graph.get_node(&edge.to).is_none() {
+                    report.issues.push(ValidationIssue::error(
+                        Some(node_id.to_string()),
+                        format!("Dangling edge points to non-existent node '{}'", edge.to),
+                    ));
+                }
+            }
+
+            // Check if node is unreachable
+            if *node_id != graph.start_node().unwrap_or("") && incoming.is_empty() {
+                report.issues.push(ValidationIssue::warning(
+                    Some(node_id.to_string()),
+                    format!("Node '{}' is unreachable (no incoming edges).", node_id),
+                ));
+            }
+
+            // End nodes shouldn't have outgoing references typically
+            if matches!(node.node_type(), NodeType::End) && !outgoing.is_empty() {
+                report.issues.push(ValidationIssue::warning(
+                    Some(node_id.to_string()),
+                    "End node has outgoing edges.",
+                ));
+            }
+        }
+    }
+
+    fn validate_cycles(graph: &WorkflowGraph, report: &mut ValidationReport) {
+        if graph.has_cycle() {
+            report.issues.push(ValidationIssue::error(
+                None,
+                "Unintentional cycle detected in graph. For explicit loops, use a Loop node.",
+            ));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workflow::node::NodeType;
+
+    #[test]
+    fn test_empty_graph_validation() {
+        let graph = WorkflowGraph::new("g1", "Empty Graph");
+        let report = WorkflowValidator::validate(&graph);
+        assert!(!report.is_valid());
+        assert_eq!(report.errors().count(), 2); // No start, No end
+    }
+
+    #[test]
+    fn test_valid_basic_graph() {
+        let mut graph = WorkflowGraph::new("g1", "Valid Graph");
+        graph.add_node(WorkflowNode::start("start"));
+        graph.add_node(WorkflowNode::end("end"));
+        graph.connect("start", "end");
+
+        let report = WorkflowValidator::validate(&graph);
+        assert!(report.is_valid());
+        assert_eq!(report.stats.total_nodes, 2);
+        assert_eq!(report.stats.total_edges, 1);
+    }
+
+    #[test]
+    fn test_unreachable_node_warning() {
+        let mut graph = WorkflowGraph::new("g1", "Unreachable Node");
+        graph.add_node(WorkflowNode::start("start"));
+        graph.add_node(WorkflowNode::end("end"));
+        graph.add_node(WorkflowNode::task("task", "Task", |_ctx, input| async move { Ok(input) }));
+        
+        graph.connect("start", "end");
+        // "task" is left floating
+
+        let report = WorkflowValidator::validate(&graph);
+        assert!(report.is_valid()); // Warnings don't invalidate
+        assert_eq!(report.warnings().count(), 1);
+        let warning = report.warnings().next().unwrap();
+        assert!(warning.message.contains("unreachable"));
+    }
+}


### PR DESCRIPTION
## Summary
Users discover workflow configuration errors only at runtime. This PR adds a `--dry-run` mode that validates the entire workflow graph without running actual logic.

Resolves #643

## Changes

### `mofa-foundation`
- **`validator.rs`** (NEW): `WorkflowValidator` with graph structure, edge connectivity, and cycle detection checks. `ValidationReport` with errors/warnings and `GraphStats`.
- **`executor.rs`**: Added `validate()` method to `WorkflowExecutor`.
- **`mod.rs`**: Exported `validator` module and public types.

### `mofa-cli`
- **`cli.rs`**: Added `--dry-run` flag to the `Run` command.
- **`run.rs`**: Implemented dry-run logic: parse YAML/TOML -> build lightweight graph -> run validator -> print formatted report.

## Validation Checks
1. **Graph Structure**: Start/End nodes present
2. **Edge Connectivity**: No dangling edges
3. **Reachability**: No orphaned nodes
4. **Cycle Detection**: No unintentional loops

## Testing
- 3 unit tests in `validator.rs` (empty graph, valid graph, unreachable node warning)
- Manual verification: `mofa run --config customer_support.yaml --dry-run` produces correct output (7 nodes, 8 edges, all green)
