### PR TITLE
chore(api): add #[must_use] to critical public result-returning APIs

### DIFF
--- a/crates/mofa-extra/src/rhai/engine.rs
+++ b/crates/mofa-extra/src/rhai/engine.rs
@@ -159,6 +159,7 @@ impl ScriptContext {
 
 /// 脚本执行结果
 /// Script execution result
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScriptResult {
     /// 是否成功

--- a/crates/mofa-extra/src/rhai/rules.rs
+++ b/crates/mofa-extra/src/rhai/rules.rs
@@ -252,6 +252,7 @@ impl RuleGroupDefinition {
 // ============================================================================
 
 /// Rule match result
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RuleMatchResult {
     /// Rule ID
@@ -263,6 +264,7 @@ pub struct RuleMatchResult {
 }
 
 /// Rule execution result
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RuleExecutionResult {
     /// Executed rule ID
@@ -282,6 +284,7 @@ pub struct RuleExecutionResult {
 }
 
 /// Rule group execution result
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RuleGroupExecutionResult {
     /// Group ID

--- a/crates/mofa-extra/src/rhai/tools.rs
+++ b/crates/mofa-extra/src/rhai/tools.rs
@@ -427,6 +427,7 @@ impl ScriptToolDefinition {
 
 /// 工具执行结果
 /// Tool execution result
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolExecutionResult {
     /// 工具 ID

--- a/crates/mofa-extra/src/rhai/workflow.rs
+++ b/crates/mofa-extra/src/rhai/workflow.rs
@@ -139,6 +139,7 @@ impl ScriptNodeConfig {
 
 /// 脚本节点执行结果
 /// Script node execution result
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScriptNodeResult {
     /// 节点 ID

--- a/crates/mofa-foundation/src/adapter/registry.rs
+++ b/crates/mofa-foundation/src/adapter/registry.rs
@@ -10,6 +10,7 @@ use super::descriptor::{AdapterDescriptor, Modality, ModelFormat};
 use super::error::{AdapterError, RejectionReason, ResolutionError};
 
 /// Result of adapter resolution containing the selected adapter and any rejection reasons
+#[must_use]
 #[derive(Debug)]
 pub struct ResolutionResult {
     /// The selected adapter

--- a/crates/mofa-foundation/src/collaboration/types.rs
+++ b/crates/mofa-foundation/src/collaboration/types.rs
@@ -304,6 +304,7 @@ impl CollaborationMessage {
 ///
 /// 包含执行结果和 LLM 的决策上下文
 /// Contains execution result and LLM's decision context
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CollaborationResult {
     /// 是否成功

--- a/crates/mofa-foundation/src/inference/types.rs
+++ b/crates/mofa-foundation/src/inference/types.rs
@@ -167,6 +167,7 @@ impl InferenceRequest {
 }
 
 /// The result of an inference request after orchestration.
+#[must_use]
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct InferenceResult {
     /// The generated output text

--- a/crates/mofa-foundation/src/llm/task_orchestrator.rs
+++ b/crates/mofa-foundation/src/llm/task_orchestrator.rs
@@ -119,6 +119,7 @@ impl BackgroundTask {
 }
 
 /// Result from a completed task
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TaskResult {
     /// Task ID

--- a/crates/mofa-foundation/src/llm/token_budget.rs
+++ b/crates/mofa-foundation/src/llm/token_budget.rs
@@ -142,6 +142,7 @@ pub enum ContextWindowPolicy {
 // ============================================================================
 
 /// Result of applying context window management.
+#[must_use]
 #[derive(Debug)]
 pub struct TrimResult {
     /// The trimmed messages, ready to send to the LLM.

--- a/crates/mofa-foundation/src/react/actor.rs
+++ b/crates/mofa-foundation/src/react/actor.rs
@@ -618,6 +618,7 @@ pub enum ExecutionMode {
 
 /// AutoAgent 执行结果
 /// AutoAgent execution result
+#[must_use]
 #[derive(Debug, Clone)]
 pub struct AutoAgentResult {
     /// 执行模式

--- a/crates/mofa-foundation/src/react/core.rs
+++ b/crates/mofa-foundation/src/react/core.rs
@@ -114,6 +114,7 @@ impl ReActStep {
 
 /// ReAct 执行结果
 /// ReAct execution result
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReActResult {
     /// 任务 ID

--- a/crates/mofa-foundation/src/react/patterns.rs
+++ b/crates/mofa-foundation/src/react/patterns.rs
@@ -458,6 +458,7 @@ impl Default for ChainAgent {
 
 /// 链式执行结果
 /// Chain execution results
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChainResult {
     /// 链 ID
@@ -500,6 +501,7 @@ impl ChainResult {
 
 /// 链式执行步骤结果
 /// Chain step execution result
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChainStepResult {
     /// 步骤序号
@@ -928,6 +930,7 @@ impl Default for ParallelAgent {
 
 /// 并行执行结果
 /// Parallel execution results
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ParallelResult {
     /// 并行执行 ID
@@ -977,6 +980,7 @@ impl ParallelResult {
 
 /// 并行执行步骤结果
 /// Parallel step execution result
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ParallelStepResult {
     /// Agent 名称
@@ -1313,6 +1317,7 @@ impl Default for MapReduceAgent {
 
 /// MapReduce 执行结果
 /// MapReduce execution result
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MapReduceResult {
     /// MapReduce ID
@@ -1334,6 +1339,7 @@ pub struct MapReduceResult {
 
 /// Map 步骤结果
 /// Map step result
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MapStepResult {
     /// 索引

--- a/crates/mofa-foundation/src/react/reflection.rs
+++ b/crates/mofa-foundation/src/react/reflection.rs
@@ -129,6 +129,7 @@ pub struct ReflectionStep {
 }
 
 /// Result of running the Reflection agent.
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReflectionResult {
     /// Original task.

--- a/crates/mofa-foundation/src/secretary/default/coordinator.rs
+++ b/crates/mofa-foundation/src/secretary/default/coordinator.rs
@@ -43,6 +43,7 @@ pub enum DispatchStrategy {
 
 /// 任务分配结果
 /// Task allocation result
+#[must_use]
 #[derive(Debug, Clone)]
 pub struct DispatchResult {
     /// 子任务ID

--- a/crates/mofa-foundation/src/secretary/default/types.rs
+++ b/crates/mofa-foundation/src/secretary/default/types.rs
@@ -192,6 +192,7 @@ pub struct Resource {
 
 /// 执行结果
 /// Execution result
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExecutionResult {
     /// 是否成功

--- a/crates/mofa-foundation/src/workflow/state.rs
+++ b/crates/mofa-foundation/src/workflow/state.rs
@@ -206,6 +206,7 @@ pub enum WorkflowStatus {
 
 /// 节点执行结果
 /// Node execution result
+#[must_use]
 #[derive(Debug, Clone)]
 pub struct NodeResult {
     /// 节点 ID
@@ -572,6 +573,7 @@ impl CheckpointData {
 
 /// 工作流执行历史记录
 /// Workflow execution history record
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExecutionRecord {
     /// 执行 ID
@@ -606,6 +608,7 @@ pub struct ExecutionRecord {
 
 /// 节点执行记录
 /// Node execution record
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NodeExecutionRecord {
     /// 节点 ID

--- a/crates/mofa-kernel/src/agent/components/coordinator.rs
+++ b/crates/mofa-kernel/src/agent/components/coordinator.rs
@@ -253,6 +253,7 @@ pub enum TaskPriority {
 
 /// 分发结果
 /// Dispatch result
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DispatchResult {
     /// 任务 ID

--- a/crates/mofa-kernel/src/agent/components/reasoner.rs
+++ b/crates/mofa-kernel/src/agent/components/reasoner.rs
@@ -82,6 +82,7 @@ pub trait Reasoner: Send + Sync {
 
 /// 推理结果
 /// Reasoning result
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReasoningResult {
     /// 思考步骤

--- a/crates/mofa-kernel/src/agent/components/tool.rs
+++ b/crates/mofa-kernel/src/agent/components/tool.rs
@@ -197,6 +197,7 @@ impl From<&str> for ToolInput<serde_json::Value> {
 
 /// 工具执行结果
 /// Tool Execution Result
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolResult<Out = serde_json::Value> {
     /// 是否成功

--- a/crates/mofa-kernel/src/rag/types.rs
+++ b/crates/mofa-kernel/src/rag/types.rs
@@ -119,6 +119,7 @@ impl DocumentChunk {
 }
 
 /// Result returned from a vector similarity search.
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SearchResult {
     /// The id of the matched chunk

--- a/crates/mofa-kernel/src/workflow/graph.rs
+++ b/crates/mofa-kernel/src/workflow/graph.rs
@@ -343,6 +343,7 @@ pub enum StreamEvent<S: GraphState, V = serde_json::Value> {
 }
 
 /// Result of a single step execution
+#[must_use]
 #[derive(Debug, Clone)]
 pub struct StepResult<S: GraphState, V = serde_json::Value> {
     /// Current state after the step

--- a/crates/mofa-plugins/src/hot_reload/manager.rs
+++ b/crates/mofa-plugins/src/hot_reload/manager.rs
@@ -105,6 +105,7 @@ impl HotReloadConfig {
 pub use mofa_kernel::plugin::{ReloadEvent, ReloadStrategy};
 
 /// Reload result
+#[must_use]
 #[derive(Debug)]
 pub struct ReloadResult {
     /// Plugin ID

--- a/crates/mofa-plugins/src/lib.rs
+++ b/crates/mofa-plugins/src/lib.rs
@@ -412,6 +412,7 @@ pub struct ToolCall {
 
 /// 工具调用结果
 /// Tool call result
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolResult {
     /// 调用 ID

--- a/crates/mofa-runtime/src/agent/execution.rs
+++ b/crates/mofa-runtime/src/agent/execution.rs
@@ -160,6 +160,7 @@ pub enum ExecutionStatus {
 
 /// 执行结果
 /// Execution result
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExecutionResult {
     /// 执行 ID

--- a/crates/mofa-runtime/src/dora_adapter/runtime.rs
+++ b/crates/mofa-runtime/src/dora_adapter/runtime.rs
@@ -247,6 +247,7 @@ pub enum RuntimeState {
 
 /// 数据流执行结果
 /// Dataflow execution result
+#[must_use]
 #[derive(Debug, Clone)]
 pub struct DataflowResult {
     /// 数据流 UUID


### PR DESCRIPTION
## 📋 Summary

Add `#[must_use]` attributes to 34 public result/outcome structs across 6 crates whose return values should never be silently discarded. This prevents subtle logic errors where callers ignore execution results, dispatch outcomes, or validation data.

## 🔗 Related Issues

Closes: #767


---

## 🧠 Context

Many public structs in the workspace represent semantically critical outcomes — execution results, dispatch decisions, reasoning outputs, tool call results, etc. Without `#[must_use]`, the compiler will not warn if a caller silently discards these values, which is almost always a logic error.

`Result<T, E>` already carries `#[must_use]` in std, so type aliases like `AgentResult<T>`, `LLMResult<T>`, and `DoraResult<T>` are already covered and were intentionally left untouched. This PR targets only the non-`Result` structs that represent outcomes where ignoring the value is clearly wrong.

---

## 🛠️ Changes

- Added `#[must_use]` to 5 outcome structs in `mofa-kernel` (`DispatchResult`, `ToolResult<Out>`, `ReasoningResult`, `SearchResult`, `StepResult<S,V>`)
- Added `#[must_use]` to 19 outcome structs in `mofa-foundation` (`NodeResult`, `ExecutionRecord`, `NodeExecutionRecord`, `ReActResult`, `ReflectionResult`, `ChainResult`, `ChainStepResult`, `ParallelResult`, `ParallelStepResult`, `MapReduceResult`, `MapStepResult`, `AutoAgentResult`, `CollaborationResult`, `DispatchResult`, `ExecutionResult`, `InferenceResult`, `TaskResult`, `TrimResult`, `ResolutionResult`)
- Added `#[must_use]` to 2 outcome structs in `mofa-runtime` (`ExecutionResult`, `DataflowResult`)
- Added `#[must_use]` to 2 outcome structs in `mofa-plugins` (`ToolResult`, `ReloadResult`)
- Added `#[must_use]` to 6 outcome structs in `mofa-extra` (`ScriptResult`, `RuleMatchResult`, `RuleExecutionResult`, `RuleGroupExecutionResult`, `ToolExecutionResult`, `ScriptNodeResult`)

---

## 🧪 How I Tested

1. Ran `cargo check` across the full workspace — compiles cleanly with zero errors
2. Ran `cargo test -p mofa-kernel -p mofa-foundation -p mofa-runtime -p mofa-plugins -p mofa-extra` — 829 passed, 0 failed
3. Ran `cargo clippy -p mofa-kernel -p mofa-foundation -p mofa-runtime -p mofa-plugins -p mofa-extra` — no warnings
4. Verified the diff contains only `#[must_use]` attribute additions — 25 files changed, 34 insertions, 0 deletions
5. Confirmed no existing `#[must_use]` was duplicated by grepping annotated structs before applying changes
---


## ⚠️ Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (describe below)

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [ ] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [ ] Public APIs documented
- [ ] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---

## 🚀 Deployment Notes (if applicable)

None. Attribute-only change with no runtime impact.

---

## 🧩 Additional Notes for Reviewers

- Every added line is exactly `#[must_use]` — zero logic, formatting, or whitespace changes.
- `Result<T, E>` aliases (`AgentResult`, `LLMResult`, `DoraResult`, `PromptResult`) were intentionally **not** annotated because `std::result::Result` already carries `#[must_use]`.
- `ConfigValidationResult` in `mofa-cli` already had `#[must_use]` and was left untouched.
- Builder `.build()` methods were conservatively excluded — they construct objects rather than represent execution outcomes, so discarding them is less clearly a bug.
- `RetryDecision` (mentioned in the issue) does not exist in the codebase and was skipped.