### PR TITLE
chore(ci): enforce cargo fmt --check in CI lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-lint-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Check formatting
+        run: cargo fmt --check
       - name: Run clippy (fail fast on errors)
         run: cargo clippy --workspace --all-features -- -D errors
 


### PR DESCRIPTION
## Summary
Enforce `cargo fmt --check` in the CI lint job.

## Motivation
Fixes #609 — formatting drift was going undetected because `cargo fmt --check`
was not part of CI. Code could be merged with inconsistent formatting.

## Changes
- `.github/workflows/ci.yml`: Added `cargo fmt --check` step to the lint job,
  running before clippy so formatting issues fail fast.

## Testing
CI-only change. Will be verified on the next PR that runs the workflow.

## Checklist
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy --workspace --all-features -- -D errors` passes
- [ ] `cargo test --workspace --all-features` passes
- [ ] `cargo build --examples` succeeds
- [ ] `cargo doc --workspace --no-deps --all-features` succeeds
- [ ] Architecture layer rules respected
- [ ] Relevant documentation updated