### PR TITLE
feat(rag): complete RAG pipeline with Qdrant integration (#747)

### DIFF
--- a/crates/mofa-cli/Cargo.toml
+++ b/crates/mofa-cli/Cargo.toml
@@ -92,6 +92,7 @@ tempfile = "3"
 default = []
 dora = ["mofa-sdk/dora"]
 db = ["dep:sqlx"]
+qdrant = ["mofa-foundation/qdrant"]
 
 [lints]
 workspace = true

--- a/crates/mofa-cli/src/cli.rs
+++ b/crates/mofa-cli/src/cli.rs
@@ -133,6 +133,12 @@ pub enum Commands {
         #[command(subcommand)]
         action: ToolCommands,
     },
+
+    /// RAG indexing and retrieval
+    Rag {
+        #[command(subcommand)]
+        action: RagCommands,
+    },
 }
 
 /// Generate subcommands
@@ -518,6 +524,91 @@ pub enum ToolCommands {
     },
 }
 
+/// RAG management subcommands
+#[derive(Subcommand)]
+pub enum RagCommands {
+    /// Index one or more documents into a RAG backend.
+    Index {
+        /// Input text files to index.
+        #[arg(short = 'i', long = "input", required = true)]
+        input: Vec<PathBuf>,
+
+        /// Backend to use: `in-memory` or `qdrant`.
+        #[arg(long, default_value = "in-memory", value_parser = ["in-memory", "qdrant"])]
+        backend: String,
+
+        /// Local index file path for `in-memory` backend.
+        #[arg(long, default_value = ".mofa/rag-index.json")]
+        index_file: PathBuf,
+
+        /// Embedding vector dimensions.
+        #[arg(long, default_value_t = 64)]
+        dimensions: usize,
+
+        /// Chunk size in characters.
+        #[arg(long, default_value_t = 512)]
+        chunk_size: usize,
+
+        /// Chunk overlap in characters.
+        #[arg(long, default_value_t = 64)]
+        chunk_overlap: usize,
+
+        /// Use sentence-based chunking instead of character windows.
+        #[arg(long)]
+        sentence_chunks: bool,
+
+        /// Qdrant URL (required for `qdrant` backend).
+        #[arg(long)]
+        qdrant_url: Option<String>,
+
+        /// Qdrant API key.
+        #[arg(long)]
+        qdrant_api_key: Option<String>,
+
+        /// Qdrant collection name.
+        #[arg(long, default_value = "mofa_documents")]
+        qdrant_collection: String,
+    },
+
+    /// Query indexed documents from a RAG backend.
+    Query {
+        /// Query text.
+        query: String,
+
+        /// Backend to use: `in-memory` or `qdrant`.
+        #[arg(long, default_value = "in-memory", value_parser = ["in-memory", "qdrant"])]
+        backend: String,
+
+        /// Local index file path for `in-memory` backend.
+        #[arg(long, default_value = ".mofa/rag-index.json")]
+        index_file: PathBuf,
+
+        /// Embedding vector dimensions (used for qdrant query embedding).
+        #[arg(long, default_value_t = 64)]
+        dimensions: usize,
+
+        /// Number of results to return.
+        #[arg(long, default_value_t = 5)]
+        top_k: usize,
+
+        /// Optional score threshold.
+        #[arg(long)]
+        threshold: Option<f32>,
+
+        /// Qdrant URL (required for `qdrant` backend).
+        #[arg(long)]
+        qdrant_url: Option<String>,
+
+        /// Qdrant API key.
+        #[arg(long)]
+        qdrant_api_key: Option<String>,
+
+        /// Qdrant collection name.
+        #[arg(long, default_value = "mofa_documents")]
+        qdrant_collection: String,
+    },
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -582,5 +673,29 @@ mod tests {
             "json",
         ]);
         assert!(parsed.is_ok(), "session export -o ... should still parse");
+    }
+
+    #[test]
+    fn test_rag_index_parses() {
+        let parsed = Cli::try_parse_from([
+            "mofa",
+            "rag",
+            "index",
+            "--input",
+            "doc1.txt",
+            "--input",
+            "doc2.txt",
+            "--backend",
+            "in-memory",
+            "--index-file",
+            ".mofa/rag.json",
+        ]);
+        assert!(parsed.is_ok(), "rag index command should parse");
+    }
+
+    #[test]
+    fn test_rag_query_parses() {
+        let parsed = Cli::try_parse_from(["mofa", "rag", "query", "what is mofa", "--top-k", "3"]);
+        assert!(parsed.is_ok(), "rag query command should parse");
     }
 }

--- a/crates/mofa-cli/src/commands/mod.rs
+++ b/crates/mofa-cli/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod generate;
 pub mod init;
 pub mod new;
 pub mod plugin;
+pub mod rag;
 pub mod run;
 pub mod session;
 pub mod tool;

