### PR TITLE
fix(runtime): prevent state corruption in AgentRunner::resume() on failure

### DIFF
--- a/crates/mofa-runtime/src/runner.rs
+++ b/crates/mofa-runtime/src/runner.rs
@@ -578,13 +578,12 @@ impl<T: MoFAAgent> AgentRunner<T> {
     where
         T: AgentLifecycle,
     {
-        *self.state.write().await = RunnerState::Running;
-
         self.agent
             .resume()
             .await
             .map_err(|e| AgentError::Other(format!("Resume failed: {}", e)))?;
 
+        *self.state.write().await = RunnerState::Running;
         Ok(())
     }
 


### PR DESCRIPTION
## 📋 Summary

This PR addresses a state machine corruption bug in the [AgentRunner](cci:2://file:///c:/Users/aftab/mofa/crates/mofa-runtime/src/runner.rs:277:0-290:1) implementation within `mofa-runtime`. Previously, [resume()](cci:1://file:///c:/Users/aftab/mofa/crates/mofa-runtime/src/runner.rs:571:4-587:5) would eagerly update the runner's internal state to `RunnerState::Running` before the underlying agent had successfully resumed. If the resume operation failed, the runner would get stuck incorrectly believing it was in a `Running` state, leading to invalid subsequent [execute()](cci:1://file:///c:/Users/aftab/mofa/crates/mofa-runtime/src/runner.rs:371:4-433:5) calls passing validation checks.

This fix aligns the resume behavior with the [pause()](cci:1://file:///c:/Users/aftab/mofa/crates/mofa-runtime/src/runner.rs:551:4-569:5) method: it now only commits the `RunnerState::Running` state if the underlying `agent.resume()` call succeeds. If it fails, the runner remains safely in its original `Paused` state.

## 🔗 Related Issues

- Closes #650

## 🧠 Context

Without this fix, MoFA risks:
- Executing inputs on an agent that is functionally paused or errored.
- Masking lifecycle transition failures.
- Corrupting the integrity of the `RunnerState` state machine, making debugging difficult.

By ensuring the state is only updated on success, the runner and agent stay perfectly synchronized.

## 🛠️ Changes

- **Modified**: [crates/mofa-runtime/src/runner.rs](cci:7://file:///c:/Users/aftab/mofa/crates/mofa-runtime/src/runner.rs:0:0-0:0)
- Moved the `*self.state.write().await = RunnerState::Running;` assignment to execute *after* `self.agent.resume()` returns `Ok(())`.

## 🧪 How you Tested

1. **Unit tests pass**: `cargo test -p mofa-runtime`
2. **Integration testing**:
   - Simulated a failing agent resume operation. The runner's state correctly remains `RunnerState::Paused`.
   - Simulated a successful agent resume. The runner correctly transitions to `RunnerState::Running`.
3. **Code quality**: `cargo fmt` and `cargo clippy` run locally.

```bash
# Run runtime tests
cargo test -p mofa-runtime

# Check formatting  
cargo fmt --all

# Lint
cargo clippy -p mofa-runtime -- -D warnings
