### PR TITLE
fix(monitoring): metrics export phase 3 - cardinality guards and overflow aggregation

### DIFF
--- a/crates/mofa-foundation/src/agent/tools/builtin.rs
+++ b/crates/mofa-foundation/src/agent/tools/builtin.rs
@@ -892,8 +892,8 @@ mod tests {
             .await;
         assert!(read.success);
         let content = read.output["content"].as_str().unwrap();
-        assert!(content.contains("line1"));
-        assert!(content.contains("line2"));
+        assert!(content.contains("line1"), "content={content:?}");
+        assert!(content.contains("line2"), "content={content:?}");
     }
 
     #[tokio::test]

--- a/crates/mofa-foundation/src/agent/tools/builtin.rs
+++ b/crates/mofa-foundation/src/agent/tools/builtin.rs
@@ -277,10 +277,16 @@ impl SimpleTool for FileWriteTool {
                 .open(&path)
                 .await
             {
-                Ok(mut file) => match file.write_all(content.as_bytes()).await {
-                    Ok(()) => file.flush().await,
-                    Err(e) => Err(e),
-                },
+                Ok(mut file) => {
+                    // Ensure appended bytes are flushed and committed before returning success.
+                    if let Err(e) = file.write_all(content.as_bytes()).await {
+                        Err(e)
+                    } else if let Err(e) = file.flush().await {
+                        Err(e)
+                    } else {
+                        file.sync_all().await
+                    }
+                }
                 Err(e) => Err(e),
             }
         } else {
@@ -887,11 +893,22 @@ mod tests {
             .await;
         assert!(w2.success, "{:?}", w2.error);
 
-        let read = FileReadTool
-            .execute(ToolInput::from_json(json!({"path": path})))
-            .await;
-        assert!(read.success);
-        let content = read.output["content"].as_str().unwrap();
+        // Retry briefly in case slower filesystems delay visible updates.
+        let mut content = String::new();
+        let mut ok = false;
+        for _ in 0..8 {
+            let read = FileReadTool
+                .execute(ToolInput::from_json(json!({"path": path})))
+                .await;
+            assert!(read.success);
+            content = read.output["content"].as_str().unwrap_or_default().to_string();
+            if content.contains("line2") {
+                ok = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(ok, "content={content:?}");
         assert!(content.contains("line1"), "content={content:?}");
         assert!(content.contains("line2"), "content={content:?}");
     }

--- a/crates/mofa-monitoring/README.md
+++ b/crates/mofa-monitoring/README.md
@@ -13,24 +13,21 @@ mofa-monitoring = "0.1"
 
 - Web-based dashboard for monitoring agent execution
 - Metrics collection and visualization
-- Prometheus-compatible metrics endpoint at `GET /metrics`
+- Prometheus text exposition via `GET /metrics`
 - Distributed tracing support with OpenTelemetry
 - Real-time agent status monitoring
 - Health checks and alerts
 - HTTP server for dashboard UI
 - Static file embedding for frontend assets
 
-## Prometheus Endpoint
+## Prometheus Export
 
-`DashboardServer` now serves metrics in Prometheus text exposition format on:
+`DashboardServer` now exposes a Prometheus-compatible endpoint at `/metrics`.
+The exporter uses a background cache worker so scrape requests stay read-only
+and low-overhead under high concurrency.
 
-```text
-GET /metrics
-```
-
-The exporter maintains a background cache worker (`refresh_interval` default:
-`1s`) so scrape handlers return cached payloads instead of rebuilding metrics on
-every request.
+Cardinality is guarded with configurable caps and an overflow `__other__`
+series to protect TSDB backends from unbounded label growth.
 
 ## Optional OTLP Metrics Export
 

--- a/crates/mofa-monitoring/src/dashboard/mod.rs
+++ b/crates/mofa-monitoring/src/dashboard/mod.rs
@@ -27,6 +27,8 @@ pub use metrics::{
     AgentMetrics, Gauge, Histogram, LLMMetrics, MetricType, MetricValue, MetricsCollector,
     MetricsConfig, MetricsRegistry, MetricsSnapshot, PluginMetrics, SystemMetrics, WorkflowMetrics,
 };
-pub use prometheus::{PrometheusExportConfig, PrometheusExportError, PrometheusExporter};
+pub use prometheus::{
+    CardinalityLimits, PrometheusExportConfig, PrometheusExportError, PrometheusExporter,
+};
 pub use server::{DashboardConfig, DashboardServer, ServerState};
 pub use websocket::{WebSocketClient, WebSocketHandler, WebSocketMessage};

--- a/crates/mofa-monitoring/src/dashboard/prometheus.rs
+++ b/crates/mofa-monitoring/src/dashboard/prometheus.rs
@@ -1019,7 +1019,6 @@ fn render_llm_metrics(
     }
 
     write_metric_header(out, "mofa_llm_errors_total", "Total LLM errors", "counter");
-    for series in limit_series(errors, limits.provider_model, &mut dropped.provider_model) {
     for series in limit_series(
         errors,
         limits.provider_model,

--- a/crates/mofa-monitoring/src/dashboard/prometheus.rs
+++ b/crates/mofa-monitoring/src/dashboard/prometheus.rs
@@ -1708,7 +1708,8 @@ mod tests {
         snapshot
             .custom
             .insert("foo_bar".to_string(), MetricValue::Integer(2));
-        let output = render_snapshot(&snapshot);
+        let mut output = String::new();
+        render_custom_metrics(&mut output, &snapshot);
 
         assert!(output.contains("# HELP foo_bar "));
         assert!(output.contains("# HELP foo_bar_1 "));

--- a/crates/mofa-monitoring/src/dashboard/prometheus.rs
+++ b/crates/mofa-monitoring/src/dashboard/prometheus.rs
@@ -40,22 +40,22 @@ impl Default for CardinalityLimits {
 
 impl CardinalityLimits {
     pub fn with_agent_id(mut self, limit: usize) -> Self {
-        self.agent_id = limit;
+        self.agent_id = sanitize_limit(limit, "agent_id");
         self
     }
 
     pub fn with_workflow_id(mut self, limit: usize) -> Self {
-        self.workflow_id = limit;
+        self.workflow_id = sanitize_limit(limit, "workflow_id");
         self
     }
 
     pub fn with_plugin_or_tool(mut self, limit: usize) -> Self {
-        self.plugin_or_tool = limit;
+        self.plugin_or_tool = sanitize_limit(limit, "plugin_or_tool");
         self
     }
 
     pub fn with_provider_model(mut self, limit: usize) -> Self {
-        self.provider_model = limit;
+        self.provider_model = sanitize_limit(limit, "provider_model");
         self
     }
 }
@@ -81,20 +81,41 @@ impl Default for PrometheusExportConfig {
 
 impl PrometheusExportConfig {
     pub fn with_refresh_interval(mut self, refresh_interval: Duration) -> Self {
-        if refresh_interval.is_zero() {
-            warn!(
-                "PrometheusExportConfig::with_refresh_interval received zero duration; clamping to 1ms"
-            );
-            self.refresh_interval = Duration::from_millis(1);
-        } else {
-            self.refresh_interval = refresh_interval;
-        }
+        self.refresh_interval = sanitize_refresh_interval(refresh_interval);
         self
     }
 
     pub fn with_cardinality(mut self, cardinality: CardinalityLimits) -> Self {
-        self.cardinality = cardinality;
+        self.cardinality = sanitize_cardinality_limits(cardinality);
         self
+    }
+}
+
+fn sanitize_limit(limit: usize, name: &str) -> usize {
+    if limit == 0 {
+        warn!("{name} cardinality limit was 0; clamping to 1");
+        1
+    } else {
+        limit
+    }
+}
+
+fn sanitize_cardinality_limits(mut limits: CardinalityLimits) -> CardinalityLimits {
+    limits.agent_id = sanitize_limit(limits.agent_id, "agent_id");
+    limits.workflow_id = sanitize_limit(limits.workflow_id, "workflow_id");
+    limits.plugin_or_tool = sanitize_limit(limits.plugin_or_tool, "plugin_or_tool");
+    limits.provider_model = sanitize_limit(limits.provider_model, "provider_model");
+    limits
+}
+
+fn sanitize_refresh_interval(refresh_interval: Duration) -> Duration {
+    if refresh_interval.is_zero() {
+        warn!(
+            "PrometheusExportConfig::with_refresh_interval received zero duration; clamping to 1ms"
+        );
+        Duration::from_millis(1)
+    } else {
+        refresh_interval
     }
 }
 
@@ -319,10 +340,13 @@ pub struct PrometheusExporter {
 }
 
 impl PrometheusExporter {
-    pub fn new(collector: Arc<MetricsCollector>, config: PrometheusExportConfig) -> Self {
+    pub fn new(collector: Arc<MetricsCollector>, mut config: PrometheusExportConfig) -> Self {
+        config.refresh_interval = sanitize_refresh_interval(config.refresh_interval);
+        config.cardinality = sanitize_cardinality_limits(config.cardinality);
+
         Self {
             collector,
-            config,
+            config: config.clone(),
             cached_body: Arc::new(RwLock::new(Bytes::new())),
             render_duration_histogram: Arc::new(RwLock::new(DurationHistogram::new(vec![
                 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0,
@@ -350,6 +374,10 @@ impl PrometheusExporter {
 
     pub async fn refresh_once(&self) -> Result<(), PrometheusExportError> {
         let snapshot = self.collector.current().await;
+        let refresh_unix_seconds = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs_f64();
 
         let render_start = Instant::now();
         let mut dropped_this_render = DroppedSeriesCounters::default();
@@ -373,8 +401,8 @@ impl PrometheusExporter {
             dropped_total.add_assign(&dropped_this_render);
         }
 
-        self.append_exporter_internal_metrics(&mut body).await;
-
+        self.append_exporter_internal_metrics(&mut body, refresh_unix_seconds)
+            .await;
         *self.cached_body.write().await = Bytes::from(body);
 
         debug!("prometheus cache refreshed in {:.6}s", render_duration);
@@ -423,7 +451,7 @@ impl PrometheusExporter {
         out
     }
 
-    async fn append_exporter_internal_metrics(&self, out: &mut String) {
+    async fn append_exporter_internal_metrics(&self, out: &mut String, last_refresh_unix_seconds: f64) {
         let render_hist = self.render_duration_histogram.read().await;
         write_metric_header(
             out,
@@ -494,10 +522,7 @@ impl PrometheusExporter {
             out,
             "mofa_exporter_last_refresh_timestamp_seconds",
             &[],
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs_f64(),
+            last_refresh_unix_seconds,
         );
     }
 }
@@ -507,6 +532,12 @@ struct LabeledValue {
     labels: Vec<(String, String)>,
     ranking_value: f64,
     sample_value: f64,
+}
+
+#[derive(Copy, Clone)]
+enum OverflowAggregation {
+    Sum,
+    Mean,
 }
 
 fn render_agent_metrics(
@@ -562,7 +593,12 @@ fn render_agent_metrics(
         "Total tasks completed by agent",
         "counter",
     );
-    for series in limit_series(task_totals, limits.agent_id, &mut dropped.agent_id) {
+    for series in limit_series(
+        task_totals,
+        limits.agent_id,
+        &mut dropped.agent_id,
+        OverflowAggregation::Sum,
+    ) {
         append_gauge_line(
             out,
             "mofa_agent_tasks_total",
@@ -577,7 +613,12 @@ fn render_agent_metrics(
         "Total failed tasks by agent",
         "counter",
     );
-    for series in limit_series(task_failed, limits.agent_id, &mut dropped.agent_id) {
+    for series in limit_series(
+        task_failed,
+        limits.agent_id,
+        &mut dropped.agent_id,
+        OverflowAggregation::Sum,
+    ) {
         append_gauge_line(
             out,
             "mofa_agent_tasks_failed_total",
@@ -592,7 +633,12 @@ fn render_agent_metrics(
         "Current in-progress tasks by agent",
         "gauge",
     );
-    for series in limit_series(task_in_progress, limits.agent_id, &mut dropped.agent_id) {
+    for series in limit_series(
+        task_in_progress,
+        limits.agent_id,
+        &mut dropped.agent_id,
+        OverflowAggregation::Sum,
+    ) {
         append_gauge_line(
             out,
             "mofa_agent_tasks_in_progress",
@@ -607,7 +653,12 @@ fn render_agent_metrics(
         "Average task duration by agent in seconds",
         "gauge",
     );
-    for series in limit_series(avg_duration, limits.agent_id, &mut dropped.agent_id) {
+    for series in limit_series(
+        avg_duration,
+        limits.agent_id,
+        &mut dropped.agent_id,
+        OverflowAggregation::Mean,
+    ) {
         append_gauge_line(
             out,
             "mofa_agent_response_time_seconds",
@@ -622,7 +673,12 @@ fn render_agent_metrics(
         "Total messages sent by agent",
         "counter",
     );
-    for series in limit_series(messages_sent, limits.agent_id, &mut dropped.agent_id) {
+    for series in limit_series(
+        messages_sent,
+        limits.agent_id,
+        &mut dropped.agent_id,
+        OverflowAggregation::Sum,
+    ) {
         append_gauge_line(
             out,
             "mofa_agent_messages_sent_total",
@@ -637,7 +693,12 @@ fn render_agent_metrics(
         "Total messages received by agent",
         "counter",
     );
-    for series in limit_series(messages_received, limits.agent_id, &mut dropped.agent_id) {
+    for series in limit_series(
+        messages_received,
+        limits.agent_id,
+        &mut dropped.agent_id,
+        OverflowAggregation::Sum,
+    ) {
         append_gauge_line(
             out,
             "mofa_agent_messages_received_total",
@@ -694,7 +755,12 @@ fn render_workflow_metrics(
         "Total workflow executions",
         "counter",
     );
-    for series in limit_series(executions, limits.workflow_id, &mut dropped.workflow_id) {
+    for series in limit_series(
+        executions,
+        limits.workflow_id,
+        &mut dropped.workflow_id,
+        OverflowAggregation::Sum,
+    ) {
         append_gauge_line(
             out,
             "mofa_workflow_executions_total",
@@ -709,7 +775,12 @@ fn render_workflow_metrics(
         "Total successful workflow executions",
         "counter",
     );
-    for series in limit_series(success, limits.workflow_id, &mut dropped.workflow_id) {
+    for series in limit_series(
+        success,
+        limits.workflow_id,
+        &mut dropped.workflow_id,
+        OverflowAggregation::Sum,
+    ) {
         append_gauge_line(
             out,
             "mofa_workflow_executions_success_total",
@@ -724,7 +795,12 @@ fn render_workflow_metrics(
         "Total failed workflow executions",
         "counter",
     );
-    for series in limit_series(failures, limits.workflow_id, &mut dropped.workflow_id) {
+    for series in limit_series(
+        failures,
+        limits.workflow_id,
+        &mut dropped.workflow_id,
+        OverflowAggregation::Sum,
+    ) {
         append_gauge_line(
             out,
             "mofa_workflow_executions_failed_total",
@@ -739,7 +815,12 @@ fn render_workflow_metrics(
         "Average workflow execution duration in seconds",
         "gauge",
     );
-    for series in limit_series(avg_duration, limits.workflow_id, &mut dropped.workflow_id) {
+    for series in limit_series(
+        avg_duration,
+        limits.workflow_id,
+        &mut dropped.workflow_id,
+        OverflowAggregation::Mean,
+    ) {
         append_gauge_line(
             out,
             "mofa_workflow_duration_seconds",
@@ -754,7 +835,12 @@ fn render_workflow_metrics(
         "Currently running workflow instances",
         "gauge",
     );
-    for series in limit_series(running, limits.workflow_id, &mut dropped.workflow_id) {
+    for series in limit_series(
+        running,
+        limits.workflow_id,
+        &mut dropped.workflow_id,
+        OverflowAggregation::Sum,
+    ) {
         append_gauge_line(
             out,
             "mofa_workflow_active",
@@ -799,7 +885,12 @@ fn render_plugin_metrics(
         "Total tool/plugin call count",
         "counter",
     );
-    for series in limit_series(calls, limits.plugin_or_tool, &mut dropped.plugin_or_tool) {
+    for series in limit_series(
+        calls,
+        limits.plugin_or_tool,
+        &mut dropped.plugin_or_tool,
+        OverflowAggregation::Sum,
+    ) {
         append_gauge_line(
             out,
             "mofa_tool_calls_total",
@@ -814,7 +905,12 @@ fn render_plugin_metrics(
         "Total tool/plugin errors",
         "counter",
     );
-    for series in limit_series(errors, limits.plugin_or_tool, &mut dropped.plugin_or_tool) {
+    for series in limit_series(
+        errors,
+        limits.plugin_or_tool,
+        &mut dropped.plugin_or_tool,
+        OverflowAggregation::Sum,
+    ) {
         append_gauge_line(
             out,
             "mofa_tool_errors_total",
@@ -833,6 +929,7 @@ fn render_plugin_metrics(
         avg_duration,
         limits.plugin_or_tool,
         &mut dropped.plugin_or_tool,
+        OverflowAggregation::Mean,
     ) {
         append_gauge_line(
             out,
@@ -887,7 +984,12 @@ fn render_llm_metrics(
         "Total LLM requests",
         "counter",
     );
-    for series in limit_series(requests, limits.provider_model, &mut dropped.provider_model) {
+    for series in limit_series(
+        requests,
+        limits.provider_model,
+        &mut dropped.provider_model,
+        OverflowAggregation::Sum,
+    ) {
         append_gauge_line(
             out,
             "mofa_llm_requests_total",
@@ -906,6 +1008,7 @@ fn render_llm_metrics(
         tokens_per_second,
         limits.provider_model,
         &mut dropped.provider_model,
+        OverflowAggregation::Mean,
     ) {
         append_gauge_line(
             out,
@@ -917,6 +1020,12 @@ fn render_llm_metrics(
 
     write_metric_header(out, "mofa_llm_errors_total", "Total LLM errors", "counter");
     for series in limit_series(errors, limits.provider_model, &mut dropped.provider_model) {
+    for series in limit_series(
+        errors,
+        limits.provider_model,
+        &mut dropped.provider_model,
+        OverflowAggregation::Sum,
+    ) {
         append_gauge_line(
             out,
             "mofa_llm_errors_total",
@@ -931,7 +1040,12 @@ fn render_llm_metrics(
         "Average LLM request latency in seconds",
         "gauge",
     );
-    for series in limit_series(latency, limits.provider_model, &mut dropped.provider_model) {
+    for series in limit_series(
+        latency,
+        limits.provider_model,
+        &mut dropped.provider_model,
+        OverflowAggregation::Mean,
+    ) {
         append_gauge_line(
             out,
             "mofa_llm_latency_seconds",
@@ -1096,8 +1210,11 @@ fn limit_series(
     mut values: Vec<LabeledValue>,
     limit: usize,
     dropped_counter: &mut u64,
+    aggregation: OverflowAggregation,
 ) -> Vec<LabeledValue> {
-    if values.len() <= limit {
+    let effective_limit = limit.max(1);
+
+    if values.len() <= effective_limit {
         values.sort_by(|a, b| compare_label_set(&a.labels, &b.labels));
         return values;
     }
@@ -1109,20 +1226,24 @@ fn limit_series(
             .then_with(|| compare_label_set(&a.labels, &b.labels))
     });
 
-    let mut kept = values.drain(..limit).collect::<Vec<_>>();
+    let mut kept = values.drain(..effective_limit).collect::<Vec<_>>();
     let overflow = values;
-
-    let overflow_sum = overflow
-        .iter()
-        .map(|entry| entry.sample_value)
-        .fold(0.0, |acc, v| acc + v);
 
     let overflow_count = overflow.len() as u64;
     *dropped_counter = dropped_counter.saturating_add(overflow_count);
 
     if overflow_count > 0 {
+        let overflow_sum = overflow
+            .iter()
+            .map(|entry| entry.sample_value)
+            .fold(0.0, |acc, v| acc + v);
+        let overflow_value = match aggregation {
+            OverflowAggregation::Sum => overflow_sum,
+            OverflowAggregation::Mean => overflow_sum / (overflow_count as f64),
+        };
+
         // Preserve original label keys; replace values with __other__.
-        let mut label_keys = if let Some(first) = kept.first() {
+        let mut label_keys = if let Some(first) = kept.first().or_else(|| overflow.first()) {
             first
                 .labels
                 .iter()
@@ -1138,8 +1259,8 @@ fn limit_series(
 
         kept.push(LabeledValue {
             labels: label_keys,
-            ranking_value: overflow_sum,
-            sample_value: overflow_sum,
+            ranking_value: overflow_value,
+            sample_value: overflow_value,
         });
     }
 
@@ -1148,17 +1269,20 @@ fn limit_series(
 }
 
 fn compare_label_set(a: &[(String, String)], b: &[(String, String)]) -> Ordering {
-    let a_key = a
-        .iter()
-        .map(|(k, v)| format!("{k}={v}"))
-        .collect::<Vec<_>>()
-        .join("|");
-    let b_key = b
-        .iter()
-        .map(|(k, v)| format!("{k}={v}"))
-        .collect::<Vec<_>>()
-        .join("|");
-    a_key.cmp(&b_key)
+    for ((ak, av), (bk, bv)) in a.iter().zip(b.iter()) {
+        match ak.cmp(bk) {
+            Ordering::Less => return Ordering::Less,
+            Ordering::Greater => return Ordering::Greater,
+            Ordering::Equal => {}
+        }
+        match av.cmp(bv) {
+            Ordering::Less => return Ordering::Less,
+            Ordering::Greater => return Ordering::Greater,
+            Ordering::Equal => {}
+        }
+    }
+
+    a.len().cmp(&b.len())
 }
 
 fn sanitize_metric_name(name: &str) -> String {
@@ -1356,6 +1480,7 @@ mod tests {
 
         exporter.refresh_once().await.expect("refresh");
         let output = exporter.render_cached().await;
+        let output = std::str::from_utf8(output.as_ref()).expect("utf8");
 
         assert!(output.contains("agent_id=\"__other__\""));
         assert!(output.contains("mofa_exporter_dropped_series_total{label=\"agent_id\"}"));
@@ -1378,11 +1503,82 @@ mod tests {
 
         let mut dropped_a = 0;
         let mut dropped_b = 0;
-        let first = limit_series(entries.clone(), 2, &mut dropped_a);
-        let second = limit_series(entries, 2, &mut dropped_b);
+        let first = limit_series(entries.clone(), 2, &mut dropped_a, OverflowAggregation::Sum);
+        let second = limit_series(entries, 2, &mut dropped_b, OverflowAggregation::Sum);
 
         assert_eq!(first[0].labels[0].1, "a");
         assert_eq!(second[0].labels[0].1, "a");
+    }
+
+    #[tokio::test]
+    async fn zero_limits_are_clamped_and_preserve_dimension_keys() {
+        let mut snapshot = sample_snapshot();
+        snapshot.agents = (0..3)
+            .map(|idx| super::super::metrics::AgentMetrics {
+                agent_id: format!("agent-{idx}"),
+                tasks_completed: (idx + 1) as u64,
+                ..Default::default()
+            })
+            .collect();
+
+        let collector = Arc::new(MetricsCollector::new(Default::default()));
+        seed_collector_from_snapshot(&collector, snapshot).await;
+
+        let exporter = PrometheusExporter::new(
+            collector,
+            PrometheusExportConfig {
+                refresh_interval: Duration::from_millis(20),
+                cardinality: CardinalityLimits {
+                    agent_id: 0,
+                    workflow_id: 0,
+                    plugin_or_tool: 0,
+                    provider_model: 0,
+                },
+            },
+        );
+        exporter.refresh_once().await.expect("refresh");
+        let output = exporter.render_cached().await;
+        let output = std::str::from_utf8(output.as_ref()).expect("utf8");
+
+        assert!(output.contains("mofa_agent_tasks_total{agent_id=\"__other__\"}"));
+        assert!(!output.contains("mofa_agent_tasks_total{label=\"__other__\"}"));
+    }
+
+    #[tokio::test]
+    async fn overflow_uses_mean_for_average_metrics() {
+        let mut snapshot = sample_snapshot();
+        snapshot.agents = vec![
+            super::super::metrics::AgentMetrics {
+                agent_id: "a".to_string(),
+                avg_task_duration_ms: 1_000.0,
+                ..Default::default()
+            },
+            super::super::metrics::AgentMetrics {
+                agent_id: "b".to_string(),
+                avg_task_duration_ms: 2_000.0,
+                ..Default::default()
+            },
+            super::super::metrics::AgentMetrics {
+                agent_id: "c".to_string(),
+                avg_task_duration_ms: 9_000.0,
+                ..Default::default()
+            },
+        ];
+
+        let collector = Arc::new(MetricsCollector::new(Default::default()));
+        seed_collector_from_snapshot(&collector, snapshot).await;
+
+        let exporter = PrometheusExporter::new(
+            collector,
+            PrometheusExportConfig::default()
+                .with_refresh_interval(Duration::from_millis(10))
+                .with_cardinality(CardinalityLimits::default().with_agent_id(1)),
+        );
+        exporter.refresh_once().await.expect("refresh");
+        let output = exporter.render_cached().await;
+        let output = std::str::from_utf8(output.as_ref()).expect("utf8");
+
+        assert!(output.contains("mofa_agent_response_time_seconds{agent_id=\"__other__\"} 1.5"));
     }
 
     #[tokio::test]

--- a/crates/mofa-monitoring/src/dashboard/prometheus.rs
+++ b/crates/mofa-monitoring/src/dashboard/prometheus.rs
@@ -2,13 +2,63 @@
 
 use super::metrics::{MetricValue, MetricsCollector, MetricsSnapshot};
 use axum::body::Bytes;
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::RwLock;
-use tracing::warn;
+use tracing::{debug, warn};
+
+const OTHER_LABEL_VALUE: &str = "__other__";
+
+/// Cardinality limits for exported label dimensions.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct CardinalityLimits {
+    /// Maximum number of distinct `agent_id` series.
+    pub agent_id: usize,
+    /// Maximum number of distinct `workflow_id` series.
+    pub workflow_id: usize,
+    /// Maximum number of distinct `plugin_id`/`tool_name` series.
+    pub plugin_or_tool: usize,
+    /// Maximum number of distinct `(provider, model)` series.
+    pub provider_model: usize,
+}
+
+impl Default for CardinalityLimits {
+    fn default() -> Self {
+        Self {
+            agent_id: 100,
+            workflow_id: 100,
+            plugin_or_tool: 100,
+            provider_model: 50,
+        }
+    }
+}
+
+impl CardinalityLimits {
+    pub fn with_agent_id(mut self, limit: usize) -> Self {
+        self.agent_id = limit;
+        self
+    }
+
+    pub fn with_workflow_id(mut self, limit: usize) -> Self {
+        self.workflow_id = limit;
+        self
+    }
+
+    pub fn with_plugin_or_tool(mut self, limit: usize) -> Self {
+        self.plugin_or_tool = limit;
+        self
+    }
+
+    pub fn with_provider_model(mut self, limit: usize) -> Self {
+        self.provider_model = limit;
+        self
+    }
+}
 
 /// Prometheus export configuration.
 #[derive(Debug, Clone)]
@@ -16,12 +66,15 @@ use tracing::warn;
 pub struct PrometheusExportConfig {
     /// Refresh interval for the background cache worker.
     pub refresh_interval: Duration,
+    /// Label cardinality limits.
+    pub cardinality: CardinalityLimits,
 }
 
 impl Default for PrometheusExportConfig {
     fn default() -> Self {
         Self {
             refresh_interval: Duration::from_secs(1),
+            cardinality: CardinalityLimits::default(),
         }
     }
 }
@@ -38,6 +91,11 @@ impl PrometheusExportConfig {
         }
         self
     }
+
+    pub fn with_cardinality(mut self, cardinality: CardinalityLimits) -> Self {
+        self.cardinality = cardinality;
+        self
+    }
 }
 
 /// Errors returned by the Prometheus exporter lifecycle.
@@ -52,7 +110,98 @@ pub enum PrometheusExportError {
 struct HistogramSample {
     count: u64,
     sum: f64,
-    bucket_counts: Vec<u64>,
+    bucket_counts: Vec<u64>, // cumulative
+}
+
+impl HistogramSample {
+    fn new(bucket_bounds: &[f64]) -> Self {
+        Self {
+            count: 0,
+            sum: 0.0,
+            bucket_counts: vec![0; bucket_bounds.len()],
+        }
+    }
+
+    fn observe(&mut self, value: f64, bucket_bounds: &[f64]) {
+        if !value.is_finite() || value < 0.0 {
+            return;
+        }
+        self.count = self.count.saturating_add(1);
+        self.sum += value;
+        for (idx, bound) in bucket_bounds.iter().enumerate() {
+            if value <= *bound {
+                self.bucket_counts[idx] = self.bucket_counts[idx].saturating_add(1);
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SeriesHistogram {
+    labels: Vec<(String, String)>,
+    sample: HistogramSample,
+}
+
+#[derive(Debug)]
+struct LabeledHistogramStore {
+    bucket_bounds: Vec<f64>,
+    series: HashMap<String, SeriesHistogram>,
+    label_limit: usize,
+    overflow_labels: Vec<(String, String)>,
+}
+
+impl LabeledHistogramStore {
+    fn new(
+        bucket_bounds: Vec<f64>,
+        label_limit: usize,
+        overflow_labels: Vec<(String, String)>,
+    ) -> Self {
+        Self {
+            bucket_bounds,
+            series: HashMap::new(),
+            label_limit,
+            overflow_labels,
+        }
+    }
+
+    fn observe(
+        &mut self,
+        key: String,
+        labels: Vec<(String, String)>,
+        value: f64,
+        dropped_series_counter: &mut u64,
+    ) {
+        if let Some(series) = self.series.get_mut(&key) {
+            series.sample.observe(value, &self.bucket_bounds);
+            return;
+        }
+
+        if self.series.len() >= self.label_limit {
+            let overflow_key = self.overflow_key();
+            let overflow = self
+                .series
+                .entry(overflow_key)
+                .or_insert_with(|| SeriesHistogram {
+                    labels: self.overflow_labels.clone(),
+                    sample: HistogramSample::new(&self.bucket_bounds),
+                });
+            overflow.sample.observe(value, &self.bucket_bounds);
+            *dropped_series_counter = dropped_series_counter.saturating_add(1);
+            return;
+        }
+
+        let mut sample = HistogramSample::new(&self.bucket_bounds);
+        sample.observe(value, &self.bucket_bounds);
+        self.series.insert(key, SeriesHistogram { labels, sample });
+    }
+
+    fn overflow_key(&self) -> String {
+        self.overflow_labels
+            .iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect::<Vec<_>>()
+            .join("|")
+    }
 }
 
 #[derive(Debug)]
@@ -63,38 +212,109 @@ struct DurationHistogram {
 
 impl DurationHistogram {
     fn new(bounds: Vec<f64>) -> Self {
-        Self {
-            sample: HistogramSample {
-                count: 0,
-                sum: 0.0,
-                bucket_counts: vec![0; bounds.len()],
-            },
-            bounds,
-        }
+        let sample = HistogramSample::new(&bounds);
+        Self { bounds, sample }
     }
 
     fn observe(&mut self, value_seconds: f64) {
-        if !value_seconds.is_finite() || value_seconds < 0.0 {
-            return;
+        self.sample.observe(value_seconds, &self.bounds);
+    }
+}
+
+#[derive(Debug)]
+struct LatencyStores {
+    agent_execution: LabeledHistogramStore,
+    tool_call: LabeledHistogramStore,
+    llm_request: LabeledHistogramStore,
+}
+
+impl LatencyStores {
+    fn new(limits: &CardinalityLimits) -> Self {
+        Self {
+            agent_execution: LabeledHistogramStore::new(
+                vec![0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0],
+                limits.agent_id,
+                vec![("agent_id".to_string(), OTHER_LABEL_VALUE.to_string())],
+            ),
+            tool_call: LabeledHistogramStore::new(
+                vec![0.01, 0.05, 0.1, 0.5, 1.0, 5.0],
+                limits.plugin_or_tool,
+                vec![("tool_name".to_string(), OTHER_LABEL_VALUE.to_string())],
+            ),
+            llm_request: LabeledHistogramStore::new(
+                vec![0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0],
+                limits.provider_model,
+                vec![
+                    ("provider".to_string(), OTHER_LABEL_VALUE.to_string()),
+                    ("model".to_string(), OTHER_LABEL_VALUE.to_string()),
+                ],
+            ),
+        }
+    }
+
+    fn observe_snapshot(
+        &mut self,
+        snapshot: &MetricsSnapshot,
+        dropped: &mut DroppedSeriesCounters,
+    ) {
+        for agent in &snapshot.agents {
+            self.agent_execution.observe(
+                format!("agent:{}", agent.agent_id),
+                vec![("agent_id".to_string(), agent.agent_id.clone())],
+                agent.avg_task_duration_ms / 1000.0,
+                &mut dropped.agent_id,
+            );
         }
 
-        self.sample.count = self.sample.count.saturating_add(1);
-        self.sample.sum += value_seconds;
+        for plugin in &snapshot.plugins {
+            self.tool_call.observe(
+                format!("tool:{}", plugin.name),
+                vec![("tool_name".to_string(), plugin.name.clone())],
+                plugin.avg_response_time_ms / 1000.0,
+                &mut dropped.plugin_or_tool,
+            );
+        }
 
-        for (idx, bound) in self.bounds.iter().enumerate() {
-            if value_seconds <= *bound {
-                self.sample.bucket_counts[idx] = self.sample.bucket_counts[idx].saturating_add(1);
-            }
+        for llm in &snapshot.llm_metrics {
+            let key = format!("{}:{}", llm.provider_name, llm.model_name);
+            self.llm_request.observe(
+                key,
+                vec![
+                    ("provider".to_string(), llm.provider_name.clone()),
+                    ("model".to_string(), llm.model_name.clone()),
+                ],
+                llm.avg_latency_ms / 1000.0,
+                &mut dropped.provider_model,
+            );
         }
     }
 }
 
-/// Prometheus exporter bridge over `MetricsCollector` snapshots.
+#[derive(Debug, Default)]
+struct DroppedSeriesCounters {
+    agent_id: u64,
+    workflow_id: u64,
+    plugin_or_tool: u64,
+    provider_model: u64,
+}
+
+impl DroppedSeriesCounters {
+    fn add_assign(&mut self, rhs: &DroppedSeriesCounters) {
+        self.agent_id = self.agent_id.saturating_add(rhs.agent_id);
+        self.workflow_id = self.workflow_id.saturating_add(rhs.workflow_id);
+        self.plugin_or_tool = self.plugin_or_tool.saturating_add(rhs.plugin_or_tool);
+        self.provider_model = self.provider_model.saturating_add(rhs.provider_model);
+    }
+}
+
+/// Prometheus exporter bridge that caches rendered exposition text.
 pub struct PrometheusExporter {
     collector: Arc<MetricsCollector>,
     config: PrometheusExportConfig,
     cached_body: Arc<RwLock<Bytes>>,
     render_duration_histogram: Arc<RwLock<DurationHistogram>>,
+    dropped_series_total: Arc<RwLock<DroppedSeriesCounters>>,
+    latency_histograms: Arc<RwLock<LatencyStores>>,
     refresh_failures: AtomicU64,
 }
 
@@ -107,6 +327,8 @@ impl PrometheusExporter {
             render_duration_histogram: Arc::new(RwLock::new(DurationHistogram::new(vec![
                 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0,
             ]))),
+            dropped_series_total: Arc::new(RwLock::new(DroppedSeriesCounters::default())),
+            latency_histograms: Arc::new(RwLock::new(LatencyStores::new(&config.cardinality))),
             refresh_failures: AtomicU64::new(0),
         }
     }
@@ -130,19 +352,32 @@ impl PrometheusExporter {
         let snapshot = self.collector.current().await;
 
         let render_start = Instant::now();
-        let mut body = render_snapshot(&snapshot);
-        self.append_exporter_internal_metrics(
-            &mut body,
-            render_start.elapsed().as_secs_f64(),
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs_f64(),
-        )
-        .await;
+        let mut dropped_this_render = DroppedSeriesCounters::default();
+
+        {
+            let mut latency = self.latency_histograms.write().await;
+            latency.observe_snapshot(&snapshot, &mut dropped_this_render);
+        }
+
+        let mut body = self
+            .render_snapshot(&snapshot, &mut dropped_this_render)
+            .await;
+
+        let render_duration = render_start.elapsed().as_secs_f64();
+        {
+            let mut histogram = self.render_duration_histogram.write().await;
+            histogram.observe(render_duration);
+        }
+        {
+            let mut dropped_total = self.dropped_series_total.write().await;
+            dropped_total.add_assign(&dropped_this_render);
+        }
+
+        self.append_exporter_internal_metrics(&mut body).await;
 
         *self.cached_body.write().await = Bytes::from(body);
 
+        debug!("prometheus cache refreshed in {:.6}s", render_duration);
         Ok(())
     }
 
@@ -151,30 +386,90 @@ impl PrometheusExporter {
         self.cached_body.read().await.clone()
     }
 
-    async fn append_exporter_internal_metrics(
+    async fn render_snapshot(
         &self,
-        out: &mut String,
-        render_duration: f64,
-        last_refresh_unix_seconds: f64,
-    ) {
-        {
-            let mut render_hist = self.render_duration_histogram.write().await;
-            render_hist.observe(render_duration);
+        snapshot: &MetricsSnapshot,
+        dropped: &mut DroppedSeriesCounters,
+    ) -> String {
+        let mut out = String::with_capacity(16 * 1024);
 
-            write_metric_header(
-                out,
-                "mofa_exporter_render_duration_seconds",
-                "Distribution of Prometheus payload render duration",
-                "histogram",
-            );
-            append_histogram_lines(
-                out,
-                "mofa_exporter_render_duration_seconds",
-                &[],
-                &render_hist.bounds,
-                &render_hist.sample,
-            );
-        }
+        render_agent_metrics(&mut out, snapshot, &self.config.cardinality, dropped);
+        render_workflow_metrics(&mut out, snapshot, &self.config.cardinality, dropped);
+        render_plugin_metrics(&mut out, snapshot, &self.config.cardinality, dropped);
+        render_llm_metrics(&mut out, snapshot, &self.config.cardinality, dropped);
+        render_system_metrics(&mut out, snapshot);
+        render_custom_metrics(&mut out, snapshot);
+
+        let latency = self.latency_histograms.read().await;
+        render_labeled_histogram_store(
+            &mut out,
+            "mofa_agent_execution_duration_seconds",
+            "Rolling distribution of agent execution duration in seconds",
+            &latency.agent_execution,
+        );
+        render_labeled_histogram_store(
+            &mut out,
+            "mofa_tool_call_duration_seconds",
+            "Rolling distribution of tool/plugin call duration in seconds",
+            &latency.tool_call,
+        );
+        render_labeled_histogram_store(
+            &mut out,
+            "mofa_llm_request_duration_seconds",
+            "Rolling distribution of LLM request duration in seconds",
+            &latency.llm_request,
+        );
+
+        out
+    }
+
+    async fn append_exporter_internal_metrics(&self, out: &mut String) {
+        let render_hist = self.render_duration_histogram.read().await;
+        write_metric_header(
+            out,
+            "mofa_exporter_render_duration_seconds",
+            "Distribution of Prometheus payload render duration",
+            "histogram",
+        );
+        append_histogram_lines(
+            out,
+            "mofa_exporter_render_duration_seconds",
+            &[],
+            &render_hist.bounds,
+            &render_hist.sample,
+        );
+
+        let dropped = self.dropped_series_total.read().await;
+        write_metric_header(
+            out,
+            "mofa_exporter_dropped_series_total",
+            "Total dropped high-cardinality time series by label dimension",
+            "counter",
+        );
+        append_gauge_line(
+            out,
+            "mofa_exporter_dropped_series_total",
+            &[("label".to_string(), "agent_id".to_string())],
+            dropped.agent_id as f64,
+        );
+        append_gauge_line(
+            out,
+            "mofa_exporter_dropped_series_total",
+            &[("label".to_string(), "workflow_id".to_string())],
+            dropped.workflow_id as f64,
+        );
+        append_gauge_line(
+            out,
+            "mofa_exporter_dropped_series_total",
+            &[("label".to_string(), "plugin_or_tool".to_string())],
+            dropped.plugin_or_tool as f64,
+        );
+        append_gauge_line(
+            out,
+            "mofa_exporter_dropped_series_total",
+            &[("label".to_string(), "provider_model".to_string())],
+            dropped.provider_model as f64,
+        );
 
         write_metric_header(
             out,
@@ -199,37 +494,80 @@ impl PrometheusExporter {
             out,
             "mofa_exporter_last_refresh_timestamp_seconds",
             &[],
-            last_refresh_unix_seconds,
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs_f64(),
         );
     }
 }
 
-fn render_snapshot(snapshot: &MetricsSnapshot) -> String {
-    let mut out = String::with_capacity(16 * 1024);
-
-    render_agent_metrics(&mut out, snapshot);
-    render_workflow_metrics(&mut out, snapshot);
-    render_plugin_metrics(&mut out, snapshot);
-    render_llm_metrics(&mut out, snapshot);
-    render_system_metrics(&mut out, snapshot);
-    render_custom_metrics(&mut out, snapshot);
-
-    out
+#[derive(Clone)]
+struct LabeledValue {
+    labels: Vec<(String, String)>,
+    ranking_value: f64,
+    sample_value: f64,
 }
 
-fn render_agent_metrics(out: &mut String, snapshot: &MetricsSnapshot) {
+fn render_agent_metrics(
+    out: &mut String,
+    snapshot: &MetricsSnapshot,
+    limits: &CardinalityLimits,
+    dropped: &mut DroppedSeriesCounters,
+) {
+    let mut task_totals = Vec::with_capacity(snapshot.agents.len());
+    let mut task_failed = Vec::with_capacity(snapshot.agents.len());
+    let mut task_in_progress = Vec::with_capacity(snapshot.agents.len());
+    let mut avg_duration = Vec::with_capacity(snapshot.agents.len());
+    let mut messages_sent = Vec::with_capacity(snapshot.agents.len());
+    let mut messages_received = Vec::with_capacity(snapshot.agents.len());
+
+    for agent in &snapshot.agents {
+        let labels = vec![("agent_id".to_string(), agent.agent_id.clone())];
+        task_totals.push(LabeledValue {
+            labels: labels.clone(),
+            ranking_value: agent.tasks_completed as f64,
+            sample_value: agent.tasks_completed as f64,
+        });
+        task_failed.push(LabeledValue {
+            labels: labels.clone(),
+            ranking_value: agent.tasks_failed as f64,
+            sample_value: agent.tasks_failed as f64,
+        });
+        task_in_progress.push(LabeledValue {
+            labels: labels.clone(),
+            ranking_value: agent.tasks_in_progress as f64,
+            sample_value: agent.tasks_in_progress as f64,
+        });
+        avg_duration.push(LabeledValue {
+            labels: labels.clone(),
+            ranking_value: agent.avg_task_duration_ms,
+            sample_value: agent.avg_task_duration_ms / 1000.0,
+        });
+        messages_sent.push(LabeledValue {
+            labels: labels.clone(),
+            ranking_value: agent.messages_sent as f64,
+            sample_value: agent.messages_sent as f64,
+        });
+        messages_received.push(LabeledValue {
+            labels,
+            ranking_value: agent.messages_received as f64,
+            sample_value: agent.messages_received as f64,
+        });
+    }
+
     write_metric_header(
         out,
         "mofa_agent_tasks_total",
         "Total tasks completed by agent",
         "counter",
     );
-    for agent in &snapshot.agents {
+    for series in limit_series(task_totals, limits.agent_id, &mut dropped.agent_id) {
         append_gauge_line(
             out,
             "mofa_agent_tasks_total",
-            &[("agent_id".to_string(), agent.agent_id.clone())],
-            agent.tasks_completed as f64,
+            &series.labels,
+            series.sample_value,
         );
     }
 
@@ -239,12 +577,12 @@ fn render_agent_metrics(out: &mut String, snapshot: &MetricsSnapshot) {
         "Total failed tasks by agent",
         "counter",
     );
-    for agent in &snapshot.agents {
+    for series in limit_series(task_failed, limits.agent_id, &mut dropped.agent_id) {
         append_gauge_line(
             out,
             "mofa_agent_tasks_failed_total",
-            &[("agent_id".to_string(), agent.agent_id.clone())],
-            agent.tasks_failed as f64,
+            &series.labels,
+            series.sample_value,
         );
     }
 
@@ -254,12 +592,12 @@ fn render_agent_metrics(out: &mut String, snapshot: &MetricsSnapshot) {
         "Current in-progress tasks by agent",
         "gauge",
     );
-    for agent in &snapshot.agents {
+    for series in limit_series(task_in_progress, limits.agent_id, &mut dropped.agent_id) {
         append_gauge_line(
             out,
             "mofa_agent_tasks_in_progress",
-            &[("agent_id".to_string(), agent.agent_id.clone())],
-            agent.tasks_in_progress as f64,
+            &series.labels,
+            series.sample_value,
         );
     }
 
@@ -269,12 +607,12 @@ fn render_agent_metrics(out: &mut String, snapshot: &MetricsSnapshot) {
         "Average task duration by agent in seconds",
         "gauge",
     );
-    for agent in &snapshot.agents {
+    for series in limit_series(avg_duration, limits.agent_id, &mut dropped.agent_id) {
         append_gauge_line(
             out,
             "mofa_agent_response_time_seconds",
-            &[("agent_id".to_string(), agent.agent_id.clone())],
-            agent.avg_task_duration_ms / 1000.0,
+            &series.labels,
+            series.sample_value,
         );
     }
 
@@ -284,12 +622,12 @@ fn render_agent_metrics(out: &mut String, snapshot: &MetricsSnapshot) {
         "Total messages sent by agent",
         "counter",
     );
-    for agent in &snapshot.agents {
+    for series in limit_series(messages_sent, limits.agent_id, &mut dropped.agent_id) {
         append_gauge_line(
             out,
             "mofa_agent_messages_sent_total",
-            &[("agent_id".to_string(), agent.agent_id.clone())],
-            agent.messages_sent as f64,
+            &series.labels,
+            series.sample_value,
         );
     }
 
@@ -299,29 +637,69 @@ fn render_agent_metrics(out: &mut String, snapshot: &MetricsSnapshot) {
         "Total messages received by agent",
         "counter",
     );
-    for agent in &snapshot.agents {
+    for series in limit_series(messages_received, limits.agent_id, &mut dropped.agent_id) {
         append_gauge_line(
             out,
             "mofa_agent_messages_received_total",
-            &[("agent_id".to_string(), agent.agent_id.clone())],
-            agent.messages_received as f64,
+            &series.labels,
+            series.sample_value,
         );
     }
 }
 
-fn render_workflow_metrics(out: &mut String, snapshot: &MetricsSnapshot) {
+fn render_workflow_metrics(
+    out: &mut String,
+    snapshot: &MetricsSnapshot,
+    limits: &CardinalityLimits,
+    dropped: &mut DroppedSeriesCounters,
+) {
+    let mut executions = Vec::with_capacity(snapshot.workflows.len());
+    let mut success = Vec::with_capacity(snapshot.workflows.len());
+    let mut failures = Vec::with_capacity(snapshot.workflows.len());
+    let mut avg_duration = Vec::with_capacity(snapshot.workflows.len());
+    let mut running = Vec::with_capacity(snapshot.workflows.len());
+
+    for workflow in &snapshot.workflows {
+        let labels = vec![("workflow_id".to_string(), workflow.workflow_id.clone())];
+        executions.push(LabeledValue {
+            labels: labels.clone(),
+            ranking_value: workflow.total_executions as f64,
+            sample_value: workflow.total_executions as f64,
+        });
+        success.push(LabeledValue {
+            labels: labels.clone(),
+            ranking_value: workflow.successful_executions as f64,
+            sample_value: workflow.successful_executions as f64,
+        });
+        failures.push(LabeledValue {
+            labels: labels.clone(),
+            ranking_value: workflow.failed_executions as f64,
+            sample_value: workflow.failed_executions as f64,
+        });
+        avg_duration.push(LabeledValue {
+            labels: labels.clone(),
+            ranking_value: workflow.avg_execution_time_ms,
+            sample_value: workflow.avg_execution_time_ms / 1000.0,
+        });
+        running.push(LabeledValue {
+            labels,
+            ranking_value: workflow.running_instances as f64,
+            sample_value: workflow.running_instances as f64,
+        });
+    }
+
     write_metric_header(
         out,
         "mofa_workflow_executions_total",
         "Total workflow executions",
         "counter",
     );
-    for workflow in &snapshot.workflows {
+    for series in limit_series(executions, limits.workflow_id, &mut dropped.workflow_id) {
         append_gauge_line(
             out,
             "mofa_workflow_executions_total",
-            &[("workflow_id".to_string(), workflow.workflow_id.clone())],
-            workflow.total_executions as f64,
+            &series.labels,
+            series.sample_value,
         );
     }
 
@@ -331,12 +709,12 @@ fn render_workflow_metrics(out: &mut String, snapshot: &MetricsSnapshot) {
         "Total successful workflow executions",
         "counter",
     );
-    for workflow in &snapshot.workflows {
+    for series in limit_series(success, limits.workflow_id, &mut dropped.workflow_id) {
         append_gauge_line(
             out,
             "mofa_workflow_executions_success_total",
-            &[("workflow_id".to_string(), workflow.workflow_id.clone())],
-            workflow.successful_executions as f64,
+            &series.labels,
+            series.sample_value,
         );
     }
 
@@ -346,12 +724,12 @@ fn render_workflow_metrics(out: &mut String, snapshot: &MetricsSnapshot) {
         "Total failed workflow executions",
         "counter",
     );
-    for workflow in &snapshot.workflows {
+    for series in limit_series(failures, limits.workflow_id, &mut dropped.workflow_id) {
         append_gauge_line(
             out,
             "mofa_workflow_executions_failed_total",
-            &[("workflow_id".to_string(), workflow.workflow_id.clone())],
-            workflow.failed_executions as f64,
+            &series.labels,
+            series.sample_value,
         );
     }
 
@@ -361,12 +739,12 @@ fn render_workflow_metrics(out: &mut String, snapshot: &MetricsSnapshot) {
         "Average workflow execution duration in seconds",
         "gauge",
     );
-    for workflow in &snapshot.workflows {
+    for series in limit_series(avg_duration, limits.workflow_id, &mut dropped.workflow_id) {
         append_gauge_line(
             out,
             "mofa_workflow_duration_seconds",
-            &[("workflow_id".to_string(), workflow.workflow_id.clone())],
-            workflow.avg_execution_time_ms / 1000.0,
+            &series.labels,
+            series.sample_value,
         );
     }
 
@@ -376,29 +754,57 @@ fn render_workflow_metrics(out: &mut String, snapshot: &MetricsSnapshot) {
         "Currently running workflow instances",
         "gauge",
     );
-    for workflow in &snapshot.workflows {
+    for series in limit_series(running, limits.workflow_id, &mut dropped.workflow_id) {
         append_gauge_line(
             out,
             "mofa_workflow_active",
-            &[("workflow_id".to_string(), workflow.workflow_id.clone())],
-            workflow.running_instances as f64,
+            &series.labels,
+            series.sample_value,
         );
     }
 }
 
-fn render_plugin_metrics(out: &mut String, snapshot: &MetricsSnapshot) {
+fn render_plugin_metrics(
+    out: &mut String,
+    snapshot: &MetricsSnapshot,
+    limits: &CardinalityLimits,
+    dropped: &mut DroppedSeriesCounters,
+) {
+    let mut calls = Vec::with_capacity(snapshot.plugins.len());
+    let mut errors = Vec::with_capacity(snapshot.plugins.len());
+    let mut avg_duration = Vec::with_capacity(snapshot.plugins.len());
+
+    for plugin in &snapshot.plugins {
+        let labels = vec![("tool_name".to_string(), plugin.name.clone())];
+        calls.push(LabeledValue {
+            labels: labels.clone(),
+            ranking_value: plugin.call_count as f64,
+            sample_value: plugin.call_count as f64,
+        });
+        errors.push(LabeledValue {
+            labels: labels.clone(),
+            ranking_value: plugin.error_count as f64,
+            sample_value: plugin.error_count as f64,
+        });
+        avg_duration.push(LabeledValue {
+            labels,
+            ranking_value: plugin.avg_response_time_ms,
+            sample_value: plugin.avg_response_time_ms / 1000.0,
+        });
+    }
+
     write_metric_header(
         out,
         "mofa_tool_calls_total",
         "Total tool/plugin call count",
         "counter",
     );
-    for plugin in &snapshot.plugins {
+    for series in limit_series(calls, limits.plugin_or_tool, &mut dropped.plugin_or_tool) {
         append_gauge_line(
             out,
             "mofa_tool_calls_total",
-            &[("tool_name".to_string(), plugin.name.clone())],
-            plugin.call_count as f64,
+            &series.labels,
+            series.sample_value,
         );
     }
 
@@ -408,12 +814,12 @@ fn render_plugin_metrics(out: &mut String, snapshot: &MetricsSnapshot) {
         "Total tool/plugin errors",
         "counter",
     );
-    for plugin in &snapshot.plugins {
+    for series in limit_series(errors, limits.plugin_or_tool, &mut dropped.plugin_or_tool) {
         append_gauge_line(
             out,
             "mofa_tool_errors_total",
-            &[("tool_name".to_string(), plugin.name.clone())],
-            plugin.error_count as f64,
+            &series.labels,
+            series.sample_value,
         );
     }
 
@@ -423,32 +829,70 @@ fn render_plugin_metrics(out: &mut String, snapshot: &MetricsSnapshot) {
         "Average tool/plugin response duration in seconds",
         "gauge",
     );
-    for plugin in &snapshot.plugins {
+    for series in limit_series(
+        avg_duration,
+        limits.plugin_or_tool,
+        &mut dropped.plugin_or_tool,
+    ) {
         append_gauge_line(
             out,
             "mofa_tool_response_time_seconds",
-            &[("tool_name".to_string(), plugin.name.clone())],
-            plugin.avg_response_time_ms / 1000.0,
+            &series.labels,
+            series.sample_value,
         );
     }
 }
 
-fn render_llm_metrics(out: &mut String, snapshot: &MetricsSnapshot) {
+fn render_llm_metrics(
+    out: &mut String,
+    snapshot: &MetricsSnapshot,
+    limits: &CardinalityLimits,
+    dropped: &mut DroppedSeriesCounters,
+) {
+    let mut requests = Vec::with_capacity(snapshot.llm_metrics.len());
+    let mut tokens_per_second = Vec::with_capacity(snapshot.llm_metrics.len());
+    let mut errors = Vec::with_capacity(snapshot.llm_metrics.len());
+    let mut latency = Vec::with_capacity(snapshot.llm_metrics.len());
+
+    for llm in &snapshot.llm_metrics {
+        let labels = vec![
+            ("provider".to_string(), llm.provider_name.clone()),
+            ("model".to_string(), llm.model_name.clone()),
+        ];
+        requests.push(LabeledValue {
+            labels: labels.clone(),
+            ranking_value: llm.total_requests as f64,
+            sample_value: llm.total_requests as f64,
+        });
+        tokens_per_second.push(LabeledValue {
+            labels: labels.clone(),
+            ranking_value: llm.tokens_per_second.unwrap_or_default(),
+            sample_value: llm.tokens_per_second.unwrap_or_default(),
+        });
+        errors.push(LabeledValue {
+            labels: labels.clone(),
+            ranking_value: llm.failed_requests as f64,
+            sample_value: llm.failed_requests as f64,
+        });
+        latency.push(LabeledValue {
+            labels,
+            ranking_value: llm.avg_latency_ms,
+            sample_value: llm.avg_latency_ms / 1000.0,
+        });
+    }
+
     write_metric_header(
         out,
         "mofa_llm_requests_total",
         "Total LLM requests",
         "counter",
     );
-    for llm in &snapshot.llm_metrics {
+    for series in limit_series(requests, limits.provider_model, &mut dropped.provider_model) {
         append_gauge_line(
             out,
             "mofa_llm_requests_total",
-            &[
-                ("provider".to_string(), llm.provider_name.clone()),
-                ("model".to_string(), llm.model_name.clone()),
-            ],
-            llm.total_requests as f64,
+            &series.labels,
+            series.sample_value,
         );
     }
 
@@ -458,28 +902,26 @@ fn render_llm_metrics(out: &mut String, snapshot: &MetricsSnapshot) {
         "LLM generation speed in tokens per second",
         "gauge",
     );
-    for llm in &snapshot.llm_metrics {
+    for series in limit_series(
+        tokens_per_second,
+        limits.provider_model,
+        &mut dropped.provider_model,
+    ) {
         append_gauge_line(
             out,
             "mofa_llm_tokens_per_second",
-            &[
-                ("provider".to_string(), llm.provider_name.clone()),
-                ("model".to_string(), llm.model_name.clone()),
-            ],
-            llm.tokens_per_second.unwrap_or_default(),
+            &series.labels,
+            series.sample_value,
         );
     }
 
     write_metric_header(out, "mofa_llm_errors_total", "Total LLM errors", "counter");
-    for llm in &snapshot.llm_metrics {
+    for series in limit_series(errors, limits.provider_model, &mut dropped.provider_model) {
         append_gauge_line(
             out,
             "mofa_llm_errors_total",
-            &[
-                ("provider".to_string(), llm.provider_name.clone()),
-                ("model".to_string(), llm.model_name.clone()),
-            ],
-            llm.failed_requests as f64,
+            &series.labels,
+            series.sample_value,
         );
     }
 
@@ -489,15 +931,12 @@ fn render_llm_metrics(out: &mut String, snapshot: &MetricsSnapshot) {
         "Average LLM request latency in seconds",
         "gauge",
     );
-    for llm in &snapshot.llm_metrics {
+    for series in limit_series(latency, limits.provider_model, &mut dropped.provider_model) {
         append_gauge_line(
             out,
             "mofa_llm_latency_seconds",
-            &[
-                ("provider".to_string(), llm.provider_name.clone()),
-                ("model".to_string(), llm.model_name.clone()),
-            ],
-            llm.avg_latency_ms / 1000.0,
+            &series.labels,
+            series.sample_value,
         );
     }
 }
@@ -631,6 +1070,97 @@ fn render_custom_metrics(out: &mut String, snapshot: &MetricsSnapshot) {
     }
 }
 
+fn render_labeled_histogram_store(
+    out: &mut String,
+    metric_name: &str,
+    help: &str,
+    store: &LabeledHistogramStore,
+) {
+    write_metric_header(out, metric_name, help, "histogram");
+
+    let mut series_entries = store.series.values().collect::<Vec<_>>();
+    series_entries.sort_by(|a, b| compare_label_set(&a.labels, &b.labels));
+
+    for series in series_entries {
+        append_histogram_lines(
+            out,
+            metric_name,
+            &series.labels,
+            &store.bucket_bounds,
+            &series.sample,
+        );
+    }
+}
+
+fn limit_series(
+    mut values: Vec<LabeledValue>,
+    limit: usize,
+    dropped_counter: &mut u64,
+) -> Vec<LabeledValue> {
+    if values.len() <= limit {
+        values.sort_by(|a, b| compare_label_set(&a.labels, &b.labels));
+        return values;
+    }
+
+    values.sort_by(|a, b| {
+        b.ranking_value
+            .partial_cmp(&a.ranking_value)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| compare_label_set(&a.labels, &b.labels))
+    });
+
+    let mut kept = values.drain(..limit).collect::<Vec<_>>();
+    let overflow = values;
+
+    let overflow_sum = overflow
+        .iter()
+        .map(|entry| entry.sample_value)
+        .fold(0.0, |acc, v| acc + v);
+
+    let overflow_count = overflow.len() as u64;
+    *dropped_counter = dropped_counter.saturating_add(overflow_count);
+
+    if overflow_count > 0 {
+        // Preserve original label keys; replace values with __other__.
+        let mut label_keys = if let Some(first) = kept.first() {
+            first
+                .labels
+                .iter()
+                .map(|(k, _)| (k.clone(), OTHER_LABEL_VALUE.to_string()))
+                .collect::<Vec<_>>()
+        } else {
+            vec![("label".to_string(), OTHER_LABEL_VALUE.to_string())]
+        };
+
+        if label_keys.is_empty() {
+            label_keys.push(("label".to_string(), OTHER_LABEL_VALUE.to_string()));
+        }
+
+        kept.push(LabeledValue {
+            labels: label_keys,
+            ranking_value: overflow_sum,
+            sample_value: overflow_sum,
+        });
+    }
+
+    kept.sort_by(|a, b| compare_label_set(&a.labels, &b.labels));
+    kept
+}
+
+fn compare_label_set(a: &[(String, String)], b: &[(String, String)]) -> Ordering {
+    let a_key = a
+        .iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect::<Vec<_>>()
+        .join("|");
+    let b_key = b
+        .iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect::<Vec<_>>()
+        .join("|");
+    a_key.cmp(&b_key)
+}
+
 fn sanitize_metric_name(name: &str) -> String {
     let mut out = String::with_capacity(name.len());
     for ch in name.chars() {
@@ -640,7 +1170,6 @@ fn sanitize_metric_name(name: &str) -> String {
             out.push('_');
         }
     }
-
     if out.is_empty() {
         return "mofa_custom_metric".to_string();
     }
@@ -735,7 +1264,7 @@ fn escape_label_value(value: &str) -> String {
 mod tests {
     use super::*;
     use axum::{Router, http::StatusCode, routing::get};
-    use tokio::time::{Duration, timeout};
+    use tokio::time::timeout;
     use tower::ServiceExt;
 
     fn sample_snapshot() -> MetricsSnapshot {
@@ -750,6 +1279,7 @@ mod tests {
             },
             agents: vec![super::super::metrics::AgentMetrics {
                 agent_id: "agent-1".to_string(),
+                name: "Agent One".to_string(),
                 tasks_completed: 42,
                 tasks_failed: 1,
                 tasks_in_progress: 2,
@@ -799,6 +1329,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn enforces_cardinality_limits_with_other_bucket() {
+        let mut snapshot = sample_snapshot();
+        snapshot.agents = (0..5)
+            .map(|idx| super::super::metrics::AgentMetrics {
+                agent_id: format!("agent-{idx}"),
+                tasks_completed: (idx + 1) as u64,
+                avg_task_duration_ms: (idx * 10) as f64,
+                ..Default::default()
+            })
+            .collect();
+
+        let collector = Arc::new(MetricsCollector::new(Default::default()));
+        seed_collector_from_snapshot(&collector, snapshot).await;
+
+        let exporter = PrometheusExporter::new(
+            collector,
+            PrometheusExportConfig {
+                refresh_interval: Duration::from_millis(50),
+                cardinality: CardinalityLimits {
+                    agent_id: 2,
+                    ..Default::default()
+                },
+            },
+        );
+
+        exporter.refresh_once().await.expect("refresh");
+        let output = exporter.render_cached().await;
+
+        assert!(output.contains("agent_id=\"__other__\""));
+        assert!(output.contains("mofa_exporter_dropped_series_total{label=\"agent_id\"}"));
+    }
+
+    #[tokio::test]
+    async fn provides_deterministic_order_for_equal_ranked_series() {
+        let entries = vec![
+            LabeledValue {
+                labels: vec![("agent_id".to_string(), "b".to_string())],
+                ranking_value: 10.0,
+                sample_value: 10.0,
+            },
+            LabeledValue {
+                labels: vec![("agent_id".to_string(), "a".to_string())],
+                ranking_value: 10.0,
+                sample_value: 10.0,
+            },
+        ];
+
+        let mut dropped_a = 0;
+        let mut dropped_b = 0;
+        let first = limit_series(entries.clone(), 2, &mut dropped_a);
+        let second = limit_series(entries, 2, &mut dropped_b);
+
+        assert_eq!(first[0].labels[0].1, "a");
+        assert_eq!(second[0].labels[0].1, "a");
+    }
+
+    #[tokio::test]
     async fn serves_metrics_route() {
         let collector = Arc::new(MetricsCollector::new(Default::default()));
         seed_collector_from_snapshot(&collector, sample_snapshot()).await;
@@ -830,29 +1417,38 @@ mod tests {
                 axum::http::Request::builder()
                     .uri("/metrics")
                     .body(axum::body::Body::empty())
-                    .expect("request"),
+                    .unwrap(),
             )
             .await
             .expect("response");
 
         assert_eq!(response.status(), StatusCode::OK);
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(content_type.starts_with("text/plain"));
     }
 
     #[tokio::test]
-    async fn concurrent_scrapes_with_refresh_worker_complete() {
+    async fn concurrent_scrapes_do_not_block_updates() {
         let collector = Arc::new(MetricsCollector::new(Default::default()));
         let exporter = Arc::new(PrometheusExporter::new(
             collector.clone(),
-            PrometheusExportConfig::default().with_refresh_interval(Duration::from_millis(20)),
+            PrometheusExportConfig {
+                refresh_interval: Duration::from_millis(20),
+                ..Default::default()
+            },
         ));
 
-        exporter.refresh_once().await.expect("initial refresh");
         let worker = exporter.clone().start();
 
         let updater = {
             let collector = collector.clone();
             tokio::spawn(async move {
-                for idx in 0..100u64 {
+                for idx in 0..200u64 {
                     collector
                         .update_agent(super::super::metrics::AgentMetrics {
                             agent_id: format!("agent-{idx}"),
@@ -867,7 +1463,7 @@ mod tests {
         };
 
         let mut scrapers = Vec::new();
-        for _ in 0..20 {
+        for _ in 0..25 {
             let exporter = exporter.clone();
             scrapers.push(tokio::spawn(async move {
                 for _ in 0..20 {

--- a/crates/mofa-monitoring/src/dashboard/server.rs
+++ b/crates/mofa-monitoring/src/dashboard/server.rs
@@ -216,12 +216,6 @@ impl DashboardServer {
         self
     }
 
-    /// Override Prometheus exporter settings.
-    pub fn with_prometheus_export_config(mut self, config: PrometheusExportConfig) -> Self {
-        self.prometheus_export_config = config;
-        self
-    }
-
     /// Attach a channel receiver for debug events to stream to WebSocket clients.
     ///
     /// This enables real-time debugging by forwarding `DebugEvent`s from the

--- a/crates/mofa-monitoring/src/dashboard/server.rs
+++ b/crates/mofa-monitoring/src/dashboard/server.rs
@@ -189,6 +189,12 @@ impl DashboardServer {
         self.ws_handler.clone()
     }
 
+    /// Override Prometheus exporter settings.
+    pub fn with_prometheus_export_config(mut self, config: PrometheusExportConfig) -> Self {
+        self.prometheus_export_config = config;
+        self
+    }
+
     /// Get the Prometheus exporter (if initialized)
     pub fn prometheus_exporter(&self) -> Option<Arc<PrometheusExporter>> {
         self.prometheus_exporter.clone()

--- a/crates/mofa-monitoring/src/lib.rs
+++ b/crates/mofa-monitoring/src/lib.rs
@@ -27,12 +27,12 @@ mod dashboard;
 pub mod tracing;
 
 pub use dashboard::{
-    AgentMetrics, AgentStatus, ApiError, ApiResponse, AuthInfo, AuthProvider, DashboardConfig,
-    DashboardServer, Gauge, Histogram, LLMMetrics, LLMStatus, LLMSummary, MetricType, MetricValue,
-    MetricsCollector, MetricsConfig, MetricsRegistry, MetricsSnapshot, NoopAuthProvider,
-    PluginMetrics, PluginStatus, PrometheusExportConfig, PrometheusExportError, PrometheusExporter,
-    ServerState, SystemMetrics, SystemStatus, TokenAuthProvider, WebSocketClient, WebSocketHandler,
-    WebSocketMessage, WorkflowMetrics,
+    AgentMetrics, AgentStatus, ApiError, ApiResponse, AuthInfo, AuthProvider, CardinalityLimits,
+    DashboardConfig, DashboardServer, Gauge, Histogram, LLMMetrics, LLMStatus, LLMSummary,
+    MetricType, MetricValue, MetricsCollector, MetricsConfig, MetricsRegistry, MetricsSnapshot,
+    NoopAuthProvider, PluginMetrics, PluginStatus, PrometheusExportConfig, PrometheusExportError,
+    PrometheusExporter, ServerState, SystemMetrics, SystemStatus, TokenAuthProvider,
+    WebSocketClient, WebSocketHandler, WebSocketMessage, WorkflowMetrics,
 };
 
 #[cfg(feature = "otlp-metrics")]

--- a/crates/mofa-monitoring/src/lib.rs
+++ b/crates/mofa-monitoring/src/lib.rs
@@ -34,6 +34,3 @@ pub use dashboard::{
     PrometheusExporter, ServerState, SystemMetrics, SystemStatus, TokenAuthProvider,
     WebSocketClient, WebSocketHandler, WebSocketMessage, WorkflowMetrics,
 };
-
-#[cfg(feature = "otlp-metrics")]
-pub use tracing::CardinalityLimits;

--- a/crates/mofa-monitoring/tests/metrics_export_integration.rs
+++ b/crates/mofa-monitoring/tests/metrics_export_integration.rs
@@ -9,12 +9,10 @@ use tower::ServiceExt;
 
 #[tokio::test]
 async fn metrics_route_returns_prometheus_payload_with_histograms() {
-    let mut server = DashboardServer::new(
-        DashboardConfig::new().with_prometheus_export_config(
-            PrometheusExportConfig::default()
-                .with_refresh_interval(Duration::from_millis(10))
-                .with_cardinality(CardinalityLimits::default()),
-        ),
+    let mut server = DashboardServer::new(DashboardConfig::new()).with_prometheus_export_config(
+        PrometheusExportConfig::default()
+            .with_refresh_interval(Duration::from_millis(10))
+            .with_cardinality(CardinalityLimits::default()),
     );
 
     server
@@ -66,7 +64,7 @@ async fn metrics_route_returns_prometheus_payload_with_histograms() {
         .unwrap_or_default();
     assert!(content_type.starts_with("text/plain"));
 
-    let body = to_bytes(response.into_body(), usize::MAX)
+    let body = to_bytes(response.into_body(), 5 * 1024 * 1024)
         .await
         .expect("read body");
     let body_str = String::from_utf8(body.to_vec()).expect("utf8");
@@ -79,18 +77,16 @@ async fn metrics_route_returns_prometheus_payload_with_histograms() {
 
 #[tokio::test]
 async fn metrics_route_applies_cardinality_overflow_bucket() {
-    let mut server = DashboardServer::new(
-        DashboardConfig::new().with_prometheus_export_config(
-            PrometheusExportConfig::default()
-                .with_refresh_interval(Duration::from_millis(10))
-                .with_cardinality(
-                    CardinalityLimits::default()
-                        .with_agent_id(1)
-                        .with_workflow_id(100)
-                        .with_plugin_or_tool(100)
-                        .with_provider_model(50),
-                ),
-        ),
+    let mut server = DashboardServer::new(DashboardConfig::new()).with_prometheus_export_config(
+        PrometheusExportConfig::default()
+            .with_refresh_interval(Duration::from_millis(10))
+            .with_cardinality(
+                CardinalityLimits::default()
+                    .with_agent_id(1)
+                    .with_workflow_id(100)
+                    .with_plugin_or_tool(100)
+                    .with_provider_model(50),
+            ),
     );
 
     for idx in 0..3 {
@@ -125,7 +121,7 @@ async fn metrics_route_applies_cardinality_overflow_bucket() {
         .await
         .expect("request success");
 
-    let body = to_bytes(response.into_body(), usize::MAX)
+    let body = to_bytes(response.into_body(), 5 * 1024 * 1024)
         .await
         .expect("read body");
     let body_str = String::from_utf8(body.to_vec()).expect("utf8");

--- a/crates/mofa-monitoring/tests/metrics_export_integration.rs
+++ b/crates/mofa-monitoring/tests/metrics_export_integration.rs
@@ -1,0 +1,135 @@
+use axum::body::{Body, to_bytes};
+use axum::http::{Request, StatusCode};
+use mofa_monitoring::{
+    AgentMetrics, CardinalityLimits, DashboardConfig, DashboardServer, PrometheusExportConfig,
+    WorkflowMetrics,
+};
+use std::time::Duration;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn metrics_route_returns_prometheus_payload_with_histograms() {
+    let mut server = DashboardServer::new(
+        DashboardConfig::new().with_prometheus_export_config(
+            PrometheusExportConfig::default()
+                .with_refresh_interval(Duration::from_millis(10))
+                .with_cardinality(CardinalityLimits::default()),
+        ),
+    );
+
+    server
+        .collector()
+        .update_agent(AgentMetrics {
+            agent_id: "agent-alpha".to_string(),
+            tasks_completed: 42,
+            avg_task_duration_ms: 120.0,
+            ..Default::default()
+        })
+        .await;
+
+    server
+        .collector()
+        .update_workflow(WorkflowMetrics {
+            workflow_id: "wf-a".to_string(),
+            total_executions: 10,
+            avg_execution_time_ms: 200.0,
+            ..Default::default()
+        })
+        .await;
+
+    let _ = server.collector().collect().await;
+    let app = server.build_router();
+
+    server
+        .prometheus_exporter()
+        .expect("prom exporter")
+        .refresh_once()
+        .await
+        .expect("refresh payload");
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/metrics")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("request success");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default();
+    assert!(content_type.starts_with("text/plain"));
+
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let body_str = String::from_utf8(body.to_vec()).expect("utf8");
+
+    assert!(body_str.contains("mofa_agent_tasks_total{agent_id=\"agent-alpha\"} 42"));
+    assert!(body_str.contains("mofa_agent_execution_duration_seconds_bucket"));
+    assert!(body_str.contains("mofa_agent_execution_duration_seconds_sum"));
+    assert!(body_str.contains("mofa_agent_execution_duration_seconds_count"));
+}
+
+#[tokio::test]
+async fn metrics_route_applies_cardinality_overflow_bucket() {
+    let mut server = DashboardServer::new(
+        DashboardConfig::new().with_prometheus_export_config(
+            PrometheusExportConfig::default()
+                .with_refresh_interval(Duration::from_millis(10))
+                .with_cardinality(
+                    CardinalityLimits::default()
+                        .with_agent_id(1)
+                        .with_workflow_id(100)
+                        .with_plugin_or_tool(100)
+                        .with_provider_model(50),
+                ),
+        ),
+    );
+
+    for idx in 0..3 {
+        server
+            .collector()
+            .update_agent(AgentMetrics {
+                agent_id: format!("agent-{idx}"),
+                tasks_completed: (10 + idx) as u64,
+                avg_task_duration_ms: 100.0,
+                ..Default::default()
+            })
+            .await;
+    }
+
+    let _ = server.collector().collect().await;
+    let app = server.build_router();
+
+    server
+        .prometheus_exporter()
+        .expect("prom exporter")
+        .refresh_once()
+        .await
+        .expect("refresh payload");
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/metrics")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("request success");
+
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let body_str = String::from_utf8(body.to_vec()).expect("utf8");
+
+    assert!(body_str.contains("agent_id=\"__other__\""));
+    assert!(body_str.contains("mofa_exporter_dropped_series_total{label=\"agent_id\"}"));
+}

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -25,7 +25,7 @@ Default hard limits:
 - `agent_id`: 100
 - `workflow_id`: 100
 - `plugin_or_tool`: 100
-- `provider+model`: 50
+- distinct `(provider, model)` pairs: 50
 
 When a limit is exceeded, overflow series keep their original label key(s)
 but replace value(s) with `__other__` (for example


### PR DESCRIPTION
## Why this PR exists
This is the safety-focused split for label cardinality.

After core + cache layers, this PR adds hard limits and deterministic overflow behavior so `/metrics` remains safe for TSDB backends.

## Proof of work (real benchmark numbers)

<img width="536" height="560" alt="image" src="https://github.com/user-attachments/assets/8d021960-c03d-4609-810c-95692c95d1aa" />


I ran a synthetic stress benchmark locally with:
- 5000 agents
- 2000 workflows
- 2000 tools/plugins
- 1000 provider-model series

Compared two configs on the same codepath:
- **UNLIMITED**: very high per-label limits
- **CAPPED_DEFAULT**: default limits (`agent=100, workflow=100, plugin_or_tool=100, provider_model=50`)

> Note: this PR is opened against `main` (fork->upstream branch-base constraint), but it is intended to be reviewed/merged **after #659**.

## What this PR changes
- introduces `CardinalityLimits` and wires them into exporter config
- applies deterministic top-K retention with `__other__` overflow aggregation
- exports dropped-series counters per label family
- adds latency histogram families and overflow-focused integration coverage
- updates docs with defaults and behavior

## Correctness fixes included
I also fixed two accounting bugs found during review:
- render duration now measures the full render path
- dropped-series totals are updated after full render/limiting work completes

## Mentor-feedback alignment
This addresses: “be wary of high cardinality … can lead to TSDB bloat.”

## Local verification
- `cargo check -p mofa-monitoring`
- `cargo test -p mofa-monitoring dashboard::prometheus -- --nocapture`
- `cargo test -p mofa-monitoring --test metrics_export_integration -- --nocapture`
- `cargo test -p mofa-monitoring --test metrics_export_core_integration -- --nocapture`
