### PR TITLE
fix(runtime): prevent stale sender accumulation on agent re-registration

### DIFF
--- a/crates/mofa-runtime/src/builder.rs
+++ b/crates/mofa-runtime/src/builder.rs
@@ -661,11 +661,13 @@ impl SimpleMessageBus {
 
     /// 注册智能体
     /// Register agent
+    ///
+    /// Replaces any existing senders for `agent_id` so that stale clones from
+    /// previous registrations (e.g. after an agent restart) do not accumulate
+    /// in the Vec and leak memory.
     pub async fn register(&self, agent_id: &str, tx: tokio::sync::mpsc::Sender<AgentEvent>) {
         let mut subs = self.subscribers.write().await;
-        subs.entry(agent_id.to_string())
-            .or_insert_with(Vec::new)
-            .push(tx);
+        subs.insert(agent_id.to_string(), vec![tx]);
     }
 
     /// 订阅主题

--- a/crates/mofa-runtime/src/lib.rs
+++ b/crates/mofa-runtime/src/lib.rs
@@ -762,9 +762,8 @@ impl SimpleMessageBus {
     /// Register an agent
     pub async fn register(&self, agent_id: &str, tx: tokio::sync::mpsc::Sender<AgentEvent>) {
         let mut subs = self.subscribers.write().await;
-        subs.entry(agent_id.to_string())
-            .or_insert_with(Vec::new)
-            .push(tx);
+        subs.insert(agent_id.to_string(), vec![tx]);
+            
     }
 
     /// 订阅主题
@@ -1308,6 +1307,21 @@ mod tests {
         let _ = slow_rx.recv().await;
         send_task.await.unwrap().unwrap();
     }
+    
+    #[tokio::test]
+    async fn re_registration_replaces_stale_sender() {
+        let bus = SimpleMessageBus::new();
+
+        let (tx1, rx1) = tokio::sync::mpsc::channel(1);
+        bus.register("agent-a", tx1).await;
+        drop(rx1); // simulate agent restart
+
+        let (tx2, _rx2) = tokio::sync::mpsc::channel(1);
+        bus.register("agent-a", tx2).await;
+
+        let subs = bus.subscribers.read().await;
+        assert_eq!(subs["agent-a"].len(), 1);
+}
 }
 
 /// 智能体节点存储类型


### PR DESCRIPTION
## **Summary**

This PR fixes a memory and performance issue in:

```
crates/mofa-runtime/src/builder.rs
```

Specifically in `SimpleMessageBus::register`.

Previously, each call to `register()` appended a new `Sender` into a `Vec`:

```rust
subs.entry(agent_id.to_string())
    .or_insert_with(Vec::new)
    .push(tx);
```

On agent restarts, a new channel was created and appended , but the old sender clone stored in the `Vec` was never removed. Over time, this caused the per-agent subscriber list to grow indefinitely with dead senders.

Since `send()` errors were discarded (`let _ = tx.send(...).await`), this degradation was silent.

---

## **Steps to Reproduce**

1. Start a `SimpleRuntime`.
2. Repeatedly call `register_agent()` for the same `agent_id`.
3. Drop the old receiver each time (simulating restart).
4. Inspect `subscribers[agent_id]`.

Result:

* The `Vec` grows with each restart.
* Old senders remain even though their receivers are gone.
* Every `broadcast()` iterates over all historical entries.

---

## **Impact**

* **Memory growth** proportional to restart count.
* Each dead `Sender` retains an `Arc` to its channel.
* `broadcast` / `send_to` latency increases linearly with accumulated restarts.
* No visible warning ; system continues operating while silently degrading.

In long-running systems with agent reload/restart cycles (a supported MoFA feature), this accumulation becomes production-relevant.

---

## **Fix**

Re-registration now replaces the existing entry instead of appending:

```rust
subs.insert(agent_id.to_string(), vec![tx]);
```

This ensures:

* One sender per agent ID.
* Old sender clones are dropped immediately.
* The `Vec` remains bounded.

The change matches actual runtime semantics: one active channel per agent.

---

## **Result**

* Subscriber list remains constant in size.
* Closed channels are released promptly.
* Broadcast performance stays proportional to live agents.
* Memory usage no longer grows with restart cycles.

This keeps `SimpleMessageBus` aligned with intended lifecycle behavior and prevents silent long-term degradation.
