### PR TITLE
Feature] Integrate TTS and ASR Services from Cloud Vendors (Microkernel Design)

### DIFF
--- a/crates/mofa-plugins/Cargo.toml
+++ b/crates/mofa-plugins/Cargo.toml
@@ -35,12 +35,7 @@ rand.workspace = true
 wasmtime = { version = "40", features = ["component-model", "async"] }
 # Local dependencies
 mofa-kernel = { path = "../mofa-kernel", version = "0.1" }
-reqwest = { workspace = true, features = ["json", "rustls-tls"] }
-reqwest = { version = "0.12.28", features = [
-    "json",
-    "rustls-tls",
-    "multipart",
-] }
+reqwest = { workspace = true, features = ["json", "rustls-tls", "multipart"] }
 chrono = { workspace = true, features = ["serde"] }
 mofa-extra = { version = "0.1", path = "../mofa-extra" }
 rhai = { version = "1.20", features = ["sync", "serde"] }

--- a/crates/mofa-plugins/Cargo.toml
+++ b/crates/mofa-plugins/Cargo.toml
@@ -29,13 +29,18 @@ libloading.workspace = true
 tempfile.workspace = true
 sha2.workspace = true
 tracing.workspace = true
-uuid = {workspace = true,features = ["v7"]}
+uuid = { workspace = true, features = ["v7"] }
 rand.workspace = true
 # WASM plugin runtime
 wasmtime = { version = "40", features = ["component-model", "async"] }
 # Local dependencies
 mofa-kernel = { path = "../mofa-kernel", version = "0.1" }
 reqwest = { workspace = true, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12.28", features = [
+    "json",
+    "rustls-tls",
+    "multipart",
+] }
 chrono = { workspace = true, features = ["serde"] }
 mofa-extra = { version = "0.1", path = "../mofa-extra" }
 rhai = { version = "1.20", features = ["sync", "serde"] }

