### PR TITLE
Fix/gemini client builder fallback

### DIFF
--- a/crates/mofa-foundation/src/agent/tools/mcp/client.rs
+++ b/crates/mofa-foundation/src/agent/tools/mcp/client.rs
@@ -236,11 +236,12 @@ impl McpClient for McpClientManager {
 
         let params = CallToolRequestParams {
             name: tool_name.to_string().into(),
-            arguments: if arguments.is_object() {
-                Some(arguments.as_object().unwrap().clone())
-            } else {
-                Some(serde_json::Map::new())
-            },
+            arguments: Some(
+                arguments
+                    .as_object()
+                    .map(|m| m.clone())
+                    .unwrap_or_default(),
+            ),
             meta: None,
             task: None,
         };

--- a/crates/mofa-foundation/src/llm/google.rs
+++ b/crates/mofa-foundation/src/llm/google.rs
@@ -103,10 +103,20 @@ impl GeminiProvider {
     }
 
     pub fn with_config(config: GeminiConfig) -> Self {
-        let client = reqwest::Client::builder()
+        let client = match reqwest::Client::builder()
             .timeout(Duration::from_secs(config.timeout_secs))
             .build()
-            .expect("Failed to build reqwest client");
+        {
+            Ok(client) => client,
+            Err(e) => {
+                tracing::error!(
+                    "Failed to build Gemini reqwest client (timeout_secs={}): {}. Falling back to default client.",
+                    config.timeout_secs,
+                    e
+                );
+                reqwest::Client::new()
+            }
+        };
         Self { client, config }
     }
 


### PR DESCRIPTION
## Summary

Avoid a potential panic when constructing the Gemini `reqwest::Client` by removing `expect` and using a logged fallback instead.

## Motivation

`GeminiProvider::with_config` previously built its HTTP client with:

```rust
let client = reqwest::Client::builder()
    .timeout(Duration::from_secs(config.timeout_secs))
    .build()
    .expect("Failed to build reqwest client");
```

If the underlying `reqwest::Client::builder().build()` failed (for example due to environment-specific TLS or HTTP configuration issues), this would panic and bring down any caller using the Gemini provider. This conflicts with the project guideline to avoid `unwrap`/`expect` in production paths and makes the system less robust to configuration errors.

## Changes

- In `crates/mofa-foundation/src/llm/google.rs`, updated `GeminiProvider::with_config` to handle client construction failures gracefully:

```rust
pub fn with_config(config: GeminiConfig) -> Self {
    let client = match reqwest::Client::builder()
        .timeout(Duration::from_secs(config.timeout_secs))
        .build()
    {
        Ok(client) => client,
        Err(e) => {
            tracing::error!(
                "Failed to build Gemini reqwest client (timeout_secs={}): {}. Falling back to default client.",
                config.timeout_secs,
                e
            );
            reqwest::Client::new()
        }
    };
    Self { client, config }
}
```

- On error, the code now:
  - Logs the failure (including `timeout_secs` and the error message).
  - Falls back to `reqwest::Client::new()` instead of panicking.

This removes the `expect` from a production path while preserving a usable client in the face of configuration errors.

## Behavioral Notes

- **Success path:** When `Client::builder().build()` succeeds, behavior is unchanged.
- **Failure path:** Instead of panicking, the provider logs the error and falls back to a default client. Callers can still observe failures through downstream HTTP errors, but the process is no longer terminated by a panic at construction time.

## Related Issues

- N/A – incremental hardening as part of reducing `unwrap`/`expect` usage in `mofa-foundation`.

## Testing

- `cargo check -p mofa-foundation`
- `cargo test -p mofa-foundation` (run locally outside sandbox)
- `cargo fmt --check`
- `cargo clippy --workspace --all-features -- -D errors`

## Checklist

- [x] No public API changes  
- [x] No new dependencies introduced  
- [x] Architecture layer rules respected  
- [x] Replaces `expect` in a production path with logged, non-panicking behavior

