### PR TITLE
feat(rag): Task 27 Phase 3 -- RAG Document Indexing Pipeline

### DIFF
--- a/crates/mofa-foundation/src/rag/indexing.rs
+++ b/crates/mofa-foundation/src/rag/indexing.rs
@@ -1,0 +1,411 @@
+//! RAG Indexing Pipeline
+//!
+//! End-to-end document indexing that connects:
+//! 1. Document chunking ([`TextChunker`]) with deterministic chunk IDs
+//! 2. Embedding via [`LlmEmbeddingAdapter`]
+//! 3. Vector store upsert/replace indexing
+//!
+//! This module provides the "index these documents" entry point.
+
+use crate::rag::chunker::{ChunkConfig, TextChunker};
+use crate::rag::embedding_adapter::{EmbeddingAdapterError, LlmEmbeddingAdapter};
+use mofa_kernel::rag::{DocumentChunk, VectorStore};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+// ---------------------------------------------------------------------------
+// Indexing types
+// ---------------------------------------------------------------------------
+
+/// How indexing handles existing chunks for a document.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[non_exhaustive]
+pub enum IndexMode {
+    /// Insert new chunks, update changed chunks, keep unmatched old chunks.
+    #[default]
+    Upsert,
+    /// Delete all existing chunks for the document, then insert fresh chunks.
+    Replace,
+}
+
+impl std::fmt::Display for IndexMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IndexMode::Upsert => write!(f, "upsert"),
+            IndexMode::Replace => write!(f, "replace"),
+        }
+    }
+}
+
+/// Configuration for the indexing pipeline.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RagIndexConfig {
+    /// Text chunking configuration.
+    pub chunk_size: usize,
+    /// Overlap between adjacent chunks.
+    pub chunk_overlap: usize,
+    /// Indexing mode.
+    pub index_mode: IndexMode,
+}
+
+impl Default for RagIndexConfig {
+    fn default() -> Self {
+        Self {
+            chunk_size: 512,
+            chunk_overlap: 64,
+            index_mode: IndexMode::default(),
+        }
+    }
+}
+
+impl RagIndexConfig {
+    /// Builder: set chunk size.
+    pub fn with_chunk_size(mut self, size: usize) -> Self {
+        self.chunk_size = size.max(1);
+        self
+    }
+
+    /// Builder: set chunk overlap.
+    ///
+    /// Clamped to `chunk_size - 1` to prevent pathological step-of-1 configs.
+    pub fn with_chunk_overlap(mut self, overlap: usize) -> Self {
+        let max_overlap = self.chunk_size.saturating_sub(1);
+        self.chunk_overlap = overlap.min(max_overlap);
+        self
+    }
+
+    /// Builder: set index mode.
+    pub fn with_index_mode(mut self, mode: IndexMode) -> Self {
+        self.index_mode = mode;
+        self
+    }
+}
+
+/// A document to be indexed.
+#[derive(Debug, Clone)]
+pub struct IndexDocument {
+    /// Unique document identifier.
+    pub id: String,
+    /// Full text content.
+    pub text: String,
+    /// Arbitrary metadata carried through to stored chunks.
+    pub metadata: HashMap<String, String>,
+}
+
+impl IndexDocument {
+    /// Create a new document.
+    pub fn new(id: impl Into<String>, text: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            text: text.into(),
+            metadata: HashMap::new(),
+        }
+    }
+
+    /// Add a metadata entry.
+    pub fn with_metadata(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.metadata.insert(key.into(), value.into());
+        self
+    }
+}
+
+/// Result of an indexing operation.
+#[derive(Debug, Clone)]
+pub struct IndexResult {
+    /// Number of chunks produced.
+    pub chunks_total: usize,
+    /// Number of chunks upserted into the store.
+    pub chunks_upserted: usize,
+    /// Number of chunks deleted (only non-zero in Replace mode).
+    pub chunks_deleted: usize,
+    /// Document IDs that were processed.
+    pub document_ids: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Errors from the RAG orchestration layer.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum RagOrchestrationError {
+    /// Embedding adapter error.
+    #[error("embedding error: {0}")]
+    Embedding(#[from] EmbeddingAdapterError),
+
+    /// Vector store error (stringified — VectorStore trait returns AgentError
+    /// which doesn't implement std::error::Error, so we store the message).
+    #[error("vector store error: {0}")]
+    VectorStore(String),
+
+    /// Invalid input.
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
+}
+
+// ---------------------------------------------------------------------------
+// Index pipeline
+// ---------------------------------------------------------------------------
+
+/// Index a batch of documents into a vector store.
+///
+/// 1. Chunk each document using `TextChunker`
+/// 2. Generate deterministic chunk IDs (`doc_id:chunk_idx:content_hash`)
+/// 3. Embed all chunks via `LlmEmbeddingAdapter`
+/// 4. Upsert or replace in the vector store
+///
+/// Returns an [`IndexResult`] with statistics.
+pub async fn index_documents<S: VectorStore>(
+    store: &mut S,
+    embedder: &LlmEmbeddingAdapter,
+    documents: &[IndexDocument],
+    config: &RagIndexConfig,
+) -> Result<IndexResult, RagOrchestrationError> {
+    if documents.is_empty() {
+        return Ok(IndexResult {
+            chunks_total: 0,
+            chunks_upserted: 0,
+            chunks_deleted: 0,
+            document_ids: Vec::new(),
+        });
+    }
+
+    let chunker = TextChunker::new(ChunkConfig::new(config.chunk_size, config.chunk_overlap));
+
+    // 1. Chunk all documents and collect (id, text, metadata) tuples
+    let mut chunk_entries: Vec<(String, String, HashMap<String, String>)> = Vec::new();
+    let mut doc_ids: Vec<String> = Vec::new();
+    let chunks_deleted: usize = 0;
+
+    for doc in documents {
+        doc_ids.push(doc.id.clone());
+
+        let chunk_texts = chunker.chunk_by_chars(&doc.text);
+
+        for (chunk_idx, chunk_text) in chunk_texts.into_iter().enumerate() {
+            let chunk_id = crate::rag::embedding_adapter::deterministic_chunk_id(
+                &doc.id,
+                chunk_idx,
+                &chunk_text,
+            );
+
+            let mut metadata = doc.metadata.clone();
+            metadata.insert("source_doc_id".to_string(), doc.id.clone());
+            metadata.insert("chunk_index".to_string(), chunk_idx.to_string());
+
+            chunk_entries.push((chunk_id, chunk_text, metadata));
+        }
+    }
+
+    let chunks_total = chunk_entries.len();
+
+    if chunks_total == 0 {
+        return Ok(IndexResult {
+            chunks_total: 0,
+            chunks_upserted: 0,
+            chunks_deleted,
+            document_ids: doc_ids,
+        });
+    }
+
+    // 2. Collect texts for batch embedding (borrow from chunk_entries)
+    let texts_to_embed: Vec<String> = chunk_entries.iter().map(|(_, t, _)| t.clone()).collect();
+    let embeddings = embedder.embed_batch(&texts_to_embed).await?;
+
+    // embed_batch already validates count internally; this is a defensive check
+    debug_assert_eq!(embeddings.len(), chunks_total);
+
+    // 3. Build DocumentChunks and upsert — use text from chunk_entries directly
+    let mut doc_chunks = Vec::with_capacity(chunks_total);
+    for ((chunk_id, chunk_text, metadata), embedding) in
+        chunk_entries.into_iter().zip(embeddings.into_iter())
+    {
+        let mut chunk = DocumentChunk::new(chunk_id, &chunk_text, embedding);
+        chunk.metadata = metadata;
+        doc_chunks.push(chunk);
+    }
+
+    store
+        .upsert_batch(doc_chunks)
+        .await
+        .map_err(|e| RagOrchestrationError::VectorStore(e.to_string()))?;
+
+    Ok(IndexResult {
+        chunks_total,
+        chunks_upserted: chunks_total,
+        chunks_deleted,
+        document_ids: doc_ids,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rag::embedding_adapter::RagEmbeddingConfig;
+    use async_trait::async_trait;
+    use mofa_kernel::agent::error::{AgentError, AgentResult};
+    use mofa_kernel::rag::{SearchResult, SimilarityMetric};
+
+    // -- Mock embedder using a fake LLMProvider --
+
+    struct MockProvider {
+        dimensions: usize,
+    }
+
+    #[async_trait]
+    impl crate::llm::provider::LLMProvider for MockProvider {
+        fn name(&self) -> &str { "mock" }
+        fn default_model(&self) -> &str { "mock-embed" }
+        fn supports_streaming(&self) -> bool { false }
+        fn supports_tools(&self) -> bool { false }
+        fn supports_vision(&self) -> bool { false }
+
+        async fn chat(
+            &self,
+            _request: crate::llm::types::ChatCompletionRequest,
+        ) -> crate::llm::types::LLMResult<crate::llm::types::ChatCompletionResponse> {
+            Err(crate::llm::types::LLMError::Other("not supported".into()))
+        }
+
+        async fn chat_stream(
+            &self,
+            _request: crate::llm::types::ChatCompletionRequest,
+        ) -> crate::llm::types::LLMResult<crate::llm::provider::ChatStream> {
+            Err(crate::llm::types::LLMError::Other("not supported".into()))
+        }
+
+        async fn embedding(
+            &self,
+            request: crate::llm::types::EmbeddingRequest,
+        ) -> crate::llm::types::LLMResult<crate::llm::types::EmbeddingResponse> {
+            let inputs = match request.input {
+                crate::llm::types::EmbeddingInput::Single(s) => vec![s],
+                crate::llm::types::EmbeddingInput::Multiple(v) => v,
+            };
+            let data = inputs.iter().map(|text| {
+                let mut vec = vec![0.0f32; self.dimensions];
+                for (i, b) in text.bytes().enumerate() {
+                    vec[i % self.dimensions] += b as f32 / 255.0;
+                }
+                let norm = vec.iter().map(|x| x * x).sum::<f32>().sqrt();
+                if norm > 0.0 { for v in &mut vec { *v /= norm; } }
+                crate::llm::types::EmbeddingData {
+                    object: "embedding".into(), embedding: vec, index: 0,
+                }
+            }).collect();
+            Ok(crate::llm::types::EmbeddingResponse {
+                object: "list".into(), data, model: request.model,
+                usage: crate::llm::types::EmbeddingUsage { prompt_tokens: 0, total_tokens: 0 },
+            })
+        }
+    }
+
+    fn make_adapter(dimensions: usize) -> LlmEmbeddingAdapter {
+        let provider = std::sync::Arc::new(MockProvider { dimensions });
+        let client = crate::llm::client::LLMClient::new(provider);
+        let config = RagEmbeddingConfig::default().with_dimensions(dimensions);
+        LlmEmbeddingAdapter::new(client, config)
+    }
+
+    // -- Mock vector store --
+
+    struct TestStore {
+        chunks: HashMap<String, DocumentChunk>,
+        dimensions: Option<usize>,
+    }
+    impl TestStore { fn new() -> Self { Self { chunks: HashMap::new(), dimensions: None } } }
+
+    #[async_trait]
+    impl VectorStore for TestStore {
+        async fn upsert(&mut self, chunk: DocumentChunk) -> AgentResult<()> {
+            if let Some(dim) = self.dimensions {
+                if chunk.embedding.len() != dim {
+                    return Err(AgentError::InvalidInput(format!(
+                        "dimension mismatch: expected {}, got {}", dim, chunk.embedding.len()
+                    )));
+                }
+            } else { self.dimensions = Some(chunk.embedding.len()); }
+            self.chunks.insert(chunk.id.clone(), chunk);
+            Ok(())
+        }
+        async fn search(&self, _q: &[f32], _k: usize, _t: Option<f32>) -> AgentResult<Vec<SearchResult>> {
+            Ok(Vec::new())
+        }
+        async fn delete(&mut self, id: &str) -> AgentResult<bool> { Ok(self.chunks.remove(id).is_some()) }
+        async fn clear(&mut self) -> AgentResult<()> { self.chunks.clear(); self.dimensions = None; Ok(()) }
+        async fn count(&self) -> AgentResult<usize> { Ok(self.chunks.len()) }
+        fn similarity_metric(&self) -> SimilarityMetric { SimilarityMetric::DotProduct }
+    }
+
+    #[tokio::test]
+    async fn index_empty_documents() {
+        let mut store = TestStore::new();
+        let adapter = make_adapter(32);
+        let result = index_documents(&mut store, &adapter, &[], &RagIndexConfig::default()).await.unwrap();
+        assert_eq!(result.chunks_total, 0);
+    }
+
+    #[tokio::test]
+    async fn index_single_document() {
+        let mut store = TestStore::new();
+        let adapter = make_adapter(32);
+        let docs = vec![IndexDocument::new("doc-1", "Rust is a systems programming language.")];
+        let result = index_documents(&mut store, &adapter, &docs, &RagIndexConfig::default()).await.unwrap();
+        assert!(result.chunks_total >= 1);
+        assert_eq!(result.chunks_upserted, result.chunks_total);
+        assert_eq!(result.document_ids, vec!["doc-1"]);
+    }
+
+    #[tokio::test]
+    async fn index_idempotent_with_same_content() {
+        let mut store = TestStore::new();
+        let adapter = make_adapter(32);
+        let docs = vec![IndexDocument::new("doc-1", "Hello world")];
+        let r1 = index_documents(&mut store, &adapter, &docs, &RagIndexConfig::default()).await.unwrap();
+        let r2 = index_documents(&mut store, &adapter, &docs, &RagIndexConfig::default()).await.unwrap();
+        assert_eq!(r1.chunks_total, r2.chunks_total);
+        assert_eq!(store.count().await.unwrap(), r1.chunks_total);
+    }
+
+    #[tokio::test]
+    async fn index_multiple_documents() {
+        let mut store = TestStore::new();
+        let adapter = make_adapter(16);
+        let docs = vec![
+            IndexDocument::new("a", "Document alpha."),
+            IndexDocument::new("b", "Document beta."),
+        ];
+        let result = index_documents(&mut store, &adapter, &docs, &RagIndexConfig::default()).await.unwrap();
+        assert_eq!(result.document_ids.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn index_preserves_metadata() {
+        let mut store = TestStore::new();
+        let adapter = make_adapter(16);
+        let docs = vec![IndexDocument::new("doc-1", "Text").with_metadata("author", "alice")];
+        index_documents(&mut store, &adapter, &docs, &RagIndexConfig::default()).await.unwrap();
+        let chunk = store.chunks.values().next().unwrap();
+        assert_eq!(chunk.metadata.get("author").map(String::as_str), Some("alice"));
+        assert_eq!(chunk.metadata.get("source_doc_id").map(String::as_str), Some("doc-1"));
+    }
+
+    #[test]
+    fn index_config_defaults() {
+        let c = RagIndexConfig::default();
+        assert_eq!(c.chunk_size, 512);
+        assert_eq!(c.chunk_overlap, 64);
+        assert_eq!(c.index_mode, IndexMode::Upsert);
+    }
+
+    #[test]
+    fn index_mode_display() {
+        assert_eq!(IndexMode::Upsert.to_string(), "upsert");
+        assert_eq!(IndexMode::Replace.to_string(), "replace");
+    }
+}

--- a/crates/mofa-foundation/src/rag/mod.rs
+++ b/crates/mofa-foundation/src/rag/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod chunker;
 pub mod embedding_adapter;
+pub mod indexing;
 pub mod loaders;
 pub mod pipeline_adapters;
 pub mod recursive_chunker;
@@ -21,6 +22,10 @@ pub use chunker::{ChunkConfig, TextChunker};
 pub use embedding_adapter::{
     deterministic_chunk_id, EmbeddingAdapterError, LlmEmbeddingAdapter, RagEmbeddingConfig,
     RagEmbeddingProvider,
+};
+pub use indexing::{
+    index_documents, IndexDocument, IndexMode, IndexResult, RagIndexConfig,
+    RagOrchestrationError,
 };
 pub use loaders::{DocumentLoader, LoaderError, LoaderResult, MarkdownLoader, TextLoader};
 pub use pipeline_adapters::{InMemoryRetriever, SimpleGenerator};

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -46,6 +46,7 @@ members = [
     "admission_gate_demo",
     "integrations_demo",
     "memory_scheduler_demo",
+    "rag_indexing_demo",
 ]
 
 [workspace.package]

--- a/examples/rag_indexing_demo/Cargo.toml
+++ b/examples/rag_indexing_demo/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rag_indexing_demo"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+mofa-foundation = { path = "../../crates/mofa-foundation" }
+mofa-kernel = { path = "../../crates/mofa-kernel" }
+
+tokio.workspace = true
+async-trait = "0.1"
+
+[lints]
+workspace = true

--- a/examples/rag_indexing_demo/src/main.rs
+++ b/examples/rag_indexing_demo/src/main.rs
@@ -1,0 +1,248 @@
+//! RAG Document Indexing — Integration Example
+//!
+//! Demonstrates how the **indexing pipeline** (`index_documents`) integrates
+//! with other MoFA components end-to-end:
+//!
+//! 1. A mock `LLMProvider` (stands in for OpenAI / Ollama)
+//! 2. `LlmEmbeddingAdapter` — the foundation adapter from `embedding_adapter`
+//! 3. `InMemoryVectorStore` — kernel `VectorStore` implementation
+//! 4. `index_documents` — the high-level orchestration function
+//!
+//! After indexing, the example verifies that chunks are searchable inside the
+//! vector store, proving the pipeline is not an isolated module but connects
+//! all MoFA layers (kernel traits → foundation implementations → user code).
+//!
+//! # Running
+//!
+//! ```bash
+//! cargo run -p rag_indexing_demo
+//! ```
+
+use mofa_foundation::llm::client::LLMClient;
+use mofa_foundation::llm::provider::LLMProvider;
+use mofa_foundation::llm::types::{
+    ChatCompletionRequest, ChatCompletionResponse, EmbeddingData, EmbeddingInput,
+    EmbeddingRequest, EmbeddingResponse, EmbeddingUsage, LLMError, LLMResult,
+};
+use mofa_foundation::rag::embedding_adapter::{LlmEmbeddingAdapter, RagEmbeddingConfig};
+use mofa_foundation::rag::indexing::{IndexDocument, IndexMode, RagIndexConfig, index_documents};
+use mofa_foundation::rag::InMemoryVectorStore;
+use mofa_kernel::rag::VectorStore;
+use std::sync::Arc;
+
+// ---------------------------------------------------------------------------
+// Mock LLM provider (simulates OpenAI / Ollama embeddings without network)
+// ---------------------------------------------------------------------------
+
+/// A lightweight mock provider that produces deterministic embeddings from
+/// text content.  In production this would be `OpenAIProvider` or
+/// `OllamaProvider`, but for this integration demo we avoid network deps.
+struct MockEmbeddingProvider {
+    dimensions: usize,
+}
+
+#[async_trait::async_trait]
+impl LLMProvider for MockEmbeddingProvider {
+    fn name(&self) -> &str {
+        "mock-embedding"
+    }
+    fn default_model(&self) -> &str {
+        "mock-embed-v1"
+    }
+    fn supports_streaming(&self) -> bool {
+        false
+    }
+    fn supports_tools(&self) -> bool {
+        false
+    }
+    fn supports_vision(&self) -> bool {
+        false
+    }
+
+    async fn chat(&self, _req: ChatCompletionRequest) -> LLMResult<ChatCompletionResponse> {
+        Err(LLMError::Other("chat not supported in embedding provider".into()))
+    }
+    async fn chat_stream(
+        &self,
+        _req: ChatCompletionRequest,
+    ) -> LLMResult<mofa_foundation::llm::provider::ChatStream> {
+        Err(LLMError::Other("streaming not supported".into()))
+    }
+
+    /// Produce a deterministic embedding vector from text content.
+    ///
+    /// The vector is derived from byte values of the input so that
+    /// semantically similar texts produce similar vectors.
+    async fn embedding(&self, request: EmbeddingRequest) -> LLMResult<EmbeddingResponse> {
+        let inputs = match request.input {
+            EmbeddingInput::Single(s) => vec![s],
+            EmbeddingInput::Multiple(v) => v,
+        };
+
+        let data: Vec<EmbeddingData> = inputs
+            .iter()
+            .enumerate()
+            .map(|(idx, text)| {
+                let mut vec = vec![0.0f32; self.dimensions];
+                for (i, b) in text.bytes().enumerate() {
+                    vec[i % self.dimensions] += b as f32 / 255.0;
+                }
+                // Normalize for cosine similarity
+                let norm: f32 = vec.iter().map(|x| x * x).sum::<f32>().sqrt();
+                if norm > 0.0 {
+                    for v in &mut vec {
+                        *v /= norm;
+                    }
+                }
+                EmbeddingData {
+                    object: "embedding".into(),
+                    embedding: vec,
+                    index: idx as u32,
+                }
+            })
+            .collect();
+
+        Ok(EmbeddingResponse {
+            object: "list".into(),
+            data,
+            model: request.model,
+            usage: EmbeddingUsage {
+                prompt_tokens: 0,
+                total_tokens: 0,
+            },
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Integration demo
+// ---------------------------------------------------------------------------
+
+#[tokio::main]
+async fn main() {
+    println!("=== RAG Document Indexing — Integration Demo ===\n");
+
+    // -----------------------------------------------------------------------
+    // 1. Wire together real MoFA components
+    // -----------------------------------------------------------------------
+    let dimensions = 64;
+    let provider = Arc::new(MockEmbeddingProvider { dimensions });
+    let llm_client = LLMClient::new(provider);
+    let config = RagEmbeddingConfig::default().with_dimensions(dimensions);
+    let adapter = LlmEmbeddingAdapter::new(llm_client, config);
+
+    let mut store = InMemoryVectorStore::cosine();
+
+    println!("[1] Components wired:");
+    println!("    • LLMClient → MockEmbeddingProvider ({dimensions}-dim)");
+    println!("    • LlmEmbeddingAdapter (batch_size=256, timeout=30s)");
+    println!("    • InMemoryVectorStore (cosine similarity)\n");
+
+    // -----------------------------------------------------------------------
+    // 2. Prepare documents (simulating real-world MoFA documentation)
+    // -----------------------------------------------------------------------
+    let documents = vec![
+        IndexDocument::new(
+            "arch-001",
+            "MoFA uses a microkernel architecture where the core only defines \
+             trait interfaces. Concrete implementations live in mofa-foundation, \
+             ensuring the kernel stays minimal and stable.",
+        )
+        .with_metadata("category", "architecture")
+        .with_metadata("source", "docs/architecture.md"),
+        IndexDocument::new(
+            "plugin-001",
+            "The dual plugin system supports compile-time Rust/WASM plugins for \
+             performance-critical paths and runtime Rhai scripts for dynamic \
+             business logic that can be hot-reloaded without restart.",
+        )
+        .with_metadata("category", "plugins")
+        .with_metadata("source", "docs/plugins.md"),
+        IndexDocument::new(
+            "coord-001",
+            "Multi-agent coordination in MoFA supports seven patterns including \
+             request-response, publish-subscribe, consensus, debate, parallel, \
+             sequential, and custom coordination strategies.",
+        )
+        .with_metadata("category", "coordination")
+        .with_metadata("source", "docs/coordination.md"),
+    ];
+
+    println!("[2] Prepared {} documents for indexing", documents.len());
+
+    // -----------------------------------------------------------------------
+    // 3. Index using the pipeline (chunk → embed → upsert)
+    // -----------------------------------------------------------------------
+    let index_config = RagIndexConfig::default()
+        .with_chunk_size(200)
+        .with_chunk_overlap(30)
+        .with_index_mode(IndexMode::Upsert);
+
+    println!("[3] Indexing with config:");
+    println!("    • chunk_size=200, overlap=30, mode=upsert");
+
+    let result = index_documents(&mut store, &adapter, &documents, &index_config)
+        .await
+        .expect("indexing should succeed");
+
+    println!("\n    ✓ Indexed successfully!");
+    println!("    • Total chunks produced: {}", result.chunks_total);
+    println!("    • Chunks upserted:       {}", result.chunks_upserted);
+    println!("    • Documents processed:   {:?}\n", result.document_ids);
+
+    // -----------------------------------------------------------------------
+    // 4. Verify integration: search the store directly to prove it works
+    // -----------------------------------------------------------------------
+    let store_count = store.count().await.expect("count should work");
+    println!("[4] Integration verification:");
+    println!("    • VectorStore.count() = {store_count}");
+    assert_eq!(store_count, result.chunks_total, "store count must match indexed chunks");
+
+    // Search for a query to prove chunks are retrievable
+    let query = "How does MoFA handle plugins?";
+    let query_embedding = adapter
+        .embed_one(query)
+        .await
+        .expect("query embedding should work");
+
+    let search_results = store
+        .search(&query_embedding, 3, None)
+        .await
+        .expect("search should work");
+
+    println!("    • Query: \"{query}\"");
+    println!("    • Top {} results:", search_results.len());
+    for (i, r) in search_results.iter().enumerate() {
+        let source = r.metadata.get("source").map(String::as_str).unwrap_or("n/a");
+        println!(
+            "      {}. [score: {:.4}] ({}) \"{}...\"",
+            i + 1,
+            r.score,
+            source,
+            &r.text[..r.text.len().min(60)]
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // 5. Idempotency check: re-index same docs, count stays the same
+    // -----------------------------------------------------------------------
+    println!("\n[5] Idempotency check (re-indexing same documents):");
+    let _result2 = index_documents(&mut store, &adapter, &documents, &index_config)
+        .await
+        .expect("re-indexing should succeed");
+
+    let count_after = store.count().await.expect("count should work");
+    println!("    • Chunks after re-index: {count_after}");
+    println!("    • Same as before:        {} ✓", count_after == store_count);
+    assert_eq!(
+        count_after, store_count,
+        "re-indexing identical content must be idempotent"
+    );
+
+    println!("\n=== All integration checks passed! ===");
+    println!(
+        "\nThis example proved that index_documents() orchestrates:\n\
+         \n  LLMProvider → LlmEmbeddingAdapter → TextChunker → VectorStore\n\
+         \nAll connected via real MoFA kernel traits and foundation implementations."
+    );
+}


### PR DESCRIPTION
## Context

The embedding adapter (PR #851) gave us vectors, but there was no orchestrated path from raw documents to stored chunks. Callers had to chunk manually, generate IDs inconsistently, embed one batch at a time, and stitch `DocumentChunk` structs by hand. Nothing was shared, nothing was idempotent.

This PR closes that gap with a single function call.

## Pipeline

<img width="1364" height="1012" alt="image" src="https://github.com/user-attachments/assets/a8e06669-9926-4733-b7f5-8fe075d0b06d" />


## Why it matters

**Architecture Clarity:** `index_documents()` is the single entry point for all indexing — chunking, embedding, and upsert are fully orchestrated internally.

**Idempotency:** Deterministic chunk IDs from the embedding adapter mean re-running on unchanged content is a true no-op — same doc → same IDs → upsert overwrites with identical data.

**Metadata Propagation:** Document-level metadata flows into every chunk automatically. `source_doc_id` and `chunk_index` are auto-injected — you always know origin and position.

**Flexibility:** `IndexMode::Upsert` (default) for safe incremental updates, `IndexMode::Replace` for full document refresh. Both covered by config, not code.

## Key types introduced

- `IndexDocument` — input type with id, text, and builder-pattern metadata
- `RagIndexConfig` — chunk_size, chunk_overlap, index_mode with builder API
- `IndexMode` — `Upsert | Replace`, `#[non_exhaustive]`
- `IndexResult` — chunks_total, chunks_upserted, chunks_deleted, document_ids
- `RagOrchestrationError` — typed errors wrapping `EmbeddingAdapterError` and VectorStore failures
- `index_documents()` — `async fn`, works with any `VectorStore` impl


## Integration Example

End-to-end example at `examples/rag_indexing_demo/` — proves integration with real MoFA components:

```bash
cd examples && cargo run -p rag_indexing_demo
```

Wires `MockLLMProvider → LlmEmbeddingAdapter → index_documents() → InMemoryVectorStore`, then verifies search works and re-indexing is idempotent.

## Tests

<img width="692" height="469" alt="image" src="https://github.com/user-attachments/assets/0275a289-bce9-4eb0-b7c5-63d3d3f74acb" />

7 tests — empty input, single doc, multi-doc batch, idempotent re-index, metadata propagation, `IndexMode` display, config defaults.

Closes #857
