### PR TITLE
fix: reject duplicate tool registration and add collision test

### DIFF
--- a/crates/mofa-foundation/src/agent/tools/registry.rs
+++ b/crates/mofa-foundation/src/agent/tools/registry.rs
@@ -102,6 +102,11 @@ impl ToolRegistry {
         source: ToolSource,
     ) -> AgentResult<()> {
         let name = tool.name().to_string();
+        if self.tools.contains_key(&name) {
+            return Err(AgentError::RegistrationFailed(format!(
+                "Tool '{name}' is already registered",
+            )));
+        }
         self.sources.insert(name.clone(), source);
         self.tools.insert(name, tool);
         Ok(())
@@ -571,5 +576,26 @@ mod tests {
             .expect_err("reload should fail");
         assert!(matches!(err, AgentError::NotFound(_)));
         assert!(err.to_string().contains("Plugin loader not registered"));
+    }
+
+    #[tokio::test]
+    async fn register_with_source_rejects_duplicate_tool_names() {
+        let mut registry = ToolRegistry::new();
+
+        registry
+            .register_with_source(TestTool::new("dup_tool").into_dynamic(), ToolSource::Builtin)
+            .unwrap();
+
+        let err = registry
+            .register_with_source(TestTool::new("dup_tool").into_dynamic(), ToolSource::Dynamic)
+            .expect_err("duplicate registration should fail");
+
+        assert!(matches!(err, AgentError::RegistrationFailed(_)));
+        assert!(err.to_string().contains("already registered"));
+        assert_eq!(registry.count(), 1);
+        assert!(matches!(
+            registry.get_source("dup_tool"),
+            Some(ToolSource::Builtin)
+        ));
     }
 }


### PR DESCRIPTION
## 📋 Summary

This PR makes duplicate tool registration explicit by rejecting tools with names that are already registered. Previously, `ToolRegistry::register_with_source` would silently overwrite an existing tool and its associated source. This behavior has been changed to return an error instead.

A unit test has also been added to ensure duplicate registration is rejected and registry state remains unchanged.

## 🔗 Related Issues

Closes #736 

---

## 🧠 Context

`register_with_source` previously allowed silent overwriting:

- If a tool with the same name was already registered,
- The new tool replaced the existing one,
- The original `ToolSource` metadata was overwritten,
- No error was returned.

This behavior was unsafe and inconsistent with `hot_reload_plugin`, which already rejects duplicate tool names and rolls back on conflict.

---

## 🛠️ Changes

Duplicate registrations now return:
```rs
AgentError::RegistrationFailed("Tool '<name>' is already registered")
```
Updated implementation:
```rs
pub fn register_with_source(
    &mut self,
    tool: Arc<dyn DynTool>,
    source: ToolSource,
) -> AgentResult<()> {
    let name = tool.name().to_string();

    if self.tools.contains_key(&name) {
        return Err(AgentError::RegistrationFailed(format!(
            "Tool '{name}' is already registered",
        )));
    }

    self.sources.insert(name.clone(), source);
    self.tools.insert(name, tool);
    Ok(())
}
```
The added test now verifies:

- Second registration with same name fails
- Registry count remains unchanged
- Original source remains intact

```rs
#[tokio::test]
async fn register_with_source_rejects_duplicate_tool_names() {
    let mut registry = ToolRegistry::new();

    registry
        .register_with_source(
            TestTool::new("dup_tool").into_dynamic(),
            ToolSource::Builtin,
        )
        .unwrap();

    let err = registry
        .register_with_source(
            TestTool::new("dup_tool").into_dynamic(),
            ToolSource::Dynamic,
        )
        .expect_err("duplicate registration should fail");

    assert!(matches!(err, AgentError::RegistrationFailed(_)));
    assert!(err.to_string().contains("already registered"));

    assert_eq!(registry.count(), 1);
    assert!(matches!(
        registry.get_source("dup_tool"),
        Some(ToolSource::Builtin)
    ));
}
```
---

## 🧪 How you Tested

The new behavior and test were verified locally:
```
cargo test -p mofa-foundation register_with_source_rejects_duplicate_tool_names
```

---

## 📸 Screenshots / Logs (if applicable)

<img width="1448" height="400" alt="image" src="https://github.com/user-attachments/assets/e2373d9e-928d-4cb6-a6bd-e392444fb407" />


---

## ⚠️ Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (describe below)
---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [ ] Public APIs documented
- [ ] README / docs updated (if needed)

### PR Hygiene
- [ ] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [ ] Commit messages explain **why**, not only **what**

---

