### PR TITLE
fix(security): harden http_request SSRF protections

### DIFF
--- a/crates/mofa-plugins/src/tools/http.rs
+++ b/crates/mofa-plugins/src/tools/http.rs
@@ -1,7 +1,7 @@
 use super::*;
 use reqwest::Client;
 use serde_json::json;
-use std::net::ToSocketAddrs;
+use std::net::{IpAddr, Ipv4Addr, ToSocketAddrs};
 use url::Url;
 
 /// HTTP 请求工具 - 发送网络请求
@@ -51,9 +51,23 @@ impl HttpRequestTool {
             },
             client: Client::builder()
                 .timeout(std::time::Duration::from_secs(30))
+                // Avoid following redirects to internal/private networks.
+                .redirect(reqwest::redirect::Policy::none())
                 .build()
-                .unwrap(),
+                .expect("failed to build HTTP client"),
         }
+    }
+
+    fn truncate_utf8(input: &str, max_bytes: usize) -> String {
+        if input.len() <= max_bytes {
+            return input.to_string();
+        }
+
+        let mut end = max_bytes.min(input.len());
+        while end > 0 && !input.is_char_boundary(end) {
+            end -= 1;
+        }
+        input[..end].to_string()
     }
 
     /// Validate that a URL is safe to request (not targeting internal/private networks).
@@ -75,7 +89,7 @@ impl HttpRequestTool {
         };
 
         // Block well-known dangerous hostnames
