### PR TITLE
feat(monitoring): metrics export phase 1 - core Prometheus /metrics bridge

### DIFF
--- a/crates/mofa-monitoring/README.md
+++ b/crates/mofa-monitoring/README.md
@@ -13,11 +13,20 @@ mofa-monitoring = "0.1"
 
 - Web-based dashboard for monitoring agent execution
 - Metrics collection and visualization
+- Prometheus-compatible metrics endpoint at `GET /metrics`
 - Distributed tracing support with OpenTelemetry
 - Real-time agent status monitoring
 - Health checks and alerts
 - HTTP server for dashboard UI
 - Static file embedding for frontend assets
+
+## Prometheus Endpoint
+
+`DashboardServer` now serves metrics in Prometheus text exposition format on:
+
+```text
+GET /metrics
+```
 
 ## Documentation
 

--- a/crates/mofa-monitoring/src/dashboard/mod.rs
+++ b/crates/mofa-monitoring/src/dashboard/mod.rs
@@ -14,6 +14,7 @@ mod api;
 mod assets;
 pub mod auth;
 mod metrics;
+mod prometheus;
 mod server;
 mod websocket;
 
@@ -26,5 +27,6 @@ pub use metrics::{
     AgentMetrics, Gauge, Histogram, LLMMetrics, MetricType, MetricValue, MetricsCollector,
     MetricsConfig, MetricsRegistry, MetricsSnapshot, PluginMetrics, SystemMetrics, WorkflowMetrics,
 };
+pub use prometheus::{PrometheusExportConfig, PrometheusExportError, PrometheusExporter};
 pub use server::{DashboardConfig, DashboardServer, ServerState};
 pub use websocket::{WebSocketClient, WebSocketHandler, WebSocketMessage};

