### PR TITLE
fix(security): fail closed for --verify-signature in plugin install

### DIFF
--- a/crates/mofa-cli/src/commands/plugin/install.rs
+++ b/crates/mofa-cli/src/commands/plugin/install.rs
@@ -21,6 +21,12 @@ pub async fn run(
         return Err(CliError::PluginError("Plugin name cannot be empty".into()));
     }
 
+    if verify_signature {
+        return Err(CliError::PluginError(
+            "Signature verification requested with --verify-signature, but this feature is not implemented yet. Remove the flag or use --checksum for integrity verification.".into(),
+        ));
+    }
+
     println!("{} Installing plugin: {}", "→".green(), normalized.cyan());
 
     let plugin_source = determine_plugin_source(normalized)?;
@@ -28,11 +34,17 @@ pub async fn run(
     if let PluginSource::Registry(_) = plugin_source {
         let (repo_id, plugin_id) = parse_plugin_reference(normalized)?;
         let entry = find_catalog_entry(&repo_id, &plugin_id).ok_or_else(|| {
-            CliError::PluginError(format!("Plugin '{}' not found in repository '{}'", plugin_id, repo_id))
+            CliError::PluginError(format!(
+                "Plugin '{}' not found in repository '{}'",
+                plugin_id, repo_id
+            ))
         })?;
 
         if ctx.plugin_registry.contains(&entry.id) {
-            return Err(CliError::PluginError(format!("Plugin '{}' is already installed", entry.id)));
+            return Err(CliError::PluginError(format!(
+                "Plugin '{}' is already installed",
+                entry.id
+            )));
         }
 
         if let Ok(Some(existing)) = ctx.plugin_store.get(&entry.id) {
@@ -54,18 +66,30 @@ pub async fn run(
         };
 
         let plugin = instantiate_plugin_from_spec(&spec).ok_or_else(|| {
-            CliError::PluginError(format!("CLI installer does not support plugin kind '{}'", spec.kind))
+            CliError::PluginError(format!(
+                "CLI installer does not support plugin kind '{}'",
+                spec.kind
+            ))
         })?;
 
-        ctx.plugin_registry.register(plugin)
-            .map_err(|e| CliError::PluginError(format!("Failed to register plugin '{}': {}", entry.id, e)))?;
+        ctx.plugin_registry.register(plugin).map_err(|e| {
+            CliError::PluginError(format!("Failed to register plugin '{}': {}", entry.id, e))
+        })?;
 
         if let Err(e) = ctx.plugin_store.save(&spec.id, &spec) {
             let _ = ctx.plugin_registry.unregister(&spec.id);
-            return Err(CliError::PluginError(format!("Failed to persist plugin '{}': {}. Rolled back in-memory registration.", spec.id, e)));
+            return Err(CliError::PluginError(format!(
+                "Failed to persist plugin '{}': {}. Rolled back in-memory registration.",
+                spec.id, e
+            )));
         }
 
-        println!("{} Installed plugin '{}' from repository '{}'", "✓".green(), spec.id, repo_id);
+        println!(
+            "{} Installed plugin '{}' from repository '{}'",
+            "✓".green(),
+            spec.id,
+            repo_id
+        );
         return Ok(());
     }
 
@@ -79,7 +103,10 @@ pub async fn run(
     }
 
     if ctx.plugin_store.get(&plugin_id)?.is_some() {
-        return Err(CliError::PluginError(format!("Plugin '{}' is already installed", plugin_id)));
+        return Err(CliError::PluginError(format!(
+            "Plugin '{}' is already installed",
+            plugin_id
+        )));
     }
 
     let plugin_dir = match plugin_source {
@@ -89,7 +116,7 @@ pub async fn run(
         }
         PluginSource::Url(url) => {
             println!("  {} Source: URL", "•".bright_black());
-            install_from_url(&ctx.data_dir, &plugin_id, &url, checksum, verify_signature).await?
+            install_from_url(&ctx.data_dir, &plugin_id, &url, checksum).await?
         }
         PluginSource::Registry(_) => unreachable!(),
     };
@@ -108,12 +135,28 @@ pub async fn run(
         repo_id: None,
     };
 
-    ctx.plugin_store.save(&plugin_id, &spec)
-        .map_err(|e| CliError::PluginError(format!("Failed to persist plugin spec for '{}': {}", plugin_id, e)))?;
+    ctx.plugin_store.save(&plugin_id, &spec).map_err(|e| {
+        CliError::PluginError(format!(
+            "Failed to persist plugin spec for '{}': {}",
+            plugin_id, e
+        ))
+    })?;
 
-    println!("{} Plugin '{}' installed successfully", "✓".green(), plugin_id);
-    println!("  {} Location: {}", "•".bright_black(), plugin_dir.display().to_string().cyan());
-    println!("  {} Use {} to activate it", "•".bright_black(), "mofa plugin enable".yellow());
+    println!(
+        "{} Plugin '{}' installed successfully",
+        "✓".green(),
+        plugin_id
+    );
+    println!(
+        "  {} Location: {}",
+        "•".bright_black(),
+        plugin_dir.display().to_string().cyan()
+    );
+    println!(
+        "  {} Use {} to activate it",
+        "•".bright_black(),
+        "mofa plugin enable".yellow()
+    );
 
     Ok(())
 }
@@ -124,7 +167,9 @@ fn parse_plugin_reference(value: &str) -> Result<(String, String), CliError> {
         let plugin = plugin.trim();
 
         if repo.is_empty() || plugin.is_empty() {
-            return Err(CliError::PluginError("Plugin reference must be '<repo>/<plugin>'".into()));
+            return Err(CliError::PluginError(
+                "Plugin reference must be '<repo>/<plugin>'".into(),
+            ));
         }
 
         Ok((repo.to_string(), plugin.to_string()))
@@ -165,13 +210,13 @@ async fn install_from_local_path(
 
     // Remove existing directory if present
     if dest_dir.exists() {
-        tokio::fs::remove_dir_all(&dest_dir).await
-            .map_err(|e| {
-                CliError::PluginError(format!(
-                    "Failed to remove existing plugin directory '{}': {}",
-                    dest_dir.display(), e
-                ))
-            })?;
+        tokio::fs::remove_dir_all(&dest_dir).await.map_err(|e| {
+            CliError::PluginError(format!(
+                "Failed to remove existing plugin directory '{}': {}",
+                dest_dir.display(),
+                e
+            ))
+        })?;
     }
 
     // Copy plugin files
@@ -186,7 +231,6 @@ async fn install_from_url(
     plugin_name: &str,
     url: &str,
     expected_checksum: Option<&str>,
-    verify_signature: bool,
 ) -> Result<PathBuf, CliError> {
     let plugins_dir = data_dir.join("plugins");
     tokio::fs::create_dir_all(&plugins_dir)
@@ -196,12 +240,15 @@ async fn install_from_url(
     // Download the file with progress bar
     println!("  {} Downloading from {}", "•".bright_black(), url.cyan());
 
-    let response = reqwest::get(url)
-        .await
-        .map_err(|e| CliError::PluginError(format!("Failed to download plugin from {}: {}", url, e)))?;
+    let response = reqwest::get(url).await.map_err(|e| {
+        CliError::PluginError(format!("Failed to download plugin from {}: {}", url, e))
+    })?;
 
     if !response.status().is_success() {
-        return Err(CliError::PluginError(format!("Download failed with status: {}", response.status())));
+        return Err(CliError::PluginError(format!(
+            "Download failed with status: {}",
+            response.status()
+        )));
     }
 
     // Get content length for progress bar
@@ -218,7 +265,8 @@ async fn install_from_url(
     let mut bytes = Vec::new();
     let mut stream = response.bytes_stream();
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|e| CliError::PluginError(format!("Failed to read download chunk: {}", e)))?;
+        let chunk = chunk
+            .map_err(|e| CliError::PluginError(format!("Failed to read download chunk: {}", e)))?;
         bytes.extend_from_slice(&chunk);
         pb.inc(chunk.len() as u64);
     }
@@ -235,24 +283,16 @@ async fn install_from_url(
         if computed_hex.to_lowercase() != expected.to_lowercase() {
             return Err(CliError::PluginError(format!(
                 "Checksum mismatch!\n  Expected: {}\n  Computed: {}\n\nPlugin may be corrupted or tampered with.",
-                expected,
-                computed_hex
+                expected, computed_hex
             )));
         }
         println!("  {} Checksum verified", "✓".green());
     }
 
-    if verify_signature {
-        println!(
-            "  {} Signature verification not yet implemented",
-            "⚠".yellow()
-        );
-        println!("  {} Consider using --checksum for now", "•".bright_black());
-    }
-
     // Determine if it's an archive or single file
     let dest_dir = plugins_dir.join(plugin_name);
-    tokio::fs::create_dir_all(&dest_dir).await
+    tokio::fs::create_dir_all(&dest_dir)
+        .await
         .map_err(|e| CliError::PluginError(format!("Failed to create plugin directory: {}", e)))?;
 
     // For simplicity, assume it's a tar.gz or zip based on URL
@@ -264,7 +304,8 @@ async fn install_from_url(
         // Treat as single file, save it directly
         let filename = url.split('/').next_back().unwrap_or("plugin");
         let file_path = dest_dir.join(filename);
-        tokio::fs::write(&file_path, &bytes).await
+        tokio::fs::write(&file_path, &bytes)
+            .await
             .map_err(|e| CliError::PluginError(format!("Failed to write plugin file: {}", e)))?;
     }
 
@@ -274,18 +315,29 @@ async fn install_from_url(
 /// Validate that the plugin directory has required structure
 fn validate_plugin_structure(plugin_dir: &Path) -> Result<(), CliError> {
     if !plugin_dir.exists() {
-        return Err(CliError::PluginError(format!("Plugin directory does not exist: {}", plugin_dir.display())));
+        return Err(CliError::PluginError(format!(
+            "Plugin directory does not exist: {}",
+            plugin_dir.display()
+        )));
     }
 
     if !plugin_dir.is_dir() {
-        return Err(CliError::PluginError(format!("Plugin path is not a directory: {}", plugin_dir.display())));
+        return Err(CliError::PluginError(format!(
+            "Plugin path is not a directory: {}",
+            plugin_dir.display()
+        )));
     }
 
     // Check for at least one file (skip . and .. entries)
     let mut has_files = false;
     let mut entry_count = 0;
-    let entries = std::fs::read_dir(plugin_dir)
-        .map_err(|e| CliError::PluginError(format!("Failed to read plugin directory '{}': {}", plugin_dir.display(), e)))?;
+    let entries = std::fs::read_dir(plugin_dir).map_err(|e| {
+        CliError::PluginError(format!(
+            "Failed to read plugin directory '{}': {}",
+            plugin_dir.display(),
+            e
+        ))
+    })?;
     for entry in entries {
         entry_count += 1;
         match entry {
@@ -323,13 +375,21 @@ fn copy_dir_recursive<'a>(
     dest: &'a Path,
 ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), CliError>> + Send + 'a>> {
     Box::pin(async move {
-        tokio::fs::create_dir_all(dest)
-            .await
-            .map_err(|e| CliError::PluginError(format!("Failed to create directory '{}': {}", dest.display(), e)))?;
+        tokio::fs::create_dir_all(dest).await.map_err(|e| {
+            CliError::PluginError(format!(
+                "Failed to create directory '{}': {}",
+                dest.display(),
+                e
+            ))
+        })?;
 
-        let mut entries = tokio::fs::read_dir(src)
-            .await
-            .map_err(|e| CliError::PluginError(format!("Failed to read source directory '{}': {}", src.display(), e)))?;
+        let mut entries = tokio::fs::read_dir(src).await.map_err(|e| {
+            CliError::PluginError(format!(
+                "Failed to read source directory '{}': {}",
+                src.display(),
+                e
+            ))
+        })?;
 
         while let Some(entry) = entries
             .next_entry()
@@ -344,12 +404,14 @@ fn copy_dir_recursive<'a>(
             } else {
                 tokio::fs::copy(&entry_path, &dest_path)
                     .await
-                    .map_err(|e| CliError::PluginError(format!(
-                        "Failed to copy file from {} to {}: {}",
-                        entry_path.display(),
-                        dest_path.display(),
-                        e
-                    )))?;
+                    .map_err(|e| {
+                        CliError::PluginError(format!(
+                            "Failed to copy file from {} to {}: {}",
+                            entry_path.display(),
+                            dest_path.display(),
+                            e
+                        ))
+                    })?;
             }
         }
 
@@ -378,7 +440,8 @@ fn extract_zip(bytes: &[u8], dest_dir: &Path) -> Result<(), CliError> {
     use zip::ZipArchive;
 
     let cursor = Cursor::new(bytes);
-    let mut archive = ZipArchive::new(cursor).map_err(|e| CliError::PluginError(format!("Failed to read zip archive: {}", e)))?;
+    let mut archive = ZipArchive::new(cursor)
+        .map_err(|e| CliError::PluginError(format!("Failed to read zip archive: {}", e)))?;
 
     for i in 0..archive.len() {
         let mut file = archive
@@ -391,16 +454,33 @@ fn extract_zip(bytes: &[u8], dest_dir: &Path) -> Result<(), CliError> {
         };
 
         if file.name().ends_with('/') {
-            std::fs::create_dir_all(&outpath)
-                .map_err(|e| CliError::PluginError(format!("Failed to create directory '{}': {}", outpath.display(), e)))?;
+            std::fs::create_dir_all(&outpath).map_err(|e| {
+                CliError::PluginError(format!(
+                    "Failed to create directory '{}': {}",
+                    outpath.display(),
+                    e
+                ))
+            })?;
         } else {
             if let Some(parent) = outpath.parent() {
-                std::fs::create_dir_all(parent).map_err(|e| CliError::PluginError(format!("Failed to create parent directory '{}': {}", parent.display(), e)))?;
+                std::fs::create_dir_all(parent).map_err(|e| {
+                    CliError::PluginError(format!(
+                        "Failed to create parent directory '{}': {}",
+                        parent.display(),
+                        e
+                    ))
+                })?;
             }
-            let mut outfile = std::fs::File::create(&outpath)
-                .map_err(|e| CliError::PluginError(format!("Failed to create file '{}': {}", outpath.display(), e)))?;
-            std::io::copy(&mut file, &mut outfile)
-                .map_err(|e| CliError::PluginError(format!("Failed to write file contents: {}", e)))?;
+            let mut outfile = std::fs::File::create(&outpath).map_err(|e| {
+                CliError::PluginError(format!(
+                    "Failed to create file '{}': {}",
+                    outpath.display(),
+                    e
+                ))
+            })?;
+            std::io::copy(&mut file, &mut outfile).map_err(|e| {
+                CliError::PluginError(format!("Failed to write file contents: {}", e))
+            })?;
         }
     }
 
@@ -413,7 +493,6 @@ enum PluginSource {
     Url(String),
     Registry(String),
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -504,13 +583,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_install_rejects_verify_signature_until_implemented() {
+        let temp = TempDir::new().unwrap();
+        let ctx = CliContext::with_temp_dir(temp.path()).await.unwrap();
+
+        let err = run(&ctx, "http-plugin", None, true).await.unwrap_err();
+        assert!(err.to_string().contains("not implemented yet"));
+        assert!(err.to_string().contains("--verify-signature"));
+    }
+
+    #[tokio::test]
     async fn test_install_supports_repo_prefixed_reference() {
         let temp = TempDir::new().unwrap();
         let ctx = CliContext::with_temp_dir(temp.path()).await.unwrap();
 
         disable_default_http_plugin(&ctx);
 
-        run(&ctx, "official/http-plugin", None, false).await.unwrap();
+        run(&ctx, "official/http-plugin", None, false)
+            .await
+            .unwrap();
 
         let spec = ctx.plugin_store.get("http-plugin").unwrap().unwrap();
         assert_eq!(spec.repo_id.as_deref(), Some(DEFAULT_PLUGIN_REPO_ID));
@@ -522,7 +613,9 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let ctx = CliContext::with_temp_dir(temp.path()).await.unwrap();
 
-        let err = run(&ctx, "official/not-real", None, false).await.unwrap_err();
+        let err = run(&ctx, "official/not-real", None, false)
+            .await
+            .unwrap_err();
         assert!(err.to_string().contains("not found in repository"));
     }
 

--- a/crates/mofa-plugins/src/tools/http.rs
+++ b/crates/mofa-plugins/src/tools/http.rs
@@ -1,7 +1,7 @@
 use super::*;
 use reqwest::Client;
 use serde_json::json;
-use std::net::ToSocketAddrs;
+use std::net::{IpAddr, Ipv4Addr, ToSocketAddrs};
 use url::Url;
 
 /// HTTP 请求工具 - 发送网络请求
@@ -51,9 +51,23 @@ impl HttpRequestTool {
             },
             client: Client::builder()
                 .timeout(std::time::Duration::from_secs(30))
+                // Avoid following redirects to internal/private networks.
+                .redirect(reqwest::redirect::Policy::none())
                 .build()
-                .unwrap(),
+                .expect("failed to build HTTP client"),
         }
+    }
+
+    fn truncate_utf8(input: &str, max_bytes: usize) -> String {
+        if input.len() <= max_bytes {
+            return input.to_string();
+        }
+
+        let mut end = max_bytes.min(input.len());
+        while end > 0 && !input.is_char_boundary(end) {
+            end -= 1;
+        }
+        input[..end].to_string()
     }
 
     /// Validate that a URL is safe to request (not targeting internal/private networks).
@@ -75,7 +89,7 @@ impl HttpRequestTool {
         };
 
         // Block well-known dangerous hostnames
-        if host == "metadata.google.internal" {
+        if host.eq_ignore_ascii_case("metadata.google.internal") {
             return false;
         }
 
@@ -94,12 +108,7 @@ impl HttpRequestTool {
         }
 
         for addr in addrs {
-            let ip = addr.ip();
-            if ip.is_loopback()
-                || ip.is_unspecified()
-                || ip.is_multicast()
-                || Self::is_private_ip(&ip)
-            {
+            if Self::is_blocked_ip(&addr.ip()) {
                 return false;
             }
         }
@@ -107,28 +116,44 @@ impl HttpRequestTool {
         true
     }
 
-    /// Check if an IP address is in a private/reserved range.
-    fn is_private_ip(ip: &std::net::IpAddr) -> bool {
+    /// Check if an IP address is blocked for security reasons.
+    fn is_blocked_ip(ip: &IpAddr) -> bool {
         match ip {
-            std::net::IpAddr::V4(ipv4) => {
-                let octets = ipv4.octets();
-                // 10.0.0.0/8
-                octets[0] == 10
-                // 172.16.0.0/12
-                || (octets[0] == 172 && (16..=31).contains(&octets[1]))
-                // 192.168.0.0/16
-                || (octets[0] == 192 && octets[1] == 168)
-                // 169.254.0.0/16 (link-local, includes cloud metadata 169.254.169.254)
-                || (octets[0] == 169 && octets[1] == 254)
-                // 100.64.0.0/10 (carrier-grade NAT)
-                || (octets[0] == 100 && (64..=127).contains(&octets[1]))
+            IpAddr::V4(ipv4) => {
+                ipv4.is_private()
+                    || ipv4.is_loopback()
+                    || ipv4.is_unspecified()
+                    || ipv4.is_multicast()
+                    || ipv4.is_link_local()
+                    || ipv4.is_broadcast()
+                    || ipv4.is_documentation()
+                    || Self::is_cgnat_ipv4(*ipv4)
             }
-            std::net::IpAddr::V6(ipv6) => {
-                // Block unique local (fc00::/7) and link-local (fe80::/10)
-                let segments = ipv6.segments();
-                (segments[0] & 0xfe00) == 0xfc00 || (segments[0] & 0xffc0) == 0xfe80
+            IpAddr::V6(ipv6) => {
+                // Handle IPv4-mapped IPv6 addresses, e.g. ::ffff:127.0.0.1.
+                if let Some(mapped) = ipv6.to_ipv4_mapped() {
+                    return Self::is_blocked_ip(&IpAddr::V4(mapped));
+                }
+
+                ipv6.is_loopback()
+                    || ipv6.is_unspecified()
+                    || ipv6.is_multicast()
+                    || ipv6.is_unique_local()
+                    || ipv6.is_unicast_link_local()
+                    || Self::is_documentation_ipv6(*ipv6)
             }
         }
+    }
+
+    fn is_cgnat_ipv4(ipv4: Ipv4Addr) -> bool {
+        let octets = ipv4.octets();
+        octets[0] == 100 && (64..=127).contains(&octets[1])
+    }
+
+    fn is_documentation_ipv6(ipv6: std::net::Ipv6Addr) -> bool {
+        let segments = ipv6.segments();
+        // 2001:db8::/32
+        segments[0] == 0x2001 && segments[1] == 0x0db8
     }
 }
 
@@ -140,9 +165,9 @@ impl ToolExecutor for HttpRequestTool {
 
     async fn execute(&self, arguments: serde_json::Value) -> PluginResult<serde_json::Value> {
         let method = arguments["method"].as_str().unwrap_or("GET");
-        let url = arguments["url"]
-            .as_str()
-            .ok_or_else(|| mofa_kernel::plugin::PluginError::ExecutionFailed("URL is required".to_string()))?;
+        let url = arguments["url"].as_str().ok_or_else(|| {
+            mofa_kernel::plugin::PluginError::ExecutionFailed("URL is required".to_string())
+        })?;
 
         // Validate URL to prevent SSRF attacks
         if !Self::is_url_allowed(url) {
@@ -157,7 +182,12 @@ impl ToolExecutor for HttpRequestTool {
             "POST" => self.client.post(url),
             "PUT" => self.client.put(url),
             "DELETE" => self.client.delete(url),
-            _ => return Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!("Unsupported HTTP method: {}", method))),
+            _ => {
+                return Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!(
+                    "Unsupported HTTP method: {}",
+                    method
+                )));
+            }
         };
 
         // Add headers if provided
@@ -174,7 +204,9 @@ impl ToolExecutor for HttpRequestTool {
             request = request.body(body.to_string());
         }
 
-        let response = request.send().await
+        let response = request
+            .send()
+            .await
             .map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(e.to_string()))?;
         let status = response.status().as_u16();
         let headers: std::collections::HashMap<String, String> = response
@@ -183,14 +215,16 @@ impl ToolExecutor for HttpRequestTool {
             .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
             .collect();
 
-        let body = response.text().await
+        let body = response
+            .text()
+            .await
             .map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(e.to_string()))?;
 
         // Truncate body if too long
         let truncated_body = if body.len() > 5000 {
             format!(
                 "{}... [truncated, total {} bytes]",
-                &body[..5000],
+                Self::truncate_utf8(&body, 5000),
                 body.len()
             )
         } else {
@@ -202,5 +236,41 @@ impl ToolExecutor for HttpRequestTool {
             "headers": headers,
             "body": truncated_body
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blocks_ipv4_mapped_loopback() {
+        let ip: IpAddr = "::ffff:127.0.0.1".parse().unwrap();
+        assert!(HttpRequestTool::is_blocked_ip(&ip));
+    }
+
+    #[test]
+    fn blocks_localhost_url() {
+        assert!(!HttpRequestTool::is_url_allowed("http://127.0.0.1:8080/"));
+    }
+
+    #[test]
+    fn blocks_ipv4_mapped_loopback_url() {
+        assert!(!HttpRequestTool::is_url_allowed(
+            "http://[::ffff:127.0.0.1]:8080/"
+        ));
+    }
+
+    #[test]
+    fn blocks_metadata_hostname_case_insensitively() {
+        assert!(!HttpRequestTool::is_url_allowed(
+            "http://METADATA.GOOGLE.INTERNAL/"
+        ));
+    }
+
+    #[test]
+    fn truncates_utf8_without_panicking() {
+        let value = "A🙂B";
+        assert_eq!(HttpRequestTool::truncate_utf8(value, 2), "A");
     }
 }


### PR DESCRIPTION
## 🔍 Issue Description
`mofa plugin install --verify-signature` previously behaved as a no-op security flag. This PR changes that behavior to fail closed until real signature verification is implemented.

## 📌 Issue Type
- [x] Bug
- [x] Enhancement

## 📝 Description
- What is happening?
  - `--verify-signature` was accepted but installation still continued.
- What should happen instead?
  - Installation must stop with an error if `--verify-signature` is requested and not implemented.
- Why is this needed?
  - Avoid false security assumptions in plugin supply-chain flow.

## 🎯 Proposed Solution
- Add an early fail-closed check in plugin install flow when `verify_signature` is true.
- Remove old warning-only no-op path.
- Add regression test ensuring `--verify-signature` is rejected.

## 📎 Additional Context
- Target file: `crates/mofa-cli/src/commands/plugin/install.rs`
- Validation:
  - `cargo test -p mofa-cli commands::plugin::install::tests::test_install_rejects_verify_signature_until_implemented --quiet`
  - `cargo test -p mofa-cli commands::plugin::install --quiet`

Closes #679
