### PR TITLE
feat(mofa-cli): add Rust vibe flow command parity

### DIFF
--- a/crates/mofa-cli/src/cli.rs
+++ b/crates/mofa-cli/src/cli.rs
@@ -143,7 +143,7 @@ pub enum Commands {
     /// Vibe code and flow generation commands
     Vibe {
         #[command(subcommand)]
-        action: VibeCommands,
+        action: Option<VibeCommands>,
     },
 }
 
@@ -626,13 +626,36 @@ pub enum RagCommands {
 pub enum VibeCommands {
     /// Generate a dataflow from a natural language requirement
     Flow {
-        /// LLM model label to embed in generated metadata
+        /// LLM model to use for flow generation
         #[arg(long)]
         llm: Option<String>,
 
         /// Output path for the generated dataflow YAML
         #[arg(short, long)]
         output: Option<PathBuf>,
+
+        /// Requirement text (if omitted, prompt interactively)
+        #[arg(short = 'r', long)]
+        requirement: Option<String>,
+    },
+
+    /// Generate an agent from a natural language requirement
+    Agent {
+        /// LLM model to use for agent generation
+        #[arg(long)]
+        llm: Option<String>,
+
+        /// Maximum optimization rounds hint
+        #[arg(long)]
+        max_rounds: Option<u32>,
+
+        /// Output directory for generated agent files
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+
+        /// Optional base agent path
+        #[arg(short, long)]
+        base: Option<PathBuf>,
 
         /// Requirement text (if omitted, prompt interactively)
         #[arg(short = 'r', long)]
@@ -728,5 +751,47 @@ mod tests {
     fn test_rag_query_parses() {
         let parsed = Cli::try_parse_from(["mofa", "rag", "query", "what is mofa", "--top-k", "3"]);
         assert!(parsed.is_ok(), "rag query command should parse");
+    }
+
+    #[test]
+    fn test_bare_vibe_parses_for_interactive_mode() {
+        let parsed = Cli::try_parse_from(["mofa", "vibe"]);
+        assert!(parsed.is_ok(), "bare vibe command should parse");
+    }
+
+    #[test]
+    fn test_vibe_flow_parses() {
+        let parsed = Cli::try_parse_from([
+            "mofa",
+            "vibe",
+            "flow",
+            "--llm",
+            "gpt-4o-mini",
+            "--output",
+            "flows/generated.yml",
+            "--requirement",
+            "build a multilingual translation flow",
+        ]);
+        assert!(parsed.is_ok(), "vibe flow should parse");
+    }
+
+    #[test]
+    fn test_vibe_agent_parses() {
+        let parsed = Cli::try_parse_from([
+            "mofa",
+            "vibe",
+            "agent",
+            "--llm",
+            "gpt-4o-mini",
+            "--max-rounds",
+            "4",
+            "--output",
+            "agents/new-agent",
+            "--base",
+            "agents/base-agent",
+            "--requirement",
+            "build a support triage agent",
+        ]);
+        assert!(parsed.is_ok(), "vibe agent should parse");
     }
 }

--- a/crates/mofa-cli/src/cli.rs
+++ b/crates/mofa-cli/src/cli.rs
@@ -139,6 +139,12 @@ pub enum Commands {
         #[command(subcommand)]
         action: RagCommands,
     },
+
+    /// Vibe code and flow generation commands
+    Vibe {
+        #[command(subcommand)]
+        action: VibeCommands,
+    },
 }
 
 /// Generate subcommands
@@ -612,6 +618,25 @@ pub enum RagCommands {
         /// Qdrant collection name.
         #[arg(long, default_value = "mofa_documents")]
         qdrant_collection: String,
+    },
+}
+
+/// Vibe generation subcommands
+#[derive(Subcommand)]
+pub enum VibeCommands {
+    /// Generate a dataflow from a natural language requirement
+    Flow {
+        /// LLM model label to embed in generated metadata
+        #[arg(long)]
+        llm: Option<String>,
+
+        /// Output path for the generated dataflow YAML
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+
+        /// Requirement text (if omitted, prompt interactively)
+        #[arg(short = 'r', long)]
+        requirement: Option<String>,
     },
 }
 

--- a/crates/mofa-cli/src/commands/mod.rs
+++ b/crates/mofa-cli/src/commands/mod.rs
@@ -12,3 +12,4 @@ pub mod rag;
 pub mod run;
 pub mod session;
 pub mod tool;
+pub mod vibe;

--- a/crates/mofa-cli/src/commands/vibe.rs
+++ b/crates/mofa-cli/src/commands/vibe.rs
@@ -1,0 +1,159 @@
+//! `mofa vibe` command implementation
+
+use crate::CliError;
+use colored::Colorize;
+use dialoguer::Input;
+use serde::Serialize;
+use std::path::Path;
+
+const DEFAULT_MODEL: &str = "gpt-4o-mini";
+const DEFAULT_OUTPUT: &str = "dataflow.yml";
+
+#[derive(Serialize)]
+struct VibeMeta<'a> {
+    model: &'a str,
+    requirement: &'a str,
+}
+
+#[derive(Serialize)]
+struct OperatorSpec<'a> {
+    python: &'a str,
+}
+
+#[derive(Serialize)]
+struct NodeSpec<'a> {
+    id: &'a str,
+    operator: OperatorSpec<'a>,
+    inputs: std::collections::BTreeMap<&'a str, &'a str>,
+    outputs: Vec<&'a str>,
+}
+
+#[derive(Serialize)]
+struct FlowTemplate<'a> {
+    vibe: VibeMeta<'a>,
+    nodes: Vec<NodeSpec<'a>>,
+}
+
+/// Execute `mofa vibe flow`
+pub fn run_flow(
+    llm: Option<&str>,
+    output: Option<&Path>,
+    requirement: Option<&str>,
+) -> Result<(), CliError> {
+    let model = llm.unwrap_or(DEFAULT_MODEL);
+    let output_path = output.unwrap_or_else(|| Path::new(DEFAULT_OUTPUT));
+    let requirement = resolve_requirement(requirement)?;
+
+    println!(
+        "{} Generating vibe flow: {}",
+        "→".green(),
+        output_path.display()
+    );
+
+    let yaml = render_flow_yaml(&requirement, model)?;
+    std::fs::write(output_path, yaml).map_err(|err| {
+        CliError::Other(format!(
+            "failed to write generated flow to {}: {}",
+            output_path.display(),
+            err
+        ))
+    })?;
+
+    println!("{} Flow generated!", "✓".green());
+    println!("  Requirement: {}", requirement);
+    println!("  Model: {}", model);
+    println!("  Next: mofa dataflow {}", output_path.display());
+    Ok(())
+}
+
+fn resolve_requirement(requirement: Option<&str>) -> Result<String, CliError> {
+    let raw = if let Some(value) = requirement {
+        value.to_string()
+    } else {
+        Input::<String>::new()
+            .with_prompt("Describe the flow (what it should do)")
+            .interact_text()
+            .map_err(|err| CliError::Other(format!("failed to read requirement input: {}", err)))?
+    };
+
+    let normalized = raw.trim().to_string();
+    if normalized.is_empty() {
+        return Err(CliError::Other("requirement cannot be empty".to_string()));
+    }
+    Ok(normalized)
+}
+
+fn render_flow_yaml(requirement: &str, model: &str) -> Result<String, CliError> {
+    let mut source_inputs = std::collections::BTreeMap::new();
+    source_inputs.insert("task_input", "source/output");
+
+    let mut worker_inputs = std::collections::BTreeMap::new();
+    worker_inputs.insert("task_input", "agent-1/task_output");
+
+    let template = FlowTemplate {
+        vibe: VibeMeta { model, requirement },
+        nodes: vec![
+            NodeSpec {
+                id: "agent-1",
+                operator: OperatorSpec {
+                    python: "agents/agent.py",
+                },
+                inputs: source_inputs,
+                outputs: vec!["task_output"],
+            },
+            NodeSpec {
+                id: "agent-2",
+                operator: OperatorSpec {
+                    python: "agents/worker.py",
+                },
+                inputs: worker_inputs,
+                outputs: vec!["result"],
+            },
+        ],
+    };
+
+    serde_yaml::to_string(&template)
+        .map_err(|err| CliError::Other(format!("failed to serialize flow template: {}", err)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn render_flow_yaml_includes_metadata() {
+        let yaml = render_flow_yaml("Build a translation pipeline", "gpt-4o-mini").unwrap();
+        assert!(yaml.contains("requirement: Build a translation pipeline"));
+        assert!(yaml.contains("model: gpt-4o-mini"));
+        assert!(yaml.contains("id: agent-1"));
+        assert!(yaml.contains("id: agent-2"));
+    }
+
+    #[test]
+    fn run_flow_writes_yaml_to_output_file() {
+        let dir = tempdir().unwrap();
+        let output = dir.path().join("vibe-flow.yml");
+
+        run_flow(
+            Some("gpt-4o-mini"),
+            Some(&output),
+            Some("Summarize and classify user messages"),
+        )
+        .unwrap();
+
+        let content = std::fs::read_to_string(output).unwrap();
+        assert!(content.contains("Summarize and classify user messages"));
+        assert!(content.contains("vibe:"));
+        assert!(content.contains("nodes:"));
+    }
+
+    #[test]
+    fn run_flow_rejects_empty_requirement() {
+        let dir = tempdir().unwrap();
+        let output = dir.path().join("vibe-flow.yml");
+
+        let err = run_flow(Some("gpt-4o-mini"), Some(&output), Some("   ")).unwrap_err();
+        assert!(err.to_string().contains("requirement cannot be empty"));
+    }
+}

--- a/crates/mofa-cli/src/commands/vibe.rs
+++ b/crates/mofa-cli/src/commands/vibe.rs
@@ -1,57 +1,73 @@
-//! `mofa vibe` command implementation
+//! `mofa vibe` command implementation.
 
 use crate::CliError;
-use colored::Colorize;
-use dialoguer::Input;
-use serde::Serialize;
-use std::path::Path;
+use dialoguer::{Input, Select};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
 
 const DEFAULT_MODEL: &str = "gpt-4o-mini";
-const DEFAULT_OUTPUT: &str = "dataflow.yml";
+const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
+const DEFAULT_FLOW_OUTPUT: &str = "dataflow.yml";
+const DEFAULT_AGENT_OUTPUT: &str = "agents/generated-agent";
 
-#[derive(Serialize)]
-struct VibeMeta<'a> {
-    model: &'a str,
-    requirement: &'a str,
+#[derive(Debug, Serialize)]
+struct ChatRequest {
+    model: String,
+    messages: Vec<ChatMessage>,
+    temperature: f32,
 }
 
-#[derive(Serialize)]
-struct OperatorSpec<'a> {
-    python: &'a str,
+#[derive(Debug, Serialize)]
+struct ChatMessage {
+    role: String,
+    content: String,
 }
 
-#[derive(Serialize)]
-struct NodeSpec<'a> {
-    id: &'a str,
-    operator: OperatorSpec<'a>,
-    inputs: std::collections::BTreeMap<&'a str, &'a str>,
-    outputs: Vec<&'a str>,
+#[derive(Debug, Deserialize)]
+struct ChatResponse {
+    choices: Vec<ChatChoice>,
 }
 
-#[derive(Serialize)]
-struct FlowTemplate<'a> {
-    vibe: VibeMeta<'a>,
-    nodes: Vec<NodeSpec<'a>>,
+#[derive(Debug, Deserialize)]
+struct ChatChoice {
+    message: ChatChoiceMessage,
 }
 
-/// Execute `mofa vibe flow`
-pub fn run_flow(
+#[derive(Debug, Deserialize)]
+struct ChatChoiceMessage {
+    content: String,
+}
+
+pub async fn run_tui() -> Result<(), CliError> {
+    let selection = Select::new()
+        .with_prompt("MoFA Vibe")
+        .items(&["Generate flow", "Generate agent", "Quit"])
+        .default(0)
+        .interact()
+        .map_err(CliError::from)?;
+
+    match selection {
+        0 => run_flow(None, None, None).await,
+        1 => run_agent(None, None, None, None, None).await,
+        _ => Ok(()),
+    }
+}
+
+pub async fn run_flow(
     llm: Option<&str>,
     output: Option<&Path>,
     requirement: Option<&str>,
 ) -> Result<(), CliError> {
     let model = llm.unwrap_or(DEFAULT_MODEL);
-    let output_path = output.unwrap_or_else(|| Path::new(DEFAULT_OUTPUT));
-    let requirement = resolve_requirement(requirement)?;
+    let output_path = output.unwrap_or_else(|| Path::new(DEFAULT_FLOW_OUTPUT));
+    let requirement = resolve_requirement(requirement, "Describe the flow (what it should do)")?;
 
-    println!(
-        "{} Generating vibe flow: {}",
-        "→".green(),
-        output_path.display()
-    );
+    println!("Generating vibe flow: {}", output_path.display());
+    let prompt = build_flow_prompt(&requirement);
+    let generated = generate_via_llm(model, &prompt).await?;
+    validate_flow_output(&generated)?;
 
-    let yaml = render_flow_yaml(&requirement, model)?;
-    std::fs::write(output_path, yaml).map_err(|err| {
+    std::fs::write(output_path, generated).map_err(|err| {
         CliError::Other(format!(
             "failed to write generated flow to {}: {}",
             output_path.display(),
@@ -59,21 +75,59 @@ pub fn run_flow(
         ))
     })?;
 
-    println!("{} Flow generated!", "✓".green());
-    println!("  Requirement: {}", requirement);
-    println!("  Model: {}", model);
-    println!("  Next: mofa dataflow {}", output_path.display());
+    println!("Flow generated at {}", output_path.display());
     Ok(())
 }
 
-fn resolve_requirement(requirement: Option<&str>) -> Result<String, CliError> {
+pub async fn run_agent(
+    llm: Option<&str>,
+    max_rounds: Option<u32>,
+    output: Option<&Path>,
+    base: Option<&Path>,
+    requirement: Option<&str>,
+) -> Result<(), CliError> {
+    let model = llm.unwrap_or(DEFAULT_MODEL);
+    let output_dir = output
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_AGENT_OUTPUT));
+    let requirement = resolve_requirement(requirement, "Describe the agent (what it should do)")?;
+
+    println!("Generating vibe agent: {}", output_dir.display());
+    let prompt = build_agent_prompt(
+        &requirement,
+        max_rounds,
+        base.map(|path| path.display().to_string()),
+    );
+    let generated = generate_via_llm(model, &prompt).await?;
+
+    std::fs::create_dir_all(&output_dir).map_err(|err| {
+        CliError::Other(format!(
+            "failed to create output directory {}: {}",
+            output_dir.display(),
+            err
+        ))
+    })?;
+    let main_py = output_dir.join("main.py");
+    std::fs::write(&main_py, generated).map_err(|err| {
+        CliError::Other(format!(
+            "failed to write generated agent to {}: {}",
+            main_py.display(),
+            err
+        ))
+    })?;
+
+    println!("Agent generated at {}", output_dir.display());
+    Ok(())
+}
+
+fn resolve_requirement(requirement: Option<&str>, prompt: &str) -> Result<String, CliError> {
     let raw = if let Some(value) = requirement {
         value.to_string()
     } else {
         Input::<String>::new()
-            .with_prompt("Describe the flow (what it should do)")
+            .with_prompt(prompt)
             .interact_text()
-            .map_err(|err| CliError::Other(format!("failed to read requirement input: {}", err)))?
+            .map_err(CliError::from)?
     };
 
     let normalized = raw.trim().to_string();
@@ -83,77 +137,134 @@ fn resolve_requirement(requirement: Option<&str>) -> Result<String, CliError> {
     Ok(normalized)
 }
 
-fn render_flow_yaml(requirement: &str, model: &str) -> Result<String, CliError> {
-    let mut source_inputs = std::collections::BTreeMap::new();
-    source_inputs.insert("task_input", "source/output");
+fn build_flow_prompt(requirement: &str) -> String {
+    format!(
+        "Generate a MoFA dataflow YAML for this requirement:\n{requirement}\n\
+Return only YAML. The YAML must contain `nodes`, use realistic MoFA operators, \
+and reflect the requirement rather than a generic scaffold."
+    )
+}
 
-    let mut worker_inputs = std::collections::BTreeMap::new();
-    worker_inputs.insert("task_input", "agent-1/task_output");
+fn build_agent_prompt(
+    requirement: &str,
+    max_rounds: Option<u32>,
+    base_path: Option<String>,
+) -> String {
+    let mut prompt = format!(
+        "Generate a Python MoFA agent implementation for this requirement:\n{requirement}\n\
+Return only Python source code for `main.py`."
+    );
 
-    let template = FlowTemplate {
-        vibe: VibeMeta { model, requirement },
-        nodes: vec![
-            NodeSpec {
-                id: "agent-1",
-                operator: OperatorSpec {
-                    python: "agents/agent.py",
-                },
-                inputs: source_inputs,
-                outputs: vec!["task_output"],
+    if let Some(rounds) = max_rounds {
+        prompt.push_str(&format!("\nMaximum optimization rounds hint: {rounds}."));
+    }
+    if let Some(base) = base_path {
+        prompt.push_str(&format!(
+            "\nBase the result on this existing agent path when relevant: {base}."
+        ));
+    }
+
+    prompt
+}
+
+fn validate_flow_output(output: &str) -> Result<(), CliError> {
+    if !output.contains("nodes:") {
+        return Err(CliError::Other(
+            "LLM output does not look like a MoFA flow YAML (`nodes:` missing)".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+async fn generate_via_llm(model: &str, prompt: &str) -> Result<String, CliError> {
+    let api_key = std::env::var("OPENAI_API_KEY").map_err(|_| {
+        CliError::Other("OPENAI_API_KEY is required for `mofa vibe` commands".to_string())
+    })?;
+    let base_url =
+        std::env::var("OPENAI_BASE_URL").unwrap_or_else(|_| DEFAULT_OPENAI_BASE_URL.to_string());
+    let endpoint = format!("{}/chat/completions", base_url.trim_end_matches('/'));
+
+    let request = ChatRequest {
+        model: model.to_string(),
+        messages: vec![
+            ChatMessage {
+                role: "system".to_string(),
+                content: "You generate MoFA artifacts. Return only the requested artifact with no markdown fencing.".to_string(),
             },
-            NodeSpec {
-                id: "agent-2",
-                operator: OperatorSpec {
-                    python: "agents/worker.py",
-                },
-                inputs: worker_inputs,
-                outputs: vec!["result"],
+            ChatMessage {
+                role: "user".to_string(),
+                content: prompt.to_string(),
             },
         ],
+        temperature: 0.2,
     };
 
-    serde_yaml::to_string(&template)
-        .map_err(|err| CliError::Other(format!("failed to serialize flow template: {}", err)))
+    let response = reqwest::Client::new()
+        .post(endpoint)
+        .bearer_auth(api_key)
+        .json(&request)
+        .send()
+        .await
+        .map_err(|err| CliError::ApiError(format!("OpenAI request failed: {err}")))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "<unreadable response body>".to_string());
+        return Err(CliError::ApiError(format!(
+            "OpenAI API error {status}: {body}"
+        )));
+    }
+
+    let parsed: ChatResponse = response
+        .json()
+        .await
+        .map_err(|err| CliError::ApiError(format!("failed to parse OpenAI response: {err}")))?;
+
+    parsed
+        .choices
+        .into_iter()
+        .next()
+        .map(|choice| choice.message.content.trim().to_string())
+        .filter(|content| !content.is_empty())
+        .ok_or_else(|| CliError::ApiError("OpenAI response had no generated content".to_string()))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::tempdir;
 
     #[test]
-    fn render_flow_yaml_includes_metadata() {
-        let yaml = render_flow_yaml("Build a translation pipeline", "gpt-4o-mini").unwrap();
-        assert!(yaml.contains("requirement: Build a translation pipeline"));
-        assert!(yaml.contains("model: gpt-4o-mini"));
-        assert!(yaml.contains("id: agent-1"));
-        assert!(yaml.contains("id: agent-2"));
+    fn build_flow_prompt_includes_requirement_and_yaml_contract() {
+        let prompt = build_flow_prompt("build a multilingual translation workflow");
+        assert!(prompt.contains("multilingual translation workflow"));
+        assert!(prompt.contains("Return only YAML"));
+        assert!(prompt.contains("reflect the requirement"));
     }
 
     #[test]
-    fn run_flow_writes_yaml_to_output_file() {
-        let dir = tempdir().unwrap();
-        let output = dir.path().join("vibe-flow.yml");
-
-        run_flow(
-            Some("gpt-4o-mini"),
-            Some(&output),
-            Some("Summarize and classify user messages"),
-        )
-        .unwrap();
-
-        let content = std::fs::read_to_string(output).unwrap();
-        assert!(content.contains("Summarize and classify user messages"));
-        assert!(content.contains("vibe:"));
-        assert!(content.contains("nodes:"));
+    fn build_agent_prompt_includes_requirement_and_options() {
+        let prompt = build_agent_prompt(
+            "build a support triage agent",
+            Some(4),
+            Some("agents/base-agent".to_string()),
+        );
+        assert!(prompt.contains("support triage agent"));
+        assert!(prompt.contains("Maximum optimization rounds hint: 4"));
+        assert!(prompt.contains("agents/base-agent"));
     }
 
     #[test]
-    fn run_flow_rejects_empty_requirement() {
-        let dir = tempdir().unwrap();
-        let output = dir.path().join("vibe-flow.yml");
+    fn validate_flow_output_rejects_non_flow_content() {
+        let err = validate_flow_output("name: not-a-flow").unwrap_err();
+        assert!(err.to_string().contains("nodes:` missing"));
+    }
 
-        let err = run_flow(Some("gpt-4o-mini"), Some(&output), Some("   ")).unwrap_err();
+    #[test]
+    fn resolve_requirement_rejects_empty_input() {
+        let err = resolve_requirement(Some("  "), "ignored").unwrap_err();
         assert!(err.to_string().contains("requirement cannot be empty"));
     }
 }

--- a/crates/mofa-cli/src/main.rs
+++ b/crates/mofa-cli/src/main.rs
@@ -3,9 +3,9 @@
 mod cli;
 mod commands;
 mod config;
-mod plugin_catalog;
 mod context;
 mod output;
+mod plugin_catalog;
 mod render;
 mod state;
 mod store;
@@ -106,7 +106,9 @@ async fn run_command(cli: Cli) -> CliResult<()> {
         }) => {
             commands::new::run(&name, &template, output.as_deref())
                 .into_report()
-                .attach_with(|| format!("scaffolding project '{name}' with template '{template}'"))?;
+                .attach_with(|| {
+                    format!("scaffolding project '{name}' with template '{template}'")
+                })?;
         }
 
         Some(Commands::Init { path }) => {
@@ -275,13 +277,8 @@ async fn run_command(cli: Cli) -> CliResult<()> {
                         url,
                         description,
                     } => {
-                        commands::plugin::repository::add(
-                            ctx,
-                            &id,
-                            &url,
-                            description.as_deref(),
-                        )
-                        .await?;
+                        commands::plugin::repository::add(ctx, &id, &url, description.as_deref())
+                            .await?;
                     }
                 },
             }
@@ -382,16 +379,39 @@ async fn run_command(cli: Cli) -> CliResult<()> {
         },
 
         Some(Commands::Vibe { action }) => match action {
-            cli::VibeCommands::Flow {
+            None => {
+                commands::vibe::run_tui()
+                    .await
+                    .into_report()
+                    .attach("running interactive vibe mode")?;
+            }
+            Some(cli::VibeCommands::Flow {
                 llm,
                 output,
                 requirement,
-            } => {
-                commands::vibe::run_flow(
+            }) => {
+                commands::vibe::run_flow(llm.as_deref(), output.as_deref(), requirement.as_deref())
+                    .await
+                    .into_report()
+                    .attach("running vibe flow generation")?;
+            }
+            Some(cli::VibeCommands::Agent {
+                llm,
+                max_rounds,
+                output,
+                base,
+                requirement,
+            }) => {
+                commands::vibe::run_agent(
                     llm.as_deref(),
+                    max_rounds,
                     output.as_deref(),
+                    base.as_deref(),
                     requirement.as_deref(),
-                )?;
+                )
+                .await
+                .into_report()
+                .attach("running vibe agent generation")?;
             }
         },
 
@@ -439,6 +459,8 @@ fn normalize_legacy_output_flags(args: &mut [String]) {
         // normalisation for those subcommands.  All other `session` subcommands (e.g. `list`)
         // use the global output-format flag and should be normalised.
         Some("session") => !matches!(sub_command, Some("show") | Some("export")),
+        // `vibe` uses local file/directory outputs, not global output-format values.
+        Some("vibe") => false,
         _ => false,
     };
 
@@ -667,5 +689,30 @@ mod tests {
         ];
         normalize_legacy_output_flags(&mut args);
         assert_eq!(args[4], "-o=json");
+    }
+
+    #[test]
+    fn test_do_not_normalize_vibe_short_output_path() {
+        let mut args = vec![
+            "mofa".to_string(),
+            "vibe".to_string(),
+            "flow".to_string(),
+            "-o".to_string(),
+            "generated.yml".to_string(),
+        ];
+        normalize_legacy_output_flags(&mut args);
+        assert_eq!(args[3], "-o");
+    }
+
+    #[test]
+    fn test_do_not_normalize_vibe_equals_output_path() {
+        let mut args = vec![
+            "mofa".to_string(),
+            "vibe".to_string(),
+            "flow".to_string(),
+            "--output=json".to_string(),
+        ];
+        normalize_legacy_output_flags(&mut args);
+        assert_eq!(args[3], "--output=json");
     }
 }

--- a/crates/mofa-cli/src/main.rs
+++ b/crates/mofa-cli/src/main.rs
@@ -381,6 +381,20 @@ async fn run_command(cli: Cli) -> CliResult<()> {
             }
         },
 
+        Some(Commands::Vibe { action }) => match action {
+            cli::VibeCommands::Flow {
+                llm,
+                output,
+                requirement,
+            } => {
+                commands::vibe::run_flow(
+                    llm.as_deref(),
+                    output.as_deref(),
+                    requirement.as_deref(),
+                )?;
+            }
+        },
+
         None => {
             // Should have been handled by TUI check above
             // If we get here, show help
@@ -398,7 +412,7 @@ async fn run_command(cli: Cli) -> CliResult<()> {
 fn normalize_legacy_output_flags(args: &mut [String]) {
     const TOP_LEVEL_COMMANDS: &[&str] = &[
         "new", "init", "build", "run", "dataflow", "generate", "info", "db", "agent", "config",
-        "plugin", "session", "tool", "rag",
+        "plugin", "session", "tool", "rag", "vibe",
     ];
 
     let top_command_index = args


### PR DESCRIPTION
## 📋 Summary

Add a Rust CLI `mofa vibe flow` command in `crates/mofa-cli` to provide parity with the existing Python-side `mofa vibe flow` entrypoint.

## 🔗 Related Issues

Closes #809

Related to #341

---

## 🧠 Context

Python CLI already provides `mofa vibe flow` in `mofa/commands/vibe.py`, but Rust CLI currently has no equivalent command.

This PR is intentionally scoped to Rust CLI parity for `vibe flow`, not full Python vibe-engine reimplementation.

---

## 🛠️ Changes

- Added `Vibe` subcommand in `crates/mofa-cli/src/cli.rs`
- Implemented `Flow` handler in `crates/mofa-cli/src/commands/vibe.rs`
- Wired dispatch in `crates/mofa-cli/src/main.rs`
- Added regression tests for:
  - requirement-driven flow generation behavior
  - file output generation
  - empty requirement validation

---

## 🧪 How I Tested

1. `cargo fmt --all`
2. `cargo test -p mofa-cli -- --nocapture`

---

## ⚠️ Scope Notes

- This PR targets Rust CLI parity for `mofa vibe flow`.
- It does not claim full parity with the broader Python `vibe` surface.

---

## ⚠️ Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (describe below)
