### PR TITLE
fix(qdrant): delete returns false when point does not exist

### DIFF
--- a/crates/mofa-foundation/src/rag/qdrant_store.rs
+++ b/crates/mofa-foundation/src/rag/qdrant_store.rs
@@ -8,8 +8,8 @@ use mofa_kernel::agent::error::{AgentError, AgentResult};
 use mofa_kernel::rag::{DocumentChunk, SearchResult, SimilarityMetric, VectorStore};
 use qdrant_client::Qdrant;
 use qdrant_client::qdrant::{
-    CountPointsBuilder, CreateCollectionBuilder, DeletePointsBuilder, Distance, PointStruct,
-    PointsIdsList, QueryPointsBuilder, UpsertPointsBuilder, VectorParamsBuilder,
+    CountPointsBuilder, CreateCollectionBuilder, DeletePointsBuilder, Distance, GetPointsBuilder,
+    PointStruct, PointsIdsList, QueryPointsBuilder, UpsertPointsBuilder, VectorParamsBuilder,
 };
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
@@ -270,6 +270,22 @@ impl VectorStore for QdrantVectorStore {
 
     async fn delete(&mut self, id: &str) -> AgentResult<bool> {
         let point_id = string_id_to_u64(id);
+
+        // Check if the point exists before attempting deletion.
+        let existing = self
+            .client
+            .get_points(
+                GetPointsBuilder::new(&self.collection_name, vec![point_id.into()])
+                    .with_payload(false)
+                    .with_vectors(false),
+            )
+            .await
+            .map_err(|e| AgentError::Internal(format!("Qdrant get_points failed: {e}")))?;
+
+        if existing.result.is_empty() {
+            return Ok(false);
+        }
+
         self.client
             .delete_points(
                 DeletePointsBuilder::new(&self.collection_name)


### PR DESCRIPTION
## Problem

`QdrantVectorStore::delete` always returned `true` regardless of whether the point actually existed in the collection. Qdrant's `delete_points` API is a no-op for non-existent IDs and does not return an error, so there was no signal to the caller that the delete was a no-op.

Flagged in community review of #249.

## Fix

Before issuing the delete, call `get_points` to check if the point exists. Return `false` if it does not, and proceed with deletion returning `true` only if the point was actually present.

The existence check uses `with_payload(false)` and `with_vectors(false)` to minimise data transfer since we only need to know if the point is there.

## Changes

`crates/mofa-foundation/src/rag/qdrant_store.rs`: added existence check in `delete`, import `GetPointsBuilder`