-        if host == "metadata.google.internal" {
+        if host.eq_ignore_ascii_case("metadata.google.internal") {
             return false;
         }
 
@@ -94,12 +108,7 @@ impl HttpRequestTool {
         }
 
         for addr in addrs {
-            let ip = addr.ip();
-            if ip.is_loopback()
-                || ip.is_unspecified()
-                || ip.is_multicast()
-                || Self::is_private_ip(&ip)
-            {
+            if Self::is_blocked_ip(&addr.ip()) {
                 return false;
             }
         }
@@ -107,28 +116,44 @@ impl HttpRequestTool {
         true
     }
 
-    /// Check if an IP address is in a private/reserved range.
-    fn is_private_ip(ip: &std::net::IpAddr) -> bool {
+    /// Check if an IP address is blocked for security reasons.
+    fn is_blocked_ip(ip: &IpAddr) -> bool {
         match ip {
-            std::net::IpAddr::V4(ipv4) => {
-                let octets = ipv4.octets();
-                // 10.0.0.0/8
-                octets[0] == 10
-                // 172.16.0.0/12
-                || (octets[0] == 172 && (16..=31).contains(&octets[1]))
-                // 192.168.0.0/16
-                || (octets[0] == 192 && octets[1] == 168)
-                // 169.254.0.0/16 (link-local, includes cloud metadata 169.254.169.254)
-                || (octets[0] == 169 && octets[1] == 254)
-                // 100.64.0.0/10 (carrier-grade NAT)
-                || (octets[0] == 100 && (64..=127).contains(&octets[1]))
+            IpAddr::V4(ipv4) => {
+                ipv4.is_private()
+                    || ipv4.is_loopback()
+                    || ipv4.is_unspecified()
+                    || ipv4.is_multicast()
+                    || ipv4.is_link_local()
+                    || ipv4.is_broadcast()
+                    || ipv4.is_documentation()
+                    || Self::is_cgnat_ipv4(*ipv4)
             }
-            std::net::IpAddr::V6(ipv6) => {
-                // Block unique local (fc00::/7) and link-local (fe80::/10)
-                let segments = ipv6.segments();
-                (segments[0] & 0xfe00) == 0xfc00 || (segments[0] & 0xffc0) == 0xfe80
+            IpAddr::V6(ipv6) => {
+                // Handle IPv4-mapped IPv6 addresses, e.g. ::ffff:127.0.0.1.
+                if let Some(mapped) = ipv6.to_ipv4_mapped() {
+                    return Self::is_blocked_ip(&IpAddr::V4(mapped));
+                }
+
+                ipv6.is_loopback()
+                    || ipv6.is_unspecified()
+                    || ipv6.is_multicast()
+                    || ipv6.is_unique_local()
+                    || ipv6.is_unicast_link_local()
+                    || Self::is_documentation_ipv6(*ipv6)
             }
         }
+    }
+
+    fn is_cgnat_ipv4(ipv4: Ipv4Addr) -> bool {
+        let octets = ipv4.octets();
+        octets[0] == 100 && (64..=127).contains(&octets[1])
+    }
+
+    fn is_documentation_ipv6(ipv6: std::net::Ipv6Addr) -> bool {
+        let segments = ipv6.segments();
+        // 2001:db8::/32
+        segments[0] == 0x2001 && segments[1] == 0x0db8
     }
 }
 
@@ -140,9 +165,9 @@ impl ToolExecutor for HttpRequestTool {
 
     async fn execute(&self, arguments: serde_json::Value) -> PluginResult<serde_json::Value> {
         let method = arguments["method"].as_str().unwrap_or("GET");
-        let url = arguments["url"]
-            .as_str()
-            .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed("URL is required".to_string()))?;
+        let url = arguments["url"].as_str().ok_or_else(|| {
+            mofa_kernel::plugin::PluginError::ExecutionFailed("URL is required".to_string())
+        })?;
 
         // Validate URL to prevent SSRF attacks
         if !Self::is_url_allowed(url) {
@@ -157,7 +182,12 @@ impl ToolExecutor for HttpRequestTool {
             "POST" => self.client.post(url),
             "PUT" => self.client.put(url),
             "DELETE" => self.client.delete(url),
-            _ => return Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Unsupported HTTP method: {}", method))),
+            _ => {
+                return Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!(
+                    "Unsupported HTTP method: {}",
+                    method
+                )));
+            }
         };
 
         // Add headers if provided
@@ -174,7 +204,9 @@ impl ToolExecutor for HttpRequestTool {
             request = request.body(body.to_string());
         }
 
-        let response = request.send().await
+        let response = request
+            .send()
+            .await
             .map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(e.to_string()))?;
         let status = response.status().as_u16();
         let headers: std::collections::HashMap<String, String> = response
@@ -183,14 +215,16 @@ impl ToolExecutor for HttpRequestTool {
             .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
             .collect();
 
-        let body = response.text().await
+        let body = response
+            .text()
+            .await
             .map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(e.to_string()))?;
 
         // Truncate body if too long
         let truncated_body = if body.len() > 5000 {
             format!(
                 "{}... [truncated, total {} bytes]",
-                &body[..5000],
+                Self::truncate_utf8(&body, 5000),
                 body.len()
             )
         } else {
@@ -202,5 +236,41 @@ impl ToolExecutor for HttpRequestTool {
             "headers": headers,
             "body": truncated_body
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blocks_ipv4_mapped_loopback() {
+        let ip: IpAddr = "::ffff:127.0.0.1".parse().unwrap();
+        assert!(HttpRequestTool::is_blocked_ip(&ip));
+    }
+
+    #[test]
+    fn blocks_localhost_url() {
+        assert!(!HttpRequestTool::is_url_allowed("http://127.0.0.1:8080/"));
+    }
+
+    #[test]
+    fn blocks_ipv4_mapped_loopback_url() {
+        assert!(!HttpRequestTool::is_url_allowed(
+            "http://[::ffff:127.0.0.1]:8080/"
+        ));
+    }
+
+    #[test]
+    fn blocks_metadata_hostname_case_insensitively() {
+        assert!(!HttpRequestTool::is_url_allowed(
+            "http://METADATA.GOOGLE.INTERNAL/"
+        ));
+    }
+
+    #[test]
+    fn truncates_utf8_without_panicking() {
+        let value = "A🙂B";
+        assert_eq!(HttpRequestTool::truncate_utf8(value, 2), "A");
     }
 }


### PR DESCRIPTION
## 📋 Summary

Harden the built-in `http_request` tool against SSRF bypasses by tightening URL/IP validation and request behavior.

This PR prevents requests from reaching internal/private targets via redirect flows or IPv4-mapped IPv6 addresses, and adds regression tests to lock this behavior in.

## 🔗 Related Issues

Closes #675

Related to #675

---

## 🧠 Context

The previous implementation validated the initial URL but still had gaps that could allow internal network access in certain scenarios:
- Redirect behavior could be abused to reach blocked/private destinations.
- IPv4-mapped IPv6 addresses (for example `::ffff:127.0.0.1`) were not explicitly blocked.
- Metadata hostname blocking was case-sensitive.

Since this tool executes outbound HTTP from agent/runtime contexts, these gaps represent a security risk (SSRF). The change is focused on reducing that risk while preserving normal external HTTP behavior.

---

## 🛠️ Changes

- Disabled automatic redirect following in `http_request` client configuration.
- Strengthened blocked-address logic to cover:
  - private/loopback/link-local/documentation/internal ranges
  - carrier-grade NAT ranges
  - IPv4-mapped IPv6 addresses
- Made metadata hostname blocking case-insensitive.
- Added targeted regression tests for:
  - localhost blocking
  - IPv4-mapped IPv6 blocking
  - metadata hostname variants
