### PR TITLE
refactor(inference): unify duplicate AdmissionOutcome enums (fixes #863)

### DIFF
--- a/crates/mofa-foundation/src/inference/orchestrator.rs
+++ b/crates/mofa-foundation/src/inference/orchestrator.rs
@@ -208,7 +208,7 @@ impl InferenceOrchestrator {
     /// # Priority semantics
     ///
     /// - `Low` / `Normal`: standard dual-threshold hysteresis — may return
-    ///   [`AdmissionOutcome::Deferred`] when usage is in the `[defer, reject)` band.
+    ///   [`AdmissionOutcome::Defer`] when usage is in the `[defer, reject)` band.
     /// - `High`: bypasses the Deferred band — admitted directly whenever usage
     ///   is at or below `reject_threshold` (skips the defer zone entirely).
     /// - `Critical`: same bypass as `High`; the caller (orchestrator) is
@@ -222,7 +222,7 @@ impl InferenceOrchestrator {
         let capacity = self.config.memory_capacity_mb;
 
         if capacity == 0 {
-            return AdmissionOutcome::Rejected;
+            return AdmissionOutcome::Reject;
         }
 
         let projected_usage = projected_mb as f64 / capacity as f64;
@@ -232,21 +232,21 @@ impl InferenceOrchestrator {
             // they are admitted whenever memory is below the reject ceiling.
             RequestPriority::High | RequestPriority::Critical => {
                 if projected_usage <= self.config.reject_threshold {
-                    AdmissionOutcome::Accepted
+                    AdmissionOutcome::Accept
                 } else {
-                    AdmissionOutcome::Rejected
+                    AdmissionOutcome::Reject
                 }
             }
             // Low and Normal use standard dual-threshold hysteresis.
             RequestPriority::Low | RequestPriority::Normal => {
                 if projected_usage <= self.config.defer_threshold {
-                    AdmissionOutcome::Accepted
+                    AdmissionOutcome::Accept
                 } else if projected_usage <= self.config.reject_threshold {
                     // Deferred: memory is tight but may be reclaimable via eviction.
                     // Phase 2 will add a queue-based scheduler with retry logic.
-                    AdmissionOutcome::Deferred
+                    AdmissionOutcome::Defer
                 } else {
-                    AdmissionOutcome::Rejected
+                    AdmissionOutcome::Reject
                 }
             }
         }

--- a/crates/mofa-foundation/src/inference/routing.rs
+++ b/crates/mofa-foundation/src/inference/routing.rs
@@ -39,17 +39,9 @@ pub enum RoutingDecision {
     Rejected { reason: String },
 }
 
-/// Represents the memory scheduler's admission outcome when evaluating
-/// whether a local backend can handle a request.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub enum AdmissionOutcome {
-    /// Request accepted — sufficient memory for local execution.
-    Accepted,
-    /// Request deferred — memory is tight, but may be reclaimable.
-    Deferred,
-    /// Request rejected — insufficient memory for local execution.
-    Rejected,
-}
+// `AdmissionOutcome` is the canonical type from `scheduler::admission`.
+// Re-exported here for convenience so callers don't need two imports.
+pub use crate::scheduler::admission::AdmissionOutcome;
 
 impl fmt::Display for RoutingPolicy {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -69,16 +61,6 @@ impl fmt::Display for RoutingDecision {
             Self::UseLocal { model_id } => write!(f, "local({})", model_id),
             Self::UseCloud { provider } => write!(f, "cloud({})", provider),
             Self::Rejected { reason } => write!(f, "rejected({})", reason),
-        }
-    }
-}
-
-impl fmt::Display for AdmissionOutcome {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Accepted => write!(f, "accepted"),
-            Self::Deferred => write!(f, "deferred"),
-            Self::Rejected => write!(f, "rejected"),
         }
     }
 }
