### PR TITLE
fix: add timeout protection to all tool execution paths

### DIFF
--- a/crates/mofa-foundation/src/agent/executor.rs
+++ b/crates/mofa-foundation/src/agent/executor.rs
@@ -39,6 +39,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::RwLock;
 
 use crate::agent::base::BaseAgent;
@@ -69,6 +70,9 @@ pub struct AgentExecutorConfig {
     /// When the estimated token count exceeds this value and a compressor is
     /// configured, compression is triggered automatically.  Defaults to 4096.
     pub max_context_tokens: usize,
+    /// Per-tool-call timeout. If a single tool execution exceeds this
+    /// duration, it is cancelled and an error is returned. Default: 30s.
+    pub tool_timeout: Duration,
 }
 
 impl Default for AgentExecutorConfig {
@@ -80,6 +84,7 @@ impl Default for AgentExecutorConfig {
             temperature: None,
             max_tokens: None,
             max_context_tokens: 4096,
+            tool_timeout: Duration::from_secs(30),
         }
     }
 }
@@ -401,19 +406,30 @@ impl AgentExecutor {
                     let result = {
                         let tools_guard = self.tools.read().await;
                         if let Some(tool) = tools_guard.get(&tool_call.name) {
-                            match tool
-                                .execute_dynamic(
+                            let timeout_dur = self.config.tool_timeout;
+                            match tokio::time::timeout(
+                                timeout_dur,
+                                tool.execute_dynamic(
                                     tool_call.arguments.clone(),
                                     &AgentContext::new("executor"),
-                                )
-                                .await
+                                ),
+                            )
+                            .await
                             {
-                                Ok(out) => {
+                                Ok(Ok(out)) => {
                                     mofa_kernel::agent::components::tool::ToolResult::success(out)
                                 }
-                                Err(e) => {
+                                Ok(Err(e)) => {
                                     mofa_kernel::agent::components::tool::ToolResult::failure(
                                         e.to_string(),
+                                    )
+                                }
+                                Err(_) => {
+                                    mofa_kernel::agent::components::tool::ToolResult::failure(
+                                        format!(
+                                            "Tool '{}' timed out after {:?}",
+                                            tool_call.name, timeout_dur
+                                        ),
                                     )
                                 }
                             }

--- a/crates/mofa-foundation/src/agent/tools/mcp/tool_adapter.rs
+++ b/crates/mofa-foundation/src/agent/tools/mcp/tool_adapter.rs
@@ -10,6 +10,7 @@ use mofa_kernel::agent::components::tool::{Tool, ToolInput, ToolMetadata, ToolRe
 use mofa_kernel::agent::context::AgentContext;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::RwLock;
 
 use super::McpClientManager;
@@ -46,6 +47,8 @@ pub struct McpToolAdapter {
     /// MCP 客户端管理器 (共享引用)
     /// MCP client manager (shared reference)
     client: Arc<RwLock<McpClientManager>>,
+    /// Per-call timeout for MCP tool execution. Default: 30s.
+    timeout_duration: Duration,
 }
 
 impl McpToolAdapter {
@@ -60,7 +63,14 @@ impl McpToolAdapter {
             server_name: server_name.into(),
             tool_info,
             client,
+            timeout_duration: Duration::from_secs(30),
         }
+    }
+
+    /// Set a custom timeout for this MCP tool.
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout_duration = timeout;
+        self
     }
 
     /// 获取服务器名称
@@ -88,12 +98,20 @@ impl Tool for McpToolAdapter {
         use mofa_kernel::agent::components::mcp::McpClient;
 
         let client = self.client.read().await;
-        match client
-            .call_tool(&self.server_name, &self.tool_info.name, input.arguments)
-            .await
+        let timeout_dur = self.timeout_duration;
+
+        match tokio::time::timeout(
+            timeout_dur,
+            client.call_tool(&self.server_name, &self.tool_info.name, input.arguments),
+        )
+        .await
         {
-            Ok(output) => ToolResult::success(output),
-            Err(e) => ToolResult::failure(format!("MCP tool call failed: {}", e)),
+            Ok(Ok(output)) => ToolResult::success(output),
+            Ok(Err(e)) => ToolResult::failure(format!("MCP tool call failed: {}", e)),
+            Err(_) => ToolResult::failure(format!(
+                "MCP tool '{}' on server '{}' timed out after {:?}",
+                self.tool_info.name, self.server_name, timeout_dur
+            )),
         }
     }
 

--- a/crates/mofa-foundation/src/llm/agent_loop.rs
+++ b/crates/mofa-foundation/src/llm/agent_loop.rs
@@ -18,6 +18,7 @@ use crate::llm::types::{
 use mofa_kernel::agent::types::error::{GlobalError, GlobalResult};
 use std::collections::HashMap;
 use std::path::Path;
+use std::time::Duration;
 
 /// Type alias for tool handler function in SimpleToolExecutor
 pub type SimpleToolHandler = Box<dyn Fn(&str) -> GlobalResult<String> + Send + Sync>;
@@ -35,6 +36,9 @@ pub struct AgentLoopConfig {
     pub temperature: Option<f32>,
     /// Maximum tokens to generate
     pub max_tokens: Option<u32>,
+    /// Per-tool-call timeout. If a single tool execution exceeds this
+    /// duration, it is cancelled and an error is returned. Default: 30s.
+    pub tool_timeout: Duration,
 }
 
 impl Default for AgentLoopConfig {
@@ -44,6 +48,7 @@ impl Default for AgentLoopConfig {
             default_model: "gpt-4o-mini".to_string(),
             temperature: Some(0.7),
             max_tokens: None,
+            tool_timeout: Duration::from_secs(30),
         }
     }
 }
@@ -295,10 +300,23 @@ impl AgentLoop {
         Ok("I've completed processing but hit the maximum iteration limit.".to_string())
     }
 
-    /// Execute a tool call
+    /// Execute a tool call (with timeout protection)
     async fn execute_tool(&self, name: &str, arguments: &str) -> LLMResult<String> {
         let span = tracing::info_span!("agent_loop.tool_call", tool = %name);
-        self.tools.execute(name, arguments).instrument(span).await
+        let timeout_dur = self.config.tool_timeout;
+
+        match tokio::time::timeout(
+            timeout_dur,
+            self.tools.execute(name, arguments).instrument(span),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => Err(crate::llm::types::LLMError::Other(format!(
+                "Tool '{}' timed out after {:?}",
+                name, timeout_dur
+            ))),
+        }
     }
 
     /// Build a vision message with images
@@ -472,6 +490,7 @@ mod tests {
             default_model: "gpt-4".to_string(),
             temperature: Some(0.5),
             max_tokens: Some(1000),
+            tool_timeout: Duration::from_secs(60),
         };
         assert_eq!(config.max_tool_iterations, 5);
         assert_eq!(config.default_model, "gpt-4");

--- a/crates/mofa-foundation/src/llm/client.rs
+++ b/crates/mofa-foundation/src/llm/client.rs
@@ -8,6 +8,7 @@ use super::provider::{LLMConfig, LLMProvider};
 use super::tool_executor::ToolExecutor;
 use super::types::*;
 use std::sync::Arc;
+use std::time::Duration;
 
 /// LLM 客户端
 /// LLM Client
@@ -171,6 +172,9 @@ pub struct ChatRequestBuilder {
     request: ChatCompletionRequest,
     tool_executor: Option<Arc<dyn ToolExecutor>>,
     max_tool_rounds: u32,
+    /// Per-tool-call timeout duration. If a single tool execution exceeds
+    /// this duration, it is cancelled and an error is returned for that call.
+    tool_timeout: Duration,
     // Retry configuration
     retry_policy: Option<LLMRetryPolicy>,
     retry_enabled: bool,
@@ -185,6 +189,7 @@ impl ChatRequestBuilder {
             request: ChatCompletionRequest::new(model),
             tool_executor: None,
             max_tool_rounds: 10,
+            tool_timeout: Duration::from_secs(30),
             retry_policy: None,
             retry_enabled: false,
         }
@@ -282,6 +287,24 @@ impl ChatRequestBuilder {
     /// Set maximum tool call rounds
     pub fn max_tool_rounds(mut self, rounds: u32) -> Self {
         self.max_tool_rounds = rounds;
+        self
+    }
+
+    /// Set per-tool-call timeout duration
+    ///
+    /// If a single tool execution takes longer than this, it is cancelled
+    /// and treated as an error. Default is 30 seconds.
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// let response = client.chat()
+    ///     .with_tool_executor(executor)
+    ///     .tool_timeout(Duration::from_secs(60))
+    ///     .send_with_tools()
+    ///     .await?;
+    /// ```
+    pub fn tool_timeout(mut self, timeout: Duration) -> Self {
+        self.tool_timeout = timeout;
         self
     }
 
@@ -454,13 +477,26 @@ impl ChatRequestBuilder {
                 self.request.messages.push(choice.message.clone());
             }
 
-            // 执行工具调用
-            // Execute tool calls
+            // 执行工具调用（带超时保护）
+            // Execute tool calls (with timeout protection)
             if let Some(tool_calls) = response.tool_calls() {
                 for tool_call in tool_calls {
-                    let result = executor
-                        .execute(&tool_call.function.name, &tool_call.function.arguments)
-                        .await;
+                    let tool_name = &tool_call.function.name;
+                    let tool_args = &tool_call.function.arguments;
+                    let timeout_dur = self.tool_timeout;
+
+                    let result = match tokio::time::timeout(
+                        timeout_dur,
+                        executor.execute(tool_name, tool_args),
+                    )
+                    .await
+                    {
+                        Ok(inner) => inner,
+                        Err(_) => Err(LLMError::Other(format!(
+                            "Tool '{}' timed out after {:?}",
+                            tool_name, timeout_dur
+                        ))),
+                    };
 
                     let result_str = match result {
                         Ok(r) => r,

--- a/crates/mofa-foundation/src/react/core.rs
+++ b/crates/mofa-foundation/src/react/core.rs
@@ -5,6 +5,7 @@ use crate::llm::{LLMAgent, LLMError, LLMResult, Tool};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::RwLock;
 use tracing::Instrument;
 
@@ -261,6 +262,8 @@ pub struct ReActConfig {
     /// 每步最大 token 数
     /// Max tokens per step
     pub max_tokens_per_step: Option<u32>,
+    /// Per-tool-call timeout. Default: 30 seconds.
+    pub tool_timeout: Duration,
 }
 
 impl Default for ReActConfig {
@@ -272,6 +275,7 @@ impl Default for ReActConfig {
             system_prompt: None,
             verbose: true,
             max_tokens_per_step: Some(2048),
+            tool_timeout: Duration::from_secs(30),
         }
     }
 }
@@ -566,18 +570,26 @@ Rules:
         ParsedResponse::Thought(response.to_string())
     }
 
-    /// 执行工具
-    /// Execute tool
+    /// 执行工具（带超时保护）
+    /// Execute tool (with timeout protection)
     async fn execute_tool(&self, tool_name: &str, input: &str) -> String {
         let span = tracing::info_span!("react.tool_call", tool = %tool_name);
+        let timeout_dur = self.config.tool_timeout;
+
         async {
             let tools = self.tools.read().await;
 
             match tools.get(tool_name) {
-                Some(tool) => match tool.execute(input).await {
-                    Ok(result) => result,
-                    Err(e) => format!("Tool error: {}", e),
-                },
+                Some(tool) => {
+                    match tokio::time::timeout(timeout_dur, tool.execute(input)).await {
+                        Ok(Ok(result)) => result,
+                        Ok(Err(e)) => format!("Tool error: {}", e),
+                        Err(_) => format!(
+                            "Tool '{}' timed out after {:?}",
+                            tool_name, timeout_dur
+                        ),
+                    }
+                }
                 None => format!(
                     "Tool '{}' not found. Available tools: {:?}",
                     tool_name,

--- a/crates/mofa-foundation/src/workflow/executor.rs
+++ b/crates/mofa-foundation/src/workflow/executor.rs
@@ -43,6 +43,9 @@ pub struct ExecutorConfig {
     /// 执行超时（毫秒）
     /// Execution timeout (milliseconds)
     pub execution_timeout_ms: Option<u64>,
+    /// Per-node execution timeout (milliseconds). If a single node takes
+    /// longer than this, it is cancelled and marked as failed. Default: 120s.
+    pub node_timeout_ms: u64,
 }
 
 impl Default for ExecutorConfig {
@@ -53,6 +56,7 @@ impl Default for ExecutorConfig {
             enable_checkpoints: true,
             checkpoint_interval: 5,
             execution_timeout_ms: None,
+            node_timeout_ms: 120_000,
         }
     }
 }
@@ -629,7 +633,31 @@ impl WorkflowExecutor {
                 }
                 NodeType::Wait => self.execute_wait(ctx, node, current_input.clone()).await,
                 _ => {
-                    let result = node.execute(ctx, current_input.clone()).await;
+                    let node_timeout = std::time::Duration::from_millis(
+                        self.config.node_timeout_ms,
+                    );
+                    let result = match tokio::time::timeout(
+                        node_timeout,
+                        node.execute(ctx, current_input.clone()),
+                    )
+                    .await
+                    {
+                        Ok(r) => r,
+                        Err(_) => {
+                            warn!(
+                                "Node {} timed out after {:?}",
+                                current_node_id, node_timeout
+                            );
+                            NodeResult::failed(
+                                &current_node_id,
+                                &format!(
+                                    "Node timed out after {:?}",
+                                    node_timeout
+                                ),
+                                node_timeout.as_millis() as u64,
+                            )
+                        }
+                    };
                     ctx.set_node_output(&current_node_id, result.output.clone())
                         .await;
                     ctx.set_node_status(&current_node_id, result.status.clone())


### PR DESCRIPTION
## fix: Add timeout protection to all tool execution paths

### Problem
## Closes #861

All tool execution in `mofa-foundation` used bare `.await` — no timeout, no cancellation. If any tool hung (slow API, unresponsive MCP server, stuck shell command), the **entire agent froze indefinitely** with zero recovery.

### What Changed

Wrapped every tool `.execute().await` call with `tokio::time::timeout()`. Added a configurable `tool_timeout` field to each layer's config struct.

| File | What was wrapped | Default timeout |
|---|---|---|
| `llm/client.rs` | `executor.execute()` in `send_with_tools()` | 30s |
| `llm/agent_loop.rs` | `self.tools.execute()` in `execute_tool()` | 30s |
| `react/core.rs` | `tool.execute()` in `ReActAgent::execute_tool()` | 30s |
| `agent/executor.rs` | `tool.execute_dynamic()` in `run_agent_loop()` | 30s |
| `workflow/executor.rs` | `node.execute()` in `execute_from_node()` | 120s |
| `agent/tools/mcp/tool_adapter.rs` | `client.call_tool()` in `McpToolAdapter::execute()` | 30s |

**6 files changed, 154 insertions, 25 deletions.**

### Why

- A single slow API call could permanently stall the agent
- MCP tools make network calls to external servers — server downtime = agent freeze
- In parallel workflow branches, one hanging node blocks the entire workflow via `JoinSet`
- No error was ever produced — monitoring sees nothing, agent goes silent

### Design Decisions

- **Non-breaking**: No trait changes. All existing `Tool` implementations work unchanged
- **Configurable**: Each layer exposes a timeout field (e.g. `.tool_timeout(Duration::from_secs(60))`)
- **Graceful errors**: On timeout, a descriptive error like `"Tool 'web_search' timed out after 30s"` flows through existing error handling
- **No new dependencies**: `tokio::time::timeout` already used elsewhere in the codebase

### Testing

- ✅ `cargo check --workspace` — zero compilation errors
- ✅ `cargo test --package mofa-foundation --lib` — **527 passed, 0 failed**

### Code Samples

**Before** (`llm/client.rs` — `send_with_tools()`):
```rust
// Bare await — hangs forever if tool is unresponsive
let result = executor
    .execute(&tool_call.function.name, &tool_call.function.arguments)
    .await;
```

**After**:
```rust
// Timeout-protected — cancels after configured duration
let result = match tokio::time::timeout(
    timeout_dur,
    executor.execute(tool_name, tool_args),
)
.await
{
    Ok(inner) => inner,
    Err(_) => Err(LLMError::Other(format!(
        "Tool '{}' timed out after {:?}", tool_name, timeout_dur
    ))),
};
```

**Before** (`react/core.rs` — `ReActAgent::execute_tool()`):
```rust
Some(tool) => match tool.execute(input).await {
    Ok(result) => result,
    Err(e) => format!("Tool error: {}", e),
},
```

**After**:
```rust
Some(tool) => {
    match tokio::time::timeout(timeout_dur, tool.execute(input)).await {
        Ok(Ok(result)) => result,
        Ok(Err(e)) => format!("Tool error: {}", e),
        Err(_) => format!("Tool '{}' timed out after {:?}", tool_name, timeout_dur),
    }
}
```
