### PR TITLE
feat(rag): Task 27 Phase 1 — Document loaders, recursive chunker, and score reranker

### DIFF
--- a/crates/mofa-foundation/src/rag/loaders.rs
+++ b/crates/mofa-foundation/src/rag/loaders.rs
@@ -1,0 +1,348 @@
+//! Document loaders for ingesting text from various sources
+//!
+//! Provides document loaders that read from files and convert them into
+//! the kernel `Document` type for use in RAG pipelines.
+
+use mofa_kernel::rag::Document;
+use std::collections::HashMap;
+use std::path::Path;
+use thiserror::Error;
+
+// =============================================================================
+// Errors
+// =============================================================================
+
+/// Errors from document loading.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum LoaderError {
+    /// File IO error (includes the path that failed)
+    #[error("Failed to read '{path}': {source}")]
+    IoError {
+        /// The path that caused the IO error
+        path: String,
+        /// The underlying IO error
+        source: std::io::Error,
+    },
+
+    /// Unsupported file format
+    #[error("Unsupported file format: {0}")]
+    UnsupportedFormat(String),
+
+    /// Empty document
+    #[error("Document is empty: {0}")]
+    EmptyDocument(String),
+}
+
+/// Result type for loader operations.
+pub type LoaderResult<T> = Result<T, LoaderError>;
+
+// =============================================================================
+// DocumentLoader Trait
+// =============================================================================
+
+/// Trait for loading documents from various sources.
+pub trait DocumentLoader: Send + Sync {
+    /// Load a document from the given path.
+    fn load(&self, path: &Path) -> LoaderResult<Vec<Document>>;
+}
+
+// =============================================================================
+// TextLoader
+// =============================================================================
+
+/// Loads plain text files into documents.
+///
+/// Each file becomes a single `Document` with the file path stored in metadata.
+#[derive(Debug, Clone, Default)]
+pub struct TextLoader;
+
+impl TextLoader {
+    /// Create a new text loader.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl DocumentLoader for TextLoader {
+    fn load(&self, path: &Path) -> LoaderResult<Vec<Document>> {
+        let content = std::fs::read_to_string(path).map_err(|e| LoaderError::IoError {
+            path: path.display().to_string(),
+            source: e,
+        })?;
+
+        if content.trim().is_empty() {
+            return Err(LoaderError::EmptyDocument(
+                path.display().to_string(),
+            ));
+        }
+
+        // Use full path for unique IDs across directories
+        let id = path.display().to_string();
+
+        let mut metadata = HashMap::new();
+        metadata.insert("source".into(), path.display().to_string());
+        metadata.insert("format".into(), "text".into());
+
+        Ok(vec![Document {
+            id,
+            text: content,
+            metadata,
+        }])
+    }
+}
+
+// =============================================================================
+// MarkdownLoader
+// =============================================================================
+
+/// Loads markdown files with heading-aware section splitting.
+///
+/// Splits markdown documents at heading boundaries (`#`, `##`, `###`, etc.)
+/// so each section becomes a separate `Document` with heading metadata.
+#[derive(Debug, Clone)]
+pub struct MarkdownLoader {
+    /// Maximum heading level to split at (1 = `#`, 2 = `##`, etc.)
+    pub split_level: usize,
+}
+
+impl Default for MarkdownLoader {
+    fn default() -> Self {
+        Self { split_level: 2 }
+    }
+}
+
+impl MarkdownLoader {
+    /// Create a new markdown loader that splits at the given heading level.
+    #[must_use]
+    pub fn new(split_level: usize) -> Self {
+        Self { split_level }
+    }
+
+    /// Parse heading level from a line (e.g. "## Foo" -> Some(2))
+    fn heading_level(line: &str) -> Option<usize> {
+        let trimmed = line.trim_start();
+        if !trimmed.starts_with('#') {
+            return None;
+        }
+        let level = trimmed.chars().take_while(|c| *c == '#').count();
+        // Must be followed by a space or end of line to be a valid heading
+        let rest = &trimmed[level..];
+        if rest.is_empty() || rest.starts_with(' ') {
+            Some(level)
+        } else {
+            None
+        }
+    }
+
+    /// Extract heading text (without the `#` prefix).
+    fn heading_text(line: &str) -> String {
+        let trimmed = line.trim_start();
+        let level = trimmed.chars().take_while(|c| *c == '#').count();
+        trimmed[level..].trim().to_string()
+    }
+}
+
+impl DocumentLoader for MarkdownLoader {
+    fn load(&self, path: &Path) -> LoaderResult<Vec<Document>> {
+        let content = std::fs::read_to_string(path).map_err(|e| LoaderError::IoError {
+            path: path.display().to_string(),
+            source: e,
+        })?;
+
+        if content.trim().is_empty() {
+            return Err(LoaderError::EmptyDocument(
+                path.display().to_string(),
+            ));
+        }
+
+        let source = path.display().to_string();
+        // Use full path for unique IDs across directories
+        let base_id = path.display().to_string();
+
+        let mut documents = Vec::new();
+        let mut current_heading = String::new();
+        let mut current_content = String::new();
+        let mut section_index = 0usize;
+
+        for line in content.lines() {
+            if let Some(level) = Self::heading_level(line) {
+                if level <= self.split_level {
+                    // Save previous section
+                    if !current_content.trim().is_empty() {
+                        let mut metadata = HashMap::new();
+                        metadata.insert("source".into(), source.clone());
+                        metadata.insert("format".into(), "markdown".into());
+                        metadata.insert("section_index".into(), section_index.to_string());
+                        if !current_heading.is_empty() {
+                            metadata.insert("heading".into(), current_heading.clone());
+                        }
+
+                        documents.push(Document {
+                            id: format!("{base_id}:s{section_index}"),
+                            text: current_content.trim().to_string(),
+                            metadata,
+                        });
+                        section_index += 1;
+                    }
+
+                    current_heading = Self::heading_text(line);
+                    current_content = format!("{line}\n");
+                    continue;
+                }
+            }
+
+            current_content.push_str(line);
+            current_content.push('\n');
+        }
+
+        // Save last section
+        if !current_content.trim().is_empty() {
+            let mut metadata = HashMap::new();
+            metadata.insert("source".into(), source);
+            metadata.insert("format".into(), "markdown".into());
+            metadata.insert("section_index".into(), section_index.to_string());
+            if !current_heading.is_empty() {
+                metadata.insert("heading".into(), current_heading);
+            }
+
+            documents.push(Document {
+                id: format!("{base_id}:s{section_index}"),
+                text: current_content.trim().to_string(),
+                metadata,
+            });
+        }
+
+        if documents.is_empty() {
+            return Err(LoaderError::EmptyDocument(
+                path.display().to_string(),
+            ));
+        }
+
+        Ok(documents)
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_temp(content: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    // --- TextLoader tests ---
+
+    #[test]
+    fn text_loader_loads_file() {
+        let f = write_temp("Hello, world!\nSecond line.");
+        let loader = TextLoader::new();
+        let docs = loader.load(f.path()).unwrap();
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0].text, "Hello, world!\nSecond line.");
+        assert_eq!(docs[0].metadata.get("format").unwrap(), "text");
+    }
+
+    #[test]
+    fn text_loader_rejects_empty() {
+        let f = write_temp("   \n  \n  ");
+        let loader = TextLoader::new();
+        let result = loader.load(f.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn text_loader_sets_source_metadata() {
+        let f = write_temp("content");
+        let loader = TextLoader::new();
+        let docs = loader.load(f.path()).unwrap();
+        assert!(docs[0].metadata.get("source").unwrap().len() > 0);
+    }
+
+    #[test]
+    fn text_loader_missing_file() {
+        let loader = TextLoader::new();
+        let result = loader.load(Path::new("/nonexistent/file.txt"));
+        assert!(result.is_err());
+    }
+
+    // --- MarkdownLoader tests ---
+
+    #[test]
+    fn markdown_splits_at_headings() {
+        let content = "# Chapter 1\nFirst content.\n\n# Chapter 2\nSecond content.\n";
+        let f = write_temp(content);
+        let loader = MarkdownLoader::new(1);
+        let docs = loader.load(f.path()).unwrap();
+        assert_eq!(docs.len(), 2);
+        assert!(docs[0].text.contains("Chapter 1"));
+        assert!(docs[1].text.contains("Chapter 2"));
+    }
+
+    #[test]
+    fn markdown_respects_split_level() {
+        let content = "# Title\n\n## Section A\nContent A.\n\n## Section B\nContent B.\n";
+        let f = write_temp(content);
+        let loader = MarkdownLoader::new(2);
+        let docs = loader.load(f.path()).unwrap();
+        // Should split at ## level: title preamble + Section A + Section B
+        assert!(docs.len() >= 2);
+    }
+
+    #[test]
+    fn markdown_preserves_heading_metadata() {
+        let content = "# Introduction\nSome intro text.\n\n# Methods\nSome methods.\n";
+        let f = write_temp(content);
+        let loader = MarkdownLoader::new(1);
+        let docs = loader.load(f.path()).unwrap();
+        assert_eq!(docs[0].metadata.get("heading").unwrap(), "Introduction");
+        assert_eq!(docs[1].metadata.get("heading").unwrap(), "Methods");
+    }
+
+    #[test]
+    fn markdown_sets_section_index() {
+        let content = "# A\nContent.\n# B\nContent.\n# C\nContent.\n";
+        let f = write_temp(content);
+        let loader = MarkdownLoader::new(1);
+        let docs = loader.load(f.path()).unwrap();
+        assert_eq!(docs[0].metadata.get("section_index").unwrap(), "0");
+        assert_eq!(docs[1].metadata.get("section_index").unwrap(), "1");
+        assert_eq!(docs[2].metadata.get("section_index").unwrap(), "2");
+    }
+
+    #[test]
+    fn markdown_rejects_empty() {
+        let f = write_temp("   ");
+        let loader = MarkdownLoader::default();
+        assert!(loader.load(f.path()).is_err());
+    }
+
+    #[test]
+    fn markdown_no_headings_single_doc() {
+        let content = "Just some text without headings.\nMore text.\n";
+        let f = write_temp(content);
+        let loader = MarkdownLoader::new(1);
+        let docs = loader.load(f.path()).unwrap();
+        assert_eq!(docs.len(), 1);
+    }
+
+    #[test]
+    fn heading_level_parsing() {
+        assert_eq!(MarkdownLoader::heading_level("# Title"), Some(1));
+        assert_eq!(MarkdownLoader::heading_level("## Section"), Some(2));
+        assert_eq!(MarkdownLoader::heading_level("### Sub"), Some(3));
+        assert_eq!(MarkdownLoader::heading_level("Not a heading"), None);
+        assert_eq!(MarkdownLoader::heading_level("#NoSpace"), None);
+        assert_eq!(MarkdownLoader::heading_level("#"), Some(1));
+    }
+}

--- a/crates/mofa-foundation/src/rag/mod.rs
+++ b/crates/mofa-foundation/src/rag/mod.rs
@@ -4,8 +4,11 @@
 //! in mofa-kernel, along with utilities for document chunking.
 
 pub mod chunker;
-pub mod default_reranker;
+pub mod loaders;
 pub mod pipeline_adapters;
+pub mod recursive_chunker;
+pub mod default_reranker;
+pub mod score_reranker;
 pub mod similarity;
 pub mod streaming_generator;
 pub mod vector_store;
@@ -14,8 +17,11 @@ pub mod vector_store;
 pub mod qdrant_store;
 
 pub use chunker::{ChunkConfig, TextChunker};
-pub use default_reranker::IdentityReranker;
+pub use loaders::{DocumentLoader, LoaderError, LoaderResult, MarkdownLoader, TextLoader};
 pub use pipeline_adapters::{InMemoryRetriever, SimpleGenerator};
+pub use recursive_chunker::{RecursiveChunker, RecursiveChunkConfig};
+pub use default_reranker::IdentityReranker;
+pub use score_reranker::ScoreReranker;
 pub use similarity::compute_similarity;
 pub use streaming_generator::PassthroughStreamingGenerator;
 pub use vector_store::InMemoryVectorStore;

--- a/crates/mofa-foundation/src/rag/recursive_chunker.rs
+++ b/crates/mofa-foundation/src/rag/recursive_chunker.rs
@@ -1,0 +1,297 @@
+//! Recursive text chunker
+//!
+//! Splits text using a hierarchy of separators, trying the most meaningful
+//! split first (paragraphs → sentences → words → characters).
+//! Inspired by LangChain's RecursiveCharacterTextSplitter.
+
+// =============================================================================
+// RecursiveChunker
+// =============================================================================
+
+/// Configuration for recursive chunking.
+#[derive(Debug, Clone)]
+pub struct RecursiveChunkConfig {
+    /// Maximum number of characters per chunk.
+    pub chunk_size: usize,
+    /// Number of characters to overlap between consecutive chunks.
+    pub chunk_overlap: usize,
+    /// Ordered list of separators to try (most → least meaningful).
+    pub separators: Vec<String>,
+}
+
+impl Default for RecursiveChunkConfig {
+    fn default() -> Self {
+        Self {
+            chunk_size: 1000,
+            chunk_overlap: 200,
+            separators: vec![
+                "\n\n".into(),  // Paragraph
+                "\n".into(),    // Line
+                ". ".into(),    // Sentence
+                ", ".into(),    // Clause
+                " ".into(),     // Word
+            ],
+        }
+    }
+}
+
+impl RecursiveChunkConfig {
+    /// Create a new config with custom chunk size and overlap.
+    #[must_use]
+    pub fn new(chunk_size: usize, chunk_overlap: usize) -> Self {
+        Self {
+            chunk_size,
+            chunk_overlap,
+            separators: Self::default().separators,
+        }
+    }
+
+    /// Set custom separators.
+    #[must_use]
+    pub fn with_separators(mut self, separators: Vec<String>) -> Self {
+        self.separators = separators;
+        self
+    }
+}
+
+/// Recursive text chunker that tries multiple separator levels.
+///
+/// Splits text using a hierarchy of separators. First tries to split at
+/// paragraph boundaries (`\n\n`), then at line boundaries (`\n`), then
+/// at sentence boundaries (`. `), and falls back to word and character
+/// boundaries as needed.
+///
+/// This produces higher-quality chunks than fixed-size splitting because
+/// it preserves semantic boundaries where possible.
+#[derive(Debug, Clone)]
+pub struct RecursiveChunker {
+    config: RecursiveChunkConfig,
+}
+
+impl Default for RecursiveChunker {
+    fn default() -> Self {
+        Self {
+            config: RecursiveChunkConfig::default(),
+        }
+    }
+}
+
+impl RecursiveChunker {
+    /// Create a new recursive chunker with the given configuration.
+    #[must_use]
+    pub fn new(config: RecursiveChunkConfig) -> Self {
+        Self { config }
+    }
+
+    /// Split text into chunks using recursive separator hierarchy.
+    pub fn chunk(&self, text: &str) -> Vec<String> {
+        if text.is_empty() {
+            return vec![];
+        }
+
+        if text.chars().count() <= self.config.chunk_size {
+            return vec![text.to_string()];
+        }
+
+        self.recursive_split(text, 0)
+    }
+
+    fn recursive_split(&self, text: &str, separator_idx: usize) -> Vec<String> {
+        if text.chars().count() <= self.config.chunk_size {
+            return vec![text.to_string()];
+        }
+
+        // If we've exhausted all separators, do a hard character split
+        if separator_idx >= self.config.separators.len() {
+            return self.hard_split(text);
+        }
+
+        let separator = &self.config.separators[separator_idx];
+        let parts: Vec<&str> = text.split(separator.as_str()).collect();
+
+        // If the separator didn't actually split anything useful, try next
+        if parts.len() <= 1 {
+            return self.recursive_split(text, separator_idx + 1);
+        }
+
+        let mut chunks = Vec::new();
+        let mut current = String::new();
+
+        for (i, part) in parts.iter().enumerate() {
+            let candidate = if current.is_empty() {
+                part.to_string()
+            } else {
+                format!("{current}{separator}{part}")
+            };
+
+            if candidate.chars().count() <= self.config.chunk_size {
+                current = candidate;
+            } else {
+                // Save current chunk
+                if !current.is_empty() {
+                    chunks.push(current.trim().to_string());
+                }
+
+                // If this single part is still too large, recurse with next separator
+                if part.chars().count() > self.config.chunk_size {
+                    let sub_chunks = self.recursive_split(part, separator_idx + 1);
+                    chunks.extend(sub_chunks);
+                    current = String::new();
+                } else {
+                    current = part.to_string();
+                }
+            }
+
+            // Add overlap from the end of the previous chunk (UTF-8 safe)
+            if i > 0 && current.is_empty() && !chunks.is_empty() {
+                let last = chunks.last().unwrap();
+                let char_count = last.chars().count();
+                let overlap_chars = char_count.min(self.config.chunk_overlap);
+                let overlap_text: String = last.chars().skip(char_count - overlap_chars).collect();
+                // Only use overlap if it doesn't make next chunk too large
+                if overlap_text.chars().count() < self.config.chunk_size / 2 {
+                    current = overlap_text;
+                }
+            }
+        }
+
+        // Save the last chunk
+        if !current.trim().is_empty() {
+            chunks.push(current.trim().to_string());
+        }
+
+        chunks.retain(|c| !c.is_empty());
+        chunks
+    }
+
+    fn hard_split(&self, text: &str) -> Vec<String> {
+        let mut chunks = Vec::new();
+        let chars: Vec<char> = text.chars().collect();
+        let step = self
+            .config
+            .chunk_size
+            .saturating_sub(self.config.chunk_overlap)
+            .max(1);
+        let mut start = 0;
+
+        while start < chars.len() {
+            let end = (start + self.config.chunk_size).min(chars.len());
+            let chunk: String = chars[start..end].iter().collect();
+            if !chunk.trim().is_empty() {
+                chunks.push(chunk);
+            }
+            if end >= chars.len() {
+                break;
+            }
+            start += step;
+        }
+
+        chunks
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_text_no_split() {
+        let chunker = RecursiveChunker::default();
+        let chunks = chunker.chunk("Short text");
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0], "Short text");
+    }
+
+    #[test]
+    fn empty_text() {
+        let chunker = RecursiveChunker::default();
+        let chunks = chunker.chunk("");
+        assert!(chunks.is_empty());
+    }
+
+    #[test]
+    fn splits_at_paragraph_boundary() {
+        let config = RecursiveChunkConfig::new(50, 0);
+        let chunker = RecursiveChunker::new(config);
+        let text = "First paragraph content.\n\nSecond paragraph content.\n\nThird paragraph content.";
+        let chunks = chunker.chunk(text);
+        assert!(chunks.len() >= 2);
+        // Each chunk should be under the size limit
+        for chunk in &chunks {
+            assert!(chunk.len() <= 50, "Chunk too large: {}", chunk.len());
+        }
+    }
+
+    #[test]
+    fn splits_at_sentence_boundary() {
+        let config = RecursiveChunkConfig::new(30, 0);
+        let chunker = RecursiveChunker::new(config);
+        let text = "First sentence. Second sentence. Third sentence.";
+        let chunks = chunker.chunk(text);
+        assert!(chunks.len() >= 2);
+    }
+
+    #[test]
+    fn respects_chunk_size() {
+        let config = RecursiveChunkConfig::new(100, 0);
+        let chunker = RecursiveChunker::new(config);
+        let text = "A ".repeat(200); // 400 chars
+        let chunks = chunker.chunk(&text);
+        assert!(chunks.len() >= 2);
+        for chunk in &chunks {
+            assert!(
+                chunk.len() <= 110, // Allow small margin due to separator handling
+                "Chunk too large: {} chars",
+                chunk.len()
+            );
+        }
+    }
+
+    #[test]
+    fn custom_separators() {
+        let config = RecursiveChunkConfig::new(20, 0)
+            .with_separators(vec!["|".into(), " ".into()]);
+        let chunker = RecursiveChunker::new(config);
+        let text = "part one content|part two content|part three content here";
+        let chunks = chunker.chunk(text);
+        assert!(chunks.len() >= 2);
+    }
+
+    #[test]
+    fn hard_split_fallback() {
+        let config = RecursiveChunkConfig::new(5, 0)
+            .with_separators(vec![]); // No separators → immediate hard split
+        let chunker = RecursiveChunker::new(config);
+        let text = "abcdefghijklmnopqrst"; // 20 chars, no separators
+        let chunks = chunker.chunk(text);
+        assert!(chunks.len() >= 2);
+        for chunk in &chunks {
+            assert!(chunk.len() <= 5);
+        }
+    }
+
+    #[test]
+    fn preserves_content() {
+        let config = RecursiveChunkConfig::new(50, 0);
+        let chunker = RecursiveChunker::new(config);
+        let text = "Hello world.\n\nThis is a test.\n\nFinal paragraph.";
+        let chunks = chunker.chunk(text);
+        let reconstructed: String = chunks.join(" ");
+        // All original words should be present
+        assert!(reconstructed.contains("Hello"));
+        assert!(reconstructed.contains("test"));
+        assert!(reconstructed.contains("Final"));
+    }
+
+    #[test]
+    fn default_config_values() {
+        let config = RecursiveChunkConfig::default();
+        assert_eq!(config.chunk_size, 1000);
+        assert_eq!(config.chunk_overlap, 200);
+        assert_eq!(config.separators.len(), 5);
+    }
+}

--- a/crates/mofa-foundation/src/rag/score_reranker.rs
+++ b/crates/mofa-foundation/src/rag/score_reranker.rs
@@ -1,0 +1,169 @@
+//! Score-based reranker with threshold filtering
+//!
+//! Provides a configurable reranker that filters results by minimum score
+//! threshold and optionally limits the number of returned results.
+
+use async_trait::async_trait;
+use mofa_kernel::agent::error::AgentResult;
+use mofa_kernel::rag::{Reranker, ScoredDocument};
+
+// =============================================================================
+// ScoreReranker
+// =============================================================================
+
+/// Score-based reranker with threshold and top-k filtering.
+///
+/// Filters documents by minimum relevance score and returns the top-k
+/// most relevant results sorted by score (descending).
+#[derive(Debug, Clone)]
+pub struct ScoreReranker {
+    /// Minimum score threshold (documents below this are dropped)
+    pub min_score: f32,
+    /// Maximum number of documents to return (None = no limit)
+    pub max_results: Option<usize>,
+}
+
+impl Default for ScoreReranker {
+    fn default() -> Self {
+        Self {
+            min_score: 0.0,
+            max_results: None,
+        }
+    }
+}
+
+impl ScoreReranker {
+    /// Create a reranker with the given minimum score threshold.
+    #[must_use]
+    pub fn with_threshold(min_score: f32) -> Self {
+        Self {
+            min_score,
+            max_results: None,
+        }
+    }
+
+    /// Create a reranker with threshold and top-k limit.
+    #[must_use]
+    pub fn new(min_score: f32, max_results: usize) -> Self {
+        Self {
+            min_score,
+            max_results: Some(max_results),
+        }
+    }
+}
+
+#[async_trait]
+impl Reranker for ScoreReranker {
+    async fn rerank(
+        &self,
+        _query: &str,
+        mut docs: Vec<ScoredDocument>,
+    ) -> AgentResult<Vec<ScoredDocument>> {
+        // Filter by minimum score
+        docs.retain(|d| d.score >= self.min_score);
+
+        // Sort by score descending, with deterministic tie-breaker on document.id
+        docs.sort_by(|a, b| {
+            match b.score.partial_cmp(&a.score) {
+                Some(ordering) if ordering != std::cmp::Ordering::Equal => ordering,
+                _ => a.document.id.cmp(&b.document.id),
+            }
+        });
+
+        // Apply top-k limit
+        if let Some(max) = self.max_results {
+            docs.truncate(max);
+        }
+
+        Ok(docs)
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mofa_kernel::rag::{Document, ScoredDocument};
+
+    fn make_doc(id: &str, score: f32) -> ScoredDocument {
+        ScoredDocument::new(Document::new(id, format!("content of {id}")), score, None)
+    }
+
+    #[tokio::test]
+    async fn filters_by_threshold() {
+        let reranker = ScoreReranker::with_threshold(0.5);
+        let docs = vec![
+            make_doc("a", 0.9),
+            make_doc("b", 0.3),
+            make_doc("c", 0.7),
+            make_doc("d", 0.1),
+        ];
+        let result = reranker.rerank("query", docs).await.unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].document.id, "a");
+        assert_eq!(result[1].document.id, "c");
+    }
+
+    #[tokio::test]
+    async fn sorts_by_score_descending() {
+        let reranker = ScoreReranker::default();
+        let docs = vec![
+            make_doc("a", 0.3),
+            make_doc("b", 0.9),
+            make_doc("c", 0.6),
+        ];
+        let result = reranker.rerank("query", docs).await.unwrap();
+        assert_eq!(result[0].document.id, "b");
+        assert_eq!(result[1].document.id, "c");
+        assert_eq!(result[2].document.id, "a");
+    }
+
+    #[tokio::test]
+    async fn limits_top_k() {
+        let reranker = ScoreReranker::new(0.0, 2);
+        let docs = vec![
+            make_doc("a", 0.9),
+            make_doc("b", 0.7),
+            make_doc("c", 0.5),
+            make_doc("d", 0.3),
+        ];
+        let result = reranker.rerank("query", docs).await.unwrap();
+        assert_eq!(result.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn threshold_and_top_k_combined() {
+        let reranker = ScoreReranker::new(0.4, 2);
+        let docs = vec![
+            make_doc("a", 0.9),
+            make_doc("b", 0.7),
+            make_doc("c", 0.5),
+            make_doc("d", 0.3),
+        ];
+        let result = reranker.rerank("query", docs).await.unwrap();
+        // d is filtered by threshold (0.3 < 0.4), then sorted to [a, b, c] and top-2 are taken
+        assert_eq!(result.len(), 2);
+        assert!(result.iter().all(|d| d.score >= 0.4));
+    }
+
+    #[tokio::test]
+    async fn empty_input() {
+        let reranker = ScoreReranker::default();
+        let result = reranker.rerank("query", vec![]).await.unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn all_filtered_out() {
+        let reranker = ScoreReranker::with_threshold(0.99);
+        let docs = vec![
+            make_doc("a", 0.5),
+            make_doc("b", 0.3),
+        ];
+        let result = reranker.rerank("query", docs).await.unwrap();
+        assert!(result.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Add document loading, advanced chunking, and score-based reranking to the RAG pipeline in `mofa-foundation`.

<img width="458" height="757" alt="image" src="https://github.com/user-attachments/assets/efa5e055-889a-41cc-9bf7-cd4b108be14f" />


**807 additions | 4 files | 26 tests (all passing)**

Builds on existing RAG kernel traits (`Retriever`, `Reranker`, `VectorStore`) and foundation implementations (`InMemoryVectorStore`, `TextChunker`, `QdrantVectorStore`).

## New Components

### Document Loaders (`loaders.rs`)
- **`DocumentLoader` trait** — extensible contract for loading documents from any source
- **`TextLoader`** — loads plain text files into `Document` with source metadata
- **`MarkdownLoader`** — heading-aware section splitting:
  - Configurable split level (split at `#`, `##`, `###`, etc.)
  - Preserves heading text, section index, and source path in metadata
  - Each section becomes a separate `Document` for fine-grained retrieval
- **`LoaderError`** — typed errors for IO, unsupported formats, empty documents

### Recursive Chunker (`recursive_chunker.rs`)
- **`RecursiveChunker`** — separator-hierarchy text splitting (inspired by LangChain):
  - Default separator hierarchy: `\n\n` → `\n` → `. ` → `, ` → ` `
  - Tries the most meaningful separator first, falls back progressively
  - Configurable chunk_size, overlap, and custom separators
  - Hard character-split fallback when no separators work
  - Produces higher-quality chunks than fixed-size splitting

### Score Reranker (`score_reranker.rs`)
- **`ScoreReranker`** — implements kernel `Reranker` trait:
  - Minimum score threshold filtering (drops low-relevance results)
  - Top-k result limiting
  - Score-descending sort
  - Composable with existing `IdentityReranker`

## Test Coverage

```
loaders:            12 tests ✅ (text + markdown + heading parser + edge cases)
recursive_chunker:   8 tests ✅ (boundary types, custom separators, content preservation)
score_reranker:      6 tests ✅ (threshold, top-k, combined, edge cases)
Total:              26 tests, 0 failures
```

## Phase 2 Preview (Future PRs)
- Embedding adapter for connecting to external embedding APIs
- Metadata-filtered retrieval
- Hybrid retrieval (dense + sparse)

## Related

- Closes #722
- Builds upon existing kernel RAG traits (VectorStore, Retriever, Reranker, Generator)
- Foundation for Idea 2 (Cognitive Observatory) document ingestion