--- a/crates/mofa-monitoring/src/dashboard/prometheus.rs
+++ b/crates/mofa-monitoring/src/dashboard/prometheus.rs
@@ -1,0 +1,621 @@
+//! Prometheus metrics export bridge for dashboard metrics.
+
+use super::metrics::{MetricValue, MetricsCollector, MetricsSnapshot};
+use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::sync::Arc;
+
+/// Prometheus export configuration.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct PrometheusExportConfig;
+
+/// Errors returned by the Prometheus exporter lifecycle.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum PrometheusExportError {
+    #[error("prometheus exporter internal error: {0}")]
+    Internal(String),
+}
+
+#[derive(Debug, Clone)]
+struct HistogramSample {
+    count: u64,
+    sum: f64,
+    bucket_counts: Vec<u64>,
+}
+
+/// Prometheus exporter bridge over `MetricsCollector` snapshots.
+pub struct PrometheusExporter {
+    collector: Arc<MetricsCollector>,
+    _config: PrometheusExportConfig,
+}
+
+impl PrometheusExporter {
+    pub fn new(collector: Arc<MetricsCollector>, config: PrometheusExportConfig) -> Self {
+        Self {
+            collector,
+            _config: config,
+        }
+    }
+
+    /// Kept for forward compatibility with cached exporter variants.
+    pub async fn refresh_once(&self) -> Result<(), PrometheusExportError> {
+        Ok(())
+    }
+
+    /// Render current snapshot into Prometheus text exposition format.
+    pub async fn render_cached(&self) -> String {
+        let snapshot = self.collector.current().await;
+        render_snapshot(&snapshot)
+    }
+}
+
+fn render_snapshot(snapshot: &MetricsSnapshot) -> String {
+    let mut out = String::with_capacity(16 * 1024);
+
+    render_agent_metrics(&mut out, snapshot);
+    render_workflow_metrics(&mut out, snapshot);
+    render_plugin_metrics(&mut out, snapshot);
+    render_llm_metrics(&mut out, snapshot);
+    render_system_metrics(&mut out, snapshot);
+    render_custom_metrics(&mut out, snapshot);
+
+    out
+}
+
+fn render_agent_metrics(out: &mut String, snapshot: &MetricsSnapshot) {
+    write_metric_header(
+        out,
+        "mofa_agent_tasks_total",
+        "Total tasks completed by agent",
+        "gauge",
+    );
+    for agent in &snapshot.agents {
+        append_gauge_line(
+            out,
+            "mofa_agent_tasks_total",
+            &[("agent_id".to_string(), agent.agent_id.clone())],
+            agent.tasks_completed as f64,
+        );
+    }
+
+    write_metric_header(
+        out,
+        "mofa_agent_tasks_failed_total",
+        "Total failed tasks by agent",
+        "gauge",
+    );
+    for agent in &snapshot.agents {
+        append_gauge_line(
+            out,
+            "mofa_agent_tasks_failed_total",
+            &[("agent_id".to_string(), agent.agent_id.clone())],
+            agent.tasks_failed as f64,
+        );
+    }
+
+    write_metric_header(
+        out,
+        "mofa_agent_tasks_in_progress",
+        "Current in-progress tasks by agent",
+        "gauge",
+    );
+    for agent in &snapshot.agents {
+        append_gauge_line(
+            out,
+            "mofa_agent_tasks_in_progress",
+            &[("agent_id".to_string(), agent.agent_id.clone())],
+            agent.tasks_in_progress as f64,
+        );
+    }
+
+    write_metric_header(
+        out,
+        "mofa_agent_response_time_seconds",
+        "Average task duration by agent in seconds",
+        "gauge",
+    );
+    for agent in &snapshot.agents {
+        append_gauge_line(
+            out,
+            "mofa_agent_response_time_seconds",
+            &[("agent_id".to_string(), agent.agent_id.clone())],
+            agent.avg_task_duration_ms / 1000.0,
+        );
+    }
+
+    write_metric_header(
+        out,
+        "mofa_agent_messages_sent_total",
+        "Total messages sent by agent",
+        "gauge",
+    );
+    for agent in &snapshot.agents {
+        append_gauge_line(
+            out,
+            "mofa_agent_messages_sent_total",
+            &[("agent_id".to_string(), agent.agent_id.clone())],
+            agent.messages_sent as f64,
+        );
+    }
+
+    write_metric_header(
+        out,
+        "mofa_agent_messages_received_total",
+        "Total messages received by agent",
+        "gauge",
+    );
+    for agent in &snapshot.agents {
+        append_gauge_line(
+            out,
+            "mofa_agent_messages_received_total",
+            &[("agent_id".to_string(), agent.agent_id.clone())],
+            agent.messages_received as f64,
+        );
+    }
+}
+
+fn render_workflow_metrics(out: &mut String, snapshot: &MetricsSnapshot) {
+    write_metric_header(
+        out,
+        "mofa_workflow_executions_total",
+        "Total workflow executions",
+        "gauge",
+    );
+    for workflow in &snapshot.workflows {
+        append_gauge_line(
+            out,
+            "mofa_workflow_executions_total",
+            &[("workflow_id".to_string(), workflow.workflow_id.clone())],
+            workflow.total_executions as f64,
+        );
+    }
+
+    write_metric_header(
+        out,
+        "mofa_workflow_executions_success_total",
+        "Total successful workflow executions",
+        "gauge",
+    );
+    for workflow in &snapshot.workflows {
+        append_gauge_line(
+            out,
+            "mofa_workflow_executions_success_total",
+            &[("workflow_id".to_string(), workflow.workflow_id.clone())],
+            workflow.successful_executions as f64,
+        );
+    }
+
+    write_metric_header(
+        out,
+        "mofa_workflow_executions_failed_total",
+        "Total failed workflow executions",
+        "gauge",
+    );
+    for workflow in &snapshot.workflows {
+        append_gauge_line(
+            out,
+            "mofa_workflow_executions_failed_total",
+            &[("workflow_id".to_string(), workflow.workflow_id.clone())],
+            workflow.failed_executions as f64,
+        );
+    }
+
+    write_metric_header(
+        out,
+        "mofa_workflow_duration_seconds",
+        "Average workflow execution duration in seconds",
+        "gauge",
+    );
+    for workflow in &snapshot.workflows {
+        append_gauge_line(
+            out,
+            "mofa_workflow_duration_seconds",
+            &[("workflow_id".to_string(), workflow.workflow_id.clone())],
+            workflow.avg_execution_time_ms / 1000.0,
+        );
+    }
+
+    write_metric_header(
+        out,
+        "mofa_workflow_active",
+        "Currently running workflow instances",
+        "gauge",
+    );
+    for workflow in &snapshot.workflows {
+        append_gauge_line(
+            out,
+            "mofa_workflow_active",
+            &[("workflow_id".to_string(), workflow.workflow_id.clone())],
+            workflow.running_instances as f64,
+        );
+    }
+}
+
+fn render_plugin_metrics(out: &mut String, snapshot: &MetricsSnapshot) {
+    write_metric_header(
+        out,
+        "mofa_tool_call_count",
+        "Total tool/plugin call count",
+        "gauge",
+    );
+    for plugin in &snapshot.plugins {
+        append_gauge_line(
+            out,
+            "mofa_tool_call_count",
+            &[("tool_name".to_string(), plugin.name.clone())],
+            plugin.call_count as f64,
+        );
+    }
+
+    write_metric_header(
+        out,
+        "mofa_tool_error_count",
+        "Total tool/plugin errors",
+        "gauge",
+    );
+    for plugin in &snapshot.plugins {
+        append_gauge_line(
+            out,
+            "mofa_tool_error_count",
+            &[("tool_name".to_string(), plugin.name.clone())],
+            plugin.error_count as f64,
+        );
+    }
+
+    write_metric_header(
+        out,
+        "mofa_tool_response_time_seconds",
+        "Average tool/plugin response duration in seconds",
+        "gauge",
+    );
+    for plugin in &snapshot.plugins {
+        append_gauge_line(
+            out,
+            "mofa_tool_response_time_seconds",
+            &[("tool_name".to_string(), plugin.name.clone())],
+            plugin.avg_response_time_ms / 1000.0,
+        );
+    }
+}
+
+fn render_llm_metrics(out: &mut String, snapshot: &MetricsSnapshot) {
+    write_metric_header(
+        out,
+        "mofa_llm_requests_total",
+        "Total LLM requests",
+        "gauge",
+    );
+    for llm in &snapshot.llm_metrics {
+        append_gauge_line(
+            out,
+            "mofa_llm_requests_total",
+            &[
+                ("provider".to_string(), llm.provider_name.clone()),
+                ("model".to_string(), llm.model_name.clone()),
+            ],
+            llm.total_requests as f64,
+        );
+    }
+
+    write_metric_header(
+        out,
+        "mofa_llm_tokens_per_second",
+        "LLM generation speed in tokens per second",
+        "gauge",
+    );
+    for llm in &snapshot.llm_metrics {
+        append_gauge_line(
+            out,
+            "mofa_llm_tokens_per_second",
+            &[
+                ("provider".to_string(), llm.provider_name.clone()),
+                ("model".to_string(), llm.model_name.clone()),
+            ],
+            llm.tokens_per_second.unwrap_or_default(),
+        );
+    }
+
+    write_metric_header(out, "mofa_llm_errors_total", "Total LLM errors", "gauge");
+    for llm in &snapshot.llm_metrics {
+        append_gauge_line(
+            out,
+            "mofa_llm_errors_total",
+            &[
+                ("provider".to_string(), llm.provider_name.clone()),
+                ("model".to_string(), llm.model_name.clone()),
+            ],
+            llm.failed_requests as f64,
+        );
+    }
+
+    write_metric_header(
+        out,
+        "mofa_llm_latency_seconds",
+        "Average LLM request latency in seconds",
+        "gauge",
+    );
+    for llm in &snapshot.llm_metrics {
+        append_gauge_line(
+            out,
+            "mofa_llm_latency_seconds",
+            &[
+                ("provider".to_string(), llm.provider_name.clone()),
+                ("model".to_string(), llm.model_name.clone()),
+            ],
+            llm.avg_latency_ms / 1000.0,
+        );
+    }
+}
+
+fn render_system_metrics(out: &mut String, snapshot: &MetricsSnapshot) {
+    write_metric_header(
+        out,
+        "mofa_system_cpu_percent",
+        "System CPU usage percentage",
+        "gauge",
+    );
+    append_gauge_line(
+        out,
+        "mofa_system_cpu_percent",
+        &[],
+        snapshot.system.cpu_usage,
+    );
+
+    write_metric_header(
+        out,
+        "mofa_system_memory_bytes",
+        "System memory used in bytes",
+        "gauge",
+    );
+    append_gauge_line(
+        out,
+        "mofa_system_memory_bytes",
+        &[],
+        snapshot.system.memory_used as f64,
+    );
+
+    write_metric_header(
+        out,
+        "mofa_system_memory_total_bytes",
+        "System total memory in bytes",
+        "gauge",
+    );
+    append_gauge_line(
+        out,
+        "mofa_system_memory_total_bytes",
+        &[],
+        snapshot.system.memory_total as f64,
+    );
+
+    write_metric_header(
+        out,
+        "mofa_system_uptime_seconds",
+        "System/process uptime in seconds",
+        "gauge",
+    );
+    append_gauge_line(
+        out,
+        "mofa_system_uptime_seconds",
+        &[],
+        snapshot.system.uptime_secs as f64,
+    );
+
+    write_metric_header(
+        out,
+        "mofa_system_thread_count",
+        "System thread count",
+        "gauge",
+    );
+    append_gauge_line(
+        out,
+        "mofa_system_thread_count",
+        &[],
+        snapshot.system.thread_count as f64,
+    );
+}
+
+fn render_custom_metrics(out: &mut String, snapshot: &MetricsSnapshot) {
+    for (name, value) in &snapshot.custom {
+        let metric_name = sanitize_metric_name(name);
+        match value {
+            MetricValue::Integer(v) => {
+                write_metric_header(
+                    out,
+                    &metric_name,
+                    "Custom metric exported from MetricsRegistry",
+                    "gauge",
+                );
+                append_gauge_line(out, &metric_name, &[], *v as f64);
+            }
+            MetricValue::Float(v) => {
+                write_metric_header(
+                    out,
+                    &metric_name,
+                    "Custom metric exported from MetricsRegistry",
+                    "gauge",
+                );
+                append_gauge_line(out, &metric_name, &[], *v);
+            }
+            MetricValue::Histogram(hist) => {
+                write_metric_header(
+                    out,
+                    &metric_name,
+                    "Custom histogram metric exported from MetricsRegistry",
+                    "histogram",
+                );
+                let mut cumulative = Vec::with_capacity(hist.buckets.len());
+                for (_, count) in &hist.buckets {
+                    cumulative.push(*count);
+                }
+                let bounds = hist
+                    .buckets
+                    .iter()
+                    .map(|(bound, _)| *bound)
+                    .collect::<Vec<_>>();
+                let sample = HistogramSample {
+                    count: hist.count,
+                    sum: hist.sum,
+                    bucket_counts: cumulative,
+                };
+                append_histogram_lines(out, &metric_name, &[], &bounds, &sample);
+            }
+        }
+    }
+}
+
+fn sanitize_metric_name(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' || ch == ':' {
+            out.push(ch);
+        } else {
+            out.push('_');
+        }
+    }
+
+    if out.is_empty() {
+        return "mofa_custom_metric".to_string();
+    }
+
+    // Prometheus requires the first character to match [a-zA-Z_:].
+    if let Some(first) = out.chars().next()
+        && !(first.is_ascii_alphabetic() || first == '_' || first == ':')
+    {
+        return format!("mofa_custom_{out}");
+    }
+
+    out
+}
+
+fn write_metric_header(out: &mut String, name: &str, help: &str, metric_type: &str) {
+    let _ = writeln!(out, "# HELP {name} {help}");
+    let _ = writeln!(out, "# TYPE {name} {metric_type}");
+}
+
+fn append_gauge_line(out: &mut String, name: &str, labels: &[(String, String)], value: f64) {
+    if !value.is_finite() {
+        return;
+    }
+
+    if labels.is_empty() {
+        let _ = writeln!(out, "{name} {}", format_float(value));
+        return;
+    }
+
+    let rendered_labels = labels
+        .iter()
+        .map(|(k, v)| {
+            let escaped = escape_label_value(v);
+            format!("{k}=\"{escaped}\"")
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    let _ = writeln!(out, "{name}{{{rendered_labels}}} {}", format_float(value));
+}
+
+fn append_histogram_lines(
+    out: &mut String,
+    base_name: &str,
+    labels: &[(String, String)],
+    bounds: &[f64],
+    sample: &HistogramSample,
+) {
+    for (idx, bound) in bounds.iter().enumerate() {
+        let mut with_le = labels.to_vec();
+        with_le.push(("le".to_string(), format_float(*bound)));
+        append_gauge_line(
+            out,
+            &format!("{base_name}_bucket"),
+            &with_le,
+            sample.bucket_counts.get(idx).copied().unwrap_or_default() as f64,
+        );
+    }
+
+    let mut with_inf = labels.to_vec();
+    with_inf.push(("le".to_string(), "+Inf".to_string()));
+    append_gauge_line(
+        out,
+        &format!("{base_name}_bucket"),
+        &with_inf,
+        sample.count as f64,
+    );
+    append_gauge_line(out, &format!("{base_name}_sum"), labels, sample.sum);
+    append_gauge_line(
+        out,
+        &format!("{base_name}_count"),
+        labels,
+        sample.count as f64,
+    );
+}
+
+fn format_float(value: f64) -> String {
+    if value.fract() == 0.0 {
+        format!("{value:.0}")
+    } else {
+        format!("{value:.6}")
+    }
+}
+
+fn escape_label_value(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('\n', "\\n")
+        .replace('"', "\\\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_snapshot() -> MetricsSnapshot {
+        MetricsSnapshot {
+            system: super::super::metrics::SystemMetrics {
+                cpu_usage: 40.5,
+                memory_used: 1024,
+                memory_total: 4096,
+                uptime_secs: 77,
+                thread_count: 5,
+                timestamp: 1,
+            },
+            agents: vec![super::super::metrics::AgentMetrics {
+                agent_id: "agent-1".to_string(),
+                tasks_completed: 42,
+                tasks_failed: 1,
+                tasks_in_progress: 2,
+                avg_task_duration_ms: 120.0,
+                messages_sent: 9,
+                messages_received: 8,
+                ..Default::default()
+            }],
+            workflows: vec![],
+            plugins: vec![],
+            llm_metrics: vec![],
+            timestamp: 2,
+            custom: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn renders_prometheus_headers_and_labels() {
+        let output = render_snapshot(&sample_snapshot());
+
+        assert!(output.contains("# HELP mofa_agent_tasks_total"));
+        assert!(output.contains("# TYPE mofa_agent_tasks_total gauge"));
+        assert!(output.contains("mofa_agent_tasks_total{agent_id=\"agent-1\"} 42"));
+        assert!(output.contains("# HELP mofa_system_cpu_percent"));
+    }
+
+    #[test]
+    fn escapes_label_values() {
+        let escaped = escape_label_value("a\"b\\c\n");
+        assert_eq!(escaped, "a\\\"b\\\\c\\n");
+    }
+
+    #[test]
+    fn sanitizes_metric_names_with_invalid_first_char() {
+        assert_eq!(sanitize_metric_name("1foo"), "mofa_custom_1foo");
+        assert_eq!(sanitize_metric_name(""), "mofa_custom_metric");
+    }
+}

--- a/crates/mofa-monitoring/src/dashboard/server.rs
+++ b/crates/mofa-monitoring/src/dashboard/server.rs
@@ -23,6 +23,7 @@ use super::api::create_api_router;
 use super::assets::{INDEX_HTML, serve_asset};
 use super::auth::{AuthProvider, NoopAuthProvider};
 use super::metrics::{MetricsCollector, MetricsConfig};
+use super::prometheus::{PrometheusExportConfig, PrometheusExporter};
 use super::websocket::{WebSocketHandler, create_websocket_handler};
 use tokio::sync::mpsc;
 
@@ -41,6 +42,8 @@ pub struct DashboardConfig {
     pub ws_update_interval: Duration,
     /// Enable request tracing
     pub enable_tracing: bool,
+    /// Prometheus export configuration
+    pub prometheus_export_config: PrometheusExportConfig,
     /// WebSocket authentication provider (default: NoopAuthProvider)
     pub auth_provider: Arc<dyn AuthProvider>,
 }
@@ -67,6 +70,7 @@ impl Default for DashboardConfig {
             metrics_config: MetricsConfig::default(),
             ws_update_interval: Duration::from_secs(1),
             enable_tracing: true,
+            prometheus_export_config: PrometheusExportConfig::default(),
             auth_provider: Arc::new(NoopAuthProvider),
         }
     }
@@ -102,6 +106,11 @@ impl DashboardConfig {
         self
     }
 
+    pub fn with_prometheus_export_config(mut self, config: PrometheusExportConfig) -> Self {
+        self.prometheus_export_config = config;
+        self
+    }
+
     /// Set the WebSocket authentication provider.
     pub fn with_auth(mut self, provider: Arc<dyn AuthProvider>) -> Self {
         self.auth_provider = provider;
@@ -128,6 +137,7 @@ pub struct DashboardServer {
     config: DashboardConfig,
     collector: Arc<MetricsCollector>,
     ws_handler: Option<Arc<WebSocketHandler>>,
+    prometheus_exporter: Option<Arc<PrometheusExporter>>,
     session_recorder: Option<Arc<dyn SessionRecorder>>,
     debug_event_rx: Option<mpsc::Receiver<DebugEvent>>,
 }
@@ -141,6 +151,7 @@ impl DashboardServer {
             config,
             collector,
             ws_handler: None,
+            prometheus_exporter: None,
             session_recorder: None,
             debug_event_rx: None,
         }
@@ -154,6 +165,11 @@ impl DashboardServer {
     /// Get the WebSocket handler (if started)
     pub fn ws_handler(&self) -> Option<Arc<WebSocketHandler>> {
         self.ws_handler.clone()
+    }
+
+    /// Get the Prometheus exporter (if initialized)
+    pub fn prometheus_exporter(&self) -> Option<Arc<PrometheusExporter>> {
+        self.prometheus_exporter.clone()
     }
 
     /// Get the session recorder (if configured)
@@ -191,6 +207,16 @@ impl DashboardServer {
 
         // API routes
         let api_router = create_api_router(self.collector.clone(), self.session_recorder.clone());
+        let prometheus_exporter = if let Some(exporter) = &self.prometheus_exporter {
+            exporter.clone()
+        } else {
+            let exporter = Arc::new(PrometheusExporter::new(
+                self.collector.clone(),
+                self.config.prometheus_export_config.clone(),
+            ));
+            self.prometheus_exporter = Some(exporter.clone());
+            exporter
+        };
 
         // Build main router
         let mut router = Router::new()
@@ -203,6 +229,17 @@ impl DashboardServer {
             .route("/app.js", get(serve_app_js))
             .route("/debugger.js", get(serve_debugger_js))
             .route("/assets/{*path}", get(serve_static))
+            // Prometheus endpoint
+            .route(
+                "/metrics",
+                get({
+                    let exporter = prometheus_exporter.clone();
+                    move || {
+                        let exporter = exporter.clone();
+                        async move { serve_prometheus_metrics(exporter).await }
+                    }
+                }),
+            )
             // API routes
             .nest("/api", api_router)
             // WebSocket
@@ -323,6 +360,18 @@ async fn serve_static(Path(path): Path<String>) -> impl IntoResponse {
     serve_asset(path).await
 }
 
+/// Serve Prometheus metrics text exposition.
+async fn serve_prometheus_metrics(exporter: Arc<PrometheusExporter>) -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        [(
+            header::CONTENT_TYPE,
+            "text/plain; version=0.0.4; charset=utf-8",
+        )],
+        exporter.render_cached().await,
+    )
+}
+
 /// Create a simple dashboard server with default configuration
 pub fn create_dashboard(port: u16) -> DashboardServer {
     let config = DashboardConfig::new().with_port(port);
@@ -369,6 +418,7 @@ mod tests {
         let server = DashboardServer::new(config);
 
         assert!(server.ws_handler.is_none());
+        assert!(server.prometheus_exporter.is_none());
         assert!(server.session_recorder.is_none());
     }
 }

--- a/crates/mofa-monitoring/src/dashboard/server.rs
+++ b/crates/mofa-monitoring/src/dashboard/server.rs
@@ -42,8 +42,6 @@ pub struct DashboardConfig {
     pub ws_update_interval: Duration,
     /// Enable request tracing
     pub enable_tracing: bool,
-    /// Prometheus export configuration
-    pub prometheus_export_config: PrometheusExportConfig,
     /// WebSocket authentication provider (default: NoopAuthProvider)
     pub auth_provider: Arc<dyn AuthProvider>,
 }
@@ -70,7 +68,6 @@ impl Default for DashboardConfig {
             metrics_config: MetricsConfig::default(),
             ws_update_interval: Duration::from_secs(1),
             enable_tracing: true,
-            prometheus_export_config: PrometheusExportConfig::default(),
             auth_provider: Arc::new(NoopAuthProvider),
         }
     }
@@ -103,11 +100,6 @@ impl DashboardConfig {
 
     pub fn with_ws_interval(mut self, interval: Duration) -> Self {
         self.ws_update_interval = interval;
-        self
-    }
-
-    pub fn with_prometheus_export_config(mut self, config: PrometheusExportConfig) -> Self {
-        self.prometheus_export_config = config;
         self
     }
 
@@ -212,7 +204,7 @@ impl DashboardServer {
         } else {
             let exporter = Arc::new(PrometheusExporter::new(
                 self.collector.clone(),
-                self.config.prometheus_export_config.clone(),
+                PrometheusExportConfig::default(),
             ));
             self.prometheus_exporter = Some(exporter.clone());
             exporter

--- a/crates/mofa-monitoring/src/lib.rs
+++ b/crates/mofa-monitoring/src/lib.rs
@@ -30,6 +30,7 @@ pub use dashboard::{
     AgentMetrics, AgentStatus, ApiError, ApiResponse, AuthInfo, AuthProvider, DashboardConfig,
     DashboardServer, Gauge, Histogram, LLMMetrics, LLMStatus, LLMSummary, MetricType, MetricValue,
     MetricsCollector, MetricsConfig, MetricsRegistry, MetricsSnapshot, NoopAuthProvider,
-    PluginMetrics, PluginStatus, ServerState, SystemMetrics, SystemStatus, TokenAuthProvider,
-    WebSocketClient, WebSocketHandler, WebSocketMessage, WorkflowMetrics,
+    PluginMetrics, PluginStatus, PrometheusExportConfig, PrometheusExportError, PrometheusExporter,
+    ServerState, SystemMetrics, SystemStatus, TokenAuthProvider, WebSocketClient, WebSocketHandler,
+    WebSocketMessage, WorkflowMetrics,
 };

--- a/crates/mofa-monitoring/tests/metrics_export_core_integration.rs
+++ b/crates/mofa-monitoring/tests/metrics_export_core_integration.rs
@@ -1,0 +1,48 @@
+use axum::body::{Body, to_bytes};
+use axum::http::{Request, StatusCode};
+use mofa_monitoring::{AgentMetrics, DashboardConfig, DashboardServer};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn metrics_route_returns_prometheus_payload() {
+    let mut server = DashboardServer::new(DashboardConfig::new());
+
+    server
+        .collector()
+        .update_agent(AgentMetrics {
+            agent_id: "agent-alpha".to_string(),
+            tasks_completed: 42,
+            ..Default::default()
+        })
+        .await;
+
+    let _ = server.collector().collect().await;
+    let app = server.build_router();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/metrics")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default();
+    assert!(content_type.starts_with("text/plain"));
+
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let body_str = String::from_utf8(body.to_vec()).expect("utf8");
+
+    assert!(body_str.contains("# HELP mofa_agent_tasks_total"));
+    assert!(body_str.contains("mofa_agent_tasks_total{agent_id=\"agent-alpha\"} 42"));
+}


### PR DESCRIPTION
### Summary
This PR is phase 1 of #563: ship a correct Prometheus `/metrics` bridge on top of the existing MetricsCollector.
In this phase I focused only on baseline export correctness (metric types/naming, valid histogram output, custom metric safety).
I validated this with unit + integration tests and manual `/metrics` scrape output.
Phase 2 and Phase 3 handle mentor feedback on concurrency performance and high-cardinality safety.

### Start dashboard Video

https://github.com/user-attachments/assets/129b1061-0135-45bc-bb4a-ccb61f2f78d9



### Screenshots
<img width="832" height="430" alt="image" src="https://github.com/user-attachments/assets/87f9b399-5b7f-4181-bee5-3afc24f75f5a" />



## What this PR does
- adds `PrometheusExporter` that renders `MetricsSnapshot` to Prometheus text format
- wires `GET /metrics` in `DashboardServer`
- re-exports exporter/config types from `mofa-monitoring`
- adds unit + integration checks for payload format and route correctness

## Why this shape
I wanted reviewers to validate baseline correctness first before we add caching and cardinality controls.

## Mentor-feedback alignment
This is the foundation step. The two mentor concerns are handled in the next split PRs:
- concurrency/perf hardening: PR #659
- high-cardinality safety: PR #660

## Local verification
- `cargo check -p mofa-monitoring`
- `cargo test -p mofa-monitoring dashboard::prometheus -- --nocapture`
- `cargo test -p mofa-monitoring --test metrics_export_core_integration -- --nocapture`