--- a/crates/mofa-plugins/src/asr.rs
+++ b/crates/mofa-plugins/src/asr.rs
@@ -1,0 +1,243 @@
+//! Automatic Speech Recognition (ASR) Plugin Module
+//!
+//! Provides ASR capabilities using a generic ASR engine interface.
+//! This module is designed to work with multiple ASR backends.
+//!
+
+pub mod openai;
+
+use crate::{AgentPlugin, PluginContext, PluginMetadata, PluginResult, PluginState, PluginType};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tracing::{debug, info, warn};
+
+// ============================================================================
+// ASR Plugin Configuration
+// ============================================================================
+
+/// ASR plugin configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ASRPluginConfig {
+    /// Default language code for transcription (e.g., "en")
+    pub default_language: String,
+    /// Default model to use
+    pub default_model: String,
+}
+
+impl Default for ASRPluginConfig {
+    fn default() -> Self {
+        Self {
+            default_language: "en".to_string(),
+            default_model: "whisper-1".to_string(),
+        }
+    }
+}
+
+// ============================================================================
+// ASR Engine Trait
+// ============================================================================
+
+/// Abstract ASR engine trait for extensibility
+#[async_trait::async_trait]
+pub trait ASREngine: Send + Sync {
+    /// Transcribe audio data to text
+    async fn transcribe(&self, audio: &[u8], language: Option<&str>) -> PluginResult<String>;
+
+    /// Get engine name
+    fn name(&self) -> &str;
+
+    /// Get as Any for downcasting to engine-specific types
+    fn as_any(&self) -> &dyn std::any::Any;
+}
+
+// ============================================================================
+// Mock ASR Engine (Placeholder)
+// ============================================================================
+
+/// A mock ASR engine for testing and development.
+pub struct MockASREngine {
+    config: ASRPluginConfig,
+}
+
+impl MockASREngine {
+    /// Create a new mock ASR engine
+    pub fn new(config: ASRPluginConfig) -> Self {
+        Self { config }
+    }
+}
+
+#[async_trait::async_trait]
+impl ASREngine for MockASREngine {
+    async fn transcribe(&self, audio: &[u8], _language: Option<&str>) -> PluginResult<String> {
+        debug!("[MockASR] Transcribing {} bytes of audio...", audio.len());
+
+        // Simulate processing delay based on audio size
+        let delay_ms = std::cmp::min(1000, audio.len() as u64 / 100);
+        tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+
+        Ok("Mock transcription result: The Quick Brown Fox Jumps Over The Lazy Dog.".to_string())
+    }
+
+    fn name(&self) -> &str {
+        "MockASR"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+// ============================================================================
+// ASR Plugin
+// ============================================================================
+
+/// ASR Plugin implementing AgentPlugin
+pub struct ASRPlugin {
+    metadata: PluginMetadata,
+    state: PluginState,
+    config: ASRPluginConfig,
+    engine: Option<Arc<dyn ASREngine>>,
+    transcription_count: u64,
+}
+
+impl ASRPlugin {
+    /// Create a new ASR plugin
+    pub fn new(plugin_id: &str) -> Self {
+        let metadata = PluginMetadata::new(plugin_id, "ASR Plugin", PluginType::Tool)
+            .with_description(
+                "Automatic Speech Recognition plugin with support for multiple backends",
+            )
+            .with_capability("audio_transcription")
+            .with_capability("speech_to_text");
+
+        Self {
+            metadata,
+            state: PluginState::Unloaded,
+            config: ASRPluginConfig::default(),
+            engine: None,
+            transcription_count: 0,
+        }
+    }
+
+    /// Create an ASR plugin with engine
+    pub fn with_engine<E: ASREngine + 'static>(plugin_id: &str, engine: E) -> Self {
+        let mut plugin = Self::new(plugin_id);
+        plugin.engine = Some(Arc::new(engine));
+        plugin
+    }
+
+    /// Set the plugin configuration
+    pub fn with_config(mut self, config: ASRPluginConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    /// Get the ASR engine
+    pub fn engine(&self) -> Option<&Arc<dyn ASREngine>> {
+        self.engine.as_ref()
+    }
+
+    /// Transcribe audio bytes to text
+    pub async fn transcribe(&mut self, audio: &[u8]) -> PluginResult<String> {
+        let engine = self.engine.as_ref().ok_or_else(|| {
+            mofa_kernel::plugin::PluginError::ExecutionFailed(
+                "ASR engine not initialized".to_string(),
+            )
+        })?;
+
+        self.transcription_count += 1;
+        engine
+            .transcribe(audio, Some(&self.config.default_language))
+            .await
+    }
+
+    /// Get usage statistics
+    pub fn stats(&self) -> HashMap<String, serde_json::Value> {
+        let mut stats = HashMap::new();
+        stats.insert(
+            "transcription_count".to_string(),
+            serde_json::json!(self.transcription_count),
+        );
+        stats.insert(
+            "default_language".to_string(),
+            serde_json::json!(self.config.default_language),
+        );
+        if let Some(engine) = &self.engine {
+            stats.insert("engine".to_string(), serde_json::json!(engine.name()));
+        }
+        stats
+    }
+}
+
+#[async_trait::async_trait]
+impl AgentPlugin for ASRPlugin {
+    fn metadata(&self) -> &PluginMetadata {
+        &self.metadata
+    }
+
+    fn state(&self) -> PluginState {
+        self.state.clone()
+    }
+
+    async fn load(&mut self, ctx: &PluginContext) -> PluginResult<()> {
+        self.state = PluginState::Loading;
+        info!("Loading ASR plugin: {}", self.metadata.id);
+
+        if let Some(lang) = ctx.config.get_string("default_language") {
+            self.config.default_language = lang;
+        }
+
+        self.state = PluginState::Loaded;
+        Ok(())
+    }
+
+    async fn init_plugin(&mut self) -> PluginResult<()> {
+        info!("Initializing ASR plugin: {}", self.metadata.id);
+
+        if self.engine.is_none() {
+            warn!("No explicit ASR engine bound; falling back to mock engine");
+            self.engine = Some(Arc::new(MockASREngine::new(self.config.clone())));
+        }
+
+        Ok(())
+    }
+
+    async fn start(&mut self) -> PluginResult<()> {
+        self.state = PluginState::Running;
+        info!("ASR plugin {} started", self.metadata.id);
+        Ok(())
+    }
+
+    async fn stop(&mut self) -> PluginResult<()> {
+        self.state = PluginState::Paused;
+        info!("ASR plugin {} stopped", self.metadata.id);
+        Ok(())
+    }
+
+    async fn unload(&mut self) -> PluginResult<()> {
+        self.engine = None;
+        self.state = PluginState::Unloaded;
+        info!("ASR plugin {} unloaded", self.metadata.id);
+        Ok(())
+    }
+
+    async fn execute(&mut self, _input: String) -> PluginResult<String> {
+        Err(mofa_kernel::plugin::PluginError::ExecutionFailed(
+            "Direct string execution not supported for ASRPlugin. Use transcribe() directly."
+                .to_string(),
+        ))
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
+        self
+    }
+}

--- a/crates/mofa-plugins/src/asr/openai.rs
+++ b/crates/mofa-plugins/src/asr/openai.rs
@@ -1,0 +1,111 @@
+//! OpenAI ASR Backend Implementation
+//!
+//! Provides an implementation of `ASREngine` that utilizes the OpenAI Whisper
+//! API for transcription.
+
+use crate::asr::{ASREngine, ASRPluginConfig};
+use mofa_kernel::plugin::{PluginError, PluginResult};
+use reqwest::multipart;
+use serde::Deserialize;
+use std::env;
+use tracing::{debug, error, info};
+
+const OPENAI_API_URL: &str = "https://api.openai.com/v1/audio/transcriptions";
+
+/// OpenAI ASR Engine Implementation
+pub struct OpenAIASR {
+    api_key: String,
+    config: ASRPluginConfig,
+    client: reqwest::Client,
+}
+
+#[derive(Debug, Deserialize)]
+struct TranscriptionResponse {
+    text: String,
+}
+
+impl OpenAIASR {
+    /// Create a new OpenAI ASR backend by reading `OPENAI_API_KEY` from the environment.
+    pub fn new(config: ASRPluginConfig) -> Result<Self, String> {
+        let api_key = env::var("OPENAI_API_KEY")
+            .map_err(|_| "OPENAI_API_KEY environment variable not set".to_string())?;
+
+        Ok(Self {
+            api_key,
+            config,
+            client: reqwest::Client::new(),
+        })
+    }
+
+    /// Create with an explicit API key
+    pub fn with_api_key(api_key: impl Into<String>, config: ASRPluginConfig) -> Self {
+        Self {
+            api_key: api_key.into(),
+            config,
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ASREngine for OpenAIASR {
+    async fn transcribe(&self, audio: &[u8], language: Option<&str>) -> PluginResult<String> {
+        debug!(
+            "Sending {} bytes of audio to OpenAI Whisper API",
+            audio.len()
+        );
+
+        // Create the multipart form
+        let file_part = multipart::Part::bytes(audio.to_vec())
+            .file_name("audio.wav")
+            .mime_str("audio/wav")
+            .map_err(|e| {
+                PluginError::ExecutionFailed(format!("Failed to build multipart chunk: {}", e))
+            })?;
+
+        let model = self.config.default_model.clone();
+
+        let mut form = multipart::Form::new()
+            .part("file", file_part)
+            .text("model", model);
+
+        if let Some(l) = language.or(Some(&self.config.default_language)) {
+            form = form.text("language", l.to_string());
+        }
+
+        // Execute Request
+        let res = self
+            .client
+            .post(OPENAI_API_URL)
+            .bearer_auth(&self.api_key)
+            .multipart(form)
+            .send()
+            .await
+            .map_err(|e| PluginError::ExecutionFailed(format!("HTTP request failed: {}", e)))?;
+
+        if !res.status().is_success() {
+            let status = res.status();
+            let body = res.text().await.unwrap_or_default();
+            error!("OpenAI API error: {} - {}", status, body);
+            return Err(PluginError::ExecutionFailed(format!(
+                "OpenAI API error {}: {}",
+                status, body
+            )));
+        }
+
+        let resp: TranscriptionResponse = res.json().await.map_err(|e| {
+            PluginError::ExecutionFailed(format!("Failed to parse JSON response: {}", e))
+        })?;
+
+        info!("Successfully received transcription from OpenAI Whisper");
+        Ok(resp.text)
+    }
+
+    fn name(&self) -> &str {
+        "OpenAIASR"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}

--- a/crates/mofa-plugins/src/lib.rs
+++ b/crates/mofa-plugins/src/lib.rs
@@ -12,12 +12,15 @@
 // Unified error conversions (GlobalError <-> plugin errors)
 pub mod error_conversions;
 
+pub mod asr;
 pub mod hot_reload;
 pub mod skill;
 pub mod tool;
 pub mod tools;
 pub mod tts;
 pub mod wasm_runtime;
+
+pub use asr::{ASREngine, ASRPlugin, ASRPluginConfig, MockASREngine};
 
 pub use mofa_kernel::{
     AgentPlugin, PluginConfig, PluginContext, PluginError, PluginEvent, PluginMetadata,

--- a/crates/mofa-plugins/src/tts.rs
+++ b/crates/mofa-plugins/src/tts.rs
@@ -10,6 +10,7 @@
 // Model cache and download modules
 pub mod cache;
 pub mod model_downloader;
+pub mod openai;
 
 // Kokoro TTS wrapper (available with kokoro feature)
 #[cfg(feature = "kokoro")]

--- a/crates/mofa-plugins/src/tts/openai.rs
+++ b/crates/mofa-plugins/src/tts/openai.rs
@@ -1,0 +1,143 @@
+//! OpenAI TTS Backend Implementation
+//!
+//! Provides an implementation of `TTSEngine` that utilizes the OpenAI audio
+//! API for text-to-speech synthesis (e.g. tts-1).
+
+use crate::tts::{TTSEngine, TTSPluginConfig, VoiceInfo};
+use mofa_kernel::plugin::{PluginError, PluginResult};
+use serde::{Deserialize, Serialize};
+use std::env;
+use tracing::{debug, error, info};
+
+const OPENAI_API_URL: &str = "https://api.openai.com/v1/audio/speech";
+
+/// OpenAI TTS Engine Implementation
+pub struct OpenAITTS {
+    api_key: String,
+    config: TTSPluginConfig,
+    client: reqwest::Client,
+    voices: Vec<VoiceInfo>,
+}
+
+#[derive(Debug, Serialize)]
+struct TtsRequest<'a> {
+    model: &'a str,
+    input: &'a str,
+    voice: &'a str,
+    response_format: &'a str,
+}
+
+impl OpenAITTS {
+    /// Create a new OpenAI TTS backend by reading `OPENAI_API_KEY` from the environment.
+    pub fn new(config: TTSPluginConfig) -> Result<Self, String> {
+        let api_key = env::var("OPENAI_API_KEY")
+            .map_err(|_| "OPENAI_API_KEY environment variable not set".to_string())?;
+
+        Ok(Self::with_api_key(api_key, config))
+    }
+
+    /// Create with an explicit API key
+    pub fn with_api_key(api_key: impl Into<String>, config: TTSPluginConfig) -> Self {
+        // OpenAI standard voices
+        let voices = vec![
+            VoiceInfo::new("alloy", "Alloy (Neutral)", "en"),
+            VoiceInfo::new("echo", "Echo (Neutral)", "en"),
+            VoiceInfo::new("fable", "Fable (British/Happy)", "en"),
+            VoiceInfo::new("onyx", "Onyx (Deep/Authoritative)", "en"),
+            VoiceInfo::new("nova", "Nova (Energetic/Female)", "en"),
+            VoiceInfo::new("shimmer", "Shimmer (Clear/Female)", "en"),
+        ];
+
+        Self {
+            api_key: api_key.into(),
+            config,
+            client: reqwest::Client::new(),
+            voices,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl TTSEngine for OpenAITTS {
+    async fn synthesize(&self, text: &str, voice: &str) -> PluginResult<Vec<u8>> {
+        debug!(
+            "Synthesizing {} chars with OpenAI TTS (model: {}, voice: {})",
+            text.len(),
+            self.config.model_version,
+            voice
+        );
+
+        // Define default model if "v1.1" (from kokoro config) is used
+        let model = if self.config.model_version.starts_with('v') {
+            "tts-1"
+        } else {
+            &self.config.model_version
+        };
+
+        let req_body = TtsRequest {
+            model,
+            input: text,
+            voice,
+            response_format: "wav",
+        };
+
+        let res = self
+            .client
+            .post(OPENAI_API_URL)
+            .bearer_auth(&self.api_key)
+            .json(&req_body)
+            .send()
+            .await
+            .map_err(|e| PluginError::ExecutionFailed(format!("HTTP request failed: {}", e)))?;
+
+        if !res.status().is_success() {
+            let status = res.status();
+            let body = res.text().await.unwrap_or_default();
+            error!("OpenAI API error: {} - {}", status, body);
+            return Err(PluginError::ExecutionFailed(format!(
+                "OpenAI API error {}: {}",
+                status, body
+            )));
+        }
+
+        let audio_bytes = res.bytes().await.map_err(|e| {
+            PluginError::ExecutionFailed(format!("Failed to read response bytes: {}", e))
+        })?;
+
+        info!("Successfully received synthesized WAV audio from OpenAI");
+        Ok(audio_bytes.to_vec())
+    }
+
+    async fn synthesize_stream(
+        &self,
+        text: &str,
+        voice: &str,
+        callback: Box<dyn Fn(Vec<u8>) + Send + Sync>,
+    ) -> PluginResult<()> {
+        debug!(
+            "Stream synthesizing {} chars with OpenAI TTS (model: {}, voice: {})",
+            text.len(),
+            self.config.model_version,
+            voice
+        );
+
+        // OpenAI's standard TTS API currently doesn't support real chunked streaming output
+        // where it yields byte-by-byte. So we synthesize the whole block and call the callback once.
+        // (Text streaming chunking should be driven by the caller passing smaller texts in).
+        let audio = self.synthesize(text, voice).await?;
+        callback(audio);
+        Ok(())
+    }
+
+    async fn list_voices(&self) -> PluginResult<Vec<VoiceInfo>> {
+        Ok(self.voices.clone())
+    }
+
+    fn name(&self) -> &str {
+        "OpenAITTS"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "reflection_agent",
     "tool_routing",
     "runtime_message_bus_backpressure",
+    "cloud_voice_demo",
     "rag_pipeline",
     "hitl_v2",
     "agent_builder",

--- a/examples/cloud_voice_demo/Cargo.toml
+++ b/examples/cloud_voice_demo/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "cloud_voice_demo"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+mofa-kernel = { path = "../../crates/mofa-kernel" }
+mofa-plugins = { path = "../../crates/mofa-plugins" }
+tokio = { version = "1.0", features = ["full", "time"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+dotenvy = "0.15"

--- a/examples/cloud_voice_demo/src/main.rs
+++ b/examples/cloud_voice_demo/src/main.rs
@@ -1,0 +1,57 @@
+use mofa_kernel::AgentPlugin;
+use mofa_plugins::asr::openai::OpenAIASR;
+use mofa_plugins::asr::{ASRPlugin, ASRPluginConfig};
+use mofa_plugins::tts::openai::OpenAITTS;
+use mofa_plugins::tts::{TTSPlugin, TTSPluginConfig};
+use tracing::{info, warn};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_target(false)
+        .init();
+
+    info!("Starting Cloud Voice Integration Demo");
+
+    // Load .env if present (good for OPENAI_API_KEY)
+    let _ = dotenvy::dotenv();
+
+    if std::env::var("OPENAI_API_KEY").is_err() {
+        warn!("OPENAI_API_KEY is not set. The demo will likely fail.");
+        warn!("Please export OPENAI_API_KEY before running: `export OPENAI_API_KEY=sk-...`");
+    }
+
+    // 1. Test Text-to-Speech (TTS)
+    info!("--- Testing OpenAI TTS ---");
+    let tts_config = TTSPluginConfig {
+        model_version: "tts-1".to_string(),
+        default_voice: "alloy".to_string(),
+        ..Default::default()
+    };
+    
+    let openai_tts_engine = OpenAITTS::new(tts_config)?;
+    let mut tts_plugin = TTSPlugin::with_engine("openai_tts", openai_tts_engine, Some("alloy"));
+    
+    let sample_text = "Hello from the Microkernel Framework! I am speaking using OpenAI's cloud API.";
+    info!("Synthesizing: '{}'", sample_text);
+    let audio_bytes = tts_plugin.synthesize_to_audio(sample_text).await?;
+    info!("Success! Received {} bytes of WAV/MP3 audio from OpenAI TTS.", audio_bytes.len());
+
+    // 2. Test Automatic Speech Recognition (ASR)
+    info!("--- Testing OpenAI ASR (Whisper) ---");
+    let asr_config = ASRPluginConfig {
+        default_language: "en".to_string(),
+        default_model: "whisper-1".to_string(),
+    };
+    
+    let openai_asr_engine = OpenAIASR::new(asr_config)?;
+    let mut asr_plugin = ASRPlugin::with_engine("openai_asr", openai_asr_engine);
+    
+    info!("Uploading the just-synthesized {} bytes back to Whisper...", audio_bytes.len());
+    let transcription = asr_plugin.transcribe(&audio_bytes).await?;
+    info!("Transcribed Text: '{}'", transcription);
+
+    info!("Demo completed successfully.");
+    Ok(())
+}


### PR DESCRIPTION
Closes #714.

## Description
This PR introduces robust cloud integrations for Text-to-Speech (TTS) and Automatic Speech Recognition (ASR) to complement local inference, fulfilling the requirements for GSoC Idea 21.

By strictly adhering to the MoFA microkernel architectural design principles, the [ASRPlugin](cci:2://file:///Users/yash/Desktop/MOFA/mofa/crates/mofa-plugins/src/asr.rs:95:0-101:1) and [TTSPlugin](cci:2://file:///Users/yash/Desktop/MOFA/mofa/crates/mofa-plugins/src/tts.rs:361:0-373:1) integrate seamlessly into the `mofa-plugins` workspace without bloating the core runtime.

## Changes
- **ASR Foundation**: Introduced the [ASREngine](cci:2://file:///Users/yash/Desktop/MOFA/mofa/crates/mofa-plugins/src/asr.rs:42:0-51:1) async trait and [ASRPlugin](cci:2://file:///Users/yash/Desktop/MOFA/mofa/crates/mofa-plugins/src/asr.rs:95:0-101:1) inside [mofa-plugins/src/asr.rs](cci:7://file:///Users/yash/Desktop/MOFA/mofa/crates/mofa-plugins/src/asr.rs:0:0-0:0).
- **OpenAI ASR Backend**: Implemented the [OpenAIASR](cci:2://file:///Users/yash/Desktop/MOFA/mofa/crates/mofa-plugins/src/asr/openai.rs:15:0-19:1) engine using the Whisper API (`api.openai.com/v1/audio/transcriptions`), leveraging the `multipart` feature in `reqwest` for raw byte uploads.
- **OpenAI TTS Backend**: Implemented the [OpenAITTS](cci:2://file:///Users/yash/Desktop/MOFA/mofa/crates/mofa-plugins/src/tts/openai.rs:14:0-19:1) engine for the existing [TTSEngine](cci:2://file:///Users/yash/Desktop/MOFA/mofa/crates/mofa-plugins/src/tts.rs:112:0-135:1) trait, using the standard TTS API (`api.openai.com/v1/audio/speech`).
- **Demo Application**: Added a runnable `cloud_voice_demo` in the `examples` workspace that performs a complete roundtrip (TTS -> Audio Bytes -> ASR) verifying API communication.

## Verification
- [x] Verified zero trait bloat in `mofa-kernel` / `mofa-foundation`.
- [x] `cargo build -p mofa-plugins` resolves dependencies cleanly over `reqwest`.
- [x] `cargo clippy -p mofa-plugins` enforces clean code.
- [x] Tested roundtrip parsing of binary audio payloads using the `cloud_voice_demo`.