@@ -124,16 +106,16 @@ pub fn resolve(
 /// LocalOnly: only use local backends; reject if admission fails.
 fn resolve_local_only(request: &InferenceRequest, admission: AdmissionOutcome) -> RoutingDecision {
     match admission {
-        AdmissionOutcome::Accepted => RoutingDecision::UseLocal {
+        AdmissionOutcome::Accept => RoutingDecision::UseLocal {
             model_id: request.model_id.clone(),
         },
-        AdmissionOutcome::Deferred => RoutingDecision::Rejected {
+        AdmissionOutcome::Defer => RoutingDecision::Rejected {
             reason: format!(
                 "Local admission deferred for '{}' and cloud fallback is disabled (LocalOnly policy)",
                 request.model_id
             ),
         },
-        AdmissionOutcome::Rejected => RoutingDecision::Rejected {
+        AdmissionOutcome::Reject => RoutingDecision::Rejected {
             reason: format!(
                 "Local admission rejected for '{}' ({}MB required) and cloud fallback is disabled (LocalOnly policy)",
                 request.model_id, request.required_memory_mb
@@ -149,10 +131,10 @@ fn resolve_local_first(
     cloud_provider: &str,
 ) -> RoutingDecision {
     match admission {
-        AdmissionOutcome::Accepted => RoutingDecision::UseLocal {
+        AdmissionOutcome::Accept => RoutingDecision::UseLocal {
             model_id: request.model_id.clone(),
         },
-        AdmissionOutcome::Deferred | AdmissionOutcome::Rejected => RoutingDecision::UseCloud {
+        AdmissionOutcome::Defer | AdmissionOutcome::Reject => RoutingDecision::UseCloud {
             provider: cloud_provider.to_string(),
         },
     }
@@ -167,7 +149,7 @@ fn resolve_latency_optimized(
     cloud_provider: &str,
 ) -> RoutingDecision {
     // If local hardware has GPU acceleration and memory is available, use local
-    if hardware.gpu_available && admission == AdmissionOutcome::Accepted {
+    if hardware.gpu_available && admission == AdmissionOutcome::Accept {
         return RoutingDecision::UseLocal {
             model_id: request.model_id.clone(),
         };
@@ -185,13 +167,13 @@ fn resolve_cost_optimized(
     cloud_provider: &str,
 ) -> RoutingDecision {
     match admission {
-        AdmissionOutcome::Accepted | AdmissionOutcome::Deferred => {
+        AdmissionOutcome::Accept | AdmissionOutcome::Defer => {
             // Even deferred requests are worth waiting for locally to save cost
             RoutingDecision::UseLocal {
                 model_id: request.model_id.clone(),
             }
         }
-        AdmissionOutcome::Rejected => {
+        AdmissionOutcome::Reject => {
             // Only use cloud as absolute last resort
             RoutingDecision::UseCloud {
                 provider: cloud_provider.to_string(),
@@ -225,7 +207,7 @@ mod tests {
         let decision = resolve(
             &RoutingPolicy::LocalOnly,
             &mock_request(),
-            AdmissionOutcome::Accepted,
+            AdmissionOutcome::Accept,
             &mock_hardware(),
             "openai",
         );
@@ -242,7 +224,7 @@ mod tests {
         let decision = resolve(
             &RoutingPolicy::LocalOnly,
             &mock_request(),
-            AdmissionOutcome::Rejected,
+            AdmissionOutcome::Reject,
             &mock_hardware(),
             "openai",
         );
@@ -254,7 +236,7 @@ mod tests {
         let decision = resolve(
             &RoutingPolicy::LocalOnly,
             &mock_request(),
-            AdmissionOutcome::Deferred,
+            AdmissionOutcome::Defer,
             &mock_hardware(),
             "openai",
         );
@@ -267,7 +249,7 @@ mod tests {
         let decision = resolve(
             &RoutingPolicy::CloudOnly,
             &mock_request(),
-            AdmissionOutcome::Accepted, // Even if local would accept
+            AdmissionOutcome::Accept, // Even if local would accept
             &mock_hardware(),
             "openai",
         );
@@ -284,7 +266,7 @@ mod tests {
         let decision = resolve(
             &RoutingPolicy::LocalFirstWithCloudFallback,
             &mock_request(),
-            AdmissionOutcome::Rejected,
+            AdmissionOutcome::Reject,
             &mock_hardware(),
             "openai",
         );
@@ -301,7 +283,7 @@ mod tests {
         let decision = resolve(
             &RoutingPolicy::LocalFirstWithCloudFallback,
             &mock_request(),
-            AdmissionOutcome::Accepted,
+            AdmissionOutcome::Accept,
             &mock_hardware(),
             "openai",
         );
@@ -318,7 +300,7 @@ mod tests {
         let decision = resolve(
             &RoutingPolicy::CostOptimized,
             &mock_request(),
-            AdmissionOutcome::Deferred,
+            AdmissionOutcome::Defer,
             &mock_hardware(),
             "openai",
         );
@@ -344,7 +326,7 @@ mod tests {
         let decision = resolve(
             &RoutingPolicy::LatencyOptimized,
             &mock_request(),
-            AdmissionOutcome::Accepted,
+            AdmissionOutcome::Accept,
             &hw,
             "openai",
         );
@@ -408,9 +390,9 @@ mod tests {
 
     #[test]
     fn test_admission_outcome_display() {
-        assert_eq!(format!("{}", AdmissionOutcome::Accepted), "accepted");
-        assert_eq!(format!("{}", AdmissionOutcome::Deferred), "deferred");
-        assert_eq!(format!("{}", AdmissionOutcome::Rejected), "rejected");
+        assert_eq!(format!("{}", AdmissionOutcome::Accept), "accept");
+        assert_eq!(format!("{}", AdmissionOutcome::Defer), "defer");
+        assert_eq!(format!("{}", AdmissionOutcome::Reject), "reject");
     }
 
     #[test]
@@ -451,9 +433,9 @@ mod tests {
     #[test]
     fn test_admission_outcome_serde_roundtrip() {
         for variant in [
-            AdmissionOutcome::Accepted,
-            AdmissionOutcome::Deferred,
-            AdmissionOutcome::Rejected,
+            AdmissionOutcome::Accept,
+            AdmissionOutcome::Defer,
+            AdmissionOutcome::Reject,
         ] {
             let json = serde_json::to_string(&variant).unwrap();
             let back: AdmissionOutcome = serde_json::from_str(&json).unwrap();

--- a/crates/mofa-foundation/src/scheduler/mod.rs
+++ b/crates/mofa-foundation/src/scheduler/mod.rs
@@ -49,7 +49,7 @@
 //! }
 //! ```
 
-mod admission;
+pub mod admission;
 mod budget;
 mod deferred;
 mod stability;


### PR DESCRIPTION
## Summary

Fixes **Issue #863** — two separate `AdmissionOutcome` enums described the same concept in different modules.

### Changes

| File | What changed |
|------|-------------|
| `scheduler/mod.rs` | Make `admission` module `pub` (was private) |
| `inference/routing.rs` | Remove local enum, add `pub use scheduler::admission::AdmissionOutcome` |
| `inference/orchestrator.rs` | Update variant refs: `Accepted→Accept`, `Deferred→Defer`, `Rejected→Reject` |

**3 files changed, 33 insertions(+), 51 deletions(−)**

### Why

The scheduler's `AdmissionOutcome` (variants: `Accept/Defer/Reject`) is the canonical type — it also carries `AdmissionDecision` with diagnostic metadata (reason, memory usage). Having a duplicate in `routing.rs` (variants: `Accepted/Deferred/Rejected`) prevented `MemoryScheduler` and `InferenceOrchestrator` from interoperating on the same type.

```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.23s
```

All existing tests pass.