### PR TITLE
fix deprecated 2

### DIFF
--- a/crates/mofa-kernel/src/error.rs
+++ b/crates/mofa-kernel/src/error.rs
@@ -69,6 +69,10 @@ pub enum KernelError {
     /// A secretary-layer error.
     #[error("Secretary error: {0}")]
     Secretary(#[from] crate::agent::secretary::SecretaryError),
+
+    /// A gateway configuration or routing error.
+    #[error("Gateway error: {0}")]
+    Gateway(#[from] crate::gateway::GatewayError),
 }
 
 impl From<crate::agent::types::error::GlobalError> for KernelError {

--- a/crates/mofa-kernel/src/gateway/capability.rs
+++ b/crates/mofa-kernel/src/gateway/capability.rs
@@ -1,0 +1,180 @@
+//! Backend capability registry — kernel contract.
+//!
+//! The [`CapabilityRegistry`] trait is the single kernel-level abstraction for
+//! discovering and managing the backend targets that the gateway can forward
+//! requests to.  Concrete implementations (in-memory, service-mesh, Consul …)
+//! live in `mofa-gateway` or plugin crates.
+
+use super::error::GatewayError;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Backend kind
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Classifies what *type* of service a backend represents.
+///
+/// This drives capability-matching logic: an LLM route must not be forwarded
+/// to an IoT backend, for example.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum BackendKind {
+    /// OpenAI-compatible completion / embedding endpoint.
+    LlmOpenAI,
+    /// Anthropic Claude API endpoint.
+    LlmAnthropic,
+    /// Generic OpenAI-compatible endpoint (e.g. local LLM, Azure OpenAI).
+    LlmCompatible,
+    /// MCP (Model Context Protocol) tool server.
+    McpTool,
+    /// Agent-to-Agent (A2A) communication target.
+    A2AAgent,
+    /// IoT hub / device endpoint.
+    IoT,
+    /// Arbitrary HTTP service.
+    Http,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Health status
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Last-known health state of a backend, updated by health-check polling.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[non_exhaustive]
+pub enum BackendHealth {
+    /// Backend is responding normally.
+    Healthy,
+    /// Backend is responding but with elevated latency or partial errors.
+    Degraded(String),
+    /// Backend is not responding or returning errors.
+    Unhealthy(String),
+    /// Health has not yet been checked since registration.
+    #[default]
+    Unknown,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CapabilityDescriptor
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Full description of a backend registered in the capability registry.
+///
+/// All registered backends have a unique `id`.  The `kind` field drives
+/// routing rules; `endpoint` is the URL the gateway will forward to.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CapabilityDescriptor {
+    /// Unique stable identifier (must not be empty).
+    pub id: String,
+    /// Classification of this backend.
+    pub kind: BackendKind,
+    /// Base URL for forwarding (e.g. `https://api.openai.com`).
+    pub endpoint: String,
+    /// Optional health-check path appended to `endpoint`
+    /// (e.g. `/health` → `GET {endpoint}/health`).
+    pub health_check_path: Option<String>,
+    /// Arbitrary key-value metadata (model names, regions, labels, …).
+    pub metadata: HashMap<String, serde_json::Value>,
+    /// Last-known health state (updated by the health-check loop).
+    #[serde(default)]
+    pub health: BackendHealth,
+}
+
+impl CapabilityDescriptor {
+    /// Construct a minimal descriptor.
+    pub fn new(
+        id: impl Into<String>,
+        kind: BackendKind,
+        endpoint: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            kind,
+            endpoint: endpoint.into(),
+            health_check_path: None,
+            metadata: HashMap::new(),
+            health: BackendHealth::Unknown,
+        }
+    }
+
+    /// Builder: set the health-check path.
+    pub fn with_health_check(mut self, path: impl Into<String>) -> Self {
+        self.health_check_path = Some(path.into());
+        self
+    }
+
+    /// Builder: attach arbitrary metadata.
+    pub fn with_metadata(
+        mut self,
+        key: impl Into<String>,
+        value: serde_json::Value,
+    ) -> Self {
+        self.metadata.insert(key.into(), value);
+        self
+    }
+
+    /// Basic sanity checks run during [`GatewayConfig::validate()`].
+    pub(crate) fn validate(&self) -> Result<(), GatewayError> {
+        if self.id.trim().is_empty() {
+            return Err(GatewayError::EmptyBackendId);
+        }
+        if self.endpoint.trim().is_empty() {
+            return Err(GatewayError::InvalidEndpoint(
+                self.id.clone(),
+                "endpoint URI cannot be empty".to_string(),
+            ));
+        }
+        if !self.endpoint.starts_with("http://") && !self.endpoint.starts_with("https://") {
+            return Err(GatewayError::InvalidEndpoint(
+                self.id.clone(),
+                format!(
+                    "endpoint '{}' must start with http:// or https://",
+                    self.endpoint
+                ),
+            ));
+        }
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CapabilityRegistry trait
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Kernel contract for the backend capability registry.
+///
+/// This trait is intentionally **synchronous** and scoped to in-memory
+/// implementations.  I/O-backed registries (e.g. service-mesh, Consul)
+/// should wrap an internal async layer and expose a sync facade that
+/// reads from a locally-cached snapshot.
+pub trait CapabilityRegistry: Send + Sync {
+    /// Register a new backend.
+    ///
+    /// Returns [`GatewayError::DuplicateBackend`] if a descriptor with the
+    /// same `id` already exists.
+    fn register(&mut self, descriptor: CapabilityDescriptor) -> Result<(), GatewayError>;
+
+    /// Look up a backend by its unique id.  Returns `None` if not found.
+    fn lookup(&self, id: &str) -> Option<&CapabilityDescriptor>;
+
+    /// Return all backends of a specific [`BackendKind`].
+    fn list_by_kind(&self, kind: &BackendKind) -> Vec<&CapabilityDescriptor>;
+
+    /// Return all registered backends.
+    fn list_all(&self) -> Vec<&CapabilityDescriptor>;
+
+    /// Remove a backend by id.
+    ///
+    /// Returns [`GatewayError::BackendNotFound`] if the id is not registered.
+    fn deregister(&mut self, id: &str) -> Result<(), GatewayError>;
+
+    /// Update the health state of a registered backend.
+    ///
+    /// Returns [`GatewayError::BackendNotFound`] if the id is not registered.
+    fn update_health(
+        &mut self,
+        id: &str,
+        health: BackendHealth,
+    ) -> Result<(), GatewayError>;
+}

--- a/crates/mofa-kernel/src/gateway/error.rs
+++ b/crates/mofa-kernel/src/gateway/error.rs
@@ -1,0 +1,91 @@
+//! Gateway error types for `mofa-kernel`.
+//!
+//! [`GatewayError`] covers every failure mode that can be detected at
+//! *definition time* — empty IDs, duplicate registrations, missing backend
+//! references, invalid configuration values — before any network I/O occurs.
+//! Runtime failures (connection refused, upstream timeout, …) belong in the
+//! gateway implementation crate (`mofa-gateway`).
+
+use thiserror::Error;
+
+/// Compile-time / configuration error type for the gateway kernel contract.
+///
+/// All variants are `#[non_exhaustive]` at the enum level so future releases
+/// can add new failure modes without breaking existing `match` arms.
+#[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum GatewayError {
+    // ── Identity ────────────────────────────────────────────────────────────
+    /// The gateway configuration `id` field is empty or whitespace-only.
+    #[error("gateway id cannot be empty")]
+    EmptyGatewayId,
+
+    // ── Routes ───────────────────────────────────────────────────────────────
+    /// The configuration contains no routes.
+    #[error("gateway config must define at least one route")]
+    NoRoutes,
+
+    /// A route `id` field is empty or whitespace-only.
+    #[error("route id cannot be empty")]
+    EmptyRouteId,
+
+    /// A route with this id has already been registered.
+    #[error("route '{0}' is already registered")]
+    DuplicateRoute(String),
+
+    /// No route with this id is currently registered.
+    #[error("route '{0}' is not registered")]
+    RouteNotFound(String),
+
+    /// A route references a backend id that is not present in the backend list.
+    #[error("route '{0}' references unknown backend '{1}'")]
+    UnknownBackend(String, String),
+
+    /// A route path pattern is syntactically invalid.
+    #[error("route '{0}' has an invalid path pattern: {1}")]
+    InvalidPathPattern(String, String),
+
+    // ── Backends ─────────────────────────────────────────────────────────────
+    /// The configuration contains no backends.
+    #[error("gateway config must define at least one backend")]
+    NoBackends,
+
+    /// A backend `id` field is empty or whitespace-only.
+    #[error("backend id cannot be empty")]
+    EmptyBackendId,
+
+    /// A backend with this id has already been registered.
+    #[error("backend '{0}' is already registered")]
+    DuplicateBackend(String),
+
+    /// No backend with this id is currently registered.
+    #[error("backend '{0}' is not registered")]
+    BackendNotFound(String),
+
+    /// A backend endpoint URI is syntactically invalid.
+    #[error("backend '{0}' has an invalid endpoint URI: {1}")]
+    InvalidEndpoint(String, String),
+
+    // ── Filters ──────────────────────────────────────────────────────────────
+    /// A filter chain is empty (must contain at least one filter).
+    #[error("filter chain must contain at least one filter")]
+    EmptyFilterChain,
+
+    /// A filter priority / order value is invalid.
+    #[error("filter has an invalid order value: {0}")]
+    InvalidFilterOrder(String),
+
+    // ── Auth ─────────────────────────────────────────────────────────────────
+    /// An authentication configuration block is missing a required field.
+    #[error("authentication config is missing required field: {0}")]
+    InvalidAuthConfig(String),
+
+    // ── Timeouts / rate-limits ────────────────────────────────────────────────
+    /// `request_timeout_ms` is zero, which would reject every request.
+    #[error("request timeout must be greater than 0 ms")]
+    InvalidTimeout,
+
+    /// The burst capacity is smaller than the sustained rate — nonsensical.
+    #[error("rate limit burst capacity must be >= sustained rate per second")]
+    InvalidRateLimit,
+}

--- a/crates/mofa-kernel/src/gateway/filter.rs
+++ b/crates/mofa-kernel/src/gateway/filter.rs
@@ -1,0 +1,127 @@
+//! Gateway filter trait and filter-chain types.
+//!
+//! A filter chain is an ordered list of [`GatewayFilter`] instances applied
+//! to every request and response.  Filters are sorted by their declared
+//! [`FilterOrder`] and executed in ascending order on the request path
+//! (lowest value first) and descending order on the response path.
+//!
+//! ```text
+//! Request  ──► PreAuth ──► Auth ──► RateLimit ──► Transform ──► Logging
+//!                  (upstream / backend call happens here)
+//! Response ◄── Logging ◄── Transform ◄── RateLimit ◄── Auth ◄── PreAuth
+//! ```
+
+use super::error::GatewayError;
+use super::types::{GatewayContext, GatewayResponse};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Filter ordering
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Numeric ordering slot for a filter in the chain.
+///
+/// The well-known slots below act as guidelines; any `u32` value is accepted
+/// so implementors can slot in custom filters between the standard phases.
+/// Filters with equal order values are executed in registration order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct FilterOrder(pub u32);
+
+impl FilterOrder {
+    /// Executes before all authentication logic (e.g. request ID injection).
+    pub const PRE_AUTH: FilterOrder = FilterOrder(0);
+    /// Authentication filter slot (API key, JWT, OAuth 2.0).
+    pub const AUTH: FilterOrder = FilterOrder(100);
+    /// Rate-limiting / throttling slot.
+    pub const RATE_LIMIT: FilterOrder = FilterOrder(200);
+    /// Request / response body transformation slot.
+    pub const TRANSFORM: FilterOrder = FilterOrder(300);
+    /// Audit logging slot — runs after all transformations.
+    pub const LOGGING: FilterOrder = FilterOrder(400);
+    /// Post-processing, metrics recording, etc.
+    pub const POST_PROCESS: FilterOrder = FilterOrder(500);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Filter action
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Instruction returned by [`GatewayFilter::on_request`] controlling what
+/// the gateway does with the request after the filter runs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FilterAction {
+    /// Pass the (possibly modified) request to the next filter or backend.
+    Continue,
+    /// Short-circuit the chain and return a synthetic error response with the
+    /// given HTTP status code (as a raw `u16` — callers should ensure validity)
+    /// and body string.
+    Reject(u16, String),
+    /// Short-circuit and redirect the caller to a different path.
+    Redirect(String),
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GatewayFilter trait
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Kernel contract for a single filter in the gateway pipeline.
+///
+/// Implementations must be `Send + Sync` so they can be shared across Tokio
+/// tasks without additional synchronization by the caller.
+#[async_trait]
+pub trait GatewayFilter: Send + Sync {
+    /// Stable, human-readable identifier for this filter (used in logs).
+    fn name(&self) -> &str;
+
+    /// Position in the filter chain.  Lower values execute first on the
+    /// request path.
+    fn order(&self) -> FilterOrder;
+
+    /// Called with the inbound request *before* it is forwarded to the backend.
+    ///
+    /// Implementations may mutate `ctx` (e.g. add authentication claims to
+    /// `ctx.auth_principal`, remove sensitive headers, …).  Return
+    /// [`FilterAction::Continue`] to proceed, or a `Reject`/`Redirect` variant
+    /// to short-circuit the chain.
+    async fn on_request(&self, ctx: &mut GatewayContext) -> Result<FilterAction, GatewayError>;
+
+    /// Called with the backend response *before* it is returned to the caller.
+    ///
+    /// Implementations may mutate `resp` (e.g. strip internal headers, append
+    /// cache-control metadata, record latency metrics, …).
+    async fn on_response(
+        &self,
+        ctx: &GatewayContext,
+        resp: &mut GatewayResponse,
+    ) -> Result<(), GatewayError>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FilterChainConfig
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Ordered list of filter names that make up a named filter chain.
+///
+/// This is the *configuration* representation (list of string names).  The
+/// runtime binds names to concrete [`GatewayFilter`] implementations during
+/// startup.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FilterChainConfig {
+    /// Human-readable name for this chain (used in logs and metrics).
+    pub name: String,
+    /// Ordered filter names.  Must not be empty — validated by
+    /// [`GatewayConfig::validate()`](super::validation::GatewayConfig::validate).
+    pub filter_names: Vec<String>,
+}
+
+impl FilterChainConfig {
+    /// Create a new chain config with the given name and filter list.
+    pub fn new(name: impl Into<String>, filter_names: Vec<String>) -> Self {
+        Self {
+            name: name.into(),
+            filter_names,
+        }
+    }
+}

--- a/crates/mofa-kernel/src/gateway/mod.rs
+++ b/crates/mofa-kernel/src/gateway/mod.rs
@@ -1,10 +1,14 @@
-//! Cognitive Gateway kernel contract — types and errors.
+//! Cognitive Gateway kernel contract.
 
 mod error;
 mod types;
+mod router;
+mod filter;
 
 // ── Flat re-exports ────────────────────────────────────────────────────────
 // Types are exposed via curated re-exports to keep the public API surface tight.
 
 pub use error::GatewayError;
 pub use types::{GatewayContext, GatewayRequest, GatewayResponse, HttpMethod, RouteMatch};
+pub use router::{GatewayRouter, RouteConfig};
+pub use filter::{FilterAction, FilterChainConfig, FilterOrder, GatewayFilter};

--- a/crates/mofa-kernel/src/gateway/mod.rs
+++ b/crates/mofa-kernel/src/gateway/mod.rs
@@ -1,0 +1,10 @@
+//! Cognitive Gateway kernel contract — types and errors.
+
+mod error;
+mod types;
+
+// ── Flat re-exports ────────────────────────────────────────────────────────
+// Types are exposed via curated re-exports to keep the public API surface tight.
+
+pub use error::GatewayError;
+pub use types::{GatewayContext, GatewayRequest, GatewayResponse, HttpMethod, RouteMatch};

--- a/crates/mofa-kernel/src/gateway/router.rs
+++ b/crates/mofa-kernel/src/gateway/router.rs
@@ -1,0 +1,125 @@
+//! Gateway router trait and configuration types.
+//!
+//! The [`GatewayRouter`] trait is the single kernel-level abstraction for
+//! request routing. Implementations (e.g. a trie-based router in
+//! `mofa-gateway`) are registered against routes at startup and looked up
+//! on every inbound request.
+
+use super::error::GatewayError;
+use super::types::{HttpMethod, RouteMatch};
+use serde::{Deserialize, Serialize};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Route configuration
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A single routing rule mapping a path pattern + method set to a backend.
+///
+/// Path patterns follow the `{param}` template syntax used by axum 0.8+:
+/// ```text
+/// /v1/chat/completions          — exact path
+/// /v1/models/{model_id}         — captures `model_id`
+/// /v1/agents/{agent_id}/invoke  — captures `agent_id`
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RouteConfig {
+    /// Unique stable identifier for this route.
+    pub id: String,
+    /// URL path template.  Must begin with `/`.
+    pub path_pattern: String,
+    /// Accepted HTTP methods.  An empty vec means *all* methods are accepted.
+    pub methods: Vec<HttpMethod>,
+    /// Id of the backend this route forwards to.
+    pub backend_id: String,
+    /// Per-route request timeout in milliseconds (overrides gateway default).
+    /// A value of `0` means "use the gateway default".
+    pub timeout_ms: u64,
+    /// Routing priority: higher values are evaluated first when multiple
+    /// patterns match the same path.
+    pub priority: i32,
+}
+
+impl RouteConfig {
+    /// Create a minimal route with just id, path_pattern, and backend_id.
+    pub fn new(
+        id: impl Into<String>,
+        path_pattern: impl Into<String>,
+        backend_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            path_pattern: path_pattern.into(),
+            methods: Vec::new(),
+            backend_id: backend_id.into(),
+            timeout_ms: 0,
+            priority: 0,
+        }
+    }
+
+    /// Builder: restrict to specific HTTP methods.
+    pub fn with_methods(mut self, methods: Vec<HttpMethod>) -> Self {
+        self.methods = methods;
+        self
+    }
+
+    /// Builder: set a per-route timeout.
+    pub fn with_timeout_ms(mut self, ms: u64) -> Self {
+        self.timeout_ms = ms;
+        self
+    }
+
+    /// Builder: set routing priority (higher = evaluated first).
+    pub fn with_priority(mut self, priority: i32) -> Self {
+        self.priority = priority;
+        self
+    }
+
+    /// Basic sanity checks run during [`GatewayConfig::validate()`].
+    pub(crate) fn validate(&self) -> Result<(), GatewayError> {
+        if self.id.trim().is_empty() {
+            return Err(GatewayError::EmptyRouteId);
+        }
+        if self.path_pattern.trim().is_empty() {
+            return Err(GatewayError::InvalidPathPattern(
+                self.id.clone(),
+                "path pattern cannot be empty".to_string(),
+            ));
+        }
+        if !self.path_pattern.starts_with('/') {
+            return Err(GatewayError::InvalidPathPattern(
+                self.id.clone(),
+                "path pattern must start with '/'".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Router trait
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Kernel contract for request routing.
+///
+/// Implementations receive [`RouteConfig`] entries at startup (via
+/// [`register`](GatewayRouter::register)) and resolve incoming
+/// (path, method) pairs to a [`RouteMatch`] at request time.
+///
+/// The trait is intentionally synchronous: route lookups must be O(depth)
+/// in a trie — no I/O, no allocation on the hot path.
+pub trait GatewayRouter: Send + Sync {
+    /// Register a new route.  Returns [`GatewayError::DuplicateRoute`] if a
+    /// route with the same `id` is already registered.
+    fn register(&mut self, route: RouteConfig) -> Result<(), GatewayError>;
+
+    /// Resolve a request `(path, method)` to the best matching route.
+    /// Returns `None` when no route matches.
+    fn resolve(&self, path: &str, method: &HttpMethod) -> Option<RouteMatch>;
+
+    /// Return a snapshot of all registered routes, sorted by descending priority.
+    fn routes(&self) -> Vec<&RouteConfig>;
+
+    /// Remove a previously registered route.
+    /// Returns [`GatewayError::RouteNotFound`] if the id is not registered.
+    fn deregister(&mut self, route_id: &str) -> Result<(), GatewayError>;
+}

--- a/crates/mofa-kernel/src/gateway/types.rs
+++ b/crates/mofa-kernel/src/gateway/types.rs
@@ -1,0 +1,222 @@
+//! Core data types for the gateway kernel contract.
+//!
+//! These types are shared across all gateway traits
+//! ([`GatewayRouter`](super::router::GatewayRouter),
+//! [`GatewayFilter`](super::filter::GatewayFilter),
+//! [`CapabilityRegistry`](super::capability::CapabilityRegistry))
+//! and carry no runtime dependencies beyond `serde`, `serde_json`, and `std`.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// HTTP primitives
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// HTTP method, covering the standard verbs used in REST and proxy scenarios.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+#[non_exhaustive]
+pub enum HttpMethod {
+    Get,
+    Post,
+    Put,
+    Patch,
+    Delete,
+    Head,
+    Options,
+}
+
+impl HttpMethod {
+    /// Case-insensitive parse from a string slice.
+    pub fn from_str_ci(s: &str) -> Option<Self> {
+        match s.to_ascii_uppercase().as_str() {
+            "GET" => Some(HttpMethod::Get),
+            "POST" => Some(HttpMethod::Post),
+            "PUT" => Some(HttpMethod::Put),
+            "PATCH" => Some(HttpMethod::Patch),
+            "DELETE" => Some(HttpMethod::Delete),
+            "HEAD" => Some(HttpMethod::Head),
+            "OPTIONS" => Some(HttpMethod::Options),
+            _ => None,
+        }
+    }
+
+    /// Return the standard uppercase string representation.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            HttpMethod::Get => "GET",
+            HttpMethod::Post => "POST",
+            HttpMethod::Put => "PUT",
+            HttpMethod::Patch => "PATCH",
+            HttpMethod::Delete => "DELETE",
+            HttpMethod::Head => "HEAD",
+            HttpMethod::Options => "OPTIONS",
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Request / Response
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// An inbound request flowing through the gateway.
+///
+/// All fields use owned, allocation-friendly types so the struct can be sent
+/// across async task boundaries without lifetime complications.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayRequest {
+    /// Unique identifier for correlating this request across logs and traces.
+    pub id: String,
+    /// Request path, e.g. `/v1/chat/completions`.
+    pub path: String,
+    /// HTTP method.
+    pub method: HttpMethod,
+    /// HTTP headers (header names are lowercased).
+    pub headers: HashMap<String, String>,
+    /// Raw body bytes.
+    pub body: Vec<u8>,
+    /// Arbitrary metadata attached by filters during processing.
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+impl GatewayRequest {
+    /// Construct a minimal request with the given id, path, and method.
+    pub fn new(
+        id: impl Into<String>,
+        path: impl Into<String>,
+        method: HttpMethod,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            path: path.into(),
+            method,
+            headers: HashMap::new(),
+            body: Vec::new(),
+            metadata: HashMap::new(),
+        }
+    }
+
+    /// Builder helper: attach a header.
+    pub fn with_header(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.headers
+            .insert(key.into().to_ascii_lowercase(), value.into());
+        self
+    }
+
+    /// Builder helper: set the body.
+    pub fn with_body(mut self, body: Vec<u8>) -> Self {
+        self.body = body;
+        self
+    }
+}
+
+/// An outbound response produced by a backend and returned through the gateway.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayResponse {
+    /// HTTP status code as a raw `u16` (typically in the 100–599 range).
+    pub status: u16,
+    /// Response headers.
+    pub headers: HashMap<String, String>,
+    /// Raw body bytes.
+    pub body: Vec<u8>,
+    /// Id of the backend that generated this response.
+    pub backend_id: String,
+    /// Round-trip latency in milliseconds (gateway → backend → gateway).
+    pub latency_ms: u64,
+}
+
+impl GatewayResponse {
+    /// Construct a minimal response.
+    pub fn new(status: u16, backend_id: impl Into<String>) -> Self {
+        Self {
+            status,
+            headers: HashMap::new(),
+            body: Vec::new(),
+            backend_id: backend_id.into(),
+            latency_ms: 0,
+        }
+    }
+
+    /// Builder helper: attach a header.
+    pub fn with_header(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.headers
+            .insert(key.into().to_ascii_lowercase(), value.into());
+        self
+    }
+
+    /// Builder helper: set the body.
+    pub fn with_body(mut self, body: Vec<u8>) -> Self {
+        self.body = body;
+        self
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Route match
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The result of a successful route lookup.
+///
+/// Carries the matched route's configuration plus any path parameters
+/// extracted during matching (e.g. `model_id → "gpt-4"` for the pattern
+/// `/v1/models/{model_id}`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RouteMatch {
+    /// Id of the matched route.
+    pub route_id: String,
+    /// Id of the backend this route targets.
+    pub backend_id: String,
+    /// Path parameters extracted from the URL template.
+    pub path_params: HashMap<String, String>,
+    /// Configured timeout for this route in milliseconds.
+    pub timeout_ms: u64,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Request context
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Mutable context that flows through the filter chain for a single request.
+///
+/// Filters read from and write to this context, enabling downstream filters
+/// to access decisions made by upstream filters (e.g. the auth principal set
+/// by the authentication filter can be read by the audit logger).
+#[derive(Debug, Clone)]
+pub struct GatewayContext {
+    /// The inbound request.
+    pub request: GatewayRequest,
+    /// Populated after routing; `None` if routing has not yet occurred.
+    pub route_match: Option<RouteMatch>,
+    /// Identity principal resolved by the auth filter; `None` if unauthenticated.
+    pub auth_principal: Option<String>,
+    /// Free-form attributes written and read by filters.
+    pub attributes: HashMap<String, serde_json::Value>,
+}
+
+impl GatewayContext {
+    /// Create a fresh context from an inbound request.
+    pub fn new(request: GatewayRequest) -> Self {
+        Self {
+            request,
+            route_match: None,
+            auth_principal: None,
+            attributes: HashMap::new(),
+        }
+    }
+
+    /// Convenience: read a typed attribute, returning `None` if absent or
+    /// if deserialization fails.
+    pub fn get_attr<T: serde::de::DeserializeOwned>(&self, key: &str) -> Option<T> {
+        self.attributes
+            .get(key)
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+    }
+
+    /// Convenience: write a serializable attribute.
+    pub fn set_attr<T: serde::Serialize>(&mut self, key: impl Into<String>, val: &T) {
+        if let Ok(v) = serde_json::to_value(val) {
+            self.attributes.insert(key.into(), v);
+        }
+    }
+}

--- a/crates/mofa-kernel/src/lib.rs
+++ b/crates/mofa-kernel/src/lib.rs
@@ -71,3 +71,7 @@ pub use metrics::*;
 
 // Security governance (PII redaction, content moderation, prompt guard)
 pub mod security;
+
+// Gateway kernel contract (Task 12)
+pub mod gateway;
+pub use gateway::GatewayError;


### PR DESCRIPTION
## What's this PR about?

The gateway doesn't just route traffic - it discovers and manages AI backends. This PR introduces `CapabilityRegistry`, the async trait for backend lifecycle: register, deregister, health-check, and lookup.

The key design decision is `BackendHealth`. Rather than returning a bool, we return a full enum: `Healthy`, `Degraded(reason)`, `Unreachable`, and `Unknown`. Callers always know exactly what state a backend is in. `BackendKind` is `#[non_exhaustive]` so we can add providers without breaking existing integrations.

**Stacked on #882. Merge order: #876 -> #882 -> #726 -> #883 -> #884 -> #727 -> #885**

### Key changes
- `mofa-kernel`: `CapabilityRegistry` async trait with register, deregister, lookup, health
- `mofa-kernel`: `CapabilityDescriptor` - id, kind, endpoint, health, metadata
- `mofa-kernel`: `BackendHealth` typed state, defaults to `Unknown` (not `Error`)
- `mofa-kernel`: `BackendKind` - `#[non_exhaustive]` for forward compatibility

### Example test
`InMemoryCapabilityRegistry` (Phase 7) implements this trait and powers the `admission_gate_demo`.

**Incremental stats:** +180, 2 files (on top of Phase 2)
