### PR TITLE
fix(scheduler): evict completed task metadata to prevent unbounded HashMap growth

### DIFF
--- a/crates/mofa-foundation/src/coordination/scheduler.rs
+++ b/crates/mofa-foundation/src/coordination/scheduler.rs
@@ -266,11 +266,17 @@ impl PriorityScheduler {
             let mut agent_load = self.agent_load.write().await;
             let mut task_status = self.task_status.write().await;
             let mut agent_tasks = self.agent_tasks.write().await;
+            let mut task_priorities = self.task_priorities.write().await;
 
             agent_load
                 .entry(agent_id.to_string())
                 .and_modify(|count| *count = count.saturating_sub(1));
-            task_status.insert(task_id.to_string(), SchedulingStatus::Completed);
+
+            // Remove completed task metadata to prevent unbounded map growth.
+            // Completed tasks are never re-queued, so these entries serve no
+            // further purpose and would otherwise accumulate indefinitely.
+            task_status.remove(task_id);
+            task_priorities.remove(task_id);
 
             // Remove completed task from agent's task list
             if let Some(tasks) = agent_tasks.get_mut(agent_id) {
@@ -352,8 +358,11 @@ mod tests {
         // Verify state was updated correctly.
         let load = scheduler.agent_load.read().await;
         assert_eq!(*load.get("agent-1").unwrap(), 0);
+        // Completed task metadata is evicted — entry must not linger in the map.
         let status = scheduler.task_status.read().await;
-        assert_eq!(*status.get("t1").unwrap(), SchedulingStatus::Completed);
+        assert!(status.get("t1").is_none(), "task_status entry should be removed on completion");
+        let priorities = scheduler.task_priorities.read().await;
+        assert!(priorities.get("t1").is_none(), "task_priorities entry should be removed on completion");
     }
 
     /// Verifies the priority queue orders tasks correctly (higher priority first).


### PR DESCRIPTION
## **Summary**

This PR fixes a memory growth issue in:

```text
crates/mofa-foundation/src/coordination/scheduler.rs
```

Specifically in `PriorityScheduler::submit_task()` and `on_task_completed()`.

Every call to `submit_task()` inserts entries into two internal maps:

```rust
self.task_priorities.write().await
    .insert(task.task_id.clone(), task.priority.clone());

self.task_status.write().await
    .insert(task.task_id, SchedulingStatus::Pending);
```

However, once a task completed, those entries were never removed.
`task_status` was overwritten to `Completed`, and `task_priorities` was left untouched — meaning both maps grew forever.

Since these maps are stored inside `Arc<RwLock<HashMap<...>>>` and live for the lifetime of the scheduler, memory usage increased monotonically with total tasks ever processed.

---

## **Steps to Reproduce**

1. Create a `PriorityScheduler`.
2. Repeatedly:

   * Call `submit_task()`
   * Call `on_task_completed()`
3. Inspect:

   ```rust
   task_status.read().await.len()
   task_priorities.read().await.len()
   ```
4. Both grow linearly with total completed tasks.
5. Under sustained throughput, process RSS increases continuously.

---

## **Impact**

* Memory growth proportional to total tasks ever processed
* No eviction of completed task metadata
* Long-running deployments risk OOM
* Increasing write-lock contention as maps grow
* Scheduler throughput degradation over time

This is particularly problematic for always-on systems processing high task volumes.

---

## **Fix**

Completed tasks are now fully evicted from both maps in `on_task_completed()`.

Before:

```rust
task_status.insert(task_id.to_string(), SchedulingStatus::Completed);
```

After:

```rust
task_status.remove(task_id);
task_priorities.remove(task_id);
```

Additionally, we acquire the `task_priorities` write lock to perform cleanup:

```rust
let mut task_priorities = self.task_priorities.write().await;
```

This ensures metadata is removed once a task reaches its terminal state.

---

## **Result**

* Memory usage is now bounded by active (in-flight) tasks.
* Scheduler footprint stabilizes over time.
* Write-lock contention does not grow with historical workload.
* Long-running deployments no longer risk scheduler-induced OOM.

The scheduler now behaves as intended: task metadata lives only as long as the task itself.
