### PR TITLE
fix(qdrant): replace DefaultHasher with SHA-256 for stable point ID generation

### DIFF
--- a/crates/mofa-foundation/Cargo.toml
+++ b/crates/mofa-foundation/Cargo.toml
@@ -32,7 +32,7 @@ kokoro = ["mofa-plugins/kokoro"]
 # Enable MCP (Model Context Protocol) client support
 mcp = ["dep:rmcp"]
 # Enable Qdrant vector database support
-qdrant = ["dep:qdrant-client"]
+qdrant = ["dep:qdrant-client", "dep:sha2"]
 # Enable accurate token counting with tiktoken
 tiktoken = ["dep:tiktoken-rs"]
 # Enable parallel processing for compression

--- a/crates/mofa-foundation/src/rag/qdrant_store.rs
+++ b/crates/mofa-foundation/src/rag/qdrant_store.rs
@@ -11,8 +11,8 @@ use qdrant_client::qdrant::{
     CountPointsBuilder, CreateCollectionBuilder, DeletePointsBuilder, Distance, PointStruct,
     PointsIdsList, QueryPointsBuilder, UpsertPointsBuilder, VectorParamsBuilder,
 };
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
-use std::hash::{Hash, Hasher};
 
 /// Reserved payload keys for internal storage.
 const PAYLOAD_KEY_ORIGINAL_ID: &str = "_original_id";
@@ -50,12 +50,11 @@ pub struct QdrantVectorStore {
 
 /// Convert a string ID to a u64 point ID for Qdrant.
 ///
-/// Uses DefaultHasher for a deterministic mapping. The original string
-/// ID is always stored in the point payload so retrieval is lossless.
+/// Uses SHA-256 for stable, cross-version deterministic mapping. The original
+/// string ID is always stored in the point payload so retrieval is lossless.
 fn string_id_to_u64(id: &str) -> u64 {
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    id.hash(&mut hasher);
-    hasher.finish()
+    let digest = Sha256::digest(id.as_bytes());
+    u64::from_le_bytes(digest[..8].try_into().expect("SHA-256 output is at least 8 bytes"))
 }
 
 /// Extract a string value from a Qdrant payload Value.


### PR DESCRIPTION
## Problem

The Qdrant vector store used `std::collections::hash_map::DefaultHasher` to convert string chunk IDs to u64 point IDs. `DefaultHasher` is explicitly unstable across Rust versions, its output is not guaranteed to be consistent between compilations or future releases. This means point IDs generated in one version of Rust may not match those generated in another, silently breaking retrieval in persistent Qdrant collections.

This was flagged in the community review of #249.

## Fix

Replaced `DefaultHasher` with SHA-256 from the `sha2` crate (a well-audited, stable cryptographic hash). The first 8 bytes of the digest are taken as a little-endian u64, giving a stable and well-distributed point ID.

The `sha2` dependency is gated behind the existing `qdrant` feature flag so it adds zero overhead for users not using Qdrant.

The original string ID continues to be stored in the point payload for lossless retrieval, unchanged.

## Changes

- `crates/mofa-foundation/Cargo.toml`: added `sha2 = { version = "0.10", optional = true }` under the `qdrant` feature
- `crates/mofa-foundation/src/rag/qdrant_store.rs`: replaced `DefaultHasher` with `Sha256::digest`

Closes the stability concern raised on #249.