### PR TITLE
add durable checkpoint store for cross process workflow recovery

### DIFF
--- a/crates/mofa-foundation/src/persistence/checkpoint_store.rs
+++ b/crates/mofa-foundation/src/persistence/checkpoint_store.rs
@@ -1,0 +1,283 @@
+//! File based checkpoint store
+
+use mofa_kernel::checkpoint::{CheckpointError, CheckpointStore, CheckpointSummary};
+use async_trait::async_trait;
+use std::path::{Path, PathBuf};
+
+/// File based checkpoint store
+pub struct FileCheckpointStore {
+    dir: PathBuf,
+}
+
+impl FileCheckpointStore {
+    pub fn new(dir: impl AsRef<Path>) -> Result<Self, CheckpointError> {
+        let dir = dir.as_ref().to_path_buf();
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| CheckpointError::Storage(format!("create dir: {}", e)))?;
+        Ok(Self { dir })
+    }
+
+    fn file_path(&self, execution_id: &str, label: &str) -> PathBuf {
+        let safe_id = execution_id.replace(['/', '\\', ':', '*', '?'], "_");
+        let safe_label = label.replace(['/', '\\', ':', '*', '?'], "_");
+        self.dir.join(format!("{}_{}.json", safe_id, safe_label))
+    }
+
+    fn read_wrapper(&self, path: &Path) -> Result<CheckpointWrapper, CheckpointError> {
+        let contents = std::fs::read_to_string(path)
+            .map_err(|e| CheckpointError::Storage(e.to_string()))?;
+        serde_json::from_str(&contents)
+            .map_err(|e| CheckpointError::Serialization(e.to_string()))
+    }
+}
+
+/// On-disk checkpoint envelope
+#[derive(serde::Serialize, serde::Deserialize)]
+struct CheckpointWrapper {
+    execution_id: String,
+    workflow_id: String,
+    label: String,
+    created_at: u64,
+    node_count: usize,
+    data: serde_json::Value,
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+#[async_trait]
+impl CheckpointStore for FileCheckpointStore {
+    async fn save(
+        &self,
+        execution_id: &str,
+        workflow_id: &str,
+        label: &str,
+        data: &serde_json::Value,
+    ) -> Result<(), CheckpointError> {
+        let node_count = data
+            .get("node_outputs")
+            .and_then(|v| v.as_object())
+            .map(|m| m.len())
+            .unwrap_or(0);
+
+        let wrapper = CheckpointWrapper {
+            execution_id: execution_id.to_string(),
+            workflow_id: workflow_id.to_string(),
+            label: label.to_string(),
+            created_at: now_ms(),
+            node_count,
+            data: data.clone(),
+        };
+
+        let json = serde_json::to_string_pretty(&wrapper)
+            .map_err(|e| CheckpointError::Serialization(e.to_string()))?;
+
+        let path = self.file_path(execution_id, label);
+        std::fs::write(&path, json)
+            .map_err(|e| CheckpointError::Storage(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn load(
+        &self,
+        execution_id: &str,
+    ) -> Result<Option<serde_json::Value>, CheckpointError> {
+
+        let prefix = format!(
+            "{}_",
+            execution_id.replace(['/', '\\', ':', '*', '?'], "_")
+        );
+
+        let mut best: Option<CheckpointWrapper> = None;
+
+        let entries = std::fs::read_dir(&self.dir)
+            .map_err(|e| CheckpointError::Storage(e.to_string()))?;
+
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            if name_str.starts_with(&prefix) && name_str.ends_with(".json") {
+                if let Ok(wrapper) = self.read_wrapper(&entry.path()) {
+                    if best.as_ref().map_or(true, |b| wrapper.created_at > b.created_at) {
+                        best = Some(wrapper);
+                    }
+                }
+            }
+        }
+
+        Ok(best.map(|w| w.data))
+    }
+
+    async fn list(
+        &self,
+        workflow_id: Option<&str>,
+    ) -> Result<Vec<CheckpointSummary>, CheckpointError> {
+        let entries = std::fs::read_dir(&self.dir)
+            .map_err(|e| CheckpointError::Storage(e.to_string()))?;
+
+        let mut summaries = Vec::new();
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().map_or(true, |e| e != "json") {
+                continue;
+            }
+            if let Ok(wrapper) = self.read_wrapper(&path) {
+                if let Some(wid) = workflow_id {
+                    if wrapper.workflow_id != wid {
+                        continue;
+                    }
+                }
+                summaries.push(CheckpointSummary {
+                    execution_id: wrapper.execution_id,
+                    workflow_id: wrapper.workflow_id,
+                    created_at: wrapper.created_at,
+                    node_count: wrapper.node_count,
+                    label: wrapper.label,
+                });
+            }
+        }
+
+        summaries.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(summaries)
+    }
+
+    async fn delete(&self, execution_id: &str) -> Result<bool, CheckpointError> {
+        let prefix = format!(
+            "{}_",
+            execution_id.replace(['/', '\\', ':', '*', '?'], "_")
+        );
+
+        let entries = std::fs::read_dir(&self.dir)
+            .map_err(|e| CheckpointError::Storage(e.to_string()))?;
+
+        let mut deleted = false;
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            if name.to_string_lossy().starts_with(&prefix) {
+                let _ = std::fs::remove_file(entry.path());
+                deleted = true;
+            }
+        }
+
+        Ok(deleted)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    fn sample_snapshot(exec_id: &str, wf_id: &str) -> serde_json::Value {
+        json!({
+            "version": 1,
+            "workflow_id": wf_id,
+            "execution_id": exec_id,
+            "input": null,
+            "node_outputs": {
+                "step_1": "result_1",
+                "step_2": "result_2"
+            },
+            "node_statuses": {
+                "step_1": "Completed",
+                "step_2": "Completed"
+            },
+            "variables": {},
+            "checkpoints": [],
+            "paused_at": null,
+            "last_waiting_node": null,
+            "total_wait_time_ms": 0
+        })
+    }
+
+    fn temp_store() -> (TempDir, FileCheckpointStore) {
+        let dir = TempDir::new().unwrap();
+        let store = FileCheckpointStore::new(dir.path()).unwrap();
+        (dir, store)
+    }
+
+    // Roundtrip: save checkpoint then load it back
+    #[tokio::test]
+    async fn test_save_and_load() {
+        let (_dir, store) = temp_store();
+        let data = sample_snapshot("exec-1", "wf-1");
+        store.save("exec-1", "wf-1", "auto_1", &data).await.unwrap();
+
+        let loaded = store.load("exec-1").await.unwrap();
+        assert!(loaded.is_some());
+        let loaded = loaded.unwrap();
+        assert_eq!(loaded["workflow_id"], "wf-1");
+        assert_eq!(loaded["node_outputs"]["step_1"], "result_1");
+    }
+
+    // Loading a missing execution returns None
+    #[tokio::test]
+    async fn test_load_nonexistent() {
+        let (_dir, store) = temp_store();
+        assert!(store.load("nope").await.unwrap().is_none());
+    }
+
+    // List returns all stored checkpoints
+    #[tokio::test]
+    async fn test_list_all() {
+        let (_dir, store) = temp_store();
+        store.save("exec-1", "wf-1", "cp1", &sample_snapshot("exec-1", "wf-1")).await.unwrap();
+        store.save("exec-2", "wf-2", "cp1", &sample_snapshot("exec-2", "wf-2")).await.unwrap();
+
+        let all = store.list(None).await.unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    // List filters by workflow_id correctly
+    #[tokio::test]
+    async fn test_list_by_workflow() {
+        let (_dir, store) = temp_store();
+        store.save("exec-1", "wf-1", "cp1", &sample_snapshot("exec-1", "wf-1")).await.unwrap();
+        store.save("exec-2", "wf-2", "cp1", &sample_snapshot("exec-2", "wf-2")).await.unwrap();
+        store.save("exec-3", "wf-1", "cp1", &sample_snapshot("exec-3", "wf-1")).await.unwrap();
+
+        let wf1 = store.list(Some("wf-1")).await.unwrap();
+        assert_eq!(wf1.len(), 2);
+        assert!(wf1.iter().all(|s| s.workflow_id == "wf-1"));
+    }
+
+    // Delete removes files, second delete returns false
+    #[tokio::test]
+    async fn test_delete() {
+        let (_dir, store) = temp_store();
+        store.save("exec-1", "wf-1", "cp1", &sample_snapshot("exec-1", "wf-1")).await.unwrap();
+        assert!(store.delete("exec-1").await.unwrap());
+        assert!(!store.delete("exec-1").await.unwrap());
+        assert!(store.load("exec-1").await.unwrap().is_none());
+    }
+
+    // Same (exec_id, label) overwrites the previous file
+    #[tokio::test]
+    async fn test_overwrite_same_label() {
+        let (_dir, store) = temp_store();
+        let mut data = sample_snapshot("exec-1", "wf-1");
+        store.save("exec-1", "wf-1", "latest", &data).await.unwrap();
+
+        data["node_outputs"]["step_3"] = json!("result_3");
+        store.save("exec-1", "wf-1", "latest", &data).await.unwrap();
+
+        let loaded = store.load("exec-1").await.unwrap().unwrap();
+        assert_eq!(loaded["node_outputs"]["step_3"], "result_3");
+    }
+
+    // node_count is extracted from the JSON payload
+    #[tokio::test]
+    async fn test_node_count_extracted() {
+        let (_dir, store) = temp_store();
+        store.save("exec-1", "wf-1", "cp1", &sample_snapshot("exec-1", "wf-1")).await.unwrap();
+        let list = store.list(None).await.unwrap();
+        assert_eq!(list[0].node_count, 2);
+    }
+}

--- a/crates/mofa-foundation/src/persistence/mod.rs
+++ b/crates/mofa-foundation/src/persistence/mod.rs
@@ -143,6 +143,7 @@ mod memory;
 mod metrics_source;
 mod plugin;
 mod traits;
+pub mod checkpoint_store;
 
 pub use entities::*;
 pub use memory::*;

--- a/crates/mofa-foundation/src/workflow/executor.rs
+++ b/crates/mofa-foundation/src/workflow/executor.rs
@@ -15,6 +15,7 @@ use super::state::{
     ExecutionCheckpoint, ExecutionRecord, NodeExecutionRecord, NodeResult, NodeStatus,
     WorkflowContext, WorkflowStatus, WorkflowValue,
 };
+use mofa_kernel::checkpoint::CheckpointStore;
 use mofa_kernel::workflow::telemetry::{DebugEvent, TelemetryEmitter};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -114,6 +115,8 @@ pub struct WorkflowExecutor {
     semaphore: Arc<Semaphore>,
     /// Profiler for execution timing (optional)
     profiler: ProfilerMode,
+    /// Optional durable checkpoint store
+    checkpoint_store: Option<Arc<dyn CheckpointStore>>,
 }
 
 impl WorkflowExecutor {
@@ -127,6 +130,7 @@ impl WorkflowExecutor {
             event_waiters: Arc::new(RwLock::new(HashMap::new())),
             semaphore,
             profiler: ProfilerMode::Disabled,
+            checkpoint_store: None,
         }
     }
 
@@ -151,6 +155,12 @@ impl WorkflowExecutor {
     /// When set, the executor will record execution timing spans.
     pub fn with_profiler(mut self, mode: ProfilerMode) -> Self {
         self.profiler = mode;
+        self
+    }
+
+    /// Attach a durable checkpoint store for cross-process recovery.
+    pub fn with_checkpoint_store(mut self, store: Arc<dyn CheckpointStore>) -> Self {
+        self.checkpoint_store = Some(store);
         self
     }
 
@@ -676,6 +686,16 @@ impl WorkflowExecutor {
             {
                 let label = format!("auto_checkpoint_{}", record.node_records.len());
                 ctx.create_checkpoint(&label).await;
+
+                if let Some(ref store) = self.checkpoint_store {
+                    let snapshot = ctx.snapshot().await;
+                    if let Ok(json) = serde_json::to_value(&snapshot) {
+                        let _ = store
+                            .save(&ctx.execution_id, &ctx.workflow_id, &label, &json)
+                            .await;
+                    }
+                }
+
                 self.emit_event(ExecutionEvent::CheckpointCreated { label })
                     .await;
             }

--- a/crates/mofa-kernel/src/checkpoint.rs
+++ b/crates/mofa-kernel/src/checkpoint.rs
@@ -1,0 +1,60 @@
+//! Checkpoint persistence traits
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Auto-checkpoint policy
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum CheckpointPolicy {
+    Never,
+    EveryNode,
+    EveryN(usize),
+}
+
+impl Default for CheckpointPolicy {
+    fn default() -> Self {
+        Self::Never
+    }
+}
+
+/// Stored checkpoint metadata
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckpointSummary {
+    pub execution_id: String,
+    pub workflow_id: String,
+    pub created_at: u64,
+    pub node_count: usize,
+    pub label: String,
+}
+
+#[derive(Debug, Error)]
+pub enum CheckpointError {
+    #[error("serialization error: {0}")]
+    Serialization(String),
+    #[error("storage error: {0}")]
+    Storage(String),
+    #[error("checkpoint not found: {0}")]
+    NotFound(String),
+}
+
+/// Pluggable checkpoint persistence backend
+#[async_trait]
+pub trait CheckpointStore: Send + Sync {
+    async fn save(
+        &self,
+        execution_id: &str,
+        workflow_id: &str,
+        label: &str,
+        data: &serde_json::Value,
+    ) -> Result<(), CheckpointError>;
+
+    async fn load(&self, execution_id: &str) -> Result<Option<serde_json::Value>, CheckpointError>;
+
+    async fn list(
+        &self,
+        workflow_id: Option<&str>,
+    ) -> Result<Vec<CheckpointSummary>, CheckpointError>;
+
+    async fn delete(&self, execution_id: &str) -> Result<bool, CheckpointError>;
+}

--- a/crates/mofa-kernel/src/lib.rs
+++ b/crates/mofa-kernel/src/lib.rs
@@ -68,3 +68,6 @@ pub use workflow::*;
 // Metrics traits for monitoring integration
 pub mod metrics;
 pub use metrics::*;
+
+// Checkpoint persistence traits
+pub mod checkpoint;


### PR DESCRIPTION
## 📋 Summary

Adds durable checkpoint persistence so workflow execution state survives process restarts. Introduces a pluggable `CheckpointStore` trait in mofa-kernel and a zero dependency file-based implementation in mofa foundation. The executor auto-persists checkpoints to disk when a store is attached.

## 🔗 Related Issues

- Fixes: #734

## 🧠 Context

PR #150 added `ExecutionCheckpoint` and `resume_from_checkpoint`, but checkpoints only exist in memory. If the process dies, all workflow progress is lost. Long-running agent workflows (multi-step research, data pipelines) need durable state to survive restarts. This PR adds the missing storage layer.

## 🛠️ Changes

- **New**: `crates/mofa-kernel/src/checkpoint.rs`: `CheckpointStore` trait, `CheckpointPolicy` enum, `CheckpointError`
- **New**: `crates/mofa-foundation/src/persistence/checkpoint_store.rs`: `FileCheckpointStore` (JSON files, zero extra deps)
- **Modified**: `crates/mofa-foundation/src/workflow/executor.rs`: `with_checkpoint_store()` builder, auto-persist on checkpoint interval
- **Modified**: `crates/mofa-kernel/src/lib.rs`: registered `checkpoint` module
- **Modified**: `crates/mofa-foundation/src/persistence/mod.rs`: registered `checkpoint_store` module

## 🧪 How you Tested

1. `cargo check -p mofa-kernel -p mofa-foundation`: compiles clean
2. `cargo test -p mofa-foundation -- checkpoint_store`: 7/7 tests pass:
   - Save/load roundtrip
   - Load nonexistent returns None
   - List all checkpoints
   - List filtered by workflow_id
   - Delete + idempotent second delete
   - Overwrite same label
   - node_count metadata extraction

```bash
cargo test -p mofa-foundation -- checkpoint_store
cargo check -p mofa-kernel -p mofa-foundation
```

## ⚠️ Breaking Changes

- [x] No breaking changes

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [x] Tests added (7 unit tests in `checkpoint_store.rs`)
- [x] All existing tests still pass

### Documentation
- [x] Public APIs documented with doc comments
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`

## 🚀 Deployment Notes

No special deployment requirements. Pure library addition to mofa-kernel and mofa-foundation.

## 🧩 Additional Notes for Reviewers

- File-based storage chosen over SQLite because `rusqlite` is not in the workspace (project uses `sqlx` behind feature flags). The `CheckpointStore` trait is backend-agnostic, a `SqlxCheckpointStore` can be added later without changing callers.
- Builds on existing auto-checkpoint logic in `executor.rs` only adds `store.save()` alongside the in-memory `create_checkpoint()`.
- Compatible with `ExecutionCheckpoint` and `WorkflowContextSnapshot`.