--- a/crates/mofa-cli/src/commands/rag.rs
+++ b/crates/mofa-cli/src/commands/rag.rs
@@ -1,0 +1,410 @@
+//! `mofa rag` command implementation.
+
+use crate::CliError;
+use mofa_foundation::rag::InMemoryVectorStore;
+#[cfg(feature = "qdrant")]
+use mofa_foundation::rag::{QdrantConfig, QdrantVectorStore};
+use mofa_kernel::rag::{Document, DocumentChunk, SearchResult, SimilarityMetric, VectorStore};
+use mofa_runtime::rag::{
+    ChunkingStrategy, DeterministicEmbeddingProvider, RagIngestionConfig, index_documents,
+    merge_chunks, query_store,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+struct LocalRagIndex {
+    dimensions: usize,
+    chunks: Vec<DocumentChunk>,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn run_index(
+    input: Vec<PathBuf>,
+    backend: &str,
+    index_file: &Path,
+    dimensions: usize,
+    chunk_size: usize,
+    chunk_overlap: usize,
+    sentence_chunks: bool,
+    qdrant_url: Option<&str>,
+    qdrant_api_key: Option<&str>,
+    qdrant_collection: &str,
+) -> Result<(), CliError> {
+    let documents = load_documents(&input)?;
+    if documents.is_empty() {
+        return Err(CliError::Other("no input documents supplied".to_string()));
+    }
+
+    let embedder = DeterministicEmbeddingProvider::new(dimensions).map_err(map_global_error)?;
+    let ingestion = RagIngestionConfig {
+        chunk_size,
+        chunk_overlap,
+        chunking: if sentence_chunks {
+            ChunkingStrategy::Sentences
+        } else {
+            ChunkingStrategy::Characters
+        },
+    };
+
+    match backend {
+        "in-memory" => {
+            let mut index = load_local_index(index_file)?;
+            if index.dimensions != 0 && index.dimensions != dimensions {
+                return Err(CliError::Other(format!(
+                    "index file dimensions ({}) do not match requested dimensions ({})",
+                    index.dimensions, dimensions
+                )));
+            }
+
+            let mut store = InMemoryVectorStore::cosine();
+            if !index.chunks.is_empty() {
+                store
+                    .upsert_batch(index.chunks.clone())
+                    .await
+                    .map_err(map_agent_error)?;
+            }
+
+            let new_chunks = index_documents(&mut store, &documents, &embedder, &ingestion)
+                .await
+                .map_err(map_global_error)?;
+            let new_count = new_chunks.len();
+
+            index.dimensions = dimensions;
+            index.chunks = merge_chunks(index.chunks, new_chunks);
+            save_local_index(index_file, &index)?;
+
+            println!(
+                "Indexed {} chunks from {} documents into local index {} (total chunks: {}).",
+                new_count,
+                documents.len(),
+                index_file.display(),
+                index.chunks.len()
+            );
+        }
+        "qdrant" => {
+            let indexed = index_qdrant(
+                &documents,
+                &embedder,
+                &ingestion,
+                dimensions,
+                qdrant_url,
+                qdrant_api_key,
+                qdrant_collection,
+            )
+            .await?;
+            println!(
+                "Indexed {} chunks from {} documents into Qdrant collection '{}'.",
+                indexed,
+                documents.len(),
+                qdrant_collection
+            );
+        }
+        other => {
+            return Err(CliError::Other(format!(
+                "unsupported backend '{}'; expected 'in-memory' or 'qdrant'",
+                other
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn run_query(
+    query: &str,
+    backend: &str,
+    index_file: &Path,
+    dimensions: usize,
+    top_k: usize,
+    threshold: Option<f32>,
+    qdrant_url: Option<&str>,
+    qdrant_api_key: Option<&str>,
+    qdrant_collection: &str,
+) -> Result<(), CliError> {
+    let results = match backend {
+        "in-memory" => {
+            let index = load_local_index(index_file)?;
+            if index.chunks.is_empty() {
+                return Err(CliError::Other(format!(
+                    "no indexed chunks found in {}; run 'mofa rag index' first",
+                    index_file.display()
+                )));
+            }
+
+            let mut store = InMemoryVectorStore::cosine();
+            store
+                .upsert_batch(index.chunks)
+                .await
+                .map_err(map_agent_error)?;
+
+            let embedder =
+                DeterministicEmbeddingProvider::new(index.dimensions).map_err(map_global_error)?;
+            query_store(&store, &embedder, query, top_k, threshold)
+                .await
+                .map_err(map_global_error)?
+        }
+        "qdrant" => {
+            let embedder =
+                DeterministicEmbeddingProvider::new(dimensions).map_err(map_global_error)?;
+            query_qdrant(
+                query,
+                &embedder,
+                top_k,
+                threshold,
+                dimensions,
+                qdrant_url,
+                qdrant_api_key,
+                qdrant_collection,
+            )
+            .await?
+        }
+        other => {
+            return Err(CliError::Other(format!(
+                "unsupported backend '{}'; expected 'in-memory' or 'qdrant'",
+                other
+            )));
+        }
+    };
+
+    print_results(query, &results);
+    Ok(())
+}
+
+#[cfg(feature = "qdrant")]
+#[allow(clippy::too_many_arguments)]
+async fn index_qdrant(
+    documents: &[Document],
+    embedder: &DeterministicEmbeddingProvider,
+    ingestion: &RagIngestionConfig,
+    dimensions: usize,
+    qdrant_url: Option<&str>,
+    qdrant_api_key: Option<&str>,
+    qdrant_collection: &str,
+) -> Result<usize, CliError> {
+    let url = qdrant_url
+        .ok_or_else(|| CliError::Other("qdrant backend requires --qdrant-url".to_string()))?;
+    let mut store = QdrantVectorStore::new(QdrantConfig {
+        url: url.to_string(),
+        api_key: qdrant_api_key.map(str::to_string),
+        collection_name: qdrant_collection.to_string(),
+        vector_dimensions: dimensions as u64,
+        metric: SimilarityMetric::Cosine,
+        create_collection: true,
+    })
+    .await
+    .map_err(map_agent_error)?;
+
+    let indexed = index_documents(&mut store, documents, embedder, ingestion)
+        .await
+        .map_err(map_global_error)?;
+    Ok(indexed.len())
+}
+
+#[cfg(not(feature = "qdrant"))]
+#[allow(clippy::too_many_arguments)]
+async fn index_qdrant(
+    _documents: &[Document],
+    _embedder: &DeterministicEmbeddingProvider,
+    _ingestion: &RagIngestionConfig,
+    _dimensions: usize,
+    _qdrant_url: Option<&str>,
+    _qdrant_api_key: Option<&str>,
+    _qdrant_collection: &str,
+) -> Result<usize, CliError> {
+    Err(CliError::Other(
+        "qdrant backend requires mofa-cli built with --features qdrant".to_string(),
+    ))
+}
+
+#[cfg(feature = "qdrant")]
+#[allow(clippy::too_many_arguments)]
+async fn query_qdrant(
+    query: &str,
+    embedder: &DeterministicEmbeddingProvider,
+    top_k: usize,
+    threshold: Option<f32>,
+    dimensions: usize,
+    qdrant_url: Option<&str>,
+    qdrant_api_key: Option<&str>,
+    qdrant_collection: &str,
+) -> Result<Vec<SearchResult>, CliError> {
+    let url = qdrant_url
+        .ok_or_else(|| CliError::Other("qdrant backend requires --qdrant-url".to_string()))?;
+    let store = QdrantVectorStore::new(QdrantConfig {
+        url: url.to_string(),
+        api_key: qdrant_api_key.map(str::to_string),
+        collection_name: qdrant_collection.to_string(),
+        vector_dimensions: dimensions as u64,
+        metric: SimilarityMetric::Cosine,
+        create_collection: true,
+    })
+    .await
+    .map_err(map_agent_error)?;
+
+    query_store(&store, embedder, query, top_k, threshold)
+        .await
+        .map_err(map_global_error)
+}
+
+#[cfg(not(feature = "qdrant"))]
+#[allow(clippy::too_many_arguments)]
+async fn query_qdrant(
+    _query: &str,
+    _embedder: &DeterministicEmbeddingProvider,
+    _top_k: usize,
+    _threshold: Option<f32>,
+    _dimensions: usize,
+    _qdrant_url: Option<&str>,
+    _qdrant_api_key: Option<&str>,
+    _qdrant_collection: &str,
+) -> Result<Vec<SearchResult>, CliError> {
+    Err(CliError::Other(
+        "qdrant backend requires mofa-cli built with --features qdrant".to_string(),
+    ))
+}
+
+fn load_documents(paths: &[PathBuf]) -> Result<Vec<Document>, CliError> {
+    let mut documents = Vec::new();
+    for (index, path) in paths.iter().enumerate() {
+        let text = fs::read_to_string(path)?;
+        let stem = path
+            .file_stem()
+            .and_then(|value| value.to_str())
+            .unwrap_or("document");
+        let mut metadata = HashMap::new();
+        metadata.insert("source_path".to_string(), path.display().to_string());
+        documents.push(Document {
+            id: format!("{stem}-{index}"),
+            text,
+            metadata,
+        });
+    }
+    Ok(documents)
+}
+
+fn load_local_index(path: &Path) -> Result<LocalRagIndex, CliError> {
+    if !path.exists() {
+        return Ok(LocalRagIndex::default());
+    }
+    let data = fs::read(path)?;
+    let index: LocalRagIndex = serde_json::from_slice(&data)?;
+    Ok(index)
+}
+
+fn save_local_index(path: &Path, index: &LocalRagIndex) -> Result<(), CliError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let encoded = serde_json::to_vec_pretty(index)?;
+    fs::write(path, encoded)?;
+    Ok(())
+}
+
+fn print_results(query: &str, results: &[SearchResult]) {
+    println!("RAG query: {}", query);
+    if results.is_empty() {
+        println!("No results found.");
+        return;
+    }
+
+    for (index, result) in results.iter().enumerate() {
+        println!(
+            "{}. score={:.4} id={} text={}",
+            index + 1,
+            result.score,
+            result.id,
+            truncate_text(&result.text, 140)
+        );
+    }
+}
+
+fn truncate_text(input: &str, max_chars: usize) -> String {
+    if input.chars().count() <= max_chars {
+        return input.to_string();
+    }
+    let mut output = input.chars().take(max_chars).collect::<String>();
+    output.push_str("...");
+    output
+}
+
+fn map_agent_error(err: mofa_kernel::agent::error::AgentError) -> CliError {
+    CliError::Other(err.to_string())
+}
+
+fn map_global_error(err: mofa_kernel::agent::types::error::GlobalError) -> CliError {
+    CliError::Other(err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn in_memory_index_then_query_roundtrip() {
+        let dir = tempdir().unwrap();
+        let doc_path = dir.path().join("doc.txt");
+        let index_path = dir.path().join("rag-index.json");
+        fs::write(
+            &doc_path,
+            "MoFA uses a microkernel architecture with RAG support.",
+        )
+        .unwrap();
+
+        run_index(
+            vec![doc_path.clone()],
+            "in-memory",
+            &index_path,
+            32,
+            128,
+            16,
+            false,
+            None,
+            None,
+            "unused",
+        )
+        .await
+        .unwrap();
+
+        assert!(index_path.exists());
+        run_query(
+            "microkernel architecture",
+            "in-memory",
+            &index_path,
+            32,
+            3,
+            None,
+            None,
+            None,
+            "unused",
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn in_memory_query_without_index_fails() {
+        let dir = tempdir().unwrap();
+        let missing_index = dir.path().join("missing.json");
+
+        let err = run_query(
+            "anything",
+            "in-memory",
+            &missing_index,
+            32,
+            3,
+            None,
+            None,
+            None,
+            "unused",
+        )
+        .await
+        .unwrap_err();
+
+        assert!(err.to_string().contains("run 'mofa rag index' first"));
+    }
+}

--- a/crates/mofa-cli/src/main.rs
+++ b/crates/mofa-cli/src/main.rs
@@ -325,6 +325,59 @@ async fn run_command(cli: Cli) -> CliResult<()> {
             }
         }
 
+        Some(Commands::Rag { action }) => match action {
+            cli::RagCommands::Index {
+                input,
+                backend,
+                index_file,
+                dimensions,
+                chunk_size,
+                chunk_overlap,
+                sentence_chunks,
+                qdrant_url,
+                qdrant_api_key,
+                qdrant_collection,
+            } => {
+                commands::rag::run_index(
+                    input,
+                    &backend,
+                    &index_file,
+                    dimensions,
+                    chunk_size,
+                    chunk_overlap,
+                    sentence_chunks,
+                    qdrant_url.as_deref(),
+                    qdrant_api_key.as_deref(),
+                    &qdrant_collection,
+                )
+                .await?;
+            }
+            cli::RagCommands::Query {
+                query,
+                backend,
+                index_file,
+                dimensions,
+                top_k,
+                threshold,
+                qdrant_url,
+                qdrant_api_key,
+                qdrant_collection,
+            } => {
+                commands::rag::run_query(
+                    &query,
+                    &backend,
+                    &index_file,
+                    dimensions,
+                    top_k,
+                    threshold,
+                    qdrant_url.as_deref(),
+                    qdrant_api_key.as_deref(),
+                    &qdrant_collection,
+                )
+                .await?;
+            }
+        },
+
         None => {
             // Should have been handled by TUI check above
             // If we get here, show help
@@ -342,7 +395,7 @@ async fn run_command(cli: Cli) -> CliResult<()> {
 fn normalize_legacy_output_flags(args: &mut [String]) {
     const TOP_LEVEL_COMMANDS: &[&str] = &[
         "new", "init", "build", "run", "dataflow", "generate", "info", "db", "agent", "config",
-        "plugin", "session", "tool",
+        "plugin", "session", "tool", "rag",
     ];
 
     let top_command_index = args

--- a/crates/mofa-foundation/src/agent/tools/builtin.rs
+++ b/crates/mofa-foundation/src/agent/tools/builtin.rs
@@ -277,7 +277,10 @@ impl SimpleTool for FileWriteTool {
                 .open(&path)
                 .await
             {
-                Ok(mut file) => file.write_all(content.as_bytes()).await,
+                Ok(mut file) => match file.write_all(content.as_bytes()).await {
+                    Ok(()) => file.flush().await,
+                    Err(e) => Err(e),
+                },
                 Err(e) => Err(e),
             }
         } else {

--- a/crates/mofa-runtime/src/lib.rs
+++ b/crates/mofa-runtime/src/lib.rs
@@ -23,6 +23,7 @@ pub mod builder;
 pub mod config;
 pub mod fallback;
 pub mod interrupt;
+pub mod rag;
 pub mod retry;
 pub mod runner;
 

--- a/crates/mofa-runtime/src/rag.rs
+++ b/crates/mofa-runtime/src/rag.rs
@@ -1,0 +1,494 @@
+//! Runtime-level RAG indexing and query hooks.
+//!
+//! This module provides a concrete ingestion-to-retrieval path that can be
+//! reused by CLI and higher-level runtime integrations without binding the
+//! runtime crate to a specific vector database provider.
+
+use async_trait::async_trait;
+use mofa_kernel::agent::types::error::{GlobalError, GlobalResult};
+use mofa_kernel::rag::{Document, DocumentChunk, ScoredDocument, SearchResult, VectorStore};
+use std::collections::HashMap;
+
+/// Embedding provider abstraction used by runtime RAG hooks.
+#[async_trait]
+pub trait EmbeddingProvider: Send + Sync {
+    /// Embeds a batch of input texts.
+    async fn embed(&self, inputs: &[String]) -> GlobalResult<Vec<Vec<f32>>>;
+
+    /// Returns embedding dimensionality.
+    fn dimensions(&self) -> usize;
+}
+
+/// Deterministic local embedder for tests/dev and predictable CI behavior.
+#[derive(Debug, Clone)]
+pub struct DeterministicEmbeddingProvider {
+    dimensions: usize,
+}
+
+impl DeterministicEmbeddingProvider {
+    /// Creates a deterministic embedder with the given dimensions.
+    pub fn new(dimensions: usize) -> GlobalResult<Self> {
+        if dimensions == 0 {
+            return Err(GlobalError::Runtime(
+                "embedding dimensions must be greater than 0".to_string(),
+            ));
+        }
+        Ok(Self { dimensions })
+    }
+
+    fn embed_one(&self, text: &str) -> Vec<f32> {
+        let mut embedding = vec![0.0_f32; self.dimensions];
+        for (index, byte) in text.bytes().enumerate() {
+            embedding[index % self.dimensions] += byte as f32 / 255.0;
+        }
+
+        let norm = embedding.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 0.0 {
+            for value in &mut embedding {
+                *value /= norm;
+            }
+        }
+        embedding
+    }
+}
+
+#[async_trait]
+impl EmbeddingProvider for DeterministicEmbeddingProvider {
+    async fn embed(&self, inputs: &[String]) -> GlobalResult<Vec<Vec<f32>>> {
+        Ok(inputs.iter().map(|input| self.embed_one(input)).collect())
+    }
+
+    fn dimensions(&self) -> usize {
+        self.dimensions
+    }
+}
+
+/// Chunking strategy used during document ingestion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChunkingStrategy {
+    /// Character-window chunking with overlap.
+    Characters,
+    /// Sentence-oriented chunking.
+    Sentences,
+}
+
+/// Runtime RAG ingestion options.
+#[derive(Debug, Clone)]
+pub struct RagIngestionConfig {
+    /// Max chunk size in characters.
+    pub chunk_size: usize,
+    /// Overlap between adjacent chunks in characters.
+    pub chunk_overlap: usize,
+    /// Chunking strategy.
+    pub chunking: ChunkingStrategy,
+}
+
+impl Default for RagIngestionConfig {
+    fn default() -> Self {
+        Self {
+            chunk_size: 512,
+            chunk_overlap: 64,
+            chunking: ChunkingStrategy::Characters,
+        }
+    }
+}
+
+/// Index documents into the provided vector store.
+///
+/// Returns the chunks generated and upserted, so callers can persist/inspect
+/// the indexed units when needed.
+pub async fn index_documents<S, E>(
+    store: &mut S,
+    documents: &[Document],
+    embedder: &E,
+    config: &RagIngestionConfig,
+) -> GlobalResult<Vec<DocumentChunk>>
+where
+    S: VectorStore,
+    E: EmbeddingProvider,
+{
+    if config.chunk_size == 0 {
+        return Err(GlobalError::Runtime(
+            "chunk_size must be greater than 0".to_string(),
+        ));
+    }
+
+    let mut pending = Vec::new();
+    let mut texts = Vec::new();
+
+    for document in documents {
+        let chunks = chunk_text(&document.text, config);
+        for (chunk_index, chunk_text) in chunks.into_iter().enumerate() {
+            let mut metadata = document.metadata.clone();
+            metadata.insert("source_doc_id".to_string(), document.id.clone());
+            metadata.insert("chunk_index".to_string(), chunk_index.to_string());
+
+            pending.push((format!("{}::chunk-{}", document.id, chunk_index), metadata));
+            texts.push(chunk_text);
+        }
+    }
+
+    if texts.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let embeddings = embedder.embed(&texts).await?;
+    if embeddings.len() != texts.len() {
+        return Err(GlobalError::Runtime(format!(
+            "embedding count mismatch: expected {}, got {}",
+            texts.len(),
+            embeddings.len()
+        )));
+    }
+
+    let expected_dim = embedder.dimensions();
+    let mut chunks = Vec::with_capacity(texts.len());
+    for ((id, metadata), (text, embedding)) in pending
+        .into_iter()
+        .zip(texts.into_iter().zip(embeddings.into_iter()))
+    {
+        if embedding.len() != expected_dim {
+            return Err(GlobalError::Runtime(format!(
+                "embedding dimension mismatch: expected {}, got {}",
+                expected_dim,
+                embedding.len()
+            )));
+        }
+
+        chunks.push(DocumentChunk {
+            id,
+            text,
+            embedding,
+            metadata,
+        });
+    }
+
+    store.upsert_batch(chunks.clone()).await?;
+    Ok(chunks)
+}
+
+/// Query a vector store by embedding the query with the supplied provider.
+pub async fn query_store<S, E>(
+    store: &S,
+    embedder: &E,
+    query: &str,
+    top_k: usize,
+    threshold: Option<f32>,
+) -> GlobalResult<Vec<SearchResult>>
+where
+    S: VectorStore,
+    E: EmbeddingProvider,
+{
+    if top_k == 0 {
+        return Err(GlobalError::Runtime(
+            "top_k must be greater than 0".to_string(),
+        ));
+    }
+
+    let query = query.trim();
+    if query.is_empty() {
+        return Err(GlobalError::Runtime("query must not be empty".to_string()));
+    }
+
+    let query_embeddings = embedder.embed(&[query.to_string()]).await?;
+    let query_embedding = query_embeddings.first().ok_or_else(|| {
+        GlobalError::Runtime("embedding provider returned no vectors".to_string())
+    })?;
+    if query_embedding.len() != embedder.dimensions() {
+        return Err(GlobalError::Runtime(format!(
+            "query embedding dimension mismatch: expected {}, got {}",
+            embedder.dimensions(),
+            query_embedding.len()
+        )));
+    }
+
+    let results = store.search(query_embedding, top_k, threshold).await?;
+    Ok(results)
+}
+
+/// Convert search results into scored documents for `RagPipeline` retrieval.
+pub fn to_scored_documents(results: Vec<SearchResult>, source: &str) -> Vec<ScoredDocument> {
+    results
+        .into_iter()
+        .map(|result| ScoredDocument {
+            document: Document {
+                id: result.id,
+                text: result.text,
+                metadata: result.metadata,
+            },
+            score: result.score,
+            source: Some(source.to_string()),
+        })
+        .collect()
+}
+
+fn chunk_text(text: &str, config: &RagIngestionConfig) -> Vec<String> {
+    match config.chunking {
+        ChunkingStrategy::Characters => {
+            chunk_by_chars(text, config.chunk_size, config.chunk_overlap)
+        }
+        ChunkingStrategy::Sentences => chunk_by_sentences(text, config.chunk_size),
+    }
+}
+
+fn chunk_by_chars(text: &str, chunk_size: usize, chunk_overlap: usize) -> Vec<String> {
+    let chars: Vec<char> = text.chars().collect();
+    if chars.is_empty() {
+        return Vec::new();
+    }
+    if chars.len() <= chunk_size {
+        return vec![text.to_string()];
+    }
+
+    let mut chunks = Vec::new();
+    let step = chunk_size.saturating_sub(chunk_overlap).max(1);
+    let mut start = 0;
+
+    while start < chars.len() {
+        let end = (start + chunk_size).min(chars.len());
+        chunks.push(chars[start..end].iter().collect::<String>());
+        if end >= chars.len() {
+            break;
+        }
+        start += step;
+    }
+
+    chunks
+}
+
+fn chunk_by_sentences(text: &str, chunk_size: usize) -> Vec<String> {
+    if text.is_empty() {
+        return Vec::new();
+    }
+    if text.len() <= chunk_size {
+        return vec![text.to_string()];
+    }
+
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    let chars: Vec<char> = text.chars().collect();
+
+    for (index, character) in chars.iter().enumerate() {
+        current.push(*character);
+        let is_end = (*character == '.' || *character == '?' || *character == '!')
+            && (index + 1 == chars.len() || chars[index + 1].is_whitespace());
+        if is_end {
+            segments.push(current.clone());
+            current.clear();
+        }
+    }
+    if !current.is_empty() {
+        segments.push(current);
+    }
+
+    let mut chunks = Vec::new();
+    let mut current_chunk = String::new();
+    for segment in segments {
+        if current_chunk.is_empty() {
+            current_chunk = segment;
+            continue;
+        }
+        if current_chunk.len() + segment.len() <= chunk_size {
+            current_chunk.push_str(&segment);
+        } else {
+            chunks.push(current_chunk.trim().to_string());
+            current_chunk = segment;
+        }
+    }
+    if !current_chunk.is_empty() {
+        chunks.push(current_chunk.trim().to_string());
+    }
+
+    chunks
+}
+
+/// Merge chunks by id, using later entries as replacements.
+pub fn merge_chunks(
+    existing: Vec<DocumentChunk>,
+    new_chunks: Vec<DocumentChunk>,
+) -> Vec<DocumentChunk> {
+    let mut merged = HashMap::new();
+    for chunk in existing {
+        merged.insert(chunk.id.clone(), chunk);
+    }
+    for chunk in new_chunks {
+        merged.insert(chunk.id.clone(), chunk);
+    }
+
+    let mut values: Vec<DocumentChunk> = merged.into_values().collect();
+    values.sort_by(|a, b| a.id.cmp(&b.id));
+    values
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use mofa_kernel::agent::error::{AgentError, AgentResult};
+    use mofa_kernel::rag::SimilarityMetric;
+
+    struct TestStore {
+        chunks: HashMap<String, DocumentChunk>,
+        dimensions: Option<usize>,
+    }
+
+    impl TestStore {
+        fn new() -> Self {
+            Self {
+                chunks: HashMap::new(),
+                dimensions: None,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl VectorStore for TestStore {
+        async fn upsert(&mut self, chunk: DocumentChunk) -> AgentResult<()> {
+            if let Some(dim) = self.dimensions {
+                if chunk.embedding.len() != dim {
+                    return Err(AgentError::InvalidInput(format!(
+                        "dimension mismatch: expected {}, got {}",
+                        dim,
+                        chunk.embedding.len()
+                    )));
+                }
+            } else {
+                self.dimensions = Some(chunk.embedding.len());
+            }
+
+            self.chunks.insert(chunk.id.clone(), chunk);
+            Ok(())
+        }
+
+        async fn search(
+            &self,
+            query_embedding: &[f32],
+            top_k: usize,
+            threshold: Option<f32>,
+        ) -> AgentResult<Vec<SearchResult>> {
+            let mut results = self
+                .chunks
+                .values()
+                .map(|chunk| {
+                    let score = chunk
+                        .embedding
+                        .iter()
+                        .zip(query_embedding.iter())
+                        .map(|(lhs, rhs)| lhs * rhs)
+                        .sum::<f32>();
+                    SearchResult::from_chunk(chunk, score)
+                })
+                .filter(|result| threshold.map(|min| result.score >= min).unwrap_or(true))
+                .collect::<Vec<_>>();
+
+            results.sort_by(|lhs, rhs| {
+                rhs.score
+                    .partial_cmp(&lhs.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            results.truncate(top_k);
+            Ok(results)
+        }
+
+        async fn delete(&mut self, id: &str) -> AgentResult<bool> {
+            Ok(self.chunks.remove(id).is_some())
+        }
+
+        async fn clear(&mut self) -> AgentResult<()> {
+            self.chunks.clear();
+            self.dimensions = None;
+            Ok(())
+        }
+
+        async fn count(&self) -> AgentResult<usize> {
+            Ok(self.chunks.len())
+        }
+
+        fn similarity_metric(&self) -> SimilarityMetric {
+            SimilarityMetric::DotProduct
+        }
+    }
+
+    fn doc(id: &str, text: &str) -> Document {
+        Document {
+            id: id.to_string(),
+            text: text.to_string(),
+            metadata: HashMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn index_and_query_roundtrip() {
+        let mut store = TestStore::new();
+        let embedder = DeterministicEmbeddingProvider::new(32).unwrap();
+        let config = RagIngestionConfig::default();
+
+        let indexed = index_documents(
+            &mut store,
+            &[doc("doc-rust", "Rust microkernel architecture for agents.")],
+            &embedder,
+            &config,
+        )
+        .await
+        .unwrap();
+
+        assert!(!indexed.is_empty());
+        assert_eq!(store.count().await.unwrap(), indexed.len());
+
+        let results = query_store(&store, &embedder, "microkernel agents", 3, None)
+            .await
+            .unwrap();
+        assert!(!results.is_empty());
+        assert!(
+            results
+                .iter()
+                .any(|result| result.id.starts_with("doc-rust"))
+        );
+    }
+
+    #[tokio::test]
+    async fn sentence_chunking_generates_multiple_chunks() {
+        let mut store = TestStore::new();
+        let embedder = DeterministicEmbeddingProvider::new(16).unwrap();
+        let config = RagIngestionConfig {
+            chunk_size: 30,
+            chunk_overlap: 0,
+            chunking: ChunkingStrategy::Sentences,
+        };
+
+        let indexed = index_documents(
+            &mut store,
+            &[doc(
+                "doc-1",
+                "First sentence. Second sentence. Third sentence.",
+            )],
+            &embedder,
+            &config,
+        )
+        .await
+        .unwrap();
+
+        assert!(indexed.len() >= 2);
+    }
+
+    #[tokio::test]
+    async fn query_top_k_zero_is_rejected() {
+        let store = TestStore::new();
+        let embedder = DeterministicEmbeddingProvider::new(8).unwrap();
+
+        let err = query_store(&store, &embedder, "test", 0, None)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("top_k must be greater than 0"));
+    }
+
+    #[test]
+    fn merge_chunks_prefers_new_versions() {
+        let old = DocumentChunk::new("a", "old", vec![0.1, 0.2]);
+        let new = DocumentChunk::new("a", "new", vec![0.3, 0.4]);
+
+        let merged = merge_chunks(vec![old], vec![new]);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].text, "new");
+    }
+}

--- a/crates/mofa-sdk/src/lib.rs
+++ b/crates/mofa-sdk/src/lib.rs
@@ -198,6 +198,11 @@ pub mod runtime {
 
     pub use mofa_runtime::config::FrameworkConfig;
 
+    /// Runtime-level RAG indexing/query hooks.
+    pub mod rag {
+        pub use mofa_runtime::rag::*;
+    }
+
     // Dora runtime (only available with dora feature)
     #[cfg(feature = "dora")]
     pub use mofa_runtime::{AgentRuntime, MoFARuntime};

--- a/examples/workflow_orchestration/src/main.rs
+++ b/examples/workflow_orchestration/src/main.rs
@@ -20,7 +20,7 @@
 //! Run: cargo run --example workflow_orchestration
 
 use mofa_sdk::workflow::{
-    ExecutionEvent, ExecutorConfig, WorkflowBuilder, WorkflowExecutor, WorkflowGraph, WorkflowNode, WorkflowValue,
+    ExecutorConfig, WorkflowBuilder, WorkflowExecutor, WorkflowGraph, WorkflowNode, WorkflowValue,
 };
 use mofa_sdk::llm::{LLMAgent, LLMAgentBuilder, openai_from_env};
 use mofa_sdk::react::{ReActAgent, prelude::all_builtin_tools};
@@ -491,7 +491,7 @@ async fn run_data_pipeline() -> Result<(), Box<dyn std::error::Error>> {
 async fn run_workflow_with_events() -> Result<(), Box<dyn std::error::Error>> {
     // 创建事件通道
     // Create event channel
-    let (event_tx, mut event_rx) = mpsc::channel::<ExecutionEvent>(100);
+    let (event_tx, mut event_rx) = mpsc::channel(100);
 
     // 创建简单工作流
     // Create simple workflow
@@ -526,29 +526,9 @@ async fn run_workflow_with_events() -> Result<(), Box<dyn std::error::Error>> {
     let _event_handle = tokio::spawn(async move {
         let mut events = Vec::new();
         while let Some(event) = event_rx.recv().await {
-            match &event {
-                ExecutionEvent::WorkflowStarted { workflow_id, .. } => {
-                    info!("  [EVENT] Workflow started: {}", workflow_id);
-                    //   [EVENT] Workflow started: {}
-                }
-                ExecutionEvent::NodeStarted { node_id, .. } => {
-                    info!("  [EVENT] Node started: {}", node_id);
-                    //   [EVENT] Node started: {}
-                }
-                ExecutionEvent::NodeCompleted { node_id, duration_ms, .. } => {
-                    info!("  [EVENT] Node completed: {} ({}ms)", node_id, duration_ms);
-                    //   [EVENT] Node completed: {} ({}ms)
-                }
-                ExecutionEvent::CheckpointCreated { label } => {
-                    info!("  [EVENT] Checkpoint created: {}", label);
-                    //   [EVENT] Checkpoint created: {}
-                }
-                ExecutionEvent::WorkflowCompleted { workflow_id, .. } => {
-                    info!("  [EVENT] Workflow completed: {}", workflow_id);
-                    //   [EVENT] Workflow completed: {}
-                }
-                _ => {}
-            }
+            // Keep event logging schema-agnostic so the example remains compatible
+            // when executor event payloads evolve.
+            info!("  [EVENT] {:?}", event);
             events.push(event);
         }
         events


### PR DESCRIPTION
## Summary
- add runtime-level RAG ingestion/query module with deterministic embedding provider, chunking strategies, and reusable index/query helpers
- add `mofa rag` CLI (`index` and `query`) with in-memory index persistence and optional Qdrant backend wiring
- re-export runtime RAG utilities via `mofa-sdk` for downstream consumers
- include the workflow orchestration example event typing fix so `cargo-check-examples` remains green

## Testing
- `cargo test -p mofa-runtime rag -- --nocapture`
- `cargo test -p mofa-cli rag -- --nocapture`
- `cargo check --manifest-path examples/Cargo.toml -p workflow_orchestration`