### PR TITLE
test(retry): add invariant-style bounded tests for exponential backof…

### DIFF
--- a/crates/mofa-runtime/src/retry.rs
+++ b/crates/mofa-runtime/src/retry.rs
@@ -180,4 +180,78 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(call_count.load(Ordering::SeqCst), 1); // aborted after 1, not 5
     }
+
+    // ── Bounded-iteration invariant tests (#780) ──────────────────────
+
+    #[test]
+    fn test_backoff_delay_never_exceeds_max() {
+        let base_ms = 100;
+        let max_ms = 5_000;
+
+        // Without jitter
+        let p = RetryPolicy::ExponentialBackoff { base_ms, max_ms, jitter: false };
+        for attempt in 0..20 {
+            let delay = p.delay_for(attempt).as_millis() as u64;
+            assert!(
+                delay <= max_ms,
+                "attempt {attempt}: delay {delay} ms exceeded max {max_ms} ms (no jitter)",
+            );
+        }
+
+        // With jitter
+        let p = RetryPolicy::ExponentialBackoff { base_ms, max_ms, jitter: true };
+        for attempt in 0..20 {
+            let delay = p.delay_for(attempt).as_millis() as u64;
+            assert!(
+                delay <= max_ms,
+                "attempt {attempt}: delay {delay} ms exceeded max {max_ms} ms (jitter)",
+            );
+        }
+    }
+
+    #[test]
+    fn test_jitter_stays_within_bounds() {
+        let base_ms = 200;
+        let max_ms = 10_000;
+        let p = RetryPolicy::ExponentialBackoff { base_ms, max_ms, jitter: true };
+
+        for attempt in 0..20 {
+            let delay = p.delay_for(attempt).as_millis() as u64;
+
+            // Recompute the non-jittered capped value to derive bounds.
+            let exp = 1u64
+                .checked_shl(attempt as u32)
+                .and_then(|s| base_ms.checked_mul(s))
+                .unwrap_or(max_ms);
+            let capped = exp.min(max_ms);
+            let eighth = capped / 8;
+            let lower_bound = capped.saturating_sub(eighth);
+
+            assert!(
+                delay >= lower_bound,
+                "attempt {attempt}: delay {delay} ms below lower bound {lower_bound} ms",
+            );
+            assert!(
+                delay <= max_ms,
+                "attempt {attempt}: delay {delay} ms exceeded max {max_ms} ms",
+            );
+        }
+    }
+
+    #[test]
+    fn test_monotonic_growth_before_saturation_no_jitter() {
+        let base_ms = 50;
+        let max_ms = 3_200;
+        let p = RetryPolicy::ExponentialBackoff { base_ms, max_ms, jitter: false };
+
+        let mut prev_delay = 0u64;
+        for attempt in 0..20 {
+            let delay = p.delay_for(attempt).as_millis() as u64;
+            assert!(
+                delay >= prev_delay,
+                "attempt {attempt}: delay {delay} ms decreased from previous {prev_delay} ms",
+            );
+            prev_delay = delay;
+        }
+    }
 }


### PR DESCRIPTION
## 📋 Summary

Adds bounded-iteration invariant tests for the `RetryPolicy::ExponentialBackoff` implementation to validate that delay values respect configured bounds and that jitter stays within the expected ±12.5% range. This is a test-only change — no production code was modified.

## 🔗 Related Issues

Closes #780

---

## 🧠 Context

The existing retry test suite covered basic happy-path scenarios (fixed delays, a few specific attempt values, and the async retry helper), but lacked systematic validation of the backoff invariants across a wide range of attempts. Specifically, there were no tests asserting that:

- Delays never exceed `max_ms` for high attempt counts (where overflow or shift behavior could surface).
- Jitter-adjusted delays remain within the documented ±12.5% band.
- Delays grow monotonically before saturating at the cap (when jitter is disabled).

These invariant-style tests iterate over attempts 0–19 to cover both the exponential growth phase and the saturation region, catching edge cases that point-check tests would miss.

---

## 🛠️ Changes

- Added `test_backoff_delay_never_exceeds_max` — iterates attempts 0..20 with and without jitter, asserts `delay <= max_ms` on every attempt.
- Added `test_jitter_stays_within_bounds` — with jitter enabled, recomputes the non-jittered capped value per attempt and asserts `delay >= capped - capped/8` and `delay <= max_ms`.
- Added `test_monotonic_growth_before_saturation_no_jitter` — without jitter, asserts the delay sequence is non-decreasing across attempts 0..20.

---

## 🧪 How I Tested

1. Ran `cargo test -p mofa-runtime -- retry` — all 9 tests pass (6 existing + 3 new).
2. Verified no production files were touched via `git diff --stat` (only `crates/mofa-runtime/src/retry.rs`, +74 lines).
3. Confirmed tests are fully deterministic — no randomness mocking, no external crates, no flakiness risk.

---

## Logs 

running 9 tests
test retry::tests::test_backoff_delay_never_exceeds_max ... ok
test retry::tests::test_exponential_policy_delay ... ok
test retry::tests::test_fixed_policy_delay ... ok
test retry::tests::test_jitter_does_not_exceed_cap ... ok
test retry::tests::test_jitter_stays_within_bounds ... ok
test retry::tests::test_linear_policy_delay ... ok
test retry::tests::test_monotonic_growth_before_saturation_no_jitter ... ok
test retry::tests::test_retry_helper_fails_on_non_retryable ... ok
test retry::tests::test_retry_helper_succeeds_on_second_attempt ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 40 filtered out

---

## ⚠️ Breaking Changes

- [x] No breaking changes

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [x] Public APIs documented
- [x] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---


** test-only changes, no deployment impact.

---

## 🧩 Additional Notes for Reviewers

- All three tests are deterministic by design. The jitter in `ExponentialBackoff` is pseudo-jitter (based on attempt parity, not randomness), so no mocking or tolerance windows are needed.
- No external crates introduced (no `proptest`, `quickcheck`, etc.) — pure `#[test]` functions using iteration loops as lightweight property-style checks.
- Tests are appended to the existing `mod tests` block in `crates/mofa-runtime/src/retry.rs`; nothing else was touched.