### PR TITLE
feat: add AgentManifest and CapabilityRegistry for agent discovery

### DIFF
--- a/crates/mofa-foundation/src/capability_registry.rs
+++ b/crates/mofa-foundation/src/capability_registry.rs
@@ -1,0 +1,201 @@
+//! Agent capability registry for runtime discovery and task routing.
+//!
+//! The `CapabilityRegistry` is distinct from the runtime `AgentRegistry`
+//! which tracks running instances. This registry is about what agents *can*
+//! do, not whether they are currently alive.
+
+use mofa_kernel::agent::manifest::AgentManifest;
+use std::collections::HashMap;
+
+/// Stores agent manifests and answers routing queries.
+///
+/// Orchestrators query the registry to find the right agent for a task
+/// without holding hardcoded references to specific agent instances.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use mofa_foundation::CapabilityRegistry;
+/// use mofa_kernel::AgentManifest;
+///
+/// let mut registry = CapabilityRegistry::new();
+/// registry.register(
+///     AgentManifest::builder("agent-001", "Researcher")
+///         .description("searches the web and summarizes documents")
+///         .build(),
+/// );
+///
+/// let matches = registry.query("summarize web content");
+/// assert!(!matches.is_empty());
+/// ```
+#[derive(Debug, Default)]
+pub struct CapabilityRegistry {
+    manifests: HashMap<String, AgentManifest>,
+}
+
+impl CapabilityRegistry {
+    /// Creates an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers an agent manifest, replacing any previous entry for the same ID.
+    pub fn register(&mut self, manifest: AgentManifest) {
+        self.manifests.insert(manifest.agent_id.clone(), manifest);
+    }
+
+    /// Removes an agent manifest by ID. Returns the manifest if it existed.
+    pub fn unregister(&mut self, agent_id: &str) -> Option<AgentManifest> {
+        self.manifests.remove(agent_id)
+    }
+
+    /// Looks up a manifest by agent ID.
+    pub fn find_by_id(&self, agent_id: &str) -> Option<&AgentManifest> {
+        self.manifests.get(agent_id)
+    }
+
+    /// Returns all agents whose capability tags include `tag`.
+    pub fn find_by_tag(&self, tag: &str) -> Vec<&AgentManifest> {
+        self.manifests
+            .values()
+            .filter(|m| m.capabilities.has_tag(tag))
+            .collect()
+    }
+
+    /// Queries agents by natural-language description using keyword matching.
+    ///
+    /// Scores each manifest by counting how many words from `query` appear in
+    /// the manifest's description and capability tags. Returns results sorted
+    /// by descending relevance score, excluding zero-score entries.
+    pub fn query(&self, query: &str) -> Vec<&AgentManifest> {
+        let keywords: Vec<String> = query
+            .split_whitespace()
+            .map(|w| w.to_lowercase())
+            .collect();
+
+        let mut scored: Vec<(usize, &AgentManifest)> = self
+            .manifests
+            .values()
+            .filter_map(|m| {
+                let tags_str = m
+                    .capabilities
+                    .tags
+                    .iter()
+                    .map(|t| t.as_str())
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                let haystack = format!("{} {}", m.description.to_lowercase(), tags_str);
+                let score = keywords
+                    .iter()
+                    .filter(|kw| haystack.contains(kw.as_str()))
+                    .count();
+                if score > 0 {
+                    Some((score, m))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        scored.sort_by(|a, b| b.0.cmp(&a.0));
+        scored.into_iter().map(|(_, m)| m).collect()
+    }
+
+    /// Returns all registered manifests.
+    pub fn all(&self) -> Vec<&AgentManifest> {
+        self.manifests.values().collect()
+    }
+
+    /// Returns the number of registered agents.
+    pub fn len(&self) -> usize {
+        self.manifests.len()
+    }
+
+    /// Returns true if no agents are registered.
+    pub fn is_empty(&self) -> bool {
+        self.manifests.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mofa_kernel::agent::capabilities::AgentCapabilities;
+
+    fn make_registry() -> CapabilityRegistry {
+        let mut registry = CapabilityRegistry::new();
+
+        registry.register(
+            AgentManifest::builder("agent-research", "ResearchAgent")
+                .description("searches the web and summarizes documents and articles")
+                .capabilities(
+                    AgentCapabilities::builder()
+                        .with_tag("research")
+                        .with_tag("summarization")
+                        .with_tag("web")
+                        .build(),
+                )
+                .build(),
+        );
+
+        registry.register(
+            AgentManifest::builder("agent-code", "CodeAgent")
+                .description("writes reviews and debugs Rust and Python code")
+                .capabilities(
+                    AgentCapabilities::builder()
+                        .with_tag("coding")
+                        .with_tag("rust")
+                        .with_tag("python")
+                        .build(),
+                )
+                .build(),
+        );
+
+        registry
+    }
+
+    #[test]
+    fn test_register_and_find_by_id() {
+        let registry = make_registry();
+        assert!(registry.find_by_id("agent-research").is_some());
+        assert!(registry.find_by_id("agent-code").is_some());
+        assert!(registry.find_by_id("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_find_by_tag() {
+        let registry = make_registry();
+        let coding = registry.find_by_tag("coding");
+        assert_eq!(coding.len(), 1);
+        assert_eq!(coding[0].agent_id, "agent-code");
+    }
+
+    #[test]
+    fn test_query_returns_best_match_first() {
+        let registry = make_registry();
+
+        let results = registry.query("summarize web documents");
+        assert!(!results.is_empty());
+        assert_eq!(results[0].agent_id, "agent-research");
+
+        let results = registry.query("write rust code");
+        assert!(!results.is_empty());
+        assert_eq!(results[0].agent_id, "agent-code");
+    }
+
+    #[test]
+    fn test_query_no_match_returns_empty() {
+        let registry = make_registry();
+        let results = registry.query("quantum physics simulation");
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_unregister() {
+        let mut registry = make_registry();
+        assert_eq!(registry.len(), 2);
+        registry.unregister("agent-code");
+        assert_eq!(registry.len(), 1);
+        assert!(registry.find_by_id("agent-code").is_none());
+    }
+}

--- a/crates/mofa-foundation/src/lib.rs
+++ b/crates/mofa-foundation/src/lib.rs
@@ -55,6 +55,10 @@ pub mod rag;
 // Security governance - PII redaction, content moderation, prompt guard
 pub mod security;
 
+// Agent capability manifest and discovery registry
+pub mod capability_registry;
+pub use capability_registry::CapabilityRegistry;
+
 // Re-export config types
 pub use config::{AgentInfo, AgentYamlConfig, LLMYamlConfig, RuntimeConfig, ToolConfig};
 

--- a/crates/mofa-kernel/src/agent/manifest.rs
+++ b/crates/mofa-kernel/src/agent/manifest.rs
@@ -1,0 +1,147 @@
+//! Agent capability manifest and discovery types.
+//!
+//! Agents publish an `AgentManifest` so orchestrators can discover and route
+//! tasks without holding hardcoded references to specific agent instances.
+
+use crate::agent::capabilities::AgentCapabilities;
+use crate::agent::config::schema::CoordinationMode;
+use serde::{Deserialize, Serialize};
+
+/// Machine-readable declaration of what an agent is capable of doing.
+///
+/// Agents register a manifest with the `CapabilityRegistry` on startup so
+/// orchestrators can query for the right agent at runtime.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentManifest {
+    /// Unique agent identifier.
+    pub agent_id: String,
+    /// Human-readable agent name.
+    pub name: String,
+    /// Natural-language description of what this agent does.
+    pub description: String,
+    /// Structured capability set (input/output types, tags, tool support, etc.).
+    pub capabilities: AgentCapabilities,
+    /// Names of tools registered with this agent.
+    pub tools: Vec<String>,
+    /// Memory backend in use (e.g. `"in-memory"`, `"qdrant"`, `"postgres"`).
+    pub memory_backend: Option<String>,
+    /// Coordination modes this agent participates in.
+    pub coordination_modes: Vec<CoordinationMode>,
+}
+
+impl AgentManifest {
+    /// Returns a builder for constructing an `AgentManifest`.
+    pub fn builder(
+        agent_id: impl Into<String>,
+        name: impl Into<String>,
+    ) -> AgentManifestBuilder {
+        AgentManifestBuilder::new(agent_id.into(), name.into())
+    }
+}
+
+/// Builder for [`AgentManifest`].
+#[derive(Debug, Default)]
+pub struct AgentManifestBuilder {
+    agent_id: String,
+    name: String,
+    description: String,
+    capabilities: AgentCapabilities,
+    tools: Vec<String>,
+    memory_backend: Option<String>,
+    coordination_modes: Vec<CoordinationMode>,
+}
+
+impl AgentManifestBuilder {
+    fn new(agent_id: String, name: String) -> Self {
+        Self {
+            agent_id,
+            name,
+            ..Default::default()
+        }
+    }
+
+    /// Set the natural-language description.
+    pub fn description(mut self, desc: impl Into<String>) -> Self {
+        self.description = desc.into();
+        self
+    }
+
+    /// Set the structured capability set.
+    pub fn capabilities(mut self, caps: AgentCapabilities) -> Self {
+        self.capabilities = caps;
+        self
+    }
+
+    /// Register a tool name.
+    pub fn tool(mut self, tool: impl Into<String>) -> Self {
+        self.tools.push(tool.into());
+        self
+    }
+
+    /// Set the memory backend type.
+    pub fn memory_backend(mut self, backend: impl Into<String>) -> Self {
+        self.memory_backend = Some(backend.into());
+        self
+    }
+
+    /// Add a supported coordination mode.
+    pub fn coordination_mode(mut self, mode: CoordinationMode) -> Self {
+        self.coordination_modes.push(mode);
+        self
+    }
+
+    /// Build the `AgentManifest`.
+    pub fn build(self) -> AgentManifest {
+        AgentManifest {
+            agent_id: self.agent_id,
+            name: self.name,
+            description: self.description,
+            capabilities: self.capabilities,
+            tools: self.tools,
+            memory_backend: self.memory_backend,
+            coordination_modes: self.coordination_modes,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::capabilities::AgentCapabilities;
+
+    #[test]
+    fn test_manifest_builder() {
+        let manifest = AgentManifest::builder("agent-001", "ResearchAgent")
+            .description("searches the web and summarizes documents")
+            .capabilities(
+                AgentCapabilities::builder()
+                    .with_tag("research")
+                    .with_tag("summarization")
+                    .build(),
+            )
+            .tool("web_search")
+            .tool("document_reader")
+            .memory_backend("in-memory")
+            .coordination_mode(CoordinationMode::Sequential)
+            .build();
+
+        assert_eq!(manifest.agent_id, "agent-001");
+        assert_eq!(manifest.name, "ResearchAgent");
+        assert!(manifest.capabilities.has_tag("research"));
+        assert_eq!(manifest.tools.len(), 2);
+        assert_eq!(manifest.memory_backend.as_deref(), Some("in-memory"));
+        assert_eq!(manifest.coordination_modes.len(), 1);
+    }
+
+    #[test]
+    fn test_manifest_serialization() {
+        let manifest = AgentManifest::builder("agent-002", "CodeAgent")
+            .description("writes and reviews Rust code")
+            .build();
+
+        let json = serde_json::to_string(&manifest).unwrap();
+        let restored: AgentManifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.agent_id, "agent-002");
+        assert_eq!(restored.name, "CodeAgent");
+    }
+}

--- a/crates/mofa-kernel/src/agent/mod.rs
+++ b/crates/mofa-kernel/src/agent/mod.rs
@@ -151,6 +151,9 @@ pub mod config;
 // Registry
 pub mod registry;
 
+// Agent capability manifest
+pub mod manifest;
+
 // 工具系统
 // Tool system
 
@@ -237,6 +240,9 @@ pub use components::{
 // 重新导出工厂接口
 // Re-export factory interface
 pub use registry::AgentFactory;
+
+// Re-export manifest types
+pub use manifest::{AgentManifest, AgentManifestBuilder};
 
 // 重新导出配置
 // Re-export configuration

--- a/crates/mofa-kernel/src/lib.rs
+++ b/crates/mofa-kernel/src/lib.rs
@@ -32,6 +32,7 @@ pub use message_graph::*;
 
 // Agent Framework (统一 Agent 框架)
 pub mod agent;
+pub use agent::{AgentManifest, AgentManifestBuilder};
 
 // Global Configuration System (全局配置系统)
 #[cfg(feature = "config")]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -45,6 +45,7 @@ members = [
     "admission_gate_demo",
     "integrations_demo",
     "memory_scheduler_demo",
+    "capability_discovery",
 ]
 
 [workspace.package]

--- a/examples/capability_discovery/Cargo.toml
+++ b/examples/capability_discovery/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "capability_discovery"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+mofa-foundation = { path = "../../crates/mofa-foundation" }
+mofa-kernel = { path = "../../crates/mofa-kernel" }
+
+tokio.workspace = true
+
+[lints]
+workspace = true

--- a/examples/capability_discovery/src/main.rs
+++ b/examples/capability_discovery/src/main.rs
@@ -1,0 +1,85 @@
+//! Demonstrates agent capability manifest registration and runtime discovery.
+//!
+//! Two specialized agents register their manifests with a `CapabilityRegistry`.
+//! An orchestrator then queries the registry to route three different tasks to
+//! the correct agent automatically, without any hardcoded agent references.
+
+use mofa_foundation::CapabilityRegistry;
+use mofa_kernel::{
+    AgentManifest,
+    agent::capabilities::AgentCapabilities,
+    agent::config::schema::CoordinationMode,
+};
+
+fn main() {
+    let mut registry = CapabilityRegistry::new();
+
+    // --- agent registration ---
+
+    // ResearchAgent: specializes in web search and document summarization
+    registry.register(
+        AgentManifest::builder("agent-research", "ResearchAgent")
+            .description("searches the web and summarizes documents and articles")
+            .capabilities(
+                AgentCapabilities::builder()
+                    .with_tag("research")
+                    .with_tag("summarization")
+                    .with_tag("web")
+                    .build(),
+            )
+            .tool("web_search")
+            .tool("document_reader")
+            .memory_backend("in-memory")
+            .coordination_mode(CoordinationMode::Sequential)
+            .build(),
+    );
+
+    // CodeAgent: specializes in writing and reviewing Rust code
+    registry.register(
+        AgentManifest::builder("agent-code", "CodeAgent")
+            .description("writes reviews and debugs Rust and Python code")
+            .capabilities(
+                AgentCapabilities::builder()
+                    .with_tag("coding")
+                    .with_tag("rust")
+                    .with_tag("python")
+                    .with_tag("review")
+                    .build(),
+            )
+            .tool("code_linter")
+            .tool("test_runner")
+            .memory_backend("in-memory")
+            .coordination_mode(CoordinationMode::Sequential)
+            .build(),
+    );
+
+    println!("registered {} agents\n", registry.len());
+
+    // --- orchestrator routing ---
+
+    let tasks = [
+        "summarize recent web articles about AI",
+        "write a Rust function to parse JSON",
+        "review this Python code for bugs",
+    ];
+
+    for task in &tasks {
+        println!("task: \"{}\"", task);
+        let results = registry.query(task);
+        if let Some(best) = results.first() {
+            println!(
+                "  routed to: {} ({})\n  description: {}\n  tools: {:?}\n",
+                best.name, best.agent_id, best.description, best.tools
+            );
+        } else {
+            println!("  no matching agent found\n");
+        }
+    }
+
+    // --- direct tag lookup ---
+
+    println!("agents with 'coding' tag:");
+    for m in registry.find_by_tag("coding") {
+        println!("  {} — {}", m.name, m.description);
+    }
+}


### PR DESCRIPTION
## 📋 Summary

Implements agent capability manifest registration and runtime discovery so orchestrators can route tasks to the right agent without hardcoded references.

## 🔗 Related Issues

Closes #404

---

## 🧠 Context

MoFA agents had no machine-readable way to declare what they can do. An orchestrator wanting to route a task had to hold direct references to specific agent instances, making dynamic multi-agent systems impossible to build without tight coupling.

This PR introduces `AgentManifest` in `mofa-kernel` for agents to declare their capabilities, and `CapabilityRegistry` in `mofa-foundation` to store those manifests and answer routing queries at runtime. The registry is intentionally separate from the runtime `AgentRegistry` — this one is about what agents *can* do, not whether they are currently alive.

---

## 🛠️ Changes

- Added `AgentManifest` struct and `AgentManifestBuilder` in `mofa-kernel` — captures description, capability tags, input/output types, tool names, memory backend, and coordination modes
- Added `CapabilityRegistry` in `mofa-foundation` with `register`, `unregister`, `find_by_id`, `find_by_tag`, and `query` (keyword-based scoring)
- Added `capability_discovery` example showing two specialized agents registering manifests and an orchestrator routing three tasks to the correct agent automatically

---

## 🧪 How you Tested

1. `cargo test -p mofa-kernel -p mofa-foundation` — all tests pass including manifest builder, serialization, registry query, tag lookup, and unregister
2. `cargo check --manifest-path examples/Cargo.toml -p capability_discovery` — example compiles clean
3. `cargo clippy -p mofa-kernel -p mofa-foundation` — no errors from new code

---

## ⚠️ Breaking Changes

- [x] No breaking changes

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [x] Public APIs documented
- [ ] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---

## 🧩 Additional Notes for Reviewers

The `query` method uses keyword scoring against description text and capability tags. Semantic matching via the memory work from issue #385 can be layered on top later without changing the public API — the signature stays the same, only the scoring logic would change.
