### PR TITLE
fix: replace panic!() with Result in AdapterDescriptorBuilder and ModelConfigBuilder

### DIFF
--- a/crates/mofa-foundation/src/adapter/config.rs
+++ b/crates/mofa-foundation/src/adapter/config.rs
@@ -95,11 +95,13 @@ impl ModelConfigBuilder {
         self
     }
 
-    pub fn build(self) -> ModelConfig {
+    pub fn build(self) -> Result<ModelConfig, super::error::AdapterError> {
         if self.config.model_id.is_empty() {
-            panic!("ModelConfig must have a model_id");
+            return Err(super::error::AdapterError::InvalidConfig(
+                "ModelConfig must have a model_id".into(),
+            ));
         }
-        self.config
+        Ok(self.config)
     }
 }
 
@@ -319,7 +321,8 @@ mod tests {
             .required_format("safetensors")
             .required_quantization("q4_k")
             .min_priority(50)
-            .build();
+            .build()
+            .unwrap();
 
         assert_eq!(config.model_id, "llama-3-8b");
         assert_eq!(config.required_modality, Modality::LLM);

--- a/crates/mofa-foundation/src/adapter/descriptor.rs
+++ b/crates/mofa-foundation/src/adapter/descriptor.rs
@@ -406,20 +406,28 @@ impl AdapterDescriptorBuilder {
         self
     }
 
-    pub fn build(self) -> AdapterDescriptor {
+    pub fn build(self) -> Result<AdapterDescriptor, super::error::AdapterError> {
         if self.descriptor.id.is_empty() {
-            panic!("AdapterDescriptor must have an id");
+            return Err(super::error::AdapterError::InvalidConfig(
+                "AdapterDescriptor must have an id".into(),
+            ));
         }
         if self.descriptor.name.is_empty() {
-            panic!("AdapterDescriptor must have a name");
+            return Err(super::error::AdapterError::InvalidConfig(
+                "AdapterDescriptor must have a name".into(),
+            ));
         }
         if self.descriptor.supported_modalities.is_empty() {
-            panic!("AdapterDescriptor must have at least one supported modality");
+            return Err(super::error::AdapterError::InvalidConfig(
+                "AdapterDescriptor must have at least one supported modality".into(),
+            ));
         }
         if self.descriptor.supported_formats.is_empty() {
-            panic!("AdapterDescriptor must have at least one supported format");
+            return Err(super::error::AdapterError::InvalidConfig(
+                "AdapterDescriptor must have at least one supported format".into(),
+            ));
         }
-        self.descriptor
+        Ok(self.descriptor)
     }
 }
 
@@ -437,7 +445,8 @@ mod tests {
             .supported_format(ModelFormat::Safetensors)
             .supported_quantization("q4_k")
             .priority(100)
-            .build();
+            .build()
+            .unwrap();
 
         assert_eq!(descriptor.id, "test-adapter");
         assert_eq!(descriptor.name, "Test Adapter");

--- a/crates/mofa-foundation/src/adapter/mod.rs
+++ b/crates/mofa-foundation/src/adapter/mod.rs
@@ -24,7 +24,8 @@
 //!     .supported_format(ModelFormat::Safetensors)
 //!     .supported_quantization("q4_k".to_string())
 //!     .priority(100)
-//!     .build();
+//!     .build()
+//!     .unwrap();
 //! registry.register(descriptor);
 //!
 //! // Resolve adapter for a given model config and hardware
@@ -32,7 +33,8 @@
 //!     .model_id("llama-3-8b")
 //!     .required_modality(Modality::LLM)
 //!     .required_format_model(ModelFormat::Safetensors)
-//!     .build();
+//!     .build()
+//!     .unwrap();
 //!
 //! let hw_capability = HardwareCapability {
 //!     os: OsClassification::Linux,

--- a/crates/mofa-foundation/src/adapter/registry.rs
+++ b/crates/mofa-foundation/src/adapter/registry.rs
@@ -297,7 +297,8 @@ mod tests {
                 .supported_format(ModelFormat::GGUF)
                 .supported_quantizations(vec!["q4_k".to_string(), "q8_0".to_string()])
                 .priority(100)
-                .build(),
+                .build()
+                .unwrap(),
             AdapterDescriptor::builder()
                 .id("huggingface")
                 .name("HuggingFace Backend")
@@ -305,7 +306,8 @@ mod tests {
                 .supported_format(ModelFormat::Safetensors)
                 .supported_quantizations(vec!["bf16".to_string(), "fp16".to_string()])
                 .priority(90)
-                .build(),
+                .build()
+                .unwrap(),
             AdapterDescriptor::builder()
                 .id("mlx-backend")
                 .name("Apple MLX Backend")
@@ -313,7 +315,8 @@ mod tests {
                 .supported_modality(Modality::VLM)
                 .supported_format(ModelFormat::MLX)
                 .priority(80)
-                .build(),
+                .build()
+                .unwrap(),
         ]
     }
 
@@ -325,7 +328,8 @@ mod tests {
             .name("Test")
             .supported_modality(Modality::LLM)
             .supported_format(ModelFormat::Safetensors)
-            .build();
+            .build()
+            .unwrap();
 
         assert!(registry.register(adapter.clone()).is_ok());
         assert!(registry.register(adapter).is_err()); // Duplicate
@@ -342,7 +346,8 @@ mod tests {
             .model_id("llama-3-8b")
             .required_modality(Modality::LLM)
             .required_format("gguf")
-            .build();
+            .build()
+            .unwrap();
 
         let hardware = HardwareProfile::builder()
             .os("linux")
@@ -366,7 +371,8 @@ mod tests {
         let config = ModelConfig::builder()
             .model_id("unknown-model")
             .required_modality(Modality::ASR) // Not supported by any adapter
-            .build();
+            .build()
+            .unwrap();
 
         let hardware = HardwareProfile::default();
 
@@ -391,7 +397,8 @@ mod tests {
                     .supported_modality(Modality::LLM)
                     .supported_format(ModelFormat::Safetensors)
                     .priority(100)
-                    .build(),
+                    .build()
+                    .unwrap(),
             )
             .unwrap();
 
@@ -403,7 +410,8 @@ mod tests {
                     .supported_modality(Modality::LLM)
                     .supported_format(ModelFormat::Safetensors)
                     .priority(100)
-                    .build(),
+                    .build()
+                    .unwrap(),
             )
             .unwrap();
 
@@ -411,7 +419,8 @@ mod tests {
             .model_id("test")
             .required_modality(Modality::LLM)
             .required_format("safetensors")
-            .build();
+            .build()
+            .unwrap();
 
         let hardware = HardwareProfile::default();
 

--- a/crates/mofa-foundation/src/adapter/resolver.rs
+++ b/crates/mofa-foundation/src/adapter/resolver.rs
@@ -312,7 +312,8 @@ mod tests {
             .supported_format(super::super::descriptor::ModelFormat::Safetensors)
             .priority(100)
             .estimated_latency_ms(100)
-            .build();
+            .build()
+            .unwrap();
 
         let hardware = HardwareProfile::builder().available_ram_mb(16384).build();
 
@@ -321,7 +322,8 @@ mod tests {
             &ModelConfig::builder()
                 .model_id("test")
                 .required_modality(super::super::descriptor::Modality::LLM)
-                .build(),
+                .build()
+                .unwrap(),
             &hardware,
         );
 

--- a/crates/mofa-foundation/src/adapter/scheduler.rs
+++ b/crates/mofa-foundation/src/adapter/scheduler.rs
@@ -670,7 +670,8 @@ mod tests {
             .name("Test")
             .supported_modality(Modality::LLM)
             .supported_format(ModelFormat::Safetensors)
-            .build();
+            .build()
+            .unwrap();
 
         assert!(queue.enqueue(DeferredRequest::new(
             "req1".to_string(),
@@ -698,7 +699,8 @@ mod tests {
             .name("Test")
             .supported_modality(Modality::LLM)
             .supported_format(ModelFormat::Safetensors)
-            .build();
+            .build()
+            .unwrap();
 
         let mut req = DeferredRequest::new("req1".to_string(), 512, adapter);
         req.increment_retry();


### PR DESCRIPTION
## 📋 Summary

Replace 5 `panic!()` calls in `AdapterDescriptorBuilder::build()` and `ModelConfigBuilder::build()` with proper `Result<T, AdapterError::InvalidConfig>` returns. This prevents the process from crashing when a consumer omits a required field.

## 🔗 Related Issues

Closes #735

Related to #604, #588

---

## 🧠 Context

`AdapterDescriptorBuilder::build()` had 4 `panic!()` calls (empty id, name, modalities, formats) and `ModelConfigBuilder::build()` had 1 `panic!()` call (empty model_id). Since these are public API builders in a library crate, any downstream consumer accidentally omitting a required field would crash their entire application. The crate already has `AdapterError::InvalidConfig(String)` which is the correct error variant for these validation failures.

---

## 🛠️ Changes

- `descriptor.rs`: Changed `build()` return type from `AdapterDescriptor` to `Result<AdapterDescriptor, AdapterError>`, replacing 4 `panic!()` calls with `Err(AdapterError::InvalidConfig(...))`
- `config.rs`: Changed `build()` return type from `ModelConfig` to `Result<ModelConfig, AdapterError>`, replacing 1 `panic!()` call with `Err(AdapterError::InvalidConfig(...))`
- `registry.rs`, `resolver.rs`, `scheduler.rs`: Updated test call sites to append `.unwrap()` after `.build()`
- `mod.rs`: Updated doc example to use `.unwrap()` after `.build()`

---

## 🧪 How you Tested

1. `cargo test -p mofa-foundation --lib adapter` — **31 tests passed, 0 failed**
2. Verified all existing tests compile and pass without modification to test logic
3. Confirmed no other crates in the workspace call these builders outside of `mofa-foundation`

---

## 📸 Screenshots / Logs (if applicable)

```
running 31 tests
test adapter::descriptor::tests::test_adapter_descriptor_builder ... ok
test adapter::config::tests::test_model_config_builder ... ok
test adapter::registry::tests::test_register_adapter ... ok
test adapter::registry::tests::test_resolve_basic ... ok
test adapter::registry::tests::test_resolve_no_compatible ... ok
test adapter::registry::tests::test_resolve_deterministic_tie_break ... ok
test adapter::resolver::tests::test_resolver_scoring ... ok
test adapter::scheduler::tests::test_deferred_queue_enqueue_dequeue ... ok
test adapter::scheduler::tests::test_deferred_queue_max_retries ... ok
... (31 total)
test result: ok. 31 passed; 0 failed; 0 ignored
```

---

## ⚠️ Breaking Changes

- [x] Breaking change (describe below)

The return type of `AdapterDescriptorBuilder::build()` changed from `AdapterDescriptor` to `Result<AdapterDescriptor, AdapterError>`, and `ModelConfigBuilder::build()` changed from `ModelConfig` to `Result<ModelConfig, AdapterError>`. Any external callers need to add `.unwrap()` or `?` after `.build()`. This is an intentional breaking change that replaces silent crashes with explicit error handling.

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [x] Public APIs documented
- [x] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---

## 🚀 Deployment Notes (if applicable)

No migrations, config changes, or env vars needed.

---

## 🧩 Additional Notes for Reviewers

- The existing `AdapterError::InvalidConfig(String)` variant was already available — no new error types were added
- All call sites for these builders are currently within `mofa-foundation` tests, so no cross-crate breakage
- This follows the same pattern as the fix in #588 (replacing `expect()` with `ok_or_else()` in `StateGraphImpl::compile`)