### PR TITLE
fix: eliminate lock contention in DoraChannel async operations

### DIFF
--- a/crates/mofa-runtime/src/dora_adapter/channel.rs
+++ b/crates/mofa-runtime/src/dora_adapter/channel.rs
@@ -251,11 +251,15 @@ impl DoraChannel {
             .clone()
             .ok_or_else(|| DoraError::ChannelError("No receiver specified for P2P".to_string()))?;
 
-        let p2p_channels = self.p2p_channels.read().await;
-        let tx = p2p_channels.get(&receiver_id).ok_or_else(|| {
-            DoraError::AgentNotFound(format!("Receiver {} not registered", receiver_id))
-        })?;
+        // Clone the sender in a scoped block to release lock quickly
+        let tx = {
+            let p2p_channels = self.p2p_channels.read().await;
+            p2p_channels.get(&receiver_id).cloned().ok_or_else(|| {
+                DoraError::AgentNotFound(format!("Receiver {} not registered", receiver_id))
+            })?
+        }; // Lock released here
 
+        // Send without holding any locks
         tx.send(envelope)
             .await
             .map_err(|e| DoraError::ChannelError(e.to_string()))?;
@@ -288,11 +292,16 @@ impl DoraChannel {
             .clone()
             .ok_or_else(|| DoraError::ChannelError("No topic specified".to_string()))?;
 
-        let topic_channels = self.topic_channels.read().await;
-        let tx = topic_channels
-            .get(&topic)
-            .ok_or_else(|| DoraError::ChannelError(format!("Topic {} not found", topic)))?;
+        // Clone the broadcast sender in a scoped block to release lock quickly
+        let tx = {
+            let topic_channels = self.topic_channels.read().await;
+            topic_channels
+                .get(&topic)
+                .cloned()
+                .ok_or_else(|| DoraError::ChannelError(format!("Topic {} not found", topic)))?
+        }; // Lock released here
 
+        // Send without holding any locks
         // 如果没有接收者，send 会返回错误，但这不应该是致命错误
         // If there are no receivers, send returns an error, but this shouldn't be fatal
         match tx.send(envelope) {


### PR DESCRIPTION
# Fix: Eliminate lock contention in DoraChannel message operations
## Closes #789
## Problem

`DoraChannel::send_p2p()` and `DoraChannel::publish()` held RwLock read locks while performing async channel send operations, causing writer starvation under high message traffic. Agent registration/unregistration would freeze during message bursts.

**Root Cause**: Lock held across `.await` point (violates Tokio best practices)

```rust
// Before (BAD)
let p2p_channels = self.p2p_channels.read().await;  // ← LOCK
let tx = p2p_channels.get(&receiver_id)?;
tx.send(envelope).await  // ← Blocks with lock held
```

**Impact**: Under load, concurrent sends block write operations (register/unregister agents) indefinitely.

## Solution

Clone the channel sender before awaiting, releasing the lock immediately.

```rust
// After (GOOD)
let tx = {
    let p2p_channels = self.p2p_channels.read().await;
    p2p_channels.get(&receiver_id).cloned()?
}; // ← Lock released
tx.send(envelope).await  // ← No lock held
```

**Why safe**: `mpsc::Sender::clone()` creates a new handle to the same channel (cheap Arc increment). No behavioral changes.

## Changes

**File**: `crates/mofa-runtime/src/dora_adapter/channel.rs`

1. **`send_p2p()`** (lines 247-268) - Clone sender in scoped block
2. **`publish()`** (lines 287-315) - Clone broadcast sender in scoped block

Both now match the correct pattern in `receive_p2p()`.

## Testing

✅ `cargo check -p mofa-runtime` - Passed  
✅ All existing tests pass  
✅ No API changes  
✅ No behavioral changes  

## Impact

- ✅ Agent registration remains responsive under load
- ✅ Better concurrency and throughput  
- ✅ Follows [Tokio best practices](https://tokio.rs/tokio/tutorial/shared-state#holding-a-mutexguard-across-an-await)

## Related

Similar patterns in `SimpleMessageBus` (`builder.rs`) should be audited in follow-up PR.

---

**Breaking Changes**: None  
**Migration**: Not required
