### PR TITLE
fix(monitoring): prevent zombie BatchExporter task on channel closure

### DIFF
--- a/crates/mofa-monitoring/src/tracing/exporter.rs
+++ b/crates/mofa-monitoring/src/tracing/exporter.rs
@@ -612,6 +612,7 @@ impl TracingExporter for CompositeExporter {
 pub struct BatchExporter {
     exporter: Arc<dyn TracingExporter>,
     sender: mpsc::Sender<SpanData>,
+    _task: tokio::task::JoinHandle<()>,
 }
 
 impl BatchExporter {
@@ -624,18 +625,32 @@ impl BatchExporter {
 
         // 启动后台导出任务
         // Start background export task
-        tokio::spawn(async move {
+        let task = tokio::spawn(async move {
             let mut buffer = Vec::with_capacity(batch_size);
             let mut interval = tokio::time::interval(export_interval);
 
             loop {
                 tokio::select! {
-                    Some(span) = receiver.recv() => {
-                        buffer.push(span);
-                        if buffer.len() >= batch_size {
-                            let to_export: Vec<_> = std::mem::take(&mut buffer);
-                            if let Err(e) = exporter_clone.export(to_export).await {
-                                error!("Failed to export spans: {}", e);
+                    msg = receiver.recv() => {
+                        match msg {
+                            Some(span) => {
+                                buffer.push(span);
+                                if buffer.len() >= batch_size {
+                                    let to_export: Vec<_> = std::mem::take(&mut buffer);
+                                    if let Err(e) = exporter_clone.export(to_export).await {
+                                        error!("Failed to export spans: {}", e);
+                                    }
+                                }
+                            }
+                            // All senders dropped: flush remaining spans and exit.
+                            None => {
+                                if !buffer.is_empty() {
+                                    let to_export: Vec<_> = std::mem::take(&mut buffer);
+                                    if let Err(e) = exporter_clone.export(to_export).await {
+                                        error!("Failed to export spans on shutdown: {}", e);
+                                    }
+                                }
+                                break;
                             }
                         }
                     }
@@ -651,7 +666,7 @@ impl BatchExporter {
             }
         });
 
-        Self { exporter, sender }
+        Self { exporter, sender, _task: task }
     }
 
     pub async fn record(&self, span: SpanData) -> Result<(), String> {


### PR DESCRIPTION
## **Summary**

This PR fixes a lifecycle issue in:

```
crates/mofa-monitoring/src/tracing/exporter.rs
```

Specifically in `BatchExporter::new()` where the background export task is spawned.

Previously, the exporter spawned a background loop but did not properly exit when the `BatchExporter` was dropped:

```rust
tokio::spawn(async move {
    loop {
        tokio::select! {
            Some(span) = receiver.recv() => { /* ... */ }
            _ = interval.tick() => { /* ... */ }
        }
    }
});
```

When the `sender` was dropped, `receiver.recv()` returned `None`, but the `Some(span)` pattern did not match.
This disabled the branch silently, allowing `interval.tick()` to keep the loop alive forever.

As a result, the task never terminated and became a zombie.

---

## **Steps to Reproduce**

1. Create a `BatchExporter`.
2. Use it normally (record spans).
3. Drop it (e.g., telemetry reconfiguration).
4. Repeat this cycle multiple times.
5. Attempt clean runtime shutdown.

Observed behavior:

* Background tasks remain alive.
* Runtime shutdown hangs or waits for timeout.
* Exporter resources remain allocated.
* `tokio-console` shows tasks waking at the export interval indefinitely.

---

## **Impact**

* Zombie task accumulation on every reconfiguration.
* `Arc<dyn TracingExporter>` never freed.
* Clean shutdown blocked by permanently alive tasks.
* Long-running deployments degrade over time.
* Monitoring subsystem leaks background work.

This is production-realistic in environments where telemetry settings are reloaded or exporters are replaced dynamically.

---

## **Fix**

Two changes were introduced:

### 1️⃣ Explicitly handle channel closure

```rust
msg = receiver.recv() => {
    match msg {
        Some(span) => { /* batch logic */ }
        None => break, // channel closed → exit loop
    }
}
```

Now, once all senders are dropped, the background loop exits immediately.

---

### 2️⃣ Store the JoinHandle

The spawned task handle is now retained:

```rust
pub struct BatchExporter {
    exporter: Arc<dyn TracingExporter>,
    sender: mpsc::Sender<SpanData>,
    _task: tokio::task::JoinHandle<()>,
}
```

This ensures proper lifecycle ownership and makes the task abortable on drop if needed.

---

## **Result**

* No zombie background tasks.
* Exporter resources are released when dropped.
* Runtime shutdown completes cleanly.
* Monitoring reconfiguration no longer accumulates tasks.
* Minimal, localized fix with no architectural changes.

The `BatchExporter` now behaves correctly as a lifecycle-bound component instead of leaving detached background work behind.
