### PR TITLE
feat: added compile smoke tests for examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Build examples
         run: cargo build --examples
 
+      - name: Run targeted examples compile smoke tests
+        run: cargo test --manifest-path examples/cli_production_smoke/Cargo.toml --test examples_compile
+
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/examples/cli_production_smoke/src/lib.rs
+++ b/examples/cli_production_smoke/src/lib.rs
@@ -8,6 +8,7 @@ use tempfile::TempDir;
 
 pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
+#[allow(unused_macros)]
 macro_rules! bail {
     ($($arg:tt)*) => {
         return Err(format!($($arg)*).into())

--- a/examples/cli_production_smoke/tests/examples_compile.rs
+++ b/examples/cli_production_smoke/tests/examples_compile.rs
@@ -1,0 +1,47 @@
+#![allow(missing_docs)]
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .canonicalize()
+        .expect("resolve workspace root")
+}
+
+fn cargo_check_example(example: &str) {
+    let root = workspace_root();
+    let manifest = root.join("examples").join(example).join("Cargo.toml");
+
+    let out = Command::new("cargo")
+        .arg("check")
+        .arg("--manifest-path")
+        .arg(&manifest)
+        .current_dir(&root)
+        .output()
+        .expect("run cargo check");
+
+    assert!(
+        out.status.success(),
+        "cargo check failed for {example}\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn workflow_dsl_compiles() {
+    cargo_check_example("workflow_dsl");
+}
+
+#[test]
+fn financial_compliance_agent_compiles() {
+    cargo_check_example("financial_compliance_agent");
+}
+
+#[test]
+fn tool_routing_compiles() {
+    cargo_check_example("tool_routing");
+}


### PR DESCRIPTION
## 📋 Summary

This PR adds compile-level smoke tests for selected example projects to prevent silent regressions.

## 🔗 Related Issues

Closes #773 

## 🧠 Context

The existing `cli_production_smoke` suite validates CLI lifecycle behavior but does not compile any example crates.

## 🛠️ Changes

Added compile smoke tests: `examples/cli_production_smoke/tests/examples_compile.rs`

In lib.rs: added 
```rs
#[allow(unused_macros)]
```
to prevent any warnings

and added this in ci.yml:

```rs
  name: Run targeted examples compile smoke tests
  run: cargo test --manifest-path examples/cli_production_smoke/Cargo.toml --test examples_compile
```
---

## 🧪 How you Tested

```
cargo check --manifest-path examples/cli_production_smoke/Cargo.toml
```
```
cargo test --manifest-path examples/cli_production_smoke/Cargo.toml
```
All tests are running successfully

## 📸 Screenshots / Logs (if applicable)

<img width="1324" height="261" alt="image" src="https://github.com/user-attachments/assets/bda508e3-1d96-4ca1-8781-643c523074e9" />

---

## ⚠️ Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (describe below)


## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [ ] Public APIs documented
- [ ] README / docs updated (if needed)

### PR Hygiene
- [ ] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---
