### PR TITLE
fix: enabled proper JSON5 parsing and added regression tests

### DIFF
--- a/crates/mofa-cli/Cargo.toml
+++ b/crates/mofa-cli/Cargo.toml
@@ -41,6 +41,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = "0.9"
 toml = "0.8"
+json5 = "0.4"
 
 
 # Utilities

--- a/crates/mofa-cli/src/commands/config_cmd.rs
+++ b/crates/mofa-cli/src/commands/config_cmd.rs
@@ -210,8 +210,7 @@ fn validate_config_file(path: &PathBuf) -> Result<(), CliError> {
                 "json" => serde_json::from_str::<Value>(&substituted)
                     .map_err(|e| CliError::ConfigError(format!("JSON parsing error: {}", e))),
                 "json5" => {
-                    // Try to parse as JSON5 (fall back to JSON for validation)
-                    serde_json::from_str::<Value>(&substituted)
+                    json5::from_str::<Value>(&substituted)
                         .map_err(|e| CliError::ConfigError(format!("JSON5 parsing error: {}", e)))
                 }
                 "ini" => {
@@ -234,10 +233,10 @@ fn validate_config_file(path: &PathBuf) -> Result<(), CliError> {
         }
     };
 
+    let config = result?;
+
     // Validate required fields
-    if let Ok(config) = result
-        && let Some(obj) = config.as_object()
-    {
+    if let Some(obj) = config.as_object() {
         // Check for agent section
         if !obj.contains_key("agent") {
             return Err(CliError::ConfigError("Missing required 'agent' section".into()));
@@ -255,4 +254,92 @@ fn validate_config_file(path: &PathBuf) -> Result<(), CliError> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+        use super::validate_config_file;
+        use crate::CliError;
+        use std::fs;
+        use std::path::PathBuf;
+        use tempfile::TempDir;
+
+        fn write_temp_json5(content: &str) -> (TempDir, PathBuf) {
+                let dir = TempDir::new().expect("create temp dir");
+                let path = dir.path().join("agent.json5");
+                fs::write(&path, content).expect("write json5 file");
+                (dir, path)
+        }
+
+        #[test]
+        fn accepts_json5_comments() {
+                let json5 = r#"
+                {
+                    // comment
+                    agent: {
+                        id: "agent-1",
+                        name: "Agent One"
+                    }
+                }
+                "#;
+
+                let (_dir, path) = write_temp_json5(json5);
+                let result = validate_config_file(&path);
+
+                assert!(result.is_ok(), "expected JSON5 with comments to be valid");
+        }
+
+        #[test]
+        fn accepts_json5_trailing_commas() {
+                let json5 = r#"
+                {
+                    agent: {
+                        id: "agent-1",
+                        name: "Agent One",
+                    },
+                }
+                "#;
+
+                let (_dir, path) = write_temp_json5(json5);
+                let result = validate_config_file(&path);
+
+                assert!(result.is_ok(), "expected JSON5 with trailing commas to be valid");
+        }
+
+        #[test]
+        fn accepts_json5_unquoted_keys() {
+                let json5 = r#"
+                {
+                    agent: {
+                        id: "agent-1",
+                        name: "Agent One"
+                    }
+                }
+                "#;
+
+                let (_dir, path) = write_temp_json5(json5);
+                let result = validate_config_file(&path);
+
+                assert!(result.is_ok(), "expected JSON5 with unquoted keys to be valid");
+        }
+
+        #[test]
+        fn rejects_invalid_json5() {
+                let invalid = r#"
+                {
+                    agent: {
+                        id: "agent-1",
+                        name: "Agent One,
+                    }
+                }
+                "#;
+
+                let (_dir, path) = write_temp_json5(invalid);
+                let result = validate_config_file(&path);
+
+                match result {
+                        Err(CliError::ConfigError(_)) => {}
+                        other => panic!("expected ConfigError, got: {:?}", other),
+                }
+        }
 }


### PR DESCRIPTION
## 📋 Summary

Fixes the issue where .json5 configuration files were parsed using serde_json, causing valid JSON5 syntax to fail validation.

This PR switches the "json5" branch to use the json5 crate and adds regression tests to ensure JSON5-specific syntax is correctly supported going forward.

## 🔗 Related Issues

Closes #818 

---

## 🧠 Context

The CLI supports multiple configuration formats, including JSON5. However, the "json5" match arm was using:
```
serde_json::from_str::<Value>(...)
```
Since `serde_json` only accepts strict JSON, valid JSON5 features such as: comments,trailing commas, unquoted keys were rejected during validation.

---

## 🛠️ Changes

- Added json5 dependency to `mofa-cli/Cargo.toml`.
- Updated the "json5" parser branch in `config_cmd.rs` to:
```
"json5" => {
    json5::from_str::<Value>(&substituted)
        .map_err(|e| CliError::ConfigError(format!("JSON5 parsing error: {}", e)))
}
```

Added new tests in `config_cmd.rs` to cover:

- Acceptance of JSON5 comments
- Acceptance of trailing commas
- Acceptance of unquoted keys
- Rejection of structurally invalid JSON5

---

## 🧪 How you Tested
```
cargo test -p mofa-cli config_cmd::tests -- --nocapture
```
---

## 📸 Screenshots / Logs (if applicable)

<img width="1398" height="435" alt="image" src="https://github.com/user-attachments/assets/bb3af89a-acd9-47da-9ada-947499bb177a" />

---

## ⚠️ Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (describe below)

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [ ] Public APIs documented
- [ ] README / docs updated (if needed)

### PR Hygiene
- [ ] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [ ] Commit messages explain **why**, not only **what**

---
