### PR TITLE
enhancement(workflow): make stream() channel buffer size configurable via GraphConfig

### DIFF
--- a/crates/mofa-foundation/src/workflow/state_graph.rs
+++ b/crates/mofa-foundation/src/workflow/state_graph.rs
@@ -623,7 +623,8 @@ impl<S: GraphState + 'static> CompiledGraph<S, serde_json::Value> for CompiledGr
         let semaphore = self.parallelism_semaphore.clone();
 
         // Create a channel for streaming events
-        let (tx, rx) = tokio::sync::mpsc::channel(100);
+        let buffer_size = self.config.stream_buffer_size;
+        let (tx, rx) = tokio::sync::mpsc::channel(buffer_size);
 
         // Spawn execution task
         let stream_span = tracing::info_span!("state_graph.stream");

--- a/crates/mofa-kernel/src/workflow/context.rs
+++ b/crates/mofa-kernel/src/workflow/context.rs
@@ -92,6 +92,11 @@ impl RemainingSteps {
     }
 }
 
+/// Default stream buffer size for serde deserialization
+fn default_stream_buffer_size() -> usize {
+    100
+}
+
 /// Graph execution configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GraphConfig<V = Value> {
@@ -113,6 +118,10 @@ pub struct GraphConfig<V = Value> {
     /// Maximum parallel branches
     pub max_parallelism: usize,
 
+    /// Stream channel buffer size (for `stream()` method)
+    #[serde(default = "default_stream_buffer_size")]
+    pub stream_buffer_size: usize,
+
     /// Custom configuration data
     #[serde(default)]
     pub custom: HashMap<String, V>,
@@ -127,6 +136,7 @@ impl<V: Clone> Default for GraphConfig<V> {
             checkpoint_interval: 10,
             timeout_ms: 0,
             max_parallelism: 10,
+            stream_buffer_size: 100,
             custom: HashMap::new(),
         }
     }
@@ -166,6 +176,12 @@ impl<V: Clone> GraphConfig<V> {
     /// Set maximum parallelism
     pub fn with_max_parallelism(mut self, max: usize) -> Self {
         self.max_parallelism = max;
+        self
+    }
+
+    /// Set stream channel buffer size
+    pub fn with_stream_buffer_size(mut self, size: usize) -> Self {
+        self.stream_buffer_size = if size == 0 { 1 } else { size };
         self
     }
 
@@ -358,6 +374,26 @@ mod tests {
         assert_eq!(config.checkpoint_interval, 5);
         assert_eq!(config.timeout_ms, 30000);
         assert_eq!(config.max_parallelism, 4);
+    }
+
+    #[test]
+    fn test_stream_buffer_size_default() {
+        let config = GraphConfig::<serde_json::Value>::default();
+        assert_eq!(config.stream_buffer_size, 100);
+    }
+
+    #[test]
+    fn test_stream_buffer_size_custom() {
+        let config = GraphConfig::<serde_json::Value>::new()
+            .with_stream_buffer_size(5);
+        assert_eq!(config.stream_buffer_size, 5);
+    }
+
+    #[test]
+    fn test_stream_buffer_size_zero_clamped_to_one() {
+        let config = GraphConfig::<serde_json::Value>::new()
+            .with_stream_buffer_size(0);
+        assert_eq!(config.stream_buffer_size, 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 📋 Summary

Make the `stream()` channel buffer size configurable through `GraphConfig` instead of being hardcoded to `100`. This gives users control over backpressure behavior in streaming workflows without requiring code changes in the framework itself.

## 🔗 Related Issues

Closes #778

---

## 🧠 Context

The `stream()` method in `StateGraphImpl` creates a `tokio::sync::mpsc::channel(100)` with a hardcoded buffer size. This works for most use cases, but becomes a problem in two scenarios:

- **High-throughput pipelines** — a buffer of 100 may be too small, causing unnecessary backpressure and stalling upstream producers.
- **Memory-constrained environments** — a buffer of 100 may be too large when running many concurrent graphs with large state objects.

Since `GraphConfig` already exists and is threaded into `stream()`, adding a `stream_buffer_size` field is the natural, non-breaking way to expose this knob.

---

## 🛠️ Changes

- Added `stream_buffer_size: usize` field to `GraphConfig` with default value `100` (preserves existing behavior)
- Added `with_stream_buffer_size()` builder method with guard against zero (clamped to 1 to prevent `mpsc::channel(0)` panic)
- Added `#[serde(default)]` annotation so existing serialized configs deserialize without breakage
- Replaced hardcoded `mpsc::channel(100)` in `StateGraphImpl::stream()` with `mpsc::channel(self.config.stream_buffer_size)`

---

## 🧪 How I Tested

1. `cargo test -p mofa-kernel -- context` — all 18 tests pass, including 3 new ones:
   - `test_stream_buffer_size_default` — verifies default is 100
   - `test_stream_buffer_size_custom` — verifies custom value (5) is respected
   - `test_stream_buffer_size_zero_clamped_to_one` — verifies zero input is safely clamped to 1
2. `cargo check` — full workspace compiles cleanly
3. Manual review confirmed no other call sites are affected

---

## ⚠️ Breaking Changes

- [x] No breaking changes

The new field has a serde default and the `Default` impl sets it to `100`, so all existing code continues to work identically.

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [x] Public APIs documented (`with_stream_buffer_size` has doc comment)
- [x] README / docs updated (if needed) — N/A, internal config field

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---

## 🚀 Deployment Notes (if applicable)

None. Fully backward-compatible — no migrations, no config changes, no env vars.

---

## 🧩 Additional Notes for Reviewers

- Only two files touched: `mofa-kernel/.../context.rs` (struct + default + builder + tests) and `mofa-foundation/.../state_graph.rs` (one-line channel size swap).
- The `with_stream_buffer_size(0)` case is guarded — `mpsc::channel(0)` panics in tokio, so we clamp to 1.
- Other `mpsc::channel(100)` calls in the codebase (runtime, actor) are intentionally untouched — they serve different purposes and should be addressed separately if needed.