### PR TITLE
feat(workflow): add DSL to StateGraph compiler with strongly typed errors

### DIFF
--- a/crates/mofa-foundation/src/error_conversions.rs
+++ b/crates/mofa-foundation/src/error_conversions.rs
@@ -117,10 +117,10 @@ mod tests {
 
     #[test]
     fn test_dsl_error_to_global() {
-        let dsl_err = DslError::Validation("missing start node".to_string());
+        let dsl_err = DslError::MissingStartNode;
         let global: GlobalError = dsl_err.into();
 
         assert_eq!(global.category(), ErrorCategory::Workflow);
-        assert!(global.to_string().contains("missing start node"));
+        assert!(global.to_string().contains("Missing Start node"));
     }
 }

--- a/crates/mofa-foundation/src/workflow/dsl/compiler.rs
+++ b/crates/mofa-foundation/src/workflow/dsl/compiler.rs
@@ -1,0 +1,1145 @@
+//! DSL → StateGraph Compiler
+//!
+//! Bridges the declarative DSL workflow definitions to the StateGraph execution engine.
+//! Transforms a parsed `WorkflowDefinition` into a `CompiledGraphImpl<JsonState>` that
+//! can be invoked, streamed, or stepped through.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use mofa_foundation::workflow::dsl::{WorkflowDslParser, DslCompiler};
+//!
+//! let yaml = std::fs::read_to_string("workflow.yaml")?;
+//! let def = WorkflowDslParser::from_yaml(&yaml)?;
+//! let compiled = DslCompiler::compile(def)?;
+//! let result = compiled.invoke(JsonState::default(), None).await?;
+//! ```
+
+use super::schema::*;
+use super::{DslError, DslResult};
+use crate::llm::LLMAgent;
+use crate::workflow::state_graph::{CompiledGraphImpl, StateGraphImpl};
+use async_trait::async_trait;
+use mofa_kernel::agent::error::AgentResult;
+use mofa_kernel::workflow::{
+    Command, END, GraphState, JsonState, NodeFunc, RuntimeContext, START, StateGraph,
+};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+// Node Adapters — DSL NodeDefinition → Box<dyn NodeFunc<JsonState>>
+/// A pass-through node that forwards state unchanged.
+///
+/// Used for Start, End, and Parallel placeholder nodes.
+struct PassthroughNode {
+    node_name: String,
+}
+
+impl PassthroughNode {
+    fn new(name: impl Into<String>) -> Self {
+        Self {
+            node_name: name.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl NodeFunc<JsonState, Value> for PassthroughNode {
+    async fn call(
+        &self,
+        _state: &mut JsonState,
+        _ctx: &RuntimeContext<Value>,
+    ) -> AgentResult<Command<Value>> {
+        Ok(Command::new().continue_())
+    }
+    fn name(&self) -> &str {
+        &self.node_name
+    }
+    fn description(&self) -> Option<&str> {
+        Some("Pass-through node (no-op)")
+    }
+}
+
+/// A task node that executes a no-op (placeholder for future executor support).
+///
+/// Currently only supports `TaskExecutorDef::None`. Other executor types
+/// (Function, Http, Script) can be added in future PRs.
+struct DslTaskNode {
+    node_name: String,
+    executor: TaskExecutorDef,
+}
+
+impl DslTaskNode {
+    fn new(name: impl Into<String>, executor: TaskExecutorDef) -> Self {
+        Self {
+            node_name: name.into(),
+            executor,
+        }
+    }
+}
+
+#[async_trait]
+impl NodeFunc<JsonState, Value> for DslTaskNode {
+    async fn call(
+        &self,
+        _state: &mut JsonState,
+        _ctx: &RuntimeContext<Value>,
+    ) -> AgentResult<Command<Value>> {
+        match &self.executor {
+            TaskExecutorDef::None => Ok(Command::new().continue_()),
+            TaskExecutorDef::Function { function } => Ok(Command::new()
+                .update(
+                    &self.node_name,
+                    serde_json::json!({
+                        "type": "function",
+                        "function": function,
+                        "status": "placeholder"
+                    }),
+                )
+                .continue_()),
+            TaskExecutorDef::Http { url, method } => Ok(Command::new()
+                .update(
+                    &self.node_name,
+                    serde_json::json!({
+                        "type": "http",
+                        "url": url,
+                        "method": method.as_deref().unwrap_or("GET"),
+                        "status": "placeholder"
+                    }),
+                )
+                .continue_()),
+            TaskExecutorDef::Script { script } => Ok(Command::new()
+                .update(
+                    &self.node_name,
+                    serde_json::json!({
+                        "type": "script",
+                        "script_length": script.len(),
+                        "status": "placeholder"
+                    }),
+                )
+                .continue_()),
+        }
+    }
+    fn name(&self) -> &str {
+        &self.node_name
+    }
+    fn description(&self) -> Option<&str> {
+        Some("DSL task node")
+    }
+}
+
+/// A condition node that evaluates a condition and sets the route in state.
+///
+/// The condition result is stored in state under the node's ID key, which can
+/// then be used by conditional edges to route to the appropriate next node.
+struct DslConditionNode {
+    node_name: String,
+    condition: ConditionDef,
+}
+
+impl DslConditionNode {
+    fn new(name: impl Into<String>, condition: ConditionDef) -> Self {
+        Self {
+            node_name: name.into(),
+            condition,
+        }
+    }
+}
+
+#[async_trait]
+impl NodeFunc<JsonState, Value> for DslConditionNode {
+    async fn call(
+        &self,
+        state: &mut JsonState,
+        _ctx: &RuntimeContext<Value>,
+    ) -> AgentResult<Command<Value>> {
+        let result = match &self.condition {
+            ConditionDef::Expression { expr } => {
+                // Currently returns the expression as the route key for conditional edges.
+                // A full expression evaluator (e.g. Rhai) can be integrated in a future PR.
+                serde_json::json!(expr)
+            }
+            ConditionDef::Value {
+                field,
+                operator,
+                value,
+            } => {
+                let field_value: Option<Value> = state.get_value(field);
+                let matches = match field_value {
+                    Some(actual) => evaluate_condition(&actual, operator, value),
+                    None => false,
+                };
+                serde_json::json!(if matches { "true" } else { "false" })
+            }
+        };
+        Ok(Command::new().update(&self.node_name, result).continue_())
+    }
+    fn name(&self) -> &str {
+        &self.node_name
+    }
+    fn description(&self) -> Option<&str> {
+        Some("DSL condition node")
+    }
+}
+
+/// A join node that waits for specified upstream nodes.
+///
+/// In the StateGraph model, join semantics are handled by the graph's edge
+/// topology. This node stores the join metadata in state for observability.
+struct DslJoinNode {
+    node_name: String,
+    wait_for: Vec<String>,
+}
+
+impl DslJoinNode {
+    fn new(name: impl Into<String>, wait_for: Vec<String>) -> Self {
+        Self {
+            node_name: name.into(),
+            wait_for,
+        }
+    }
+}
+
+#[async_trait]
+impl NodeFunc<JsonState, Value> for DslJoinNode {
+    async fn call(
+        &self,
+        _state: &mut JsonState,
+        _ctx: &RuntimeContext<Value>,
+    ) -> AgentResult<Command<Value>> {
+        Ok(Command::new()
+            .update(
+                &self.node_name,
+                serde_json::json!({
+                    "type": "join",
+                    "waited_for": self.wait_for,
+                }),
+            )
+            .continue_())
+    }
+    fn name(&self) -> &str {
+        &self.node_name
+    }
+    fn description(&self) -> Option<&str> {
+        Some("DSL join node")
+    }
+}
+
+/// A transform node that records the transform definition in state.
+struct DslTransformNode {
+    node_name: String,
+    transform: TransformDef,
+}
+
+impl DslTransformNode {
+    fn new(name: impl Into<String>, transform: TransformDef) -> Self {
+        Self {
+            node_name: name.into(),
+            transform,
+        }
+    }
+}
+
+#[async_trait]
+impl NodeFunc<JsonState, Value> for DslTransformNode {
+    async fn call(
+        &self,
+        _state: &mut JsonState,
+        _ctx: &RuntimeContext<Value>,
+    ) -> AgentResult<Command<Value>> {
+        let info = match &self.transform {
+            TransformDef::Template { template } => serde_json::json!({
+                "type": "template",
+                "template": template,
+            }),
+            TransformDef::Expression { expr } => serde_json::json!({
+                "type": "expression",
+                "expr": expr,
+            }),
+            TransformDef::MapReduce { map, reduce } => serde_json::json!({
+                "type": "map_reduce",
+                "map": map,
+                "reduce": reduce,
+            }),
+        };
+        Ok(Command::new().update(&self.node_name, info).continue_())
+    }
+    fn name(&self) -> &str {
+        &self.node_name
+    }
+    fn description(&self) -> Option<&str> {
+        Some("DSL transform node")
+    }
+}
+
+/// An agent node that routes execution to an LLM.
+///
+/// Sends the current `input` from state to the agent and stores the response.
+struct DslAgentNode {
+    node_name: String,
+    agent: Arc<LLMAgent>,
+    _config: AgentRef,
+}
+
+impl DslAgentNode {
+    fn new(name: impl Into<String>, agent: Arc<LLMAgent>, config: AgentRef) -> Self {
+        Self {
+            node_name: name.into(),
+            agent,
+            _config: config,
+        }
+    }
+}
+
+#[async_trait]
+impl NodeFunc<JsonState, Value> for DslAgentNode {
+    async fn call(
+        &self,
+        state: &mut JsonState,
+        _ctx: &RuntimeContext<Value>,
+    ) -> AgentResult<Command<Value>> {
+        // Find input argument depending on upstream context
+        // Try `input` first, then error if missing
+        let input_value: Option<Value> = state.get_value("input");
+        let input_text = match input_value {
+            Some(Value::String(s)) => s,
+            Some(other) => other.to_string(),
+            None => {
+                let mut keys = state.keys();
+                keys.sort();
+                return Err(mofa_kernel::agent::error::AgentError::ExecutionFailed(
+                    format!(
+                        "Agent node '{}' requires 'input' key in state, but none found. Available keys: {:?}",
+                        self.node_name, keys
+                    ),
+                ));
+            }
+        };
+
+        // Use simple Q&A ask() for stateless workflow processing
+        let response = self.agent.ask(input_text).await.map_err(|e| {
+            mofa_kernel::agent::error::AgentError::ExecutionFailed(format!(
+                "LLM Agent failed: {}",
+                e
+            ))
+        })?;
+
+        Ok(Command::new()
+            .update(&self.node_name, serde_json::json!(response))
+            .continue_())
+    }
+    fn name(&self) -> &str {
+        &self.node_name
+    }
+    fn description(&self) -> Option<&str> {
+        Some("DSL LLM Agent node")
+    }
+}
+
+// Condition Evaluation Helper
+
+/// Evaluate a simple condition: `actual <operator> expected`
+fn evaluate_condition(actual: &Value, operator: &str, expected: &Value) -> bool {
+    match operator {
+        "==" | "eq" => actual == expected,
+        "!=" | "ne" => actual != expected,
+        ">" | "gt" => compare_values(actual, expected) == Some(std::cmp::Ordering::Greater),
+        "<" | "lt" => compare_values(actual, expected) == Some(std::cmp::Ordering::Less),
+        ">=" | "gte" => {
+            matches!(
+                compare_values(actual, expected),
+                Some(std::cmp::Ordering::Greater | std::cmp::Ordering::Equal)
+            )
+        }
+        "<=" | "lte" => {
+            matches!(
+                compare_values(actual, expected),
+                Some(std::cmp::Ordering::Less | std::cmp::Ordering::Equal)
+            )
+        }
+        "contains" => {
+            if let (Some(haystack), Some(needle)) = (actual.as_str(), expected.as_str()) {
+                haystack.contains(needle)
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+/// Compare two JSON values numerically
+fn compare_values(a: &Value, b: &Value) -> Option<std::cmp::Ordering> {
+    match (a.as_f64(), b.as_f64()) {
+        (Some(a_num), Some(b_num)) => a_num.partial_cmp(&b_num),
+        _ => match (a.as_str(), b.as_str()) {
+            (Some(a_str), Some(b_str)) => Some(a_str.cmp(b_str)),
+            _ => None,
+        },
+    }
+}
+
+// DSL Compiler
+
+/// Compiles a parsed `WorkflowDefinition` into an executable `CompiledGraphImpl<JsonState>`.
+///
+/// This bridges the declarative DSL layer (YAML/TOML) to the StateGraph
+/// execution engine, enabling users to define workflows in configuration
+/// files and execute them via `invoke()`, `stream()`, or `step()`.
+///
+/// # Supported Node Types
+///
+/// | DSL Type       | Adapter            | Behavior                          |
+/// |----------------|--------------------|-----------------------------------|
+/// | `Start`        | `PassthroughNode`  | No-op entry point                 |
+/// | `End`          | `PassthroughNode`  | No-op exit point                  |
+/// | `Task`         | `DslTaskNode`      | Executor placeholder              |
+/// | `Condition`    | `DslConditionNode` | Evaluates condition, sets route   |
+/// | `Parallel`     | `PassthroughNode`  | Marker (parallelism via edges)    |
+/// | `Join`         | `DslJoinNode`      | Records join metadata             |
+/// | `Transform`    | `DslTransformNode` | Records transform definition      |
+///
+/// # Unsupported Node Types (Future PRs)
+///
+/// - `LlmAgent` — requires LLM provider registry
+/// - `Loop` — requires runtime loop state machine
+/// - `SubWorkflow` — requires recursive workflow loading
+/// - `Wait` — requires external event system
+pub struct DslCompiler;
+
+impl DslCompiler {
+    /// Compile a `WorkflowDefinition` into an executable `CompiledGraphImpl<JsonState>`.
+    ///
+    /// This performs validation, builds the graph, and compiles it in one step.
+    /// Returns an error if any `LlmAgent` nodes are used, since no agent registry is provided.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DslError` if:
+    /// - The definition is invalid (no start/end node, dangling edges)
+    /// - An `LlmAgent`, `Loop`, `SubWorkflow`, or `Wait` node type is used
+    /// - Graph compilation fails (unreachable nodes, etc.)
+    pub fn compile(def: WorkflowDefinition) -> DslResult<CompiledGraphImpl<JsonState>> {
+        Self::compile_with_agents(def, &HashMap::new())
+    }
+
+    /// Compile a `WorkflowDefinition` with access to a registry of `LLMAgent` instances.
+    ///
+    /// This is required if the workflow definition contains `LlmAgent` nodes.
+    ///
+    /// # Errors
+    ///
+    /// Extends `compile()` errors, and will also return `DslError::MissingAgentInRegistry` if
+    /// an `LlmAgent` node references an `agent_id` not found in the `agent_registry`.
+    pub fn compile_with_agents(
+        def: WorkflowDefinition,
+        agent_registry: &HashMap<String, Arc<LLMAgent>>,
+    ) -> DslResult<CompiledGraphImpl<JsonState>> {
+        Self::validate(&def)?;
+        let mut graph = StateGraphImpl::<JsonState>::build(&def.metadata.id);
+
+        for node_def in &def.nodes {
+            let node_func = Self::compile_node(node_def, agent_registry)?;
+            let node_id = node_def.id();
+            graph.add_node(node_id, node_func);
+        }
+
+        Self::wire_edges(&mut graph, &def)?;
+        graph.compile().map_err(|e| DslError::Build(e.to_string()))
+    }
+
+    /// Compile a single `NodeDefinition` into a `Box<dyn NodeFunc<JsonState, Value>>`.
+    fn compile_node(
+        def: &NodeDefinition,
+        agent_registry: &HashMap<String, Arc<LLMAgent>>,
+    ) -> DslResult<Box<dyn NodeFunc<JsonState, Value>>> {
+        match def {
+            NodeDefinition::Start { id, .. } => {
+                Ok(Box::new(PassthroughNode::new(id)) as Box<dyn NodeFunc<JsonState, Value>>)
+            }
+            NodeDefinition::End { id, .. } => {
+                Ok(Box::new(PassthroughNode::new(id)) as Box<dyn NodeFunc<JsonState, Value>>)
+            }
+            NodeDefinition::Task { id, executor, .. } => {
+                Ok(Box::new(DslTaskNode::new(id, executor.clone()))
+                    as Box<dyn NodeFunc<JsonState, Value>>)
+            }
+            NodeDefinition::Condition { id, condition, .. } => {
+                Ok(Box::new(DslConditionNode::new(id, condition.clone()))
+                    as Box<dyn NodeFunc<JsonState, Value>>)
+            }
+            NodeDefinition::Parallel { id, .. } => {
+                Ok(Box::new(PassthroughNode::new(id)) as Box<dyn NodeFunc<JsonState, Value>>)
+            }
+            NodeDefinition::Join { id, wait_for, .. } => {
+                Ok(Box::new(DslJoinNode::new(id, wait_for.clone()))
+                    as Box<dyn NodeFunc<JsonState, Value>>)
+            }
+            NodeDefinition::Transform { id, transform, .. } => {
+                Ok(Box::new(DslTransformNode::new(id, transform.clone()))
+                    as Box<dyn NodeFunc<JsonState, Value>>)
+            }
+            NodeDefinition::LlmAgent { id, agent, .. } => {
+                let agent_id = match agent {
+                    AgentRef::Registry { agent_id } => agent_id,
+                    AgentRef::Inline(_) => {
+                        return Err(DslError::InlineAgentNotSupported(id.to_string()));
+                    }
+                };
+                if let Some(agent_instance) = agent_registry.get(agent_id) {
+                    Ok(
+                        Box::new(DslAgentNode::new(id, agent_instance.clone(), agent.clone()))
+                            as Box<dyn NodeFunc<JsonState, Value>>,
+                    )
+                } else {
+                    Err(DslError::MissingAgentInRegistry {
+                        node_id: id.to_string(),
+                        agent_id: agent_id.to_string(),
+                    })
+                }
+            }
+            NodeDefinition::Loop { id, .. } => Err(DslError::InvalidNodeType(format!(
+                "Loop node '{}' is not yet supported by the DSL compiler.",
+                id
+            ))),
+            NodeDefinition::SubWorkflow { id, .. } => Err(DslError::InvalidNodeType(format!(
+                "SubWorkflow node '{}' is not yet supported by the DSL compiler.",
+                id
+            ))),
+            NodeDefinition::Wait { id, .. } => Err(DslError::InvalidNodeType(format!(
+                "Wait node '{}' is not yet supported by the DSL compiler.",
+                id
+            ))),
+        }
+    }
+
+    /// Wire edges from the DSL definition into the StateGraph.
+    fn wire_edges(
+        graph: &mut StateGraphImpl<JsonState>,
+        def: &WorkflowDefinition,
+    ) -> DslResult<()> {
+        let start_id = def
+            .nodes
+            .iter()
+            .find(|n| matches!(n, NodeDefinition::Start { .. }))
+            .map(|n| n.id().to_string())
+            .ok_or(DslError::MissingStartNode)?;
+
+        let end_id = def
+            .nodes
+            .iter()
+            .find(|n| matches!(n, NodeDefinition::End { .. }))
+            .map(|n| n.id().to_string())
+            .ok_or(DslError::MissingEndNode)?;
+
+        graph.set_entry_point(&start_id);
+        graph.set_finish_point(&end_id);
+
+        // Group conditional edges by source: from → [(condition, to)]
+        let mut conditional_map: HashMap<String, Vec<(String, String)>> = HashMap::new();
+        for edge in &def.edges {
+            if let Some(ref condition) = edge.condition {
+                conditional_map
+                    .entry(edge.from.clone())
+                    .or_default()
+                    .push((condition.clone(), edge.to.clone()));
+            } else {
+                graph.add_edge(&edge.from, &edge.to);
+            }
+        }
+
+        for (from, conditions) in conditional_map {
+            graph.add_conditional_edges(&from, conditions);
+        }
+        Ok(())
+    }
+
+    /// Validate a workflow definition for compilation.
+    ///
+    /// This reuses the parser's validation logic and adds compiler-specific checks.
+    fn validate(def: &WorkflowDefinition) -> DslResult<()> {
+        let node_ids: Vec<&str> = def.nodes.iter().map(|n| n.id()).collect();
+
+        if !def
+            .nodes
+            .iter()
+            .any(|n| matches!(n, NodeDefinition::Start { .. }))
+        {
+            return Err(DslError::MissingStartNode);
+        }
+
+        if !def
+            .nodes
+            .iter()
+            .any(|n| matches!(n, NodeDefinition::End { .. }))
+        {
+            return Err(DslError::MissingEndNode);
+        }
+
+        for edge in &def.edges {
+            if !node_ids.contains(&edge.from.as_str()) {
+                return Err(DslError::InvalidEdge {
+                    from: edge.from.clone(),
+                    to: edge.to.clone(),
+                });
+            }
+            if !node_ids.contains(&edge.to.as_str()) {
+                return Err(DslError::InvalidEdge {
+                    from: edge.from.clone(),
+                    to: edge.to.clone(),
+                });
+            }
+        }
+
+        let mut seen = std::collections::HashSet::new();
+        for id in &node_ids {
+            if !seen.insert(*id) {
+                return Err(DslError::DuplicateNodeId(id.to_string()));
+            }
+        }
+        Ok(())
+    }
+}
+
+// Tests
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm::{LLMAgentBuilder, MockLLMProvider};
+    use mofa_kernel::workflow::CompiledGraph;
+    use mofa_kernel::workflow::GraphState;
+
+    /// Helper: parse YAML into WorkflowDefinition
+    fn parse_yaml(yaml: &str) -> WorkflowDefinition {
+        serde_yaml::from_str(yaml).expect("Failed to parse YAML")
+    }
+
+    // Compilation Tests
+
+    #[test]
+    fn test_compile_minimal_workflow() {
+        let yaml = r#"
+metadata:
+  id: minimal
+  name: Minimal Workflow
+nodes:
+  - type: start
+    id: start
+  - type: end
+    id: end
+edges:
+  - from: start
+    to: end
+"#;
+        let def = parse_yaml(yaml);
+        let compiled = DslCompiler::compile(def);
+        assert!(
+            compiled.is_ok(),
+            "Minimal workflow should compile: {:?}",
+            compiled.err()
+        );
+    }
+
+    #[test]
+    fn test_compile_linear_workflow() {
+        let yaml = r#"
+metadata:
+  id: linear
+  name: Linear Workflow
+nodes:
+  - type: start
+    id: start
+  - type: task
+    id: process
+    name: Process Data
+    executor_type: none
+  - type: task
+    id: validate
+    name: Validate Result
+    executor_type: none
+  - type: end
+    id: end
+edges:
+  - from: start
+    to: process
+  - from: process
+    to: validate
+  - from: validate
+    to: end
+"#;
+        let def = parse_yaml(yaml);
+        let compiled = DslCompiler::compile(def);
+        assert!(
+            compiled.is_ok(),
+            "Linear workflow should compile: {:?}",
+            compiled.err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_compile_and_invoke_roundtrip() {
+        let yaml = r#"
+metadata:
+  id: roundtrip
+  name: Round Trip Test
+nodes:
+  - type: start
+    id: start
+  - type: task
+    id: process
+    name: Process
+    executor_type: none
+  - type: end
+    id: end
+edges:
+  - from: start
+    to: process
+  - from: process
+    to: end
+"#;
+        let def = parse_yaml(yaml);
+        let compiled = DslCompiler::compile(def).expect("Should compile");
+        let result = compiled.invoke(JsonState::new(), None).await;
+        assert!(result.is_ok(), "Invoke should succeed: {:?}", result.err());
+    }
+
+    #[test]
+    fn test_compile_conditional_edges() {
+        let yaml = r#"
+metadata:
+  id: conditional
+  name: Conditional Workflow
+nodes:
+  - type: start
+    id: start
+  - type: condition
+    id: check
+    name: Check Value
+    condition:
+      condition_type: value
+      field: score
+      operator: ">="
+      value: 80
+  - type: task
+    id: pass
+    name: Pass
+    executor_type: none
+  - type: task
+    id: fail
+    name: Fail
+    executor_type: none
+  - type: end
+    id: end
+edges:
+  - from: start
+    to: check
+  - from: check
+    to: pass
+    condition: "true"
+  - from: check
+    to: fail
+    condition: "false"
+  - from: pass
+    to: end
+  - from: fail
+    to: end
+"#;
+        let def = parse_yaml(yaml);
+        let compiled = DslCompiler::compile(def);
+        assert!(
+            compiled.is_ok(),
+            "Conditional workflow should compile: {:?}",
+            compiled.err()
+        );
+    }
+
+    #[test]
+    fn test_compile_with_transform() {
+        let yaml = r#"
+metadata:
+  id: transform_test
+  name: Transform Test
+nodes:
+  - type: start
+    id: start
+  - type: transform
+    id: transform1
+    name: Apply Template
+    transform_type: template
+    template: "Hello {{ name }}"
+  - type: end
+    id: end
+edges:
+  - from: start
+    to: transform1
+  - from: transform1
+    to: end
+"#;
+        let def = parse_yaml(yaml);
+        let compiled = DslCompiler::compile(def);
+        assert!(
+            compiled.is_ok(),
+            "Transform workflow should compile: {:?}",
+            compiled.err()
+        );
+    }
+
+    #[test]
+    fn test_compile_with_join() {
+        let yaml = r#"
+metadata:
+  id: join_test
+  name: Join Test
+nodes:
+  - type: start
+    id: start
+  - type: task
+    id: branch_a
+    name: Branch A
+    executor_type: none
+  - type: task
+    id: branch_b
+    name: Branch B
+    executor_type: none
+  - type: join
+    id: merge
+    name: Merge Results
+    wait_for:
+      - branch_a
+      - branch_b
+  - type: end
+    id: end
+edges:
+  - from: start
+    to: branch_a
+  - from: start
+    to: branch_b
+  - from: branch_a
+    to: merge
+  - from: branch_b
+    to: merge
+  - from: merge
+    to: end
+"#;
+        let def = parse_yaml(yaml);
+        let compiled = DslCompiler::compile(def);
+        assert!(
+            compiled.is_ok(),
+            "Join workflow should compile: {:?}",
+            compiled.err()
+        );
+    }
+
+    // Validation Error Tests
+
+    #[test]
+    fn test_compile_missing_start_node() {
+        let yaml = r#"
+metadata:
+  id: no_start
+  name: No Start
+nodes:
+  - type: end
+    id: end
+edges: []
+"#;
+        let def = parse_yaml(yaml);
+        let err = match DslCompiler::compile(def) {
+            Err(e) => e,
+            Ok(_) => panic!("Expected error, got Ok"),
+        };
+        assert!(
+            matches!(err, DslError::MissingStartNode),
+            "Expected validation error about missing start, got: {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_compile_missing_end_node() {
+        let yaml = r#"
+metadata:
+  id: no_end
+  name: No End
+nodes:
+  - type: start
+    id: start
+edges: []
+"#;
+        let def = parse_yaml(yaml);
+        let err = match DslCompiler::compile(def) {
+            Err(e) => e,
+            Ok(_) => panic!("Expected error, got Ok"),
+        };
+        assert!(
+            matches!(err, DslError::MissingEndNode),
+            "Expected validation error about missing end, got: {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_compile_invalid_edge_reference() {
+        let yaml = r#"
+metadata:
+  id: bad_edge
+  name: Bad Edge
+nodes:
+  - type: start
+    id: start
+  - type: end
+    id: end
+edges:
+  - from: start
+    to: nonexistent
+"#;
+        let def = parse_yaml(yaml);
+        let err = match DslCompiler::compile(def) {
+            Err(e) => e,
+            Ok(_) => panic!("Expected error, got Ok"),
+        };
+        assert!(
+            matches!(err, DslError::InvalidEdge { .. }),
+            "Expected InvalidEdge error, got: {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_compile_duplicate_node_ids() {
+        let yaml = r#"
+metadata:
+  id: duplicates
+  name: Duplicates
+nodes:
+  - type: start
+    id: start
+  - type: task
+    id: start
+    name: Duplicate
+    executor_type: none
+  - type: end
+    id: end
+edges:
+  - from: start
+    to: end
+"#;
+        let def = parse_yaml(yaml);
+        let err = match DslCompiler::compile(def) {
+            Err(e) => e,
+            Ok(_) => panic!("Expected error, got Ok"),
+        };
+        assert!(
+            matches!(err, DslError::DuplicateNodeId(_)),
+            "Expected duplicate node ID error, got: {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_compile_unsupported_llm_agent_missing_registry() {
+        let yaml = r#"
+metadata:
+  id: llm_test_missing_registry
+  name: LLM Test Missing Registry
+nodes:
+  - type: start
+    id: start
+  - type: llm_agent
+    id: agent1
+    name: My Agent
+    agent:
+      agent_id: test_missing
+  - type: end
+    id: end
+edges:
+  - from: start
+    to: agent1
+  - from: agent1
+    to: end
+"#;
+        let def = parse_yaml(yaml);
+        let err = match DslCompiler::compile(def) {
+            Err(e) => e,
+            Ok(_) => panic!("Expected error, got Ok"),
+        };
+        assert!(
+            matches!(err, DslError::MissingAgentInRegistry { .. }),
+            "Expected missing registry validation error, got: {:?}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn test_llm_agent_missing_input_returns_safe_error() {
+        let yaml = r#"
+metadata:
+  id: llm_missing_input
+  name: LLM Missing Input
+nodes:
+  - type: start
+    id: start
+  - type: llm_agent
+    id: agent1
+    name: Classify
+    agent:
+      agent_id: classifier
+  - type: end
+    id: end
+edges:
+  - from: start
+    to: agent1
+  - from: agent1
+    to: end
+"#;
+        let def = parse_yaml(yaml);
+
+        let provider = Arc::new(MockLLMProvider::new("mock-provider").with_default_response("ok"));
+        let agent = Arc::new(
+            LLMAgentBuilder::new()
+                .with_id("classifier")
+                .with_name("Classifier")
+                .with_provider(provider)
+                .build(),
+        );
+        let mut registry = HashMap::new();
+        registry.insert("classifier".to_string(), agent);
+
+        let compiled =
+            DslCompiler::compile_with_agents(def, &registry).expect("should compile with registry");
+
+        let mut state = JsonState::new();
+        state
+            .apply_update("secret", serde_json::json!("token-123"))
+            .await
+            .unwrap();
+        state
+            .apply_update("tenant", serde_json::json!("acme"))
+            .await
+            .unwrap();
+
+        let err = compiled.invoke(state, None).await.unwrap_err().to_string();
+        assert!(err.contains("requires 'input' key"));
+        assert!(err.contains("Available keys"));
+        assert!(!err.contains("token-123"));
+    }
+
+    // Condition Evaluation Tests
+
+    #[test]
+    fn test_evaluate_condition_equality() {
+        assert!(evaluate_condition(
+            &serde_json::json!("hello"),
+            "==",
+            &serde_json::json!("hello")
+        ));
+        assert!(!evaluate_condition(
+            &serde_json::json!("hello"),
+            "==",
+            &serde_json::json!("world")
+        ));
+    }
+
+    #[test]
+    fn test_evaluate_condition_numeric() {
+        assert!(evaluate_condition(
+            &serde_json::json!(10),
+            ">",
+            &serde_json::json!(5)
+        ));
+        assert!(evaluate_condition(
+            &serde_json::json!(5),
+            "<=",
+            &serde_json::json!(5)
+        ));
+        assert!(!evaluate_condition(
+            &serde_json::json!(3),
+            ">=",
+            &serde_json::json!(5)
+        ));
+    }
+
+    #[test]
+    fn test_evaluate_condition_contains() {
+        assert!(evaluate_condition(
+            &serde_json::json!("hello world"),
+            "contains",
+            &serde_json::json!("world")
+        ));
+        assert!(!evaluate_condition(
+            &serde_json::json!("hello"),
+            "contains",
+            &serde_json::json!("world")
+        ));
+    }
+
+    #[test]
+    fn test_evaluate_condition_inequality() {
+        assert!(evaluate_condition(
+            &serde_json::json!(1),
+            "!=",
+            &serde_json::json!(2)
+        ));
+        assert!(!evaluate_condition(
+            &serde_json::json!(1),
+            "!=",
+            &serde_json::json!(1)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_condition_node_value_match() {
+        let condition = ConditionDef::Value {
+            field: "score".into(),
+            operator: ">=".into(),
+            value: serde_json::json!(80),
+        };
+        let node = DslConditionNode::new("check", condition);
+        let mut state = JsonState::new();
+        state
+            .apply_update("score", serde_json::json!(90))
+            .await
+            .unwrap();
+        let ctx = RuntimeContext::new("test");
+        let cmd = node.call(&mut state, &ctx).await.unwrap();
+
+        assert!(!cmd.updates.is_empty());
+        assert_eq!(cmd.updates[0].key, "check");
+        assert_eq!(cmd.updates[0].value, serde_json::json!("true"));
+    }
+
+    #[tokio::test]
+    async fn test_condition_node_value_no_match() {
+        let condition = ConditionDef::Value {
+            field: "score".into(),
+            operator: ">=".into(),
+            value: serde_json::json!(80),
+        };
+        let node = DslConditionNode::new("check", condition);
+        let mut state = JsonState::new();
+        state
+            .apply_update("score", serde_json::json!(50))
+            .await
+            .unwrap();
+        let ctx = RuntimeContext::new("test");
+        let cmd = node.call(&mut state, &ctx).await.unwrap();
+        assert_eq!(cmd.updates[0].value, serde_json::json!("false"));
+    }
+
+    #[tokio::test]
+    async fn test_task_node_function_executor() {
+        let node = DslTaskNode::new(
+            "task1",
+            TaskExecutorDef::Function {
+                function: "my_function".into(),
+            },
+        );
+        let mut state = JsonState::new();
+        let ctx = RuntimeContext::new("test");
+        let cmd = node.call(&mut state, &ctx).await.unwrap();
+        assert!(!cmd.updates.is_empty());
+        assert_eq!(cmd.updates[0].key, "task1");
+    }
+}

--- a/crates/mofa-foundation/src/workflow/dsl/mod.rs
+++ b/crates/mofa-foundation/src/workflow/dsl/mod.rs
@@ -35,10 +35,12 @@
 //!     to: end
 //! ```
 
+mod compiler;
 mod env;
 mod parser;
 mod schema;
 
+pub use compiler::DslCompiler;
 pub use parser::*;
 pub use schema::*;
 
@@ -77,8 +79,33 @@ pub enum DslError {
     #[error("JSON parse error: {0}")]
     JsonParse(#[from] serde_json::Error),
 
-    #[error("Validation error: {0}")]
-    Validation(String),
+    #[error("Graph validation failed: Missing Start node")]
+    MissingStartNode,
+
+    #[error("Graph validation failed: Missing End node")]
+    MissingEndNode,
+
+    #[error("Duplicate node ID found: {0}")]
+    DuplicateNodeId(String),
+
+    #[error(
+        "LlmAgent node '{node_id}' requires agent_id '{agent_id}' which is not in the registry."
+    )]
+    MissingAgentInRegistry { node_id: String, agent_id: String },
+
+    #[error(
+        "Inline agents are not supported in DslCompiler for node '{0}'. Please use registry agents."
+    )]
+    InlineAgentNotSupported(String),
+
+    #[error("TOML to JSON conversion error")]
+    TomlToJsonConversion,
+
+    #[error("No file extension provided")]
+    MissingFileExtension,
+
+    #[error("Unsupported file extension: {0}")]
+    UnsupportedFileExtension(String),
 
     #[error("Agent not found: {0}")]
     AgentNotFound(String),

--- a/crates/mofa-foundation/src/workflow/dsl/parser.rs
+++ b/crates/mofa-foundation/src/workflow/dsl/parser.rs
@@ -31,8 +31,8 @@ impl WorkflowDslParser {
     pub fn from_toml(content: &str) -> DslResult<WorkflowDefinition> {
         let value: toml::Value = toml::from_str(content)?;
         // Convert to JSON for env substitution
-        let json_value: serde_json::Value = serde_json::to_value(&value)
-            .map_err(|e| DslError::Validation(format!("TOML to JSON conversion error: {}", e)))?;
+        let json_value: serde_json::Value =
+            serde_json::to_value(&value).map_err(|_| DslError::TomlToJsonConversion)?;
         let substituted = substitute_env_recursive(&json_value);
         let def: WorkflowDefinition = serde_json::from_value(substituted)?;
         Ok(def)
@@ -43,18 +43,14 @@ impl WorkflowDslParser {
         let path = path.as_ref();
         let content = fs::read_to_string(path)?;
 
-        let extension = path
-            .extension()
-            .and_then(|e| e.to_str())
-            .ok_or_else(|| DslError::Validation("No file extension".to_string()))?;
+        let extension = path.extension().ok_or(DslError::MissingFileExtension)?;
 
-        match extension.to_lowercase().as_str() {
+        match extension.to_string_lossy().to_lowercase().as_str() {
             "yaml" | "yml" => Self::from_yaml(&content),
             "toml" => Self::from_toml(&content),
-            _ => Err(DslError::Validation(format!(
-                "Unsupported file extension: {}",
-                extension
-            ))),
+            _ => Err(DslError::UnsupportedFileExtension(
+                extension.to_string_lossy().into_owned(),
+            )),
         }
     }
 
@@ -96,27 +92,21 @@ impl WorkflowDslParser {
         let node_ids: Vec<&str> = definition.nodes.iter().map(|n| n.id()).collect();
 
         // Verify start node exists
-        if !node_ids.iter().any(|&id| {
-            definition
-                .nodes
-                .iter()
-                .any(|n| matches!(n, NodeDefinition::Start { id: start_id, .. } if start_id == id))
-        }) {
-            return Err(DslError::Validation(
-                "Workflow must have a start node".to_string(),
-            ));
+        if !definition
+            .nodes
+            .iter()
+            .any(|n| matches!(n, NodeDefinition::Start { .. }))
+        {
+            return Err(DslError::MissingStartNode);
         }
 
         // Verify end node exists
-        if !node_ids.iter().any(|&id| {
-            definition
-                .nodes
-                .iter()
-                .any(|n| matches!(n, NodeDefinition::End { id: end_id, .. } if end_id == id))
-        }) {
-            return Err(DslError::Validation(
-                "Workflow must have an end node".to_string(),
-            ));
+        if !definition
+            .nodes
+            .iter()
+            .any(|n| matches!(n, NodeDefinition::End { .. }))
+        {
+            return Err(DslError::MissingEndNode);
         }
 
         // Verify all edge references are valid
@@ -177,7 +167,7 @@ impl WorkflowDslParser {
                         builder = builder.task(&id, &name, |_ctx, input| async move { Ok(input) });
                     }
                     _ => {
-                        return Err(DslError::Validation(
+                        return Err(DslError::InvalidNodeType(
                             "Only 'none' executor type is currently supported for task nodes"
                                 .to_string(),
                         ));
@@ -242,7 +232,7 @@ impl WorkflowDslParser {
                     );
                 }
                 _ => {
-                    return Err(DslError::Validation(
+                    return Err(DslError::InvalidNodeType(
                         "Loop body executor not supported yet".to_string(),
                     ));
                 }

--- a/crates/mofa-foundation/src/workflow/state_graph.rs
+++ b/crates/mofa-foundation/src/workflow/state_graph.rs
@@ -55,10 +55,8 @@ pub struct StateGraphImpl<S: GraphState> {
     entry_point: Option<NodeId>,
     /// Finish points (nodes that connect to END)
     finish_points: Vec<NodeId>,
-    /// 图配置
     /// Graph configuration
     config: GraphConfig,
-    /// 每节点的容错策略
     /// Per-node fault-tolerance policies
     policies: HashMap<NodeId, NodePolicy>,
 }
@@ -158,11 +156,8 @@ impl<S: GraphState> StateGraphImpl<S> {
         reachable
     }
 
-    /// 为特定节点附加容错策略
     /// Attach a fault-tolerance policy to a specific node.
     ///
-    /// 策略是可选的：没有策略的节点以默认行为执行
-    /// （无重试，无断路器）。
     /// Policies are optional: nodes without a policy execute with default
     /// behavior (no retry, no circuit breaker).
     pub fn with_policy(&mut self, node_id: impl Into<String>, policy: NodePolicy) -> &mut Self {
@@ -238,7 +233,7 @@ impl<S: GraphState + 'static> mofa_kernel::workflow::StateGraph for StateGraphIm
     fn add_conditional_edges(
         &mut self,
         from: impl Into<String>,
-        conditions: HashMap<String, String>,
+        conditions: Vec<(String, String)>,
     ) -> &mut Self {
         let from_id = from.into();
         debug!(
@@ -307,17 +302,16 @@ impl<S: GraphState + 'static> mofa_kernel::workflow::StateGraph for StateGraphIm
                     node_id
                 )));
             }
-            if let Some(ref fallback) = policy.fallback_node
-                && !self.nodes.contains_key(fallback)
-            {
-                return Err(AgentError::ValidationFailed(format!(
-                    "Fallback node '{}' for node '{}' does not exist in graph",
-                    fallback, node_id
-                )));
+            if let Some(ref fallback) = policy.fallback_node {
+                if !self.nodes.contains_key(fallback) {
+                    return Err(AgentError::ValidationFailed(format!(
+                        "Fallback node '{}' for node '{}' does not exist in graph",
+                        fallback, node_id
+                    )));
+                }
             }
         }
 
-        // 创建已编译的图
         // Create compiled graph
         let max_par = self.config.max_parallelism.max(1);
         Ok(CompiledGraphImpl {
@@ -342,27 +336,24 @@ impl<S: GraphState + 'static> mofa_kernel::workflow::StateGraph for StateGraphIm
     }
 }
 
-/// 已编译的可执行图
 /// Compiled graph ready for execution
 pub struct CompiledGraphImpl<S: GraphState> {
-    /// 图 ID / Graph ID
+    /// Graph ID
     id: String,
-    /// 节点函数 / Node functions
+    /// Node functions
     nodes: Arc<HashMap<NodeId, Arc<dyn NodeFunc<S>>>>,
-    /// 边 / Edges
+    /// Edges
     edges: Arc<HashMap<NodeId, EdgeTarget>>,
-    /// 归约器 / Reducers
+    /// Reducers
     reducers: Arc<HashMap<String, Box<dyn Reducer>>>,
-    /// 入口点 / Entry point
+    /// Entry point
     entry_point: NodeId,
-    /// 配置 / Configuration
+    /// Configuration
     config: GraphConfig,
-    /// 每节点的容错策略 / Per-node fault-tolerance policies
+    /// Per-node fault-tolerance policies
     policies: Arc<HashMap<NodeId, NodePolicy>>,
-    /// 每节点的断路器状态（跨调用共享）
     /// Per-node circuit breaker state (shared across invocations)
     circuit_states: CircuitBreakerRegistry,
-    /// 并行分支的并发信号量
     /// Concurrency semaphore for parallel branches
     parallelism_semaphore: Arc<Semaphore>,
     /// Optional telemetry emitter for runtime checkpoint events.
@@ -389,7 +380,6 @@ impl<S: GraphState> CompiledGraphImpl<S> {
         }
     }
 
-    /// 并行执行多个节点，强制执行并发限制
     /// Execute multiple nodes in parallel, enforcing max_parallelism via semaphore.
     ///
     /// NOTE: Parallel nodes run without per-node retry/circuit-breaker protection.
@@ -447,12 +437,86 @@ impl<S: GraphState> CompiledGraphImpl<S> {
             .collect()
     }
 
+    /// Resolve conditional routing.
+    ///
+    /// Route selection priority:
+    /// 1. `command.route` when non-empty and present in `routes`
+    /// 2. Legacy fallback by matching `command.updates[*].key` to route labels
+    /// 3. Error if no match (strict routing)
+    ///
+    /// An empty route string is treated as "no explicit route" and falls back to legacy behavior.
+    fn resolve_conditional_next_nodes(
+        current_node: &str,
+        command: &Command,
+        routes: &[(String, String)],
+    ) -> AgentResult<Vec<String>> {
+        debug!(
+            "Routing from '{}': route={:?}, updates={:?}",
+            current_node,
+            command.route,
+            command
+                .updates
+                .iter()
+                .map(|u| u.key.as_str())
+                .collect::<Vec<_>>()
+        );
+
+        if let Some(route_name) = command.route.as_deref() {
+            if route_name.is_empty() {
+                debug!(
+                    "Empty conditional route from node '{}'; falling back to legacy update-key routing",
+                    current_node
+                );
+            } else if let Some((_, target)) = routes.iter().find(|(route, _)| route == route_name) {
+                return Ok(vec![target.clone()]);
+            } else {
+                warn!(
+                    "No conditional edge found for route '{}' from node '{}'",
+                    route_name, current_node
+                );
+            }
+        }
+
+        for update in &command.updates {
+            if let Some((_, target)) = routes.iter().find(|(route, _)| route == &update.key) {
+                debug!(
+                    "Legacy conditional routing via update key '{}' from node '{}'",
+                    update.key, current_node
+                );
+                if command
+                    .route
+                    .as_deref()
+                    .map(|route| route.is_empty())
+                    .unwrap_or(true)
+                {
+                    debug!(
+                        "Legacy routing used for node '{}'. Consider using Command::route() for explicit routing.",
+                        current_node
+                    );
+                }
+                return Ok(vec![target.clone()]);
+            }
+        }
+
+        // No route matched — report error instead of silent fallback
+        let update_keys: Vec<&str> = command.updates.iter().map(|u| u.key.as_str()).collect();
+        let route_keys: Vec<&String> = routes.iter().map(|(r, _)| r).collect();
+        warn!(
+            node_id = current_node,
+            ?update_keys,
+            ?route_keys,
+            "Conditional routing: no route matched for node"
+        );
+        Err(AgentError::Internal(format!(
+            "No conditional route matched for node '{}': update keys {:?}, available routes {:?}",
+            current_node, update_keys, route_keys
+        )))
+    }
+
     /// Get the next node(s) based on the current node and command
     fn get_next_nodes(&self, current_node: &str, command: &Command) -> AgentResult<Vec<String>> {
         match &command.control {
-            ControlFlow::Goto(target) => {
-                Ok(vec![target.clone()])
-            }
+            ControlFlow::Goto(target) => Ok(vec![target.clone()]),
             ControlFlow::Return => {
                 Ok(vec![]) // End execution
             }
@@ -466,31 +530,7 @@ impl<S: GraphState> CompiledGraphImpl<S> {
                     Some(EdgeTarget::Single(target)) => Ok(vec![target.clone()]),
                     Some(EdgeTarget::Parallel(targets)) => Ok(targets.clone()),
                     Some(EdgeTarget::Conditional(routes)) => {
-                        // Priority 1: explicit route decision
-                        if let Some(decision) = command.route_value() {
-                            if let Some(target) = routes.get(decision) {
-                                return Ok(vec![target.clone()]);
-                            }
-                        }
-                        // Priority 2: legacy key-name matching (backward compatible)
-                        for update in &command.updates {
-                            if let Some(target) = routes.get(&update.key) {
-                                return Ok(vec![target.clone()]);
-                            }
-                        }
-                        // No route matched — report error instead of silent fallback
-                        let update_keys: Vec<&str> = command.updates.iter().map(|u| u.key.as_str()).collect();
-                        let route_keys: Vec<&String> = routes.keys().collect();
-                        warn!(
-                            node_id = current_node,
-                            ?update_keys,
-                            ?route_keys,
-                            "Conditional routing: no route matched for node"
-                        );
-                        Err(AgentError::Internal(format!(
-                            "No conditional route matched for node '{}': update keys {:?}, available routes {:?}",
-                            current_node, update_keys, route_keys
-                        )))
+                        Self::resolve_conditional_next_nodes(current_node, command, routes)
                     }
                     None => Ok(vec![]),
                     _ => Ok(vec![]),
@@ -687,31 +727,7 @@ impl<S: GraphState + 'static> CompiledGraph<S, serde_json::Value> for CompiledGr
                             Some(EdgeTarget::Single(target)) => Ok(vec![target.clone()]),
                             Some(EdgeTarget::Parallel(targets)) => Ok(targets.clone()),
                             Some(EdgeTarget::Conditional(routes)) => {
-                                // Priority 1: explicit route decision
-                                if let Some(decision) = command.route_value() {
-                                    if let Some(target) = routes.get(decision) {
-                                        return Ok(vec![target.clone()]);
-                                    }
-                                }
-                                // Priority 2: legacy key-name matching (backward compatible)
-                                for update in &command.updates {
-                                    if let Some(target) = routes.get(&update.key) {
-                                        return Ok(vec![target.clone()]);
-                                    }
-                                }
-                                // No route matched — report error instead of silent fallback
-                                let update_keys: Vec<&str> = command.updates.iter().map(|u| u.key.as_str()).collect();
-                                let route_keys: Vec<&String> = routes.keys().collect();
-                                warn!(
-                                    node_id = current_node,
-                                    ?update_keys,
-                                    ?route_keys,
-                                    "Conditional routing: no route matched for node"
-                                );
-                                Err(AgentError::Internal(format!(
-                                    "No conditional route matched for node '{}': update keys {:?}, available routes {:?}",
-                                    current_node, update_keys, route_keys
-                                )))
+                                Self::resolve_conditional_next_nodes(current_node, command, routes)
                             }
                             None => Ok(vec![]),
                             _ => Ok(vec![]),
@@ -763,7 +779,6 @@ impl<S: GraphState + 'static> CompiledGraph<S, serde_json::Value> for CompiledGr
                         return;
                     }
 
-                    // 使用重试/断路器执行节点
                     // Execute node with retry/circuit-breaker
                     let policy = policies.get(&node_id).unwrap_or(&default_policy);
                     let command = match execute_with_policy(
@@ -880,10 +895,7 @@ impl<S: GraphState + 'static> CompiledGraph<S, serde_json::Value> for CompiledGr
                         Ok(results) => results,
                         Err(e) => {
                             let _ = tx
-                                .send(Ok(StreamEvent::Error {
-                                    node_id: None,
-                                    error: e.to_string(),
-                                }))
+                                .send(Err(e))
                                 .await;
                             return;
                         }
@@ -1020,7 +1032,7 @@ impl<S: GraphState + 'static> CompiledGraph<S, serde_json::Value> for CompiledGr
 mod tests {
     use super::*;
     use futures::StreamExt;
-    use mofa_kernel::workflow::telemetry::TelemetryEmitter;
+    use mofa_kernel::workflow::telemetry::{DebugEvent, TelemetryEmitter};
     use mofa_kernel::workflow::GraphConfig;
     use mofa_kernel::workflow::{JsonState, StateGraph};
     use serde_json::json;
@@ -1036,12 +1048,12 @@ mod tests {
     }
 
     #[async_trait]
-    impl NodeFunc<JsonState> for TestNode {
+    impl NodeFunc<JsonState, Value> for TestNode {
         async fn call(
             &self,
             _state: &mut JsonState,
-            _ctx: &RuntimeContext,
-        ) -> AgentResult<Command> {
+            _ctx: &RuntimeContext<Value>,
+        ) -> AgentResult<Command<Value>> {
             let mut cmd = Command::new();
             for update in &self.updates {
                 cmd = cmd.update(update.key.clone(), update.value.clone());
@@ -1061,12 +1073,12 @@ mod tests {
     }
 
     #[async_trait]
-    impl NodeFunc<JsonState> for StaticCommandNode {
+    impl NodeFunc<JsonState, Value> for StaticCommandNode {
         async fn call(
             &self,
             _state: &mut JsonState,
-            _ctx: &RuntimeContext,
-        ) -> AgentResult<Command> {
+            _ctx: &RuntimeContext<Value>,
+        ) -> AgentResult<Command<Value>> {
             Ok(self.command.clone())
         }
 
@@ -1082,12 +1094,12 @@ mod tests {
     }
 
     #[async_trait]
-    impl NodeFunc<JsonState> for ConcurrencyProbeNode {
+    impl NodeFunc<JsonState, Value> for ConcurrencyProbeNode {
         async fn call(
             &self,
             _state: &mut JsonState,
-            _ctx: &RuntimeContext,
-        ) -> AgentResult<Command> {
+            _ctx: &RuntimeContext<Value>,
+        ) -> AgentResult<Command<Value>> {
             let concurrent = self.active.fetch_add(1, Ordering::SeqCst) + 1;
             self.max_active.fetch_max(concurrent, Ordering::SeqCst);
             sleep(Duration::from_millis(100)).await;
@@ -1104,8 +1116,12 @@ mod tests {
     struct FlagReaderNode;
 
     #[async_trait]
-    impl NodeFunc<JsonState> for FlagReaderNode {
-        async fn call(&self, state: &mut JsonState, _ctx: &RuntimeContext) -> AgentResult<Command> {
+    impl NodeFunc<JsonState, Value> for FlagReaderNode {
+        async fn call(
+            &self,
+            state: &mut JsonState,
+            _ctx: &RuntimeContext<Value>,
+        ) -> AgentResult<Command<Value>> {
             let saw_flag = state.get_value::<bool>("flag").unwrap_or(false);
             Ok(Command::new()
                 .update("reader_saw_flag", json!(saw_flag))
@@ -1120,8 +1136,12 @@ mod tests {
     struct LoopNode;
 
     #[async_trait]
-    impl NodeFunc<JsonState> for LoopNode {
-        async fn call(&self, state: &mut JsonState, _ctx: &RuntimeContext) -> AgentResult<Command> {
+    impl NodeFunc<JsonState, Value> for LoopNode {
+        async fn call(
+            &self,
+            state: &mut JsonState,
+            _ctx: &RuntimeContext<Value>,
+        ) -> AgentResult<Command<Value>> {
             let count = state
                 .get_value::<serde_json::Value>("count")
                 .and_then(|v| v.as_u64())
@@ -1161,6 +1181,32 @@ mod tests {
             false
         }
     }
+
+    struct RouteNode {
+        name: String,
+        updates: Vec<StateUpdate>,
+        route: String,
+    }
+
+    #[async_trait]
+    impl NodeFunc<JsonState, Value> for RouteNode {
+        async fn call(
+            &self,
+            _state: &mut JsonState,
+            _ctx: &RuntimeContext<Value>,
+        ) -> AgentResult<Command<Value>> {
+            let mut cmd = Command::new();
+            for update in &self.updates {
+                cmd = cmd.update(update.key.clone(), update.value.clone());
+            }
+            Ok(cmd.route(self.route.clone()).continue_())
+        }
+
+        fn name(&self) -> &str {
+            &self.name
+        }
+    }
+
 
     #[tokio::test]
     async fn test_state_graph_build_and_compile() {
@@ -1337,15 +1383,165 @@ mod tests {
         );
     }
 
-    // ── Explicit route selection tests (issue #554) ──
+    // ── Conditional Routing Tests ──
+
+    #[tokio::test]
+    async fn test_conditional_routing_uses_route_value_not_update_key() {
+        let mut graph = StateGraphImpl::<JsonState>::new("route_graph");
+
+        graph
+            .add_node(
+                "decide",
+                Box::new(RouteNode {
+                    name: "decide".to_string(),
+                    // This update key collides with a route label and should NOT control routing.
+                    updates: vec![StateUpdate::new("approve", json!(true))],
+                    route: "reject".to_string(),
+                }),
+            )
+            .add_node(
+                "approved",
+                Box::new(TestNode {
+                    name: "approved".to_string(),
+                    updates: vec![StateUpdate::new("decision", json!("approved"))],
+                }),
+            )
+            .add_node(
+                "rejected",
+                Box::new(TestNode {
+                    name: "rejected".to_string(),
+                    updates: vec![StateUpdate::new("decision", json!("rejected"))],
+                }),
+            )
+            .add_edge(START, "decide")
+            .add_conditional_edges(
+                "decide",
+                vec![
+                    ("approve".to_string(), "approved".to_string()),
+                    ("reject".to_string(), "rejected".to_string()),
+                ],
+            )
+            .add_edge("approved", END)
+            .add_edge("rejected", END);
+
+        let compiled = graph.compile().unwrap();
+        let final_state = compiled.invoke(JsonState::new(), None).await.unwrap();
+
+        assert_eq!(final_state.get_value("decision"), Some(json!("rejected")));
+    }
+
+    #[tokio::test]
+    async fn test_conditional_routing_legacy_update_key_fallback() {
+        let mut graph = StateGraphImpl::<JsonState>::new("legacy_route_graph");
+
+        graph
+            .add_node(
+                "decide",
+                Box::new(TestNode {
+                    name: "decide".to_string(),
+                    // No explicit command.route; legacy update key fallback should select this route.
+                    updates: vec![StateUpdate::new("approve", json!(true))],
+                }),
+            )
+            .add_node(
+                "approved",
+                Box::new(TestNode {
+                    name: "approved".to_string(),
+                    updates: vec![StateUpdate::new("decision", json!("approved"))],
+                }),
+            )
+            .add_node(
+                "rejected",
+                Box::new(TestNode {
+                    name: "rejected".to_string(),
+                    updates: vec![StateUpdate::new("decision", json!("rejected"))],
+                }),
+            )
+            .add_edge(START, "decide")
+            .add_conditional_edges(
+                "decide",
+                vec![
+                    ("approve".to_string(), "approved".to_string()),
+                    ("reject".to_string(), "rejected".to_string()),
+                ],
+            )
+            .add_edge("approved", END)
+            .add_edge("rejected", END);
+
+        let compiled = graph.compile().unwrap();
+        let final_state = compiled.invoke(JsonState::new(), None).await.unwrap();
+
+        assert_eq!(final_state.get_value("decision"), Some(json!("approved")));
+
+        let mut stream = compiled.stream(JsonState::new(), None);
+        let mut stream_final_state: Option<JsonState> = None;
+        while let Some(event) = stream.next().await {
+            if let Ok(StreamEvent::End { final_state }) = event {
+                stream_final_state = Some(final_state);
+            }
+        }
+
+        let stream_final_state: JsonState =
+            stream_final_state.expect("stream should emit a final end event with state");
+        assert_eq!(
+            stream_final_state.get_value("decision"),
+            Some(json!("approved"))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_conditional_routing_empty_route_falls_back_to_legacy_update_key() {
+        let mut graph = StateGraphImpl::<JsonState>::new("empty_route_graph");
+
+        graph
+            .add_node(
+                "decide",
+                Box::new(RouteNode {
+                    name: "decide".to_string(),
+                    // Empty route should not match any conditional edge; fallback should still work.
+                    updates: vec![StateUpdate::new("approve", json!(true))],
+                    route: "".to_string(),
+                }),
+            )
+            .add_node(
+                "approved",
+                Box::new(TestNode {
+                    name: "approved".to_string(),
+                    updates: vec![StateUpdate::new("decision", json!("approved"))],
+                }),
+            )
+            .add_node(
+                "rejected",
+                Box::new(TestNode {
+                    name: "rejected".to_string(),
+                    updates: vec![StateUpdate::new("decision", json!("rejected"))],
+                }),
+            )
+            .add_edge(START, "decide")
+            .add_conditional_edges(
+                "decide",
+                vec![
+                    ("approve".to_string(), "approved".to_string()),
+                    ("reject".to_string(), "rejected".to_string()),
+                ],
+            )
+            .add_edge("approved", END)
+            .add_edge("rejected", END);
+
+        let compiled = graph.compile().unwrap();
+        let final_state = compiled.invoke(JsonState::new(), None).await.unwrap();
+
+        assert_eq!(final_state.get_value("decision"), Some(json!("approved")));
+    }
 
     #[tokio::test]
     async fn test_conditional_routing_prefers_route_value_in_invoke() {
         let mut graph = StateGraphImpl::<JsonState>::new("route_invoke");
 
-        let mut routes = HashMap::new();
-        routes.insert("approve".to_string(), "approved".to_string());
-        routes.insert("reject".to_string(), "rejected".to_string());
+        let routes = vec![
+            ("approve".to_string(), "approved".to_string()),
+            ("reject".to_string(), "rejected".to_string()),
+        ];
 
         graph
             .add_node(
@@ -1392,9 +1588,10 @@ mod tests {
     async fn test_conditional_routing_legacy_fallback_when_route_absent() {
         let mut graph = StateGraphImpl::<JsonState>::new("route_fallback");
 
-        let mut routes = HashMap::new();
-        routes.insert("approve".to_string(), "approved".to_string());
-        routes.insert("reject".to_string(), "rejected".to_string());
+        let routes = vec![
+            ("approve".to_string(), "approved".to_string()),
+            ("reject".to_string(), "rejected".to_string()),
+        ];
 
         graph
             .add_node(
@@ -1437,9 +1634,10 @@ mod tests {
     async fn test_conditional_routing_stream_respects_route_value() {
         let mut graph = StateGraphImpl::<JsonState>::new("route_stream");
 
-        let mut routes = HashMap::new();
-        routes.insert("approve".to_string(), "approved".to_string());
-        routes.insert("reject".to_string(), "rejected".to_string());
+        let routes = vec![
+            ("approve".to_string(), "approved".to_string()),
+            ("reject".to_string(), "rejected".to_string()),
+        ];
 
         graph
             .add_node(
@@ -1489,9 +1687,10 @@ mod tests {
     async fn test_conditional_routing_no_match_returns_error_invoke() {
         let mut graph = StateGraphImpl::<JsonState>::new("route_no_match");
 
-        let mut routes = HashMap::new();
-        routes.insert("approve".to_string(), "approved".to_string());
-        routes.insert("reject".to_string(), "rejected".to_string());
+        let routes = vec![
+            ("approve".to_string(), "approved".to_string()),
+            ("reject".to_string(), "rejected".to_string()),
+        ];
 
         graph
             .add_node(
@@ -1524,7 +1723,10 @@ mod tests {
         let compiled = graph.compile().unwrap();
         let result = compiled.invoke(JsonState::new(), None).await;
 
-        assert!(result.is_err(), "invoke should return Err when no conditional route matches");
+        assert!(
+            result.is_err(),
+            "invoke should return Err when no conditional route matches"
+        );
         let err_msg = result.unwrap_err().to_string();
         assert!(
             err_msg.contains("No conditional route matched"),
@@ -1537,9 +1739,10 @@ mod tests {
     async fn test_conditional_routing_no_match_returns_error_stream() {
         let mut graph = StateGraphImpl::<JsonState>::new("route_no_match_stream");
 
-        let mut routes = HashMap::new();
-        routes.insert("approve".to_string(), "approved".to_string());
-        routes.insert("reject".to_string(), "rejected".to_string());
+        let routes = vec![
+            ("approve".to_string(), "approved".to_string()),
+            ("reject".to_string(), "rejected".to_string()),
+        ];
 
         graph
             .add_node(
@@ -1583,6 +1786,9 @@ mod tests {
             }
         }
 
-        assert!(got_error, "stream should emit an error event when no conditional route matches");
+        assert!(
+            got_error,
+            "stream should emit an error event when no conditional route matches"
+        );
     }
 }

--- a/crates/mofa-kernel/src/workflow/command.rs
+++ b/crates/mofa-kernel/src/workflow/command.rs
@@ -130,6 +130,15 @@ impl<V> Command<V> {
         }
     }
 
+    /// Set control flow to create parallel branches while preserving builder state.
+    ///
+    /// Unlike [`Command::send`], this keeps any existing updates/route and only
+    /// switches the control-flow directive.
+    pub fn send_to(mut self, targets: Vec<SendCommand<V>>) -> Self {
+        self.control = ControlFlow::Send(targets);
+        self
+    }
+
     /// Create a command that just updates state (continues by default)
     pub fn just_update(key: impl Into<String>, value: V) -> Self {
         Self::new().update(key, value)
@@ -262,6 +271,16 @@ mod tests {
     }
 
     #[test]
+    fn test_send_to_preserves_route() {
+        let cmd = Command::new()
+            .route("approve")
+            .send_to(vec![SendCommand::new("node_a", json!({"task": 1}))]);
+
+        assert_eq!(cmd.route.as_deref(), Some("approve"));
+        assert!(cmd.is_send());
+    }
+
+    #[test]
     fn test_send_command() {
         let send = SendCommand::new("process", json!({"data": "test"}));
         assert_eq!(send.target, "process");
@@ -284,5 +303,25 @@ mod tests {
 
         let cmd = Command::<serde_json::Value>::just_return();
         assert!(cmd.is_return());
+    }
+
+    #[test]
+    fn test_route_builder() {
+        let cmd = Command::<serde_json::Value>::new()
+            .route("approve")
+            .continue_();
+        assert_eq!(cmd.route.as_deref(), Some("approve"));
+        assert_eq!(cmd.control, ControlFlow::Continue);
+    }
+
+    #[test]
+    fn test_route_chain_builder() {
+        let cmd = Command::new()
+            .update("status", json!("pending"))
+            .route("reject")
+            .continue_();
+        assert_eq!(cmd.route.as_deref(), Some("reject"));
+        assert_eq!(cmd.updates.len(), 1);
+        assert_eq!(cmd.control, ControlFlow::Continue);
     }
 }

--- a/crates/mofa-kernel/src/workflow/graph.rs
+++ b/crates/mofa-kernel/src/workflow/graph.rs
@@ -83,8 +83,8 @@ where
 pub enum EdgeTarget {
     /// Single target node
     Single(String),
-    /// Conditional edges with route names to node IDs
-    Conditional(HashMap<String, String>),
+    /// Conditional edges with route names to node IDs (declaration order preserved)
+    Conditional(Vec<(String, String)>),
     /// Multiple parallel targets
     Parallel(Vec<String>),
 }
@@ -96,7 +96,7 @@ impl EdgeTarget {
     }
 
     /// Create conditional edges
-    pub fn conditional(routes: HashMap<String, String>) -> Self {
+    pub fn conditional(routes: Vec<(String, String)>) -> Self {
         Self::Conditional(routes)
     }
 
@@ -114,7 +114,7 @@ impl EdgeTarget {
     pub fn targets(&self) -> Vec<&str> {
         match self {
             Self::Single(t) => vec![t],
-            Self::Conditional(routes) => routes.values().map(|s| s.as_str()).collect(),
+            Self::Conditional(routes) => routes.iter().map(|(_, t)| t.as_str()).collect(),
             Self::Parallel(targets) => targets.iter().map(|s| s.as_str()).collect(),
         }
     }
@@ -177,19 +177,22 @@ pub trait StateGraph: Send + Sync {
     ///
     /// # Arguments
     /// * `from` - Source node ID
-    /// * `conditions` - Map of condition names to target node IDs
+    /// * `conditions` - Ordered list of condition names to target node IDs
     ///
     /// # Example
     /// ```rust,ignore
-    /// graph.add_conditional_edges("classify", HashMap::from([
-    ///     ("type_a".to_string(), "handle_a".to_string()),
-    ///     ("type_b".to_string(), "handle_b".to_string()),
-    /// ]));
+    /// graph.add_conditional_edges(
+    ///     "classify",
+    ///     vec![
+    ///         ("type_a".to_string(), "handle_a".to_string()),
+    ///         ("type_b".to_string(), "handle_b".to_string()),
+    ///     ],
+    /// );
     /// ```
     fn add_conditional_edges(
         &mut self,
         from: impl Into<String>,
-        conditions: HashMap<String, String>,
+        conditions: Vec<(String, String)>,
     ) -> &mut Self;
 
     /// Add parallel edges from a node
@@ -288,21 +291,18 @@ pub enum StreamEvent<S: GraphState, V = serde_json::Value> {
         node_id: Option<String>,
         error: String,
     },
-    /// 瞬态失败后正在重试节点
     /// A node is being retried after a transient failure
     NodeRetry {
         node_id: String,
         attempt: u32,
         error: String,
     },
-    /// 节点永久失败，执行正在回退
     /// A node failed permanently and execution is falling back
     NodeFallback {
         from_node: String,
         to_node: String,
         reason: String,
     },
-    /// 由于重复失败，节点的断路器已打开
     /// A node's circuit breaker has opened due to repeated failures
     CircuitOpen { node_id: String },
 }
@@ -335,9 +335,10 @@ mod tests {
 
     #[test]
     fn test_edge_target_conditional() {
-        let mut routes = HashMap::new();
-        routes.insert("condition_a".to_string(), "node_a".to_string());
-        routes.insert("condition_b".to_string(), "node_b".to_string());
+        let routes = vec![
+            ("condition_a".to_string(), "node_a".to_string()),
+            ("condition_b".to_string(), "node_b".to_string()),
+        ];
 
         let target = EdgeTarget::conditional(routes);
         assert!(target.is_conditional());

--- a/crates/mofa-sdk/src/lib.rs
+++ b/crates/mofa-sdk/src/lib.rs
@@ -428,9 +428,10 @@ pub mod workflow {
 
     // DSL support
     pub use mofa_foundation::workflow::dsl::{
-        AgentRef, DslError, DslResult, EdgeDefinition, LlmAgentConfig, LoopConditionDef,
-        NodeConfigDef, NodeDefinition, RetryPolicy, TaskExecutorDef, TimeoutConfig, TransformDef,
-        WorkflowConfig, WorkflowDefinition, WorkflowDslParser, WorkflowMetadata,
+        AgentRef, DslCompiler, DslError, DslResult, EdgeDefinition, LlmAgentConfig,
+        LoopConditionDef, NodeConfigDef, NodeDefinition, RetryPolicy, TaskExecutorDef,
+        TimeoutConfig, TransformDef, WorkflowConfig, WorkflowDefinition, WorkflowDslParser,
+        WorkflowMetadata,
     };
 }
 

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2142,6 +2142,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2387,20 +2393,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
@@ -2772,7 +2778,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3112,9 +3118,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
@@ -4669,7 +4675,17 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.4.2",
+ "indexmap 2.13.0",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset 0.5.7",
  "indexmap 2.13.0",
 ]
 
@@ -4910,11 +4926,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit 0.25.4+spec-1.1.0",
 ]
 
 [[package]]
@@ -4999,7 +5015,7 @@ dependencies = [
  "log",
  "multimap",
  "once_cell",
- "petgraph",
+ "petgraph 0.7.1",
  "prettyplease",
  "prost",
  "prost-types",
@@ -5088,7 +5104,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5125,16 +5141,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -5144,6 +5160,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "ractor"
@@ -5227,7 +5249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
  "chacha20",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "rand_core 0.10.0",
 ]
 
@@ -6321,12 +6343,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6618,6 +6640,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "state_graph_core_fixes"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "mofa-sdk",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6889,7 +6921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -6969,7 +7001,7 @@ dependencies = [
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
- "fixedbitset",
+ "fixedbitset 0.4.2",
  "hex",
  "lazy_static",
  "libc",
@@ -7125,9 +7157,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -7135,7 +7167,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -7143,9 +7175,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7278,6 +7310,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.0.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7293,12 +7334,12 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
@@ -7776,12 +7817,12 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "atomic",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -7951,7 +7992,7 @@ dependencies = [
  "im-rc",
  "indexmap 2.13.0",
  "log",
- "petgraph",
+ "petgraph 0.6.5",
  "serde",
  "serde_derive",
  "serde_yaml",
@@ -9044,9 +9085,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
@@ -9168,6 +9209,7 @@ name = "workflow_dsl"
 version = "0.1.0"
 dependencies = [
  "mofa-sdk",
+ "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.22",

--- a/examples/workflow_dsl/Cargo.toml
+++ b/examples/workflow_dsl/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 mofa-sdk = { path = "../../crates/mofa-sdk"}
+serde_json.workspace = true
 
 tokio.workspace = true
 tracing.workspace = true

--- a/examples/workflow_dsl/graph_demo.yaml
+++ b/examples/workflow_dsl/graph_demo.yaml
@@ -1,0 +1,86 @@
+# DslCompiler Graph Demo
+#
+# This workflow demonstrates advanced DslCompiler features:
+# 1. External Agent Registry: Uses agents defined and built in Rust.
+# 2. Value-based Conditions: Uses a condition node to route based on input values.
+# 3. Explicit Routing: Shows how "true"/"false" results from conditions drive branching.
+
+metadata:
+  id: graph_demo
+  name: DslCompiler Graph Demo
+  description: Comprehensive demo for declarative Graph execution
+
+# Registry-based agents
+agents:
+  expert:
+    model: gpt-4
+    system_prompt: "You are a domain expert. Provide concise, accurate information."
+  reviewer:
+    model: gpt-4
+    system_prompt: "You are a critical reviewer. Evaluate the provided information for accuracy and clarity."
+
+nodes:
+  - type: start
+    id: start
+
+  - type: task
+    id: preprocess
+    name: Preprocess Input
+    executor_type: none
+
+  - type: condition
+    id: check_complex
+    name: check_complexity
+    condition:
+      condition_type: value
+      field: complexity
+      operator: ">"
+      value: 5
+
+  - type: llm_agent
+    id: expert_analysis
+    name: Expert Analysis
+    agent:
+      agent_id: expert
+    prompt_template: "Analyze this topic in depth: {{ input }}"
+
+  - type: llm_agent
+    id: simple_response
+    name: Simple Response
+    agent:
+      agent_id: expert
+    prompt_template: "Provide a quick overview of: {{ input }}"
+
+  - type: llm_agent
+    id: final_review
+    name: Final Review
+    agent:
+      agent_id: reviewer
+    prompt_template: "Review the following analysis: {{ expert_analysis }}"
+
+  - type: end
+    id: end
+
+edges:
+  - from: start
+    to: preprocess
+
+  - from: preprocess
+    to: check_complex
+
+  - from: check_complex
+    to: expert_analysis
+    condition: "true"
+
+  - from: check_complex
+    to: simple_response
+    condition: "false"
+
+  - from: expert_analysis
+    to: final_review
+
+  - from: simple_response
+    to: end
+
+  - from: final_review
+    to: end

--- a/examples/workflow_dsl/src/main.rs
+++ b/examples/workflow_dsl/src/main.rs
@@ -3,10 +3,10 @@
 //! Demonstrates how to use the workflow DSL to define and execute workflows
 //! using YAML configuration files through the mofa-sdk.
 
-use mofa_sdk::llm::{LLMAgent, LLMAgentBuilder};
+use mofa_sdk::llm::{LLMAgent, LLMAgentBuilder, MockLLMProvider};
 use mofa_sdk::workflow::{
-    ExecutorConfig, LlmAgentConfig, WorkflowDefinition, WorkflowDslParser,
-    WorkflowExecutor, WorkflowValue,
+    CompiledGraph, DslCompiler, GraphState, JsonState, LlmAgentConfig, WorkflowDefinition,
+    WorkflowDslParser,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -47,17 +47,17 @@ async fn run_customer_support() -> Result<(), Box<dyn std::error::Error>> {
     let agent_registry = build_mock_agents(&definition).await?;
 
     // Build workflow from definition
-    let workflow = WorkflowDslParser::build_with_agents(definition, &agent_registry).await?;
-    info!("Built workflow with {} nodes", workflow.node_count());
+    let compiled = DslCompiler::compile_with_agents(definition, &agent_registry)?;
+    info!("Built workflow successfully");
 
     // Execute workflow
-    let executor = WorkflowExecutor::new(ExecutorConfig::default());
-    let input = WorkflowValue::String("I was charged twice for my subscription".to_string());
+    let mut state = JsonState::new();
+    state.apply_update("input", serde_json::json!("I was charged twice for my subscription")).await?;
 
-    info!("Executing workflow with input: {}", input.as_str().unwrap_or(""));
-    let result = executor.execute(&workflow, input).await;
+    info!("Executing workflow with input: I was charged twice for my subscription");
+    let result = compiled.invoke(state, None).await?;
 
-    info!("Workflow result: {:?}", result);
+    info!("Workflow final state: {:?}", result);
 
     Ok(())
 }
@@ -78,20 +78,17 @@ async fn run_parallel_agents() -> Result<(), Box<dyn std::error::Error>> {
     let agent_registry = build_mock_agents(&definition).await?;
 
     // Build workflow from definition
-    let workflow = WorkflowDslParser::build_with_agents(definition, &agent_registry).await?;
-    info!("Built workflow with {} nodes", workflow.node_count());
+    let compiled = DslCompiler::compile_with_agents(definition, &agent_registry)?;
+    info!("Built workflow successfully");
 
     // Execute workflow
-    let executor = WorkflowExecutor::new(ExecutorConfig::default());
-    let input = WorkflowValue::String(
-        "The new product launch exceeded expectations with strong customer adoption."
-            .to_string(),
-    );
+    let mut state = JsonState::new();
+    state.apply_update("input", serde_json::json!("The new product launch exceeded expectations with strong customer adoption.")).await?;
 
-    info!("Executing workflow with input: {}", input.as_str().unwrap_or(""));
-    let result = executor.execute(&workflow, input).await;
+    info!("Executing workflow with input: The new product launch exceeded expectations with strong customer adoption.");
+    let result = compiled.invoke(state, None).await?;
 
-    info!("Workflow result: {:?}", result);
+    info!("Workflow final state: {:?}", result);
 
     Ok(())
 }
@@ -103,7 +100,7 @@ async fn run_parallel_agents() -> Result<(), Box<dyn std::error::Error>> {
 async fn build_mock_agents(
     definition: &WorkflowDefinition,
 ) -> Result<HashMap<String, Arc<LLMAgent>>, Box<dyn std::error::Error>> {
-    let mut registry = HashMap::new();
+    let mut registry: HashMap<String, Arc<LLMAgent>> = HashMap::new();
 
     // Check if we have an OpenAI API key
     let has_openai = std::env::var("OPENAI_API_KEY").is_ok();
@@ -133,19 +130,19 @@ async fn build_mock_agents(
                     builder = builder.with_max_tokens(max_tokens);
                 }
 
-                Arc::new(builder.build_async().await?)
+                Ok(Arc::new(builder.build_async().await))
             }
 
             #[cfg(not(feature = "openai"))]
             {
-                build_mock_agent(agent_id, config).await?
+                build_mock_agent(agent_id, config)
             }
         } else {
             // Build mock agent without actual LLM
-            build_mock_agent(agent_id, config).await?
-        };
+            build_mock_agent(agent_id, config)
+        }?;
 
-        registry.insert(agent_id.clone(), agent);
+        registry.insert(agent_id.to_string(), agent);
         info!("Registered agent: {}", agent_id);
     }
 
@@ -157,7 +154,7 @@ async fn build_mock_agents(
 /// This creates a simple agent that returns predefined responses
 /// based on the agent type. In production, use actual LLMAgent with
 /// configured providers.
-async fn build_mock_agent(
+fn build_mock_agent(
     agent_id: &str,
     config: &LlmAgentConfig,
 ) -> Result<Arc<LLMAgent>, Box<dyn std::error::Error>> {
@@ -167,17 +164,19 @@ async fn build_mock_agent(
         config.model
     );
 
-    // For demonstration, we'll build a simple agent
-    // In production, you would configure an actual LLM provider
+    let provider = Arc::new(
+        MockLLMProvider::new("mock-provider")
+            .with_default_response(format!("Mock response from {}", agent_id)),
+    );
+
     let mut builder = LLMAgentBuilder::new()
         .with_id(agent_id)
-        .with_name(&format!("Mock {}", agent_id));
+        .with_name(&format!("Mock {}", agent_id))
+        .with_provider(provider);
 
     if let Some(prompt) = &config.system_prompt {
         builder = builder.with_system_prompt(prompt);
     }
 
-    // Note: This won't actually work without a provider
-    // It's here to demonstrate the API structure
-    Ok(Arc::new(builder.build_async().await))
+    Ok(Arc::new(builder.build()))
 }


### PR DESCRIPTION
## 🎯 Overview
This PR introduces the DslCompiler, bridging the gap between our declarative YAML/TOML workflow definitions and the StateGraph execution engine. It allows parsed DSLs to be natively compiled into a CompiledGraphImpl<JsonState> that can be invoked, streamed, or stepped through.

Additionally, this PR refactors the parser's error handling, replacing generic string-based validation errors with strongly typed thiserror variants for much better programmatic error matching and observability.

## 🚀 Key Changes

1. DslCompiler Implementation (compiler.rs)

Node Adapters: Implemented NodeFunc adapters to translate DSL nodes into executable graph nodes (PassthroughNode, DslTaskNode, DslConditionNode, DslJoinNode, DslTransformNode, DslAgentNode).

Agent Registry: Added support for resolving LlmAgent nodes against an injected HashMap registry of LLMAgent instances.

Condition Evaluation: Built a stateless JSON value comparator to handle edge routing conditions (==, >, <=, contains).

Topology Wiring: Implemented automatic graph wiring, connecting standard edges and mapping conditional branches.

2. Strongly Typed Errors (mod.rs & parser.rs)

Deprecated DslError::Validation(String) in favor of precise error variants.

Added specific variants for topology errors: MissingStartNode, MissingEndNode, DuplicateNodeId, InvalidEdge.

Added specific variants for execution/parsing errors: MissingAgentInRegistry, InlineAgentNotSupported, TomlToJsonConversion, MissingFileExtension, UnsupportedFileExtension.

Refactored WorkflowDslParser to utilize these new errors, cleaning up the TOML/YAML file extraction logic.

3. Comprehensive Testing

Added 1,000+ lines of tests verifying workflow roundtrips, conditional edge logic, transformation nodes, and proper error propagation for invalid schemas.

## 🔗 Related Issues
Fixes #691