### PR TITLE
feat(orchestrator): End-to-End Voice Integration Pipeline (#711)

### DIFF
--- a/crates/mofa-foundation/src/agent/mod.rs
+++ b/crates/mofa-foundation/src/agent/mod.rs
@@ -11,6 +11,8 @@ pub mod context;
 pub mod executor;
 pub mod session;
 pub mod tools;
+pub mod voice;
+pub mod voice_mock;
 
 // ========================================================================
 // 从 Kernel 层重导出核心类型

--- a/crates/mofa-foundation/src/agent/voice.rs
+++ b/crates/mofa-foundation/src/agent/voice.rs
@@ -1,0 +1,118 @@
+use mofa_kernel::agent::error::{AgentError, AgentResult};
+use mofa_kernel::agent::voice::{StageInput, StageOutput, VoicePipelineConfig, VoiceStage};
+use std::time::Duration;
+use tokio::time::timeout;
+use tracing::{Instrument, error, info, info_span};
+
+/// Output from a Voice Pipeline Execution
+#[derive(Debug, Clone)]
+pub struct VoicePipelineOutput {
+    /// The final output from the last stage
+    pub final_output: StageOutput,
+    /// Per-stage latencies in milliseconds: (stage_name, latency_ms)
+    pub stage_latencies: Vec<(String, u128)>,
+    /// Total wall-clock latency across all stages
+    pub total_latency_ms: u128,
+}
+
+/// An executor that chains multiple voice stages together
+pub struct VoicePipelineExecutor {
+    stages: Vec<Box<dyn VoiceStage>>,
+    config: VoicePipelineConfig,
+}
+
+impl VoicePipelineExecutor {
+    /// Create a new pipeline executor with the given stages and config
+    pub fn new(stages: Vec<Box<dyn VoiceStage>>, config: VoicePipelineConfig) -> Self {
+        Self { stages, config }
+    }
+
+    /// Execute the pipeline with the initial input
+    pub async fn execute(&self, initial_input: StageInput) -> AgentResult<VoicePipelineOutput> {
+        if self.stages.is_empty() {
+            return Err(AgentError::InvalidInput(
+                "Voice pipeline has no stages".to_string(),
+            ));
+        }
+
+        let pipeline_start = std::time::Instant::now();
+        let mut current_input = initial_input;
+        let mut stage_latencies = Vec::new();
+
+        for stage in &self.stages {
+            let stage_name = stage.name().to_string();
+            let span = info_span!("voice_pipeline_stage", stage = %stage_name);
+
+            let result: AgentResult<StageOutput> = async {
+                info!("Starting stage: {}", stage_name);
+                let stage_start = std::time::Instant::now();
+
+                // Execute with optional timeout from config
+                let process_future = stage.process(current_input.clone());
+
+                let output = if let Some(ms) = self.config.timeout_ms {
+                    match timeout(Duration::from_millis(ms), process_future).await {
+                        Ok(res) => res,
+                        Err(_) => Err(AgentError::Timeout { duration_ms: ms }),
+                    }
+                } else {
+                    process_future.await
+                };
+
+                let latency = stage_start.elapsed().as_millis();
+                stage_latencies.push((stage_name.clone(), latency));
+
+                match output {
+                    Ok(res) => {
+                        info!("Completed stage: {} in {}ms", stage_name, latency);
+                        Ok(res)
+                    }
+                    Err(e) => {
+                        error!(
+                            "Failed stage: {} after {}ms - Error: {}",
+                            stage_name, latency, e
+                        );
+                        Err(e)
+                    }
+                }
+            }
+            .instrument(span)
+            .await;
+
+            match result {
+                Ok(next_input_output) => {
+                    // Convert Output to Input for the next stage
+                    current_input = match next_input_output.clone() {
+                        StageOutput::Audio(samples) => StageInput::Audio(samples),
+                        StageOutput::Text(text) => StageInput::Text(text),
+                    };
+                    // if it is the very last stage, the loop ends and we return the output
+                }
+                Err(e) => {
+                    if self.config.abort_on_error {
+                        return Err(e);
+                    } else {
+                        info!("Pipeline continuing despite error in stage: {}", stage_name);
+                        // If we don't abort, current_input remains the input for the *failed* stage,
+                        // which gets passed to the next stage. This might not be ideal depending on
+                        // pipeline design, but matches simple fallback behavior.
+                    }
+                }
+            }
+        }
+
+        // The final input was converted from the output of the last stage
+        let final_output = match current_input {
+            StageInput::Audio(samples) => StageOutput::Audio(samples),
+            StageInput::Text(text) => StageOutput::Text(text),
+        };
+
+        let total_latency_ms = pipeline_start.elapsed().as_millis();
+
+        Ok(VoicePipelineOutput {
+            final_output,
+            stage_latencies,
+            total_latency_ms,
+        })
+    }
+}

--- a/crates/mofa-foundation/src/agent/voice_mock.rs
+++ b/crates/mofa-foundation/src/agent/voice_mock.rs
@@ -1,0 +1,149 @@
+//! Mock Voice Stages for CI and Testing
+//!
+//! Provides functional implementations of ASR, LLM, and TTS stages
+//! that do not require GPU, model files, or network access.
+
+use async_trait::async_trait;
+use mofa_kernel::agent::error::{AgentError, AgentResult};
+use mofa_kernel::agent::voice::{StageInput, StageOutput, VoiceStage};
+use std::time::Duration;
+use tokio::time::sleep;
+
+/// A Mock Auto Speech Recognition (ASR) Stage
+pub struct MockAsrStage {
+    delay_ms: u64,
+}
+
+impl MockAsrStage {
+    pub fn new(delay_ms: u64) -> Self {
+        Self { delay_ms }
+    }
+}
+
+#[async_trait]
+impl VoiceStage for MockAsrStage {
+    fn name(&self) -> &str {
+        "MockASR"
+    }
+
+    async fn process(&self, input: StageInput) -> AgentResult<StageOutput> {
+        sleep(Duration::from_millis(self.delay_ms)).await;
+
+        match input {
+            StageInput::Audio(samples) => {
+                let simulated_text =
+                    format!("(Transcribed {} samples of audio data)", samples.len());
+                Ok(StageOutput::Text(simulated_text))
+            }
+            StageInput::Text(_) => Err(AgentError::InvalidInput(
+                "MockASR expects Audio input".to_string(),
+            )),
+        }
+    }
+}
+
+/// A Mock Large Language Model (LLM) Stage
+pub struct MockLlmStage {
+    delay_ms: u64,
+}
+
+impl MockLlmStage {
+    pub fn new(delay_ms: u64) -> Self {
+        Self { delay_ms }
+    }
+}
+
+#[async_trait]
+impl VoiceStage for MockLlmStage {
+    fn name(&self) -> &str {
+        "MockLLM"
+    }
+
+    async fn process(&self, input: StageInput) -> AgentResult<StageOutput> {
+        sleep(Duration::from_millis(self.delay_ms)).await;
+
+        match input {
+            StageInput::Text(prompt) => {
+                let response = format!(
+                    "I heard you say: '{}'. This is my mock LLM response.",
+                    prompt
+                );
+                Ok(StageOutput::Text(response))
+            }
+            StageInput::Audio(_) => Err(AgentError::InvalidInput(
+                "MockLLM expects Text input".to_string(),
+            )),
+        }
+    }
+}
+
+/// A Mock Text-to-Speech (TTS) Stage
+pub struct MockTtsStage {
+    delay_ms: u64,
+}
+
+impl MockTtsStage {
+    pub fn new(delay_ms: u64) -> Self {
+        Self { delay_ms }
+    }
+}
+
+#[async_trait]
+impl VoiceStage for MockTtsStage {
+    fn name(&self) -> &str {
+        "MockTTS"
+    }
+
+    async fn process(&self, input: StageInput) -> AgentResult<StageOutput> {
+        sleep(Duration::from_millis(self.delay_ms)).await;
+
+        match input {
+            StageInput::Text(text) => {
+                // Generate 1 second of mock 24kHz audio
+                let mock_audio_samples = vec![0.0f32; 24000];
+                let _ = text; // Just ignore the text in the mock
+                Ok(StageOutput::Audio(mock_audio_samples))
+            }
+            StageInput::Audio(_) => Err(AgentError::InvalidInput(
+                "MockTTS expects Text input".to_string(),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::voice::VoicePipelineExecutor;
+    use mofa_kernel::agent::voice::VoicePipelineConfig;
+
+    #[tokio::test]
+    async fn test_mock_voice_pipeline() {
+        let asr = Box::new(MockAsrStage::new(10));
+        let llm = Box::new(MockLlmStage::new(10));
+        let tts = Box::new(MockTtsStage::new(10));
+
+        let stages: Vec<Box<dyn VoiceStage>> = vec![asr, llm, tts];
+        let pipeline = VoicePipelineExecutor::new(stages, VoicePipelineConfig::default());
+
+        let initial_audio = vec![0.1, 0.2, 0.3];
+        let result = pipeline.execute(StageInput::Audio(initial_audio)).await;
+
+        assert!(result.is_ok());
+        let output = result.unwrap();
+
+        // Assert on final output type (TTS outputs audio)
+        match output.final_output {
+            StageOutput::Audio(samples) => {
+                assert_eq!(samples.len(), 24000);
+            }
+            StageOutput::Text(_) => panic!("Expected audio output from TTS"),
+        }
+
+        // Check latency tracking
+        assert_eq!(output.stage_latencies.len(), 3);
+        assert_eq!(output.stage_latencies[0].0, "MockASR");
+        assert_eq!(output.stage_latencies[1].0, "MockLLM");
+        assert_eq!(output.stage_latencies[2].0, "MockTTS");
+    }
+}

--- a/crates/mofa-kernel/src/agent/mod.rs
+++ b/crates/mofa-kernel/src/agent/mod.rs
@@ -164,6 +164,7 @@ pub mod manifest;
 // Secretary Agent abstraction
 pub mod plugins;
 pub mod secretary;
+pub mod voice;
 
 // AgentPlugin 统一到 plugin 模块
 // AgentPlugin unified into the plugin module

--- a/crates/mofa-kernel/src/agent/voice.rs
+++ b/crates/mofa-kernel/src/agent/voice.rs
@@ -1,0 +1,107 @@
+//! Voice Integration Pipeline Traits
+//!
+//! Provides the core abstractions for chaining ASR, LLM, and TTS models
+//! into a unified voice agent pipeline.
+
+use crate::agent::error::AgentResult;
+use async_trait::async_trait;
+use std::fmt;
+
+/// Input to a voice pipeline stage
+#[derive(Debug, Clone, PartialEq)]
+pub enum StageInput {
+    /// Raw audio waveform data (f32 samples, usually 16kHz or 24kHz)
+    Audio(Vec<f32>),
+    /// Text transcript or prompt
+    Text(String),
+}
+
+/// Output from a voice pipeline stage
+#[derive(Debug, Clone, PartialEq)]
+pub enum StageOutput {
+    /// Raw audio waveform data (f32 samples)
+    Audio(Vec<f32>),
+    /// Text transcript or output
+    Text(String),
+}
+
+impl fmt::Display for StageInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            StageInput::Audio(samples) => write!(f, "Audio({} samples)", samples.len()),
+            StageInput::Text(text) => write!(f, "Text({} chars)", text.len()),
+        }
+    }
+}
+
+impl fmt::Display for StageOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            StageOutput::Audio(samples) => write!(f, "Audio({} samples)", samples.len()),
+            StageOutput::Text(text) => write!(f, "Text({} chars)", text.len()),
+        }
+    }
+}
+
+impl From<String> for StageInput {
+    fn from(text: String) -> Self {
+        StageInput::Text(text)
+    }
+}
+
+impl From<&str> for StageInput {
+    fn from(text: &str) -> Self {
+        StageInput::Text(text.to_string())
+    }
+}
+
+impl From<Vec<f32>> for StageInput {
+    fn from(samples: Vec<f32>) -> Self {
+        StageInput::Audio(samples)
+    }
+}
+
+impl From<String> for StageOutput {
+    fn from(text: String) -> Self {
+        StageOutput::Text(text)
+    }
+}
+
+impl From<Vec<f32>> for StageOutput {
+    fn from(samples: Vec<f32>) -> Self {
+        StageOutput::Audio(samples)
+    }
+}
+
+/// A single stage in a Voice Pipeline
+///
+/// Typical implementations:
+/// - ASR Stage: `StageInput::Audio` -> `StageOutput::Text`
+/// - LLM Stage: `StageInput::Text` -> `StageOutput::Text`
+/// - TTS Stage: `StageInput::Text` -> `StageOutput::Audio`
+#[async_trait]
+pub trait VoiceStage: Send + Sync {
+    /// The unique name or identifier of this stage
+    fn name(&self) -> &str;
+
+    /// Process the input and produce output
+    async fn process(&self, input: StageInput) -> AgentResult<StageOutput>;
+}
+
+/// Configuration for a Voice Pipeline
+#[derive(Debug, Clone)]
+pub struct VoicePipelineConfig {
+    /// Whether to abort the entire pipeline if one stage fails
+    pub abort_on_error: bool,
+    /// Maximum time in milliseconds allowed for the entire pipeline
+    pub timeout_ms: Option<u64>,
+}
+
+impl Default for VoicePipelineConfig {
+    fn default() -> Self {
+        Self {
+            abort_on_error: true,
+            timeout_ms: Some(30000), // 30 seconds default timeout
+        }
+    }
+}

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -7843,6 +7843,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "voice_pipeline_demo"
+version = "0.1.0"
+dependencies = [
+ "mofa-foundation",
+ "mofa-kernel",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.22",
+ "uuid",
+]
+
+[[package]]
 name = "vtparse"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -45,6 +45,7 @@ members = [
     "context_window_demo",
     "compression_examples",
     "admission_gate_demo",
+    "voice_pipeline_demo",
     "integrations_demo",
     "native_dataflow",
     "mcp_tools",

--- a/examples/voice_pipeline_demo/Cargo.toml
+++ b/examples/voice_pipeline_demo/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "voice_pipeline_demo"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+mofa-kernel = { path = "../../crates/mofa-kernel" }
+mofa-foundation = { path = "../../crates/mofa-foundation" }
+uuid = { workspace = true }

--- a/examples/voice_pipeline_demo/src/main.rs
+++ b/examples/voice_pipeline_demo/src/main.rs
@@ -1,0 +1,57 @@
+//! Voice Pipeline Demo
+//!
+//! Demonstrates the framework-level End-to-End Voice Integration Pipeline
+//! (ASR -> LLM -> TTS) using mock backends that run without requiring any
+//! model files or GPUs.
+//!
+//! To run:
+//! `cargo run -p voice_pipeline_demo`
+
+use mofa_foundation::agent::voice::VoicePipelineExecutor;
+use mofa_foundation::agent::voice_mock::{MockAsrStage, MockLlmStage, MockTtsStage};
+use mofa_kernel::agent::voice::{StageInput, VoicePipelineConfig, VoiceStage};
+use tracing::{info, Level};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing to see the per-stage spans
+    tracing_subscriber::fmt()
+        .with_max_level(Level::INFO)
+        .init();
+
+    info!("Initializing Voice Pipeline Demo...");
+
+    // Create the mock stages (delay in ms simulates latency)
+    let asr = Box::new(MockAsrStage::new(500));
+    let llm = Box::new(MockLlmStage::new(1200));
+    let tts = Box::new(MockTtsStage::new(800));
+
+    let stages: Vec<Box<dyn VoiceStage>> = vec![asr, llm, tts];
+
+    // Configure the pipeline
+    let config = VoicePipelineConfig {
+        abort_on_error: true,
+        timeout_ms: Some(5000), // 5 seconds max for the whole pipeline
+    };
+
+    // Build the executor
+    let pipeline = VoicePipelineExecutor::new(stages, config);
+
+    // Simulate an incoming audio chunk (e.g., from a microphone)
+    let mock_audio_input = vec![0.1f32, 0.2f32, 0.3f32, 0.4f32];
+    let input = StageInput::Audio(mock_audio_input);
+
+    info!("Starting pipeline execution...");
+    
+    // Execute the pipeline
+    let output = pipeline.execute(input).await?;
+
+    info!("Pipeline execution completed successfully!");
+    info!("Total Latency: {}ms", output.total_latency_ms);
+    
+    for (stage_name, latency) in output.stage_latencies {
+        info!(" -> {} Latency: {}ms", stage_name, latency);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #711.
## Description
This PR introduces the framework-level End-to-End Voice Integration Pipeline (ASR -> LLM -> TTS) for the MoFA Edge Orchestrator. 

### Key Changes
- **mofa-kernel**: Added cross-platform traits `VoiceStage`, `StageInput`, and `StageOutput`. Added `VoicePipelineConfig` for timeout management.
- **mofa-foundation**: Implemented `VoicePipelineExecutor` for robust sequential pipeline execution with `tracing` telemetry integration.
- **Mock Backends**: Created `MockAsrStage`, `MockLlmStage`, and `MockTtsStage` to simulate stage latency and mock logic without requiring heavy model loading, ensuring CI stability.
- **Demo Application**: Created `voice_pipeline_demo` runnable example to demonstrate the end-to-end functionality.

### Verification
- [x] Tested locally via `cargo run -p voice_pipeline_demo`
- [x] Passed `cargo test -p mofa-kernel` and `cargo test -p mofa-foundation`
- [x] No clippy or formatting warnings introduced by these changes
