### PR TITLE
chore(workspace): add MSRV 1.85 to workspace Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ version = "0.1.0"
 edition = "2024"
 authors = ["MoFA Contributors <contributors@mofa.org>"]
 license = "Apache-2.0"
+rust-version = "1.85"
 repository = "https://github.com/mofa-org/mofa"
 homepage = "https://github.com/mofa-org/mofa"
 


### PR DESCRIPTION
## Summary
Add Minimum Supported Rust Version (MSRV) to workspace Cargo.toml.

## Motivation
Fixes #611 — MSRV was documented in CONTRIBUTING.md (Rust 1.85+ required
for edition 2024) but not declared in Cargo.toml, meaning cargo could not
enforce it automatically.

## Changes
- `Cargo.toml`: Added `rust-version = "1.85"` to `[workspace.package]`

## Testing
Documentation/config change only. Verify with `cargo check`.

## Checklist
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy --workspace --all-features -- -D errors` passes
- [ ] `cargo test --workspace --all-features` passes
- [ ] `cargo build --examples` succeeds
- [ ] `cargo doc --workspace --no-deps --all-features` succeeds
- [ ] Architecture layer rules respected
- [ ] Relevant documentation updated