### PR TITLE
fix: restore backward compatibility for legacy agent metadata without last_state

### DIFF
--- a/crates/mofa-cli/src/state/agent_state.rs
+++ b/crates/mofa-cli/src/state/agent_state.rs
@@ -14,9 +14,10 @@ use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 
 /// Agent runtime state (in-memory process tracking)
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum AgentProcessState {
     /// Agent is not running
+    #[default]
     Stopped,
     /// Agent is starting up
     Starting,
@@ -52,6 +53,7 @@ pub struct AgentMetadata {
     /// Path to agent configuration file
     pub config_path: Option<PathBuf>,
     /// Last known state
+    #[serde(default)]
     pub last_state: AgentProcessState,
     /// Timestamp when agent was registered (ms since epoch)
     pub registered_at: u64,
@@ -324,6 +326,26 @@ impl PersistentAgentRegistry {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn test_legacy_metadata_without_last_state_deserializes() {
+        let legacy = r#"{
+            "id": "agent-legacy",
+            "name": "Legacy Agent",
+            "description": null,
+            "config_path": null,
+            "registered_at": 1710000000000,
+            "last_started": null,
+            "last_stopped": null,
+            "process_id": null,
+            "start_count": 0,
+            "tags": []
+        }"#;
+
+        let metadata: AgentMetadata = serde_json::from_str(legacy).expect("legacy metadata should deserialize");
+        assert_eq!(metadata.last_state, AgentProcessState::Stopped);
+        assert_eq!(metadata.id, "agent-legacy");
+    }
 
     #[tokio::test]
     async fn test_agent_metadata_lifecycle() {


### PR DESCRIPTION
## 📋 Summary

Restores backward compatibility when deserializing persisted AgentMetadata that was created before the last_state field was introduced.

Older metadata files missing last_state currently fail to deserialize. This PR adds a safe default to prevent deserialization errors and unstable runtime behavior.

## 🔗 Related Issues

Closes #821 

---

## 🧠 Context

`AgentMetadata` includes a required `last_state: AgentProcessState `field.
Because this field Is not optional and does not use `#[serde(default)]`, deserialization expects it to always be present in the stored JSON.

Metadata files created before last_state was added do not include this field. As a result, loading legacy metadata can fail during deserialization, produce parse warnings, and cause unstable startup behavior.

---

## 🛠️ Changes

1. Added `default` implementation to `AgentProcessState`
2. Added `#[serde(default)]` to last_state
3. Added a regression test that deserializes a legacy metadata JSON without `last_state` and verifies it defaults to `Stopped`.

---

## 🧪 How you Tested

```
cargo test -p mofa-cli agent_state -- --nocapture
```

---

## 📸 Screenshots / Logs (if applicable)

<img width="1279" height="436" alt="image" src="https://github.com/user-attachments/assets/ead23600-c71a-4c57-a821-4a24a066b2e0" />

---

## ⚠️ Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (describe below)

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [ ] Public APIs documented
- [ ] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---