### PR TITLE
fix deprecated

### DIFF
--- a/crates/mofa-gateway/src/filter/auth.rs
+++ b/crates/mofa-gateway/src/filter/auth.rs
@@ -1,0 +1,151 @@
+//! API-key authentication filter.
+//!
+//! Accepts requests that carry a valid API key in either:
+//! - `Authorization: Bearer <key>` header
+//! - `X-Api-Key: <key>` header
+//!
+//! Requests without a valid key receive a `401 Unauthorized` response.
+
+use async_trait::async_trait;
+use mofa_kernel::gateway::{
+    FilterAction, FilterOrder, GatewayContext, GatewayError, GatewayFilter, GatewayResponse,
+};
+use std::collections::HashSet;
+use tracing::warn;
+
+/// Authentication filter that enforces API key validation.
+pub struct ApiKeyFilter {
+    /// Set of valid API keys.
+    valid_keys: HashSet<String>,
+}
+
+impl ApiKeyFilter {
+    /// Build the filter from a list of valid keys.
+    pub fn new(valid_keys: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        Self {
+            valid_keys: valid_keys.into_iter().map(Into::into).collect(),
+        }
+    }
+
+    fn extract_key(ctx: &GatewayContext) -> Option<String> {
+        // Check `X-Api-Key` first (simpler, explicit).
+        if let Some(key) = ctx.request.headers.get("x-api-key") {
+            return Some(key.clone());
+        }
+        // Fall back to `Authorization: Bearer <key>`.
+        if let Some(key) = ctx
+            .request
+            .headers
+            .get("authorization")
+            .and_then(|auth| auth.strip_prefix("Bearer "))
+        {
+            return Some(key.to_string());
+        }
+        None
+    }
+}
+
+#[async_trait]
+impl GatewayFilter for ApiKeyFilter {
+    fn name(&self) -> &str {
+        "api-key-auth"
+    }
+
+    fn order(&self) -> FilterOrder {
+        FilterOrder::AUTH
+    }
+
+    async fn on_request(&self, ctx: &mut GatewayContext) -> Result<FilterAction, GatewayError> {
+        match Self::extract_key(ctx) {
+            Some(key) if self.valid_keys.contains(&key) => {
+                // Store a non-sensitive truncated identifier, not the raw key,
+                // so it is safe to propagate into logs via LoggingFilter.
+                let truncated = format!(
+                    "{}…",
+                    key.chars().take(8).collect::<String>()
+                );
+                ctx.auth_principal = Some(truncated);
+                Ok(FilterAction::Continue)
+            }
+            Some(key) => {
+                warn!(request_id = %ctx.request.id, "rejected request: invalid API key");
+                // Redact the key in the rejection message.
+                let _ = key;
+                Ok(FilterAction::Reject(401, "Invalid API key".to_string()))
+            }
+            None => {
+                warn!(request_id = %ctx.request.id, "rejected request: missing API key");
+                Ok(FilterAction::Reject(
+                    401,
+                    "Missing authentication credentials".to_string(),
+                ))
+            }
+        }
+    }
+
+    async fn on_response(
+        &self,
+        _ctx: &GatewayContext,
+        _resp: &mut GatewayResponse,
+    ) -> Result<(), GatewayError> {
+        // Auth filter has nothing to do on the response path.
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mofa_kernel::gateway::{GatewayRequest, HttpMethod};
+
+    fn ctx(auth: Option<&str>, x_api: Option<&str>) -> GatewayContext {
+        let mut req = GatewayRequest::new("req-1", "/v1/chat", HttpMethod::Post);
+        if let Some(v) = auth {
+            req = req.with_header("authorization", v);
+        }
+        if let Some(v) = x_api {
+            req = req.with_header("x-api-key", v);
+        }
+        GatewayContext::new(req)
+    }
+
+    #[tokio::test]
+    async fn valid_bearer_token_passes() {
+        let filter = ApiKeyFilter::new(["secret-key-1"]);
+        let mut c = ctx(Some("Bearer secret-key-1"), None);
+        let action = filter.on_request(&mut c).await.unwrap();
+        assert_eq!(action, FilterAction::Continue);
+        // Principal should be truncated to first 8 chars to avoid logging secrets.
+        assert_eq!(c.auth_principal, Some("secret-k\u{2026}".to_string()));
+    }
+
+    #[tokio::test]
+    async fn valid_x_api_key_passes() {
+        let filter = ApiKeyFilter::new(["sk-abc"]);
+        let mut c = ctx(None, Some("sk-abc"));
+        let action = filter.on_request(&mut c).await.unwrap();
+        assert_eq!(action, FilterAction::Continue);
+        // Keys shorter than 8 chars are fully included before the ellipsis.
+        assert_eq!(c.auth_principal, Some("sk-abc\u{2026}".to_string()));
+    }
+
+    #[tokio::test]
+    async fn missing_key_returns_401() {
+        let filter = ApiKeyFilter::new(["sk-abc"]);
+        let mut c = ctx(None, None);
+        assert!(matches!(
+            filter.on_request(&mut c).await.unwrap(),
+            FilterAction::Reject(401, _)
+        ));
+    }
+
+    #[tokio::test]
+    async fn invalid_key_returns_401() {
+        let filter = ApiKeyFilter::new(["good-key"]);
+        let mut c = ctx(Some("Bearer bad-key"), None);
+        assert!(matches!(
+            filter.on_request(&mut c).await.unwrap(),
+            FilterAction::Reject(401, _)
+        ));
+    }
+}

--- a/crates/mofa-gateway/src/filter/logger.rs
+++ b/crates/mofa-gateway/src/filter/logger.rs
@@ -1,0 +1,89 @@
+//! Structured audit-logging filter.
+//!
+//! Emits `tracing` span events on both the request and response path,
+//! recording path, method, request id, auth principal, response status,
+//! backend, and round-trip latency.
+
+use async_trait::async_trait;
+use mofa_kernel::gateway::{
+    FilterAction, FilterOrder, GatewayContext, GatewayError, GatewayFilter, GatewayResponse,
+};
+use tracing::{error, info};
+
+/// Logging filter — records inbound requests and outbound responses.
+#[derive(Default)]
+pub struct LoggingFilter;
+
+impl LoggingFilter {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl GatewayFilter for LoggingFilter {
+    fn name(&self) -> &str {
+        "access-log"
+    }
+
+    fn order(&self) -> FilterOrder {
+        FilterOrder::LOGGING
+    }
+
+    async fn on_request(&self, ctx: &mut GatewayContext) -> Result<FilterAction, GatewayError> {
+        info!(
+            request_id  = %ctx.request.id,
+            method      = ctx.request.method.as_str(),
+            path        = %ctx.request.path,
+            principal   = ?ctx.auth_principal,
+            "→ inbound request"
+        );
+        // Record the start time for latency tracking on the response path.
+        ctx.set_attr("log.request_start_ms", now_ms());
+        Ok(FilterAction::Continue)
+    }
+
+    async fn on_response(
+        &self,
+        ctx: &GatewayContext,
+        resp: &mut GatewayResponse,
+    ) -> Result<(), GatewayError> {
+        let start_ms: u64 = ctx.get_attr("log.request_start_ms").unwrap_or(0);
+        let elapsed = now_ms().saturating_sub(start_ms);
+
+        if resp.status >= 500 {
+            error!(
+                request_id  = %ctx.request.id,
+                path        = %ctx.request.path,
+                status      = resp.status,
+                backend     = %resp.backend_id,
+                latency_ms  = elapsed,
+                "← upstream error response"
+            );
+        } else {
+            info!(
+                request_id  = %ctx.request.id,
+                path        = %ctx.request.path,
+                status      = resp.status,
+                backend     = %resp.backend_id,
+                latency_ms  = elapsed,
+                "← outbound response"
+            );
+        }
+
+        // Persist final latency in the response for upstream observability.
+        resp.latency_ms = elapsed;
+        Ok(())
+    }
+}
+
+fn now_ms() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    u64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis(),
+    )
+    .unwrap_or(u64::MAX)
+}

