### PR TITLE
remove anyhow with no breaking changes

### DIFF
--- a/crates/mofa-cli/Cargo.toml
+++ b/crates/mofa-cli/Cargo.toml
@@ -83,7 +83,6 @@ crossterm = { version = "0.29", features = ["bracketed-paste", "event-stream"] }
 tokio-stream = "0.1"
 
 [dev-dependencies]
-anyhow.workspace = true
 assert_cmd = "2"
 predicates = "3"
 tempfile = "3"


### PR DESCRIPTION
## Summary

Removes the unused `anyhow` dev-dependency from `mofa-cli/Cargo.toml`.

## Context

The `anyhow` dev-dependency was originally added to fix test compilation after the typed-errors refactor (#559). Since then, all CLI tests have been updated to use typed errors and no longer reference `anyhow`. The dependency is now dead weight.

## Changes

- Removed `anyhow.workspace = true` from `[dev-dependencies]` in `crates/mofa-cli/Cargo.toml`

## Verification

- `grep -rn "anyhow" crates/mofa-cli/src/ crates/mofa-cli/tests/`: no matches
- `cargo check -p mofa-cli --tests`: passes cleanly
<img width="804" height="293" alt="image" src="https://github.com/user-attachments/assets/610d9cc7-8695-4901-ba6e-20805c91931a" />