--- a/crates/mofa-gateway/src/filter/mod.rs
+++ b/crates/mofa-gateway/src/filter/mod.rs
@@ -1,0 +1,165 @@
+//! Filter pipeline module.
+//!
+//! Concrete filter implementations (auth, rate_limit, logger) are added
+//! in Phase 6 — this module provides the pipeline executor.
+
+use mofa_kernel::gateway::{FilterAction, GatewayContext, GatewayError, GatewayFilter, GatewayResponse};
+use std::sync::Arc;
+
+/// Ordered list of boxed filters executed as a pipeline.
+///
+/// Filters are sorted by [`FilterOrder`](mofa_kernel::gateway::FilterOrder) in
+/// ascending order (lowest value runs first on request path).
+pub struct FilterPipeline {
+    filters: Vec<Arc<dyn GatewayFilter>>,
+}
+
+impl FilterPipeline {
+    /// Build a pipeline from a list of filters, sorted by their declared order.
+    ///
+    /// `sort_by_key` is a **stable** sort (Rust stdlib guarantee), so filters
+    /// with equal [`FilterOrder`](mofa_kernel::gateway::FilterOrder) values
+    /// execute in the order they were passed to this constructor.
+    pub fn new(mut filters: Vec<Arc<dyn GatewayFilter>>) -> Self {
+        filters.sort_by_key(|f| f.order());
+        Self { filters }
+    }
+
+    /// Run all filters' `on_request` hooks in ascending order.
+    ///
+    /// Returns `Ok(FilterAction::Continue)` if all filters continue.
+    /// Short-circuits on the first `Reject` or `Redirect` action.
+    pub async fn run_request(
+        &self,
+        ctx: &mut GatewayContext,
+    ) -> Result<FilterAction, GatewayError> {
+        for filter in &self.filters {
+            match filter.on_request(ctx).await? {
+                FilterAction::Continue => {}
+                other => return Ok(other),
+            }
+        }
+        Ok(FilterAction::Continue)
+    }
+
+    /// Run all filters' `on_response` hooks in descending order
+    /// (outermost filter last, so it can finalize latency, etc.).
+    pub async fn run_response(
+        &self,
+        ctx: &GatewayContext,
+        resp: &mut GatewayResponse,
+    ) -> Result<(), GatewayError> {
+        for filter in self.filters.iter().rev() {
+            filter.on_response(ctx, resp).await?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use mofa_kernel::gateway::{
+        FilterOrder, GatewayRequest, GatewayResponse, HttpMethod,
+    };
+    use std::sync::{Arc, Mutex as StdMutex};
+
+    // A minimal filter that records which hooks were called and returns a
+    // configurable action on the request path.
+    struct RecordingFilter {
+        label: &'static str,
+        order: FilterOrder,
+        request_action: FilterAction,
+        log: Arc<StdMutex<Vec<String>>>,
+    }
+
+    #[async_trait]
+    impl GatewayFilter for RecordingFilter {
+        fn name(&self) -> &str {
+            self.label
+        }
+        fn order(&self) -> FilterOrder {
+            self.order
+        }
+        async fn on_request(
+            &self,
+            _ctx: &mut GatewayContext,
+        ) -> Result<FilterAction, GatewayError> {
+            self.log.lock().unwrap().push(format!("req:{}", self.label));
+            Ok(self.request_action.clone())
+        }
+        async fn on_response(
+            &self,
+            _ctx: &GatewayContext,
+            _resp: &mut GatewayResponse,
+        ) -> Result<(), GatewayError> {
+            self.log.lock().unwrap().push(format!("resp:{}", self.label));
+            Ok(())
+        }
+    }
+
+    fn ctx() -> GatewayContext {
+        GatewayContext::new(GatewayRequest::new("t", "/test", HttpMethod::Get))
+    }
+
+    fn filter(
+        label: &'static str,
+        order: FilterOrder,
+        action: FilterAction,
+        log: Arc<StdMutex<Vec<String>>>,
+    ) -> Arc<dyn GatewayFilter> {
+        Arc::new(RecordingFilter { label, order, request_action: action, log })
+    }
+
+    /// Filters are executed in ascending FilterOrder on the request path.
+    #[tokio::test]
+    async fn request_runs_in_ascending_order() {
+        let log = Arc::new(StdMutex::new(Vec::new()));
+        let pipeline = FilterPipeline::new(vec![
+            filter("high", FilterOrder::LOGGING, FilterAction::Continue, Arc::clone(&log)),
+            filter("low", FilterOrder::PRE_AUTH, FilterAction::Continue, Arc::clone(&log)),
+        ]);
+        pipeline.run_request(&mut ctx()).await.unwrap();
+        assert_eq!(*log.lock().unwrap(), ["req:low", "req:high"]);
+    }
+
+    /// Pipeline short-circuits on the first Reject — subsequent filters are skipped.
+    #[tokio::test]
+    async fn short_circuits_on_reject() {
+        let log = Arc::new(StdMutex::new(Vec::new()));
+        let pipeline = FilterPipeline::new(vec![
+            filter("A", FilterOrder::PRE_AUTH, FilterAction::Reject(403, "blocked".into()), Arc::clone(&log)),
+            filter("B", FilterOrder::AUTH, FilterAction::Continue, Arc::clone(&log)),
+        ]);
+        let result = pipeline.run_request(&mut ctx()).await.unwrap();
+        assert!(matches!(result, FilterAction::Reject(403, _)));
+        assert_eq!(*log.lock().unwrap(), ["req:A"]); // B was never called
+    }
+
+    /// on_response hooks run in reverse order (outermost first, like middleware unwinding).
+    #[tokio::test]
+    async fn response_runs_in_reverse_order() {
+        let log = Arc::new(StdMutex::new(Vec::new()));
+        let pipeline = FilterPipeline::new(vec![
+            filter("first", FilterOrder::PRE_AUTH, FilterAction::Continue, Arc::clone(&log)),
+            filter("second", FilterOrder::AUTH, FilterAction::Continue, Arc::clone(&log)),
+        ]);
+        let mut resp = GatewayResponse::new(200, "test");
+        pipeline.run_response(&ctx(), &mut resp).await.unwrap();
+        assert_eq!(*log.lock().unwrap(), ["resp:second", "resp:first"]);
+    }
+
+    /// Filters with equal order preserve insertion (registration) order — stable sort.
+    #[tokio::test]
+    async fn equal_order_preserves_insertion_order() {
+        let log = Arc::new(StdMutex::new(Vec::new()));
+        let pipeline = FilterPipeline::new(vec![
+            filter("X", FilterOrder::AUTH, FilterAction::Continue, Arc::clone(&log)),
+            filter("Y", FilterOrder::AUTH, FilterAction::Continue, Arc::clone(&log)),
+            filter("Z", FilterOrder::AUTH, FilterAction::Continue, Arc::clone(&log)),
+        ]);
+        pipeline.run_request(&mut ctx()).await.unwrap();
+        assert_eq!(*log.lock().unwrap(), ["req:X", "req:Y", "req:Z"]);
+    }
+}

--- a/crates/mofa-gateway/src/filter/mod.rs
+++ b/crates/mofa-gateway/src/filter/mod.rs
@@ -1,7 +1,12 @@
-//! Filter pipeline module.
-//!
-//! Concrete filter implementations (auth, rate_limit, logger) are added
-//! in Phase 6 — this module provides the pipeline executor.
+//! Filter module.
+
+mod auth;
+mod logger;
+mod rate_limit;
+
+pub use auth::ApiKeyFilter;
+pub use logger::LoggingFilter;
+pub use rate_limit::RateLimitFilter;
 
 use mofa_kernel::gateway::{FilterAction, GatewayContext, GatewayError, GatewayFilter, GatewayResponse};
 use std::sync::Arc;

--- a/crates/mofa-gateway/src/filter/rate_limit.rs
+++ b/crates/mofa-gateway/src/filter/rate_limit.rs
@@ -1,0 +1,150 @@
+//! In-memory token-bucket rate-limit filter.
+//!
+//! Each unique (IP address or auth principal) is tracked independently.
+//! The bucket is refilled in a continuous fashion: on each request the
+//! elapsed wall-clock time is converted to tokens and added to the bucket,
+//! then one token is consumed.  When no tokens remain the request is
+//! rejected with `429 Too Many Requests`.
+
+use async_trait::async_trait;
+use mofa_kernel::gateway::{
+    FilterAction, FilterOrder, GatewayContext, GatewayError, GatewayFilter, GatewayResponse,
+};
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+use tracing::warn;
+
+struct Bucket {
+    tokens: f64,
+    last_refill: Instant,
+}
+
+impl Bucket {
+    fn new(capacity: f64) -> Self {
+        Self {
+            tokens: capacity,
+            last_refill: Instant::now(),
+        }
+    }
+
+    /// Attempt to consume one token, refilling based on elapsed time first.
+    /// Returns `true` if the token was consumed (request allowed).
+    fn try_consume(&mut self, rate_per_second: f64, burst_capacity: f64) -> bool {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.last_refill);
+        let refill = elapsed.as_secs_f64() * rate_per_second;
+        self.tokens = (self.tokens + refill).min(burst_capacity);
+        self.last_refill = now;
+
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Rate-limit filter using a per-caller token-bucket algorithm.
+pub struct RateLimitFilter {
+    rate_per_second: f64,
+    burst_capacity: f64,
+    /// Suggested retry-after duration for callers when a request is rejected.
+    retry_after: Duration,
+    buckets: Mutex<HashMap<String, Bucket>>,
+}
+
+impl RateLimitFilter {
+    /// Create a new rate-limit filter.
+    ///
+    /// - `rate_per_second`: sustained request rate (tokens refilled per second).
+    /// - `burst_capacity`: maximum number of tokens in the bucket.
+    pub fn new(rate_per_second: u32, burst_capacity: u32) -> Self {
+        Self {
+            rate_per_second: rate_per_second as f64,
+            burst_capacity: burst_capacity as f64,
+            retry_after: Duration::from_secs(1),
+            buckets: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn caller_id(ctx: &GatewayContext) -> String {
+        // Prefer the authenticated principal; fall back to forwarded IP or a
+        // placeholder for unauthenticated callers.
+        if let Some(principal) = ctx.auth_principal.clone() {
+            return principal;
+        }
+        // Extract the left-most IP from `x-forwarded-for` (if present), since the
+        // header may contain a comma-separated chain of proxy addresses.
+        if let Some(xff) = ctx.request.headers.get("x-forwarded-for") {
+            if let Some(first) = xff
+                .split(',')
+                .next()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+            {
+                return first.to_string();
+            }
+        }
+        // Fall back to `x-real-ip` if no usable `x-forwarded-for` value is found.
+        if let Some(x_real_ip) = ctx.request.headers.get("x-real-ip") {
+            if !x_real_ip.is_empty() {
+                return x_real_ip.clone();
+            }
+        }
+        "anonymous".to_string()
+    }
+}
+
+#[async_trait]
+impl GatewayFilter for RateLimitFilter {
+    fn name(&self) -> &str {
+        "rate-limit"
+    }
+
+    fn order(&self) -> FilterOrder {
+        FilterOrder::RATE_LIMIT
+    }
+
+    async fn on_request(&self, ctx: &mut GatewayContext) -> Result<FilterAction, GatewayError> {
+        let caller = Self::caller_id(ctx);
+        let allowed = {
+            let mut buckets = self.buckets.lock().await;
+            let bucket = buckets
+                .entry(caller.clone())
+                .or_insert_with(|| Bucket::new(self.burst_capacity));
+            bucket.try_consume(self.rate_per_second, self.burst_capacity)
+        };
+
+        if allowed {
+            Ok(FilterAction::Continue)
+        } else {
+            warn!(
+                request_id = %ctx.request.id,
+                caller = %caller,
+                "rate limit exceeded"
+            );
+            Ok(FilterAction::Reject(
+                429,
+                format!(
+                    "Rate limit exceeded. Retry after {} second(s).",
+                    self.retry_after.as_secs()
+                ),
+            ))
+        }
+    }
+
+    async fn on_response(
+        &self,
+        _ctx: &GatewayContext,
+        resp: &mut GatewayResponse,
+    ) -> Result<(), GatewayError> {
+        // Annotate the response with the rate-limit policy for transparency.
+        resp.headers.insert(
+            "x-ratelimit-limit".to_string(),
+            (self.burst_capacity as u32).to_string(),
+        );
+        Ok(())
+    }
+}

--- a/crates/mofa-gateway/src/lib.rs
+++ b/crates/mofa-gateway/src/lib.rs
@@ -44,6 +44,10 @@ pub mod middleware;
 pub mod server;
 pub mod state;
 
+// Task 12: Cognitive Gateway runtime
+pub mod router;
+pub mod filter;
+
 pub use error::{GatewayError, GatewayResult};
 pub use middleware::RateLimiter;
 pub use server::{GatewayConfig, GatewayServer};

--- a/crates/mofa-gateway/src/router/mod.rs
+++ b/crates/mofa-gateway/src/router/mod.rs
@@ -1,0 +1,4 @@
+//! Router module.
+
+mod trie;
+pub use trie::TrieRouter;

--- a/crates/mofa-gateway/src/router/trie.rs
+++ b/crates/mofa-gateway/src/router/trie.rs
@@ -1,0 +1,196 @@
+//! Priority-sorted path router implementing [`GatewayRouter`].
+//!
+//! Routes are stored in sorted-by-priority order.  Resolution performs a
+//! linear scan with a simple path-template matcher that supports `{param}`
+//! capture groups (axum / actix style).
+//!
+//! The linear scan is O(R × D) where R = number of routes and D = path depth,
+//! which is entirely acceptable for gateway use-cases (route tables are
+//! small) and trivially correct to verify.
+
+use mofa_kernel::gateway::{
+    GatewayError, GatewayRouter, HttpMethod, RouteConfig, RouteMatch,
+};
+use std::collections::HashMap;
+
+/// [`GatewayRouter`] implementation using priority-sorted linear route lookup
+/// with `{param}` template matching.
+///
+/// Despite the name, this is a linear-scan router (not an actual trie).
+/// The route table is small enough that linear scan is preferred for
+/// simplicity and correctness.
+#[derive(Default)]
+pub struct TrieRouter {
+    /// Routes sorted by descending priority (highest first).
+    routes: Vec<RouteConfig>,
+}
+
+impl TrieRouter {
+    /// Create an empty router.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Match a concrete path against a template such as `/v1/models/{model_id}`.
+    ///
+    /// Returns `Some(params)` when the template matches, where `params` maps
+    /// capture names to their extracted values.  Returns `None` on mismatch.
+    fn match_path(template: &str, path: &str) -> Option<HashMap<String, String>> {
+        let t_parts: Vec<&str> = template.trim_matches('/').split('/').collect();
+        let p_parts: Vec<&str> = path.trim_matches('/').split('/').collect();
+
+        if t_parts.len() != p_parts.len() {
+            return None;
+        }
+
+        let mut params = HashMap::new();
+        for (t, p) in t_parts.iter().zip(p_parts.iter()) {
+            if t.starts_with('{') && t.ends_with('}') {
+                // Extract the param name (strip braces).
+                let name = &t[1..t.len() - 1];
+                params.insert(name.to_string(), p.to_string());
+            } else if *t != *p {
+                return None;
+            }
+        }
+        Some(params)
+    }
+}
+
+impl GatewayRouter for TrieRouter {
+    fn register(&mut self, route: RouteConfig) -> Result<(), GatewayError> {
+        if self.routes.iter().any(|r| r.id == route.id) {
+            return Err(GatewayError::DuplicateRoute(route.id));
+        }
+        // Insert maintaining descending priority order and stable tie-breaking
+        // (earlier-registered routes win among equal priorities).
+        let pos = self
+            .routes
+            .partition_point(|r| r.priority >= route.priority);
+        self.routes.insert(pos, route);
+        Ok(())
+    }
+
+    fn resolve(&self, path: &str, method: &HttpMethod) -> Option<RouteMatch> {
+        for route in &self.routes {
+            // Method check: empty methods vec means "accept all".
+            if !route.methods.is_empty() && !route.methods.contains(method) {
+                continue;
+            }
+            if let Some(path_params) = Self::match_path(&route.path_pattern, path) {
+                return Some(RouteMatch {
+                    route_id: route.id.clone(),
+                    backend_id: route.backend_id.clone(),
+                    path_params,
+                    timeout_ms: route.timeout_ms,
+                });
+            }
+        }
+        None
+    }
+
+    fn routes(&self) -> Vec<&RouteConfig> {
+        self.routes.iter().collect()
+    }
+
+    fn deregister(&mut self, route_id: &str) -> Result<(), GatewayError> {
+        let before = self.routes.len();
+        self.routes.retain(|r| r.id != route_id);
+        if self.routes.len() == before {
+            return Err(GatewayError::RouteNotFound(route_id.to_string()));
+        }
+        Ok(())
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mofa_kernel::gateway::RouteConfig;
+
+    fn make_route(id: &str, pattern: &str, backend: &str) -> RouteConfig {
+        RouteConfig::new(id, pattern, backend)
+    }
+
+    #[test]
+    fn exact_path_matches() {
+        let mut router = TrieRouter::new();
+        router
+            .register(make_route("health", "/health", "svc"))
+            .unwrap();
+        let m = router.resolve("/health", &HttpMethod::Get).unwrap();
+        assert_eq!(m.route_id, "health");
+        assert!(m.path_params.is_empty());
+    }
+
+    #[test]
+    fn param_path_extracts_value() {
+        let mut router = TrieRouter::new();
+        router
+            .register(make_route("model", "/v1/models/{model_id}", "openai"))
+            .unwrap();
+        let m = router
+            .resolve("/v1/models/gpt-4", &HttpMethod::Get)
+            .unwrap();
+        assert_eq!(m.path_params.get("model_id").unwrap(), "gpt-4");
+    }
+
+    #[test]
+    fn no_match_returns_none() {
+        let router = TrieRouter::new();
+        assert!(router
+            .resolve("/nonexistent", &HttpMethod::Get)
+            .is_none());
+    }
+
+    #[test]
+    fn method_filter_respected() {
+        let mut router = TrieRouter::new();
+        let route = make_route("chat", "/v1/chat", "openai")
+            .with_methods(vec![HttpMethod::Post]);
+        router.register(route).unwrap();
+        // GET should not match
+        assert!(router.resolve("/v1/chat", &HttpMethod::Get).is_none());
+        // POST should match
+        assert!(router.resolve("/v1/chat", &HttpMethod::Post).is_some());
+    }
+
+    #[test]
+    fn higher_priority_wins() {
+        let mut router = TrieRouter::new();
+        router
+            .register(make_route("low", "/v1/chat", "backend-low").with_priority(0))
+            .unwrap();
+        router
+            .register(make_route("high", "/v1/chat", "backend-high").with_priority(10))
+            .unwrap();
+        let m = router.resolve("/v1/chat", &HttpMethod::Post).unwrap();
+        assert_eq!(m.route_id, "high");
+    }
+
+    #[test]
+    fn duplicate_route_id_rejected() {
+        let mut router = TrieRouter::new();
+        router.register(make_route("r1", "/a", "b")).unwrap();
+        let err = router.register(make_route("r1", "/b", "b")).unwrap_err();
+        assert!(matches!(err, GatewayError::DuplicateRoute(ref id) if id == "r1"));
+    }
+
+    #[test]
+    fn deregister_removes_route() {
+        let mut router = TrieRouter::new();
+        router.register(make_route("r1", "/a", "b")).unwrap();
+        router.deregister("r1").unwrap();
+        assert!(router.resolve("/a", &HttpMethod::Get).is_none());
+    }
+
+    #[test]
+    fn deregister_unknown_id_returns_error() {
+        let mut router = TrieRouter::new();
+        assert!(router.deregister("ghost").is_err());
+    }
+}

--- a/crates/mofa-kernel/src/error.rs
+++ b/crates/mofa-kernel/src/error.rs
@@ -69,6 +69,10 @@ pub enum KernelError {
     /// A secretary-layer error.
     #[error("Secretary error: {0}")]
     Secretary(#[from] crate::agent::secretary::SecretaryError),
+
+    /// A gateway configuration or routing error.
+    #[error("Gateway error: {0}")]
+    Gateway(#[from] crate::gateway::GatewayError),
 }
 
 impl From<crate::agent::types::error::GlobalError> for KernelError {

--- a/crates/mofa-kernel/src/gateway/capability.rs
+++ b/crates/mofa-kernel/src/gateway/capability.rs
@@ -1,0 +1,180 @@
+//! Backend capability registry — kernel contract.
+//!
+//! The [`CapabilityRegistry`] trait is the single kernel-level abstraction for
+//! discovering and managing the backend targets that the gateway can forward
+//! requests to.  Concrete implementations (in-memory, service-mesh, Consul …)
+//! live in `mofa-gateway` or plugin crates.
+
+use super::error::GatewayError;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Backend kind
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Classifies what *type* of service a backend represents.
+///
+/// This drives capability-matching logic: an LLM route must not be forwarded
+/// to an IoT backend, for example.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum BackendKind {
+    /// OpenAI-compatible completion / embedding endpoint.
+    LlmOpenAI,
+    /// Anthropic Claude API endpoint.
+    LlmAnthropic,
+    /// Generic OpenAI-compatible endpoint (e.g. local LLM, Azure OpenAI).
+    LlmCompatible,
+    /// MCP (Model Context Protocol) tool server.
+    McpTool,
+    /// Agent-to-Agent (A2A) communication target.
+    A2AAgent,
+    /// IoT hub / device endpoint.
+    IoT,
+    /// Arbitrary HTTP service.
+    Http,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Health status
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Last-known health state of a backend, updated by health-check polling.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[non_exhaustive]
+pub enum BackendHealth {
+    /// Backend is responding normally.
+    Healthy,
+    /// Backend is responding but with elevated latency or partial errors.
+    Degraded(String),
+    /// Backend is not responding or returning errors.
+    Unhealthy(String),
+    /// Health has not yet been checked since registration.
+    #[default]
+    Unknown,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CapabilityDescriptor
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Full description of a backend registered in the capability registry.
+///
+/// All registered backends have a unique `id`.  The `kind` field drives
+/// routing rules; `endpoint` is the URL the gateway will forward to.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CapabilityDescriptor {
+    /// Unique stable identifier (must not be empty).
+    pub id: String,
+    /// Classification of this backend.
+    pub kind: BackendKind,
+    /// Base URL for forwarding (e.g. `https://api.openai.com`).
+    pub endpoint: String,
+    /// Optional health-check path appended to `endpoint`
+    /// (e.g. `/health` → `GET {endpoint}/health`).
+    pub health_check_path: Option<String>,
+    /// Arbitrary key-value metadata (model names, regions, labels, …).
+    pub metadata: HashMap<String, serde_json::Value>,
+    /// Last-known health state (updated by the health-check loop).
+    #[serde(default)]
+    pub health: BackendHealth,
+}
+
+impl CapabilityDescriptor {
+    /// Construct a minimal descriptor.
+    pub fn new(
+        id: impl Into<String>,
+        kind: BackendKind,
+        endpoint: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            kind,
+            endpoint: endpoint.into(),
+            health_check_path: None,
+            metadata: HashMap::new(),
+            health: BackendHealth::Unknown,
+        }
+    }
+
+    /// Builder: set the health-check path.
+    pub fn with_health_check(mut self, path: impl Into<String>) -> Self {
+        self.health_check_path = Some(path.into());
+        self
+    }
+
+    /// Builder: attach arbitrary metadata.
+    pub fn with_metadata(
+        mut self,
+        key: impl Into<String>,
+        value: serde_json::Value,
+    ) -> Self {
+        self.metadata.insert(key.into(), value);
+        self
+    }
+
+    /// Basic sanity checks run during [`GatewayConfig::validate()`].
+    pub(crate) fn validate(&self) -> Result<(), GatewayError> {
+        if self.id.trim().is_empty() {
+            return Err(GatewayError::EmptyBackendId);
+        }
+        if self.endpoint.trim().is_empty() {
+            return Err(GatewayError::InvalidEndpoint(
+                self.id.clone(),
+                "endpoint URI cannot be empty".to_string(),
+            ));
+        }
+        if !self.endpoint.starts_with("http://") && !self.endpoint.starts_with("https://") {
+            return Err(GatewayError::InvalidEndpoint(
+                self.id.clone(),
+                format!(
+                    "endpoint '{}' must start with http:// or https://",
+                    self.endpoint
+                ),
+            ));
+        }
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CapabilityRegistry trait
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Kernel contract for the backend capability registry.
+///
+/// This trait is intentionally **synchronous** and scoped to in-memory
+/// implementations.  I/O-backed registries (e.g. service-mesh, Consul)
+/// should wrap an internal async layer and expose a sync facade that
+/// reads from a locally-cached snapshot.
+pub trait CapabilityRegistry: Send + Sync {
+    /// Register a new backend.
+    ///
+    /// Returns [`GatewayError::DuplicateBackend`] if a descriptor with the
+    /// same `id` already exists.
+    fn register(&mut self, descriptor: CapabilityDescriptor) -> Result<(), GatewayError>;
+
+    /// Look up a backend by its unique id.  Returns `None` if not found.
+    fn lookup(&self, id: &str) -> Option<&CapabilityDescriptor>;
+
+    /// Return all backends of a specific [`BackendKind`].
+    fn list_by_kind(&self, kind: &BackendKind) -> Vec<&CapabilityDescriptor>;
+
+    /// Return all registered backends.
+    fn list_all(&self) -> Vec<&CapabilityDescriptor>;
+
+    /// Remove a backend by id.
+    ///
+    /// Returns [`GatewayError::BackendNotFound`] if the id is not registered.
+    fn deregister(&mut self, id: &str) -> Result<(), GatewayError>;
+
+    /// Update the health state of a registered backend.
+    ///
+    /// Returns [`GatewayError::BackendNotFound`] if the id is not registered.
+    fn update_health(
+        &mut self,
+        id: &str,
+        health: BackendHealth,
+    ) -> Result<(), GatewayError>;
+}

--- a/crates/mofa-kernel/src/gateway/error.rs
+++ b/crates/mofa-kernel/src/gateway/error.rs
@@ -1,0 +1,91 @@
+//! Gateway error types for `mofa-kernel`.
+//!
+//! [`GatewayError`] covers every failure mode that can be detected at
+//! *definition time* — empty IDs, duplicate registrations, missing backend
+//! references, invalid configuration values — before any network I/O occurs.
+//! Runtime failures (connection refused, upstream timeout, …) belong in the
+//! gateway implementation crate (`mofa-gateway`).
+
+use thiserror::Error;
+
+/// Compile-time / configuration error type for the gateway kernel contract.
+///
+/// All variants are `#[non_exhaustive]` at the enum level so future releases
+/// can add new failure modes without breaking existing `match` arms.
+#[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum GatewayError {
+    // ── Identity ────────────────────────────────────────────────────────────
+    /// The gateway configuration `id` field is empty or whitespace-only.
+    #[error("gateway id cannot be empty")]
+    EmptyGatewayId,
+
+    // ── Routes ───────────────────────────────────────────────────────────────
+    /// The configuration contains no routes.
+    #[error("gateway config must define at least one route")]
+    NoRoutes,
+
+    /// A route `id` field is empty or whitespace-only.
+    #[error("route id cannot be empty")]
+    EmptyRouteId,
+
+    /// A route with this id has already been registered.
+    #[error("route '{0}' is already registered")]
+    DuplicateRoute(String),
+
+    /// No route with this id is currently registered.
+    #[error("route '{0}' is not registered")]
+    RouteNotFound(String),
+
+    /// A route references a backend id that is not present in the backend list.
+    #[error("route '{0}' references unknown backend '{1}'")]
+    UnknownBackend(String, String),
+
+    /// A route path pattern is syntactically invalid.
+    #[error("route '{0}' has an invalid path pattern: {1}")]
+    InvalidPathPattern(String, String),
+
+    // ── Backends ─────────────────────────────────────────────────────────────
+    /// The configuration contains no backends.
+    #[error("gateway config must define at least one backend")]
+    NoBackends,
+
+    /// A backend `id` field is empty or whitespace-only.
+    #[error("backend id cannot be empty")]
+    EmptyBackendId,
+
+    /// A backend with this id has already been registered.
+    #[error("backend '{0}' is already registered")]
+    DuplicateBackend(String),
+
+    /// No backend with this id is currently registered.
+    #[error("backend '{0}' is not registered")]
+    BackendNotFound(String),
+
+    /// A backend endpoint URI is syntactically invalid.
+    #[error("backend '{0}' has an invalid endpoint URI: {1}")]
+    InvalidEndpoint(String, String),
+
+    // ── Filters ──────────────────────────────────────────────────────────────
+    /// A filter chain is empty (must contain at least one filter).
+    #[error("filter chain must contain at least one filter")]
+    EmptyFilterChain,
+
+    /// A filter priority / order value is invalid.
+    #[error("filter has an invalid order value: {0}")]
+    InvalidFilterOrder(String),
+
+    // ── Auth ─────────────────────────────────────────────────────────────────
+    /// An authentication configuration block is missing a required field.
+    #[error("authentication config is missing required field: {0}")]
+    InvalidAuthConfig(String),
+
+    // ── Timeouts / rate-limits ────────────────────────────────────────────────
+    /// `request_timeout_ms` is zero, which would reject every request.
+    #[error("request timeout must be greater than 0 ms")]
+    InvalidTimeout,
+
+    /// The burst capacity is smaller than the sustained rate — nonsensical.
+    #[error("rate limit burst capacity must be >= sustained rate per second")]
+    InvalidRateLimit,
+}

--- a/crates/mofa-kernel/src/gateway/filter.rs
+++ b/crates/mofa-kernel/src/gateway/filter.rs
@@ -1,0 +1,127 @@
+//! Gateway filter trait and filter-chain types.
+//!
+//! A filter chain is an ordered list of [`GatewayFilter`] instances applied
+//! to every request and response.  Filters are sorted by their declared
+//! [`FilterOrder`] and executed in ascending order on the request path
+//! (lowest value first) and descending order on the response path.
+//!
+//! ```text
+//! Request  ──► PreAuth ──► Auth ──► RateLimit ──► Transform ──► Logging
+//!                  (upstream / backend call happens here)
+//! Response ◄── Logging ◄── Transform ◄── RateLimit ◄── Auth ◄── PreAuth
+//! ```
+
+use super::error::GatewayError;
+use super::types::{GatewayContext, GatewayResponse};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Filter ordering
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Numeric ordering slot for a filter in the chain.
+///
+/// The well-known slots below act as guidelines; any `u32` value is accepted
+/// so implementors can slot in custom filters between the standard phases.
+/// Filters with equal order values are executed in registration order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct FilterOrder(pub u32);
+
+impl FilterOrder {
+    /// Executes before all authentication logic (e.g. request ID injection).
+    pub const PRE_AUTH: FilterOrder = FilterOrder(0);
+    /// Authentication filter slot (API key, JWT, OAuth 2.0).
+    pub const AUTH: FilterOrder = FilterOrder(100);
+    /// Rate-limiting / throttling slot.
+    pub const RATE_LIMIT: FilterOrder = FilterOrder(200);
+    /// Request / response body transformation slot.
+    pub const TRANSFORM: FilterOrder = FilterOrder(300);
+    /// Audit logging slot — runs after all transformations.
+    pub const LOGGING: FilterOrder = FilterOrder(400);
+    /// Post-processing, metrics recording, etc.
+    pub const POST_PROCESS: FilterOrder = FilterOrder(500);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Filter action
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Instruction returned by [`GatewayFilter::on_request`] controlling what
+/// the gateway does with the request after the filter runs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FilterAction {
+    /// Pass the (possibly modified) request to the next filter or backend.
+    Continue,
+    /// Short-circuit the chain and return a synthetic error response with the
+    /// given HTTP status code (as a raw `u16` — callers should ensure validity)
+    /// and body string.
+    Reject(u16, String),
+    /// Short-circuit and redirect the caller to a different path.
+    Redirect(String),
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GatewayFilter trait
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Kernel contract for a single filter in the gateway pipeline.
+///
+/// Implementations must be `Send + Sync` so they can be shared across Tokio
+/// tasks without additional synchronization by the caller.
+#[async_trait]
+pub trait GatewayFilter: Send + Sync {
+    /// Stable, human-readable identifier for this filter (used in logs).
+    fn name(&self) -> &str;
+
+    /// Position in the filter chain.  Lower values execute first on the
+    /// request path.
+    fn order(&self) -> FilterOrder;
+
+    /// Called with the inbound request *before* it is forwarded to the backend.
+    ///
+    /// Implementations may mutate `ctx` (e.g. add authentication claims to
+    /// `ctx.auth_principal`, remove sensitive headers, …).  Return
+    /// [`FilterAction::Continue`] to proceed, or a `Reject`/`Redirect` variant
+    /// to short-circuit the chain.
+    async fn on_request(&self, ctx: &mut GatewayContext) -> Result<FilterAction, GatewayError>;
+
+    /// Called with the backend response *before* it is returned to the caller.
+    ///
+    /// Implementations may mutate `resp` (e.g. strip internal headers, append
+    /// cache-control metadata, record latency metrics, …).
+    async fn on_response(
+        &self,
+        ctx: &GatewayContext,
+        resp: &mut GatewayResponse,
+    ) -> Result<(), GatewayError>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FilterChainConfig
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Ordered list of filter names that make up a named filter chain.
+///
+/// This is the *configuration* representation (list of string names).  The
+/// runtime binds names to concrete [`GatewayFilter`] implementations during
+/// startup.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FilterChainConfig {
+    /// Human-readable name for this chain (used in logs and metrics).
+    pub name: String,
+    /// Ordered filter names.  Must not be empty — validated by
+    /// [`GatewayConfig::validate()`](super::validation::GatewayConfig::validate).
+    pub filter_names: Vec<String>,
+}
+
+impl FilterChainConfig {
+    /// Create a new chain config with the given name and filter list.
+    pub fn new(name: impl Into<String>, filter_names: Vec<String>) -> Self {
+        Self {
+            name: name.into(),
+            filter_names,
+        }
+    }
+}

--- a/crates/mofa-kernel/src/gateway/mod.rs
+++ b/crates/mofa-kernel/src/gateway/mod.rs
@@ -1,10 +1,14 @@
-//! Cognitive Gateway kernel contract — types and errors.
+//! Cognitive Gateway kernel contract.
 
 mod error;
 mod types;
+mod router;
+mod filter;
 
 // ── Flat re-exports ────────────────────────────────────────────────────────
 // Types are exposed via curated re-exports to keep the public API surface tight.
 
 pub use error::GatewayError;
 pub use types::{GatewayContext, GatewayRequest, GatewayResponse, HttpMethod, RouteMatch};
+pub use router::{GatewayRouter, RouteConfig};
+pub use filter::{FilterAction, FilterChainConfig, FilterOrder, GatewayFilter};

--- a/crates/mofa-kernel/src/gateway/mod.rs
+++ b/crates/mofa-kernel/src/gateway/mod.rs
@@ -1,0 +1,10 @@
+//! Cognitive Gateway kernel contract — types and errors.
+
+mod error;
+mod types;
+
+// ── Flat re-exports ────────────────────────────────────────────────────────
+// Types are exposed via curated re-exports to keep the public API surface tight.
+
+pub use error::GatewayError;
+pub use types::{GatewayContext, GatewayRequest, GatewayResponse, HttpMethod, RouteMatch};

--- a/crates/mofa-kernel/src/gateway/mod.rs
+++ b/crates/mofa-kernel/src/gateway/mod.rs
@@ -4,11 +4,14 @@ mod error;
 mod types;
 mod router;
 mod filter;
+mod capability;
+mod validation;
 
 // ── Flat re-exports ────────────────────────────────────────────────────────
-// Types are exposed via curated re-exports to keep the public API surface tight.
 
 pub use error::GatewayError;
 pub use types::{GatewayContext, GatewayRequest, GatewayResponse, HttpMethod, RouteMatch};
 pub use router::{GatewayRouter, RouteConfig};
 pub use filter::{FilterAction, FilterChainConfig, FilterOrder, GatewayFilter};
+pub use capability::{BackendHealth, BackendKind, CapabilityDescriptor, CapabilityRegistry};
+pub use validation::{GatewayConfig, RateLimitConfig};

--- a/crates/mofa-kernel/src/gateway/router.rs
+++ b/crates/mofa-kernel/src/gateway/router.rs
@@ -1,0 +1,125 @@
+//! Gateway router trait and configuration types.
+//!
+//! The [`GatewayRouter`] trait is the single kernel-level abstraction for
+//! request routing. Implementations (e.g. a trie-based router in
+//! `mofa-gateway`) are registered against routes at startup and looked up
+//! on every inbound request.
+
+use super::error::GatewayError;
+use super::types::{HttpMethod, RouteMatch};
+use serde::{Deserialize, Serialize};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Route configuration
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A single routing rule mapping a path pattern + method set to a backend.
+///
+/// Path patterns follow the `{param}` template syntax used by axum 0.8+:
+/// ```text
+/// /v1/chat/completions          — exact path
+/// /v1/models/{model_id}         — captures `model_id`
+/// /v1/agents/{agent_id}/invoke  — captures `agent_id`
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RouteConfig {
+    /// Unique stable identifier for this route.
+    pub id: String,
+    /// URL path template.  Must begin with `/`.
+    pub path_pattern: String,
+    /// Accepted HTTP methods.  An empty vec means *all* methods are accepted.
+    pub methods: Vec<HttpMethod>,
+    /// Id of the backend this route forwards to.
+    pub backend_id: String,
+    /// Per-route request timeout in milliseconds (overrides gateway default).
+    /// A value of `0` means "use the gateway default".
+    pub timeout_ms: u64,
+    /// Routing priority: higher values are evaluated first when multiple
+    /// patterns match the same path.
+    pub priority: i32,
+}
+
+impl RouteConfig {
+    /// Create a minimal route with just id, path_pattern, and backend_id.
+    pub fn new(
+        id: impl Into<String>,
+        path_pattern: impl Into<String>,
+        backend_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            path_pattern: path_pattern.into(),
+            methods: Vec::new(),
+            backend_id: backend_id.into(),
+            timeout_ms: 0,
+            priority: 0,
+        }
+    }
+
+    /// Builder: restrict to specific HTTP methods.
+    pub fn with_methods(mut self, methods: Vec<HttpMethod>) -> Self {
+        self.methods = methods;
+        self
+    }
+
+    /// Builder: set a per-route timeout.
+    pub fn with_timeout_ms(mut self, ms: u64) -> Self {
+        self.timeout_ms = ms;
+        self
+    }
+
+    /// Builder: set routing priority (higher = evaluated first).
+    pub fn with_priority(mut self, priority: i32) -> Self {
+        self.priority = priority;
+        self
+    }
+
+    /// Basic sanity checks run during [`GatewayConfig::validate()`].
+    pub(crate) fn validate(&self) -> Result<(), GatewayError> {
+        if self.id.trim().is_empty() {
+            return Err(GatewayError::EmptyRouteId);
+        }
+        if self.path_pattern.trim().is_empty() {
+            return Err(GatewayError::InvalidPathPattern(
+                self.id.clone(),
+                "path pattern cannot be empty".to_string(),
+            ));
+        }
+        if !self.path_pattern.starts_with('/') {
+            return Err(GatewayError::InvalidPathPattern(
+                self.id.clone(),
+                "path pattern must start with '/'".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Router trait
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Kernel contract for request routing.
+///
+/// Implementations receive [`RouteConfig`] entries at startup (via
+/// [`register`](GatewayRouter::register)) and resolve incoming
+/// (path, method) pairs to a [`RouteMatch`] at request time.
+///
+/// The trait is intentionally synchronous: route lookups must be O(depth)
+/// in a trie — no I/O, no allocation on the hot path.
+pub trait GatewayRouter: Send + Sync {
+    /// Register a new route.  Returns [`GatewayError::DuplicateRoute`] if a
+    /// route with the same `id` is already registered.
+    fn register(&mut self, route: RouteConfig) -> Result<(), GatewayError>;
+
+    /// Resolve a request `(path, method)` to the best matching route.
+    /// Returns `None` when no route matches.
+    fn resolve(&self, path: &str, method: &HttpMethod) -> Option<RouteMatch>;
+
+    /// Return a snapshot of all registered routes, sorted by descending priority.
+    fn routes(&self) -> Vec<&RouteConfig>;
+
+    /// Remove a previously registered route.
+    /// Returns [`GatewayError::RouteNotFound`] if the id is not registered.
+    fn deregister(&mut self, route_id: &str) -> Result<(), GatewayError>;
+}

--- a/crates/mofa-kernel/src/gateway/types.rs
+++ b/crates/mofa-kernel/src/gateway/types.rs
@@ -214,7 +214,7 @@ impl GatewayContext {
     }
 
     /// Convenience: write a serializable attribute.
-    pub fn set_attr<T: serde::Serialize>(&mut self, key: impl Into<String>, val: &T) {
+    pub fn set_attr<T: serde::Serialize>(&mut self, key: impl Into<String>, val: T) {
         if let Ok(v) = serde_json::to_value(val) {
             self.attributes.insert(key.into(), v);
         }

--- a/crates/mofa-kernel/src/gateway/types.rs
+++ b/crates/mofa-kernel/src/gateway/types.rs
@@ -1,0 +1,222 @@
+//! Core data types for the gateway kernel contract.
+//!
+//! These types are shared across all gateway traits
+//! ([`GatewayRouter`](super::router::GatewayRouter),
+//! [`GatewayFilter`](super::filter::GatewayFilter),
+//! [`CapabilityRegistry`](super::capability::CapabilityRegistry))
+//! and carry no runtime dependencies beyond `serde`, `serde_json`, and `std`.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// HTTP primitives
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// HTTP method, covering the standard verbs used in REST and proxy scenarios.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+#[non_exhaustive]
+pub enum HttpMethod {
+    Get,
+    Post,
+    Put,
+    Patch,
+    Delete,
+    Head,
+    Options,
+}
+
+impl HttpMethod {
+    /// Case-insensitive parse from a string slice.
+    pub fn from_str_ci(s: &str) -> Option<Self> {
+        match s.to_ascii_uppercase().as_str() {
+            "GET" => Some(HttpMethod::Get),
+            "POST" => Some(HttpMethod::Post),
+            "PUT" => Some(HttpMethod::Put),
+            "PATCH" => Some(HttpMethod::Patch),
+            "DELETE" => Some(HttpMethod::Delete),
+            "HEAD" => Some(HttpMethod::Head),
+            "OPTIONS" => Some(HttpMethod::Options),
+            _ => None,
+        }
+    }
+
+    /// Return the standard uppercase string representation.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            HttpMethod::Get => "GET",
+            HttpMethod::Post => "POST",
+            HttpMethod::Put => "PUT",
+            HttpMethod::Patch => "PATCH",
+            HttpMethod::Delete => "DELETE",
+            HttpMethod::Head => "HEAD",
+            HttpMethod::Options => "OPTIONS",
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Request / Response
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// An inbound request flowing through the gateway.
+///
+/// All fields use owned, allocation-friendly types so the struct can be sent
+/// across async task boundaries without lifetime complications.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayRequest {
+    /// Unique identifier for correlating this request across logs and traces.
+    pub id: String,
+    /// Request path, e.g. `/v1/chat/completions`.
+    pub path: String,
+    /// HTTP method.
+    pub method: HttpMethod,
+    /// HTTP headers (header names are lowercased).
+    pub headers: HashMap<String, String>,
+    /// Raw body bytes.
+    pub body: Vec<u8>,
+    /// Arbitrary metadata attached by filters during processing.
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+impl GatewayRequest {
+    /// Construct a minimal request with the given id, path, and method.
+    pub fn new(
+        id: impl Into<String>,
+        path: impl Into<String>,
+        method: HttpMethod,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            path: path.into(),
+            method,
+            headers: HashMap::new(),
+            body: Vec::new(),
+            metadata: HashMap::new(),
+        }
+    }
+
+    /// Builder helper: attach a header.
+    pub fn with_header(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.headers
+            .insert(key.into().to_ascii_lowercase(), value.into());
+        self
+    }
+
+    /// Builder helper: set the body.
+    pub fn with_body(mut self, body: Vec<u8>) -> Self {
+        self.body = body;
+        self
+    }
+}
+
+/// An outbound response produced by a backend and returned through the gateway.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayResponse {
+    /// HTTP status code as a raw `u16` (typically in the 100–599 range).
+    pub status: u16,
+    /// Response headers.
+    pub headers: HashMap<String, String>,
+    /// Raw body bytes.
+    pub body: Vec<u8>,
+    /// Id of the backend that generated this response.
+    pub backend_id: String,
+    /// Round-trip latency in milliseconds (gateway → backend → gateway).
+    pub latency_ms: u64,
+}
+
+impl GatewayResponse {
+    /// Construct a minimal response.
+    pub fn new(status: u16, backend_id: impl Into<String>) -> Self {
+        Self {
+            status,
+            headers: HashMap::new(),
+            body: Vec::new(),
+            backend_id: backend_id.into(),
+            latency_ms: 0,
+        }
+    }
+
+    /// Builder helper: attach a header.
+    pub fn with_header(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.headers
+            .insert(key.into().to_ascii_lowercase(), value.into());
+        self
+    }
+
+    /// Builder helper: set the body.
+    pub fn with_body(mut self, body: Vec<u8>) -> Self {
+        self.body = body;
+        self
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Route match
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The result of a successful route lookup.
+///
+/// Carries the matched route's configuration plus any path parameters
+/// extracted during matching (e.g. `model_id → "gpt-4"` for the pattern
+/// `/v1/models/{model_id}`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RouteMatch {
+    /// Id of the matched route.
+    pub route_id: String,
+    /// Id of the backend this route targets.
+    pub backend_id: String,
+    /// Path parameters extracted from the URL template.
+    pub path_params: HashMap<String, String>,
+    /// Configured timeout for this route in milliseconds.
+    pub timeout_ms: u64,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Request context
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Mutable context that flows through the filter chain for a single request.
+///
+/// Filters read from and write to this context, enabling downstream filters
+/// to access decisions made by upstream filters (e.g. the auth principal set
+/// by the authentication filter can be read by the audit logger).
+#[derive(Debug, Clone)]
+pub struct GatewayContext {
+    /// The inbound request.
+    pub request: GatewayRequest,
+    /// Populated after routing; `None` if routing has not yet occurred.
+    pub route_match: Option<RouteMatch>,
+    /// Identity principal resolved by the auth filter; `None` if unauthenticated.
+    pub auth_principal: Option<String>,
+    /// Free-form attributes written and read by filters.
+    pub attributes: HashMap<String, serde_json::Value>,
+}
+
+impl GatewayContext {
+    /// Create a fresh context from an inbound request.
+    pub fn new(request: GatewayRequest) -> Self {
+        Self {
+            request,
+            route_match: None,
+            auth_principal: None,
+            attributes: HashMap::new(),
+        }
+    }
+
+    /// Convenience: read a typed attribute, returning `None` if absent or
+    /// if deserialization fails.
+    pub fn get_attr<T: serde::de::DeserializeOwned>(&self, key: &str) -> Option<T> {
+        self.attributes
+            .get(key)
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+    }
+
+    /// Convenience: write a serializable attribute.
+    pub fn set_attr<T: serde::Serialize>(&mut self, key: impl Into<String>, val: &T) {
+        if let Ok(v) = serde_json::to_value(val) {
+            self.attributes.insert(key.into(), v);
+        }
+    }
+}

--- a/crates/mofa-kernel/src/gateway/validation.rs
+++ b/crates/mofa-kernel/src/gateway/validation.rs
@@ -1,0 +1,417 @@
+//! Gateway configuration container and structural validation.
+//!
+//! [`GatewayConfig`] aggregates the three configuration dimensions
+//! (routes, backends, global settings) and exposes a single
+//! [`GatewayConfig::validate`] method that checks all structural invariants
+//! *before* any runtime resources are allocated.
+//!
+//! This mirrors the `MessageGraph::validate()` / `MessageGraph::compile()`
+//! pattern established in `mofa-kernel::message_graph`.
+
+use super::capability::CapabilityDescriptor;
+use super::error::GatewayError;
+use super::filter::FilterChainConfig;
+use super::router::RouteConfig;
+use std::collections::HashSet;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RateLimitConfig
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Simple token-bucket rate-limit parameters.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RateLimitConfig {
+    /// Sustained token refill rate (tokens per second).
+    pub rate_per_second: u32,
+    /// Maximum burst capacity (must be >= `rate_per_second`).
+    pub burst_capacity: u32,
+}
+
+impl RateLimitConfig {
+    /// Create a new rate-limit config.
+    pub fn new(rate_per_second: u32, burst_capacity: u32) -> Self {
+        Self {
+            rate_per_second,
+            burst_capacity,
+        }
+    }
+
+    fn validate(&self) -> Result<(), GatewayError> {
+        if self.burst_capacity < self.rate_per_second {
+            return Err(GatewayError::InvalidRateLimit);
+        }
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GatewayConfig
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Top-level gateway configuration.
+///
+/// Call [`validate()`](Self::validate) to check all structural invariants
+/// before passing this config to the gateway runtime.
+#[derive(Debug, Clone)]
+pub struct GatewayConfig {
+    /// Unique identifier for this gateway instance.
+    pub id: String,
+    /// All route definitions.
+    pub routes: Vec<RouteConfig>,
+    /// All registered backend descriptors.
+    pub backends: Vec<CapabilityDescriptor>,
+    /// Optional filter chain configuration.
+    pub filter_chain: Option<FilterChainConfig>,
+    /// Global default request timeout in milliseconds (must be > 0).
+    pub request_timeout_ms: u64,
+    /// Optional global rate-limit configuration.
+    pub rate_limit: Option<RateLimitConfig>,
+}
+
+impl GatewayConfig {
+    /// Construct a minimal config with only a gateway id.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            routes: Vec::new(),
+            backends: Vec::new(),
+            filter_chain: None,
+            request_timeout_ms: 30_000,
+            rate_limit: None,
+        }
+    }
+
+    /// Builder: add a route.
+    pub fn with_route(mut self, route: RouteConfig) -> Self {
+        self.routes.push(route);
+        self
+    }
+
+    /// Builder: add a backend.
+    pub fn with_backend(mut self, backend: CapabilityDescriptor) -> Self {
+        self.backends.push(backend);
+        self
+    }
+
+    /// Builder: set the filter chain.
+    pub fn with_filter_chain(mut self, chain: FilterChainConfig) -> Self {
+        self.filter_chain = Some(chain);
+        self
+    }
+
+    /// Builder: set the global request timeout.
+    pub fn with_timeout_ms(mut self, ms: u64) -> Self {
+        self.request_timeout_ms = ms;
+        self
+    }
+
+    /// Builder: set the rate-limit config.
+    pub fn with_rate_limit(mut self, rl: RateLimitConfig) -> Self {
+        self.rate_limit = Some(rl);
+        self
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Validation
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Validate all structural invariants of this configuration.
+    ///
+    /// Returns `Ok(())` if the configuration is structurally sound and can be
+    /// used to initialise the gateway runtime.  Returns the *first* detected
+    /// [`GatewayError`] otherwise.
+    ///
+    /// Checks performed (in order):
+    /// 1. Gateway id is non-empty.
+    /// 2. At least one route is defined.
+    /// 3. At least one backend is defined.
+    /// 4. Global `request_timeout_ms` is non-zero.
+    /// 5. Each backend passes its own [`CapabilityDescriptor::validate()`] check.
+    /// 6. No two backends share the same id.
+    /// 7. Each route passes its own [`RouteConfig::validate()`] check.
+    /// 8. No two routes share the same id.
+    /// 9. Every route's `backend_id` refers to a declared backend.
+    /// 10. If a filter chain is present, it is non-empty.
+    /// 11. If a rate-limit config is present, burst >= rate.
+    pub fn validate(&self) -> Result<(), GatewayError> {
+        // ── 1. Gateway id ────────────────────────────────────────────────────
+        if self.id.trim().is_empty() {
+            return Err(GatewayError::EmptyGatewayId);
+        }
+
+        // ── 2. At least one route ────────────────────────────────────────────
+        if self.routes.is_empty() {
+            return Err(GatewayError::NoRoutes);
+        }
+
+        // ── 3. At least one backend ──────────────────────────────────────────
+        if self.backends.is_empty() {
+            return Err(GatewayError::NoBackends);
+        }
+
+        // ── 4. Global timeout is non-zero ────────────────────────────────────
+        if self.request_timeout_ms == 0 {
+            return Err(GatewayError::InvalidTimeout);
+        }
+
+        // ── Build backend id lookup set ───────────────────────────────────────
+        let mut backend_ids: HashSet<&str> = HashSet::new();
+
+        // ── 5 + 6. Validate each backend, check for duplicates ────────────────
+        for backend in &self.backends {
+            backend.validate()?;
+            if !backend_ids.insert(backend.id.as_str()) {
+                return Err(GatewayError::DuplicateBackend(backend.id.clone()));
+            }
+        }
+
+        // ── 7 + 8 + 9. Validate each route ───────────────────────────────────
+        let mut route_ids: HashSet<&str> = HashSet::new();
+        for route in &self.routes {
+            route.validate()?;
+            if !route_ids.insert(route.id.as_str()) {
+                return Err(GatewayError::DuplicateRoute(route.id.clone()));
+            }
+            if !backend_ids.contains(route.backend_id.as_str()) {
+                return Err(GatewayError::UnknownBackend(
+                    route.id.clone(),
+                    route.backend_id.clone(),
+                ));
+            }
+        }
+
+        // ── 10. Filter chain must be non-empty if present ────────────────────
+        if self
+            .filter_chain
+            .as_ref()
+            .is_some_and(|chain| chain.filter_names.is_empty())
+        {
+            return Err(GatewayError::EmptyFilterChain);
+        }
+
+        // ── 11. Rate-limit burst >= rate ──────────────────────────────────────
+        if let Some(rl) = &self.rate_limit {
+            rl.validate()?;
+        }
+
+        Ok(())
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gateway::capability::{BackendKind, CapabilityDescriptor};
+    use crate::gateway::filter::FilterChainConfig;
+    use crate::gateway::router::RouteConfig;
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn openai_backend() -> CapabilityDescriptor {
+        CapabilityDescriptor::new("openai", BackendKind::LlmOpenAI, "https://api.openai.com")
+    }
+
+    fn chat_route() -> RouteConfig {
+        RouteConfig::new("chat", "/v1/chat/completions", "openai")
+    }
+
+    fn valid_config() -> GatewayConfig {
+        GatewayConfig::new("gateway-test")
+            .with_backend(openai_backend())
+            .with_route(chat_route())
+    }
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn valid_config_passes_validation() {
+        assert!(valid_config().validate().is_ok());
+    }
+
+    #[test]
+    fn valid_config_with_filter_chain_passes() {
+        let chain = FilterChainConfig::new("default", vec!["auth".to_string(), "log".to_string()]);
+        let cfg = valid_config().with_filter_chain(chain);
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn valid_config_with_rate_limit_passes() {
+        let rl = RateLimitConfig::new(100, 200);
+        let cfg = valid_config().with_rate_limit(rl);
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn multiple_routes_and_backends_pass() {
+        let anthropic =
+            CapabilityDescriptor::new("anthropic", BackendKind::LlmAnthropic, "https://api.anthropic.com");
+        let models_route = RouteConfig::new("models", "/v1/models", "anthropic");
+        let cfg = valid_config()
+            .with_backend(anthropic)
+            .with_route(models_route);
+        assert!(cfg.validate().is_ok());
+    }
+
+    // ── Identity errors ───────────────────────────────────────────────────────
+
+    #[test]
+    fn empty_gateway_id_returns_error() {
+        let cfg = GatewayConfig::new("")
+            .with_backend(openai_backend())
+            .with_route(chat_route());
+        assert_eq!(cfg.validate(), Err(GatewayError::EmptyGatewayId));
+    }
+
+    #[test]
+    fn whitespace_only_gateway_id_returns_error() {
+        let cfg = GatewayConfig::new("   ")
+            .with_backend(openai_backend())
+            .with_route(chat_route());
+        assert_eq!(cfg.validate(), Err(GatewayError::EmptyGatewayId));
+    }
+
+    // ── Route errors ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn no_routes_returns_error() {
+        let cfg = GatewayConfig::new("gw").with_backend(openai_backend());
+        assert_eq!(cfg.validate(), Err(GatewayError::NoRoutes));
+    }
+
+    #[test]
+    fn duplicate_route_id_returns_error() {
+        let cfg = GatewayConfig::new("gw")
+            .with_backend(openai_backend())
+            .with_route(chat_route())
+            .with_route(chat_route()); // same id
+        assert_eq!(
+            cfg.validate(),
+            Err(GatewayError::DuplicateRoute("chat".to_string()))
+        );
+    }
+
+    #[test]
+    fn route_with_empty_id_returns_error() {
+        let bad_route = RouteConfig::new("", "/v1/chat/completions", "openai");
+        let cfg = GatewayConfig::new("gw")
+            .with_backend(openai_backend())
+            .with_route(bad_route);
+        assert_eq!(cfg.validate(), Err(GatewayError::EmptyRouteId));
+    }
+
+    #[test]
+    fn route_path_missing_leading_slash_returns_error() {
+        let bad_route = RouteConfig::new("chat", "v1/chat/completions", "openai");
+        let cfg = GatewayConfig::new("gw")
+            .with_backend(openai_backend())
+            .with_route(bad_route);
+        assert!(matches!(
+            cfg.validate(),
+            Err(GatewayError::InvalidPathPattern(ref id, _)) if id == "chat"
+        ));
+    }
+
+    #[test]
+    fn route_referencing_unknown_backend_returns_error() {
+        let route = RouteConfig::new("chat", "/v1/chat/completions", "nonexistent-backend");
+        let cfg = GatewayConfig::new("gw")
+            .with_backend(openai_backend())
+            .with_route(route);
+        assert!(matches!(
+            cfg.validate(),
+            Err(GatewayError::UnknownBackend(ref rid, ref bid))
+                if rid == "chat" && bid == "nonexistent-backend"
+        ));
+    }
+
+    // ── Backend errors ────────────────────────────────────────────────────────
+
+    #[test]
+    fn no_backends_returns_error() {
+        let cfg = GatewayConfig::new("gw").with_route(chat_route());
+        assert_eq!(cfg.validate(), Err(GatewayError::NoBackends));
+    }
+
+    #[test]
+    fn duplicate_backend_id_returns_error() {
+        let cfg = GatewayConfig::new("gw")
+            .with_backend(openai_backend())
+            .with_backend(openai_backend()) // same id
+            .with_route(chat_route());
+        assert_eq!(
+            cfg.validate(),
+            Err(GatewayError::DuplicateBackend("openai".to_string()))
+        );
+    }
+
+    #[test]
+    fn backend_with_empty_id_returns_error() {
+        let bad = CapabilityDescriptor::new("", BackendKind::LlmOpenAI, "https://api.openai.com");
+        let cfg = GatewayConfig::new("gw")
+            .with_backend(bad)
+            .with_route(chat_route());
+        assert_eq!(cfg.validate(), Err(GatewayError::EmptyBackendId));
+    }
+
+    #[test]
+    fn backend_with_empty_endpoint_returns_error() {
+        let bad = CapabilityDescriptor::new("openai", BackendKind::LlmOpenAI, "");
+        let cfg = GatewayConfig::new("gw")
+            .with_backend(bad)
+            .with_route(chat_route());
+        assert!(matches!(
+            cfg.validate(),
+            Err(GatewayError::InvalidEndpoint(ref id, _)) if id == "openai"
+        ));
+    }
+
+    #[test]
+    fn backend_endpoint_without_http_scheme_returns_error() {
+        let bad = CapabilityDescriptor::new("openai", BackendKind::LlmOpenAI, "ftp://badscheme.com");
+        let cfg = GatewayConfig::new("gw")
+            .with_backend(bad)
+            .with_route(chat_route());
+        assert!(matches!(
+            cfg.validate(),
+            Err(GatewayError::InvalidEndpoint(ref id, _)) if id == "openai"
+        ));
+    }
+
+    // ── Timeout errors ────────────────────────────────────────────────────────
+
+    #[test]
+    fn zero_request_timeout_returns_error() {
+        let cfg = valid_config().with_timeout_ms(0);
+        assert_eq!(cfg.validate(), Err(GatewayError::InvalidTimeout));
+    }
+
+    // ── Filter chain errors ───────────────────────────────────────────────────
+
+    #[test]
+    fn empty_filter_chain_returns_error() {
+        let chain = FilterChainConfig::new("default", vec![]);
+        let cfg = valid_config().with_filter_chain(chain);
+        assert_eq!(cfg.validate(), Err(GatewayError::EmptyFilterChain));
+    }
+
+    // ── Rate limit errors ─────────────────────────────────────────────────────
+
+    #[test]
+    fn burst_less_than_rate_returns_error() {
+        let rl = RateLimitConfig::new(100, 50); // burst < rate — invalid
+        let cfg = valid_config().with_rate_limit(rl);
+        assert_eq!(cfg.validate(), Err(GatewayError::InvalidRateLimit));
+    }
+
+    #[test]
+    fn burst_equal_to_rate_passes() {
+        let rl = RateLimitConfig::new(100, 100); // burst == rate — valid
+        let cfg = valid_config().with_rate_limit(rl);
+        assert!(cfg.validate().is_ok());
+    }
+}

--- a/crates/mofa-kernel/src/lib.rs
+++ b/crates/mofa-kernel/src/lib.rs
@@ -71,3 +71,7 @@ pub use metrics::*;
 
 // Security governance (PII redaction, content moderation, prompt guard)
 pub mod security;
+
+// Gateway kernel contract (Task 12)
+pub mod gateway;
+pub use gateway::GatewayError;


### PR DESCRIPTION
## What's this PR about?

Production gateways need to know who's calling, whether they're spamming, and what happened to every request. This PR ships all three.

`ApiKeyFilter` validates `X-Api-Key` headers or `Bearer` tokens using O(1) `HashSet` lookup. Missing or invalid keys get a clean 401. `RateLimitFilter` implements a token-bucket per caller via `DashMap` for lock-free concurrency. Exhausted buckets return 429. `LoggingFilter` wraps every request in a `tracing` span. 5xx responses log at ERROR, everything else at INFO.

**Stacked on #884. Merge order: #876 -> #882 -> #726 -> #883 -> #884 -> #727 -> #885**

### Key changes
- `mofa-gateway`: `ApiKeyFilter` - O(1) key validation, header + bearer support
- `mofa-gateway`: `RateLimitFilter` - per-caller token bucket, `DashMap` for concurrency
- `mofa-gateway`: `LoggingFilter` - structured `tracing` spans on every request/response

### Example test
The `admission_gate_demo` runs all three filters in sequence. The example tests valid auth, missing key (401), and rate exhaustion (429).

**Incremental stats:** +385, 4 files (on top of Phase 5)
