### PR TITLE
fix(ffi): eliminate Box::leak memory leak in CallbackToolAdapter

### DIFF
--- a/crates/mofa-ffi/src/uniffi_bindings.rs
+++ b/crates/mofa-ffi/src/uniffi_bindings.rs
@@ -961,30 +961,32 @@ impl SessionManager {
 /// Adapter that wraps a foreign FfiToolCallback into the kernel Tool trait
 struct CallbackToolAdapter {
     callback: Box<dyn FfiToolCallback>,
+    /// Cached name to avoid `Box::leak` on every `name()` call
+    cached_name: String,
+    /// Cached description to avoid `Box::leak` on every `description()` call
+    cached_description: String,
 }
 
 impl CallbackToolAdapter {
     fn new(callback: Box<dyn FfiToolCallback>) -> Self {
-        Self { callback }
+        let cached_name = callback.name();
+        let cached_description = callback.description();
+        Self {
+            callback,
+            cached_name,
+            cached_description,
+        }
     }
 }
 
 #[async_trait::async_trait]
 impl mofa_kernel::agent::components::tool::Tool for CallbackToolAdapter {
     fn name(&self) -> &str {
-        // We store the name in a leaked string to return a &str.
-        // This is acceptable for long-lived tool registrations.
-        // Use a thread-local cache to avoid repeated leaking.
-        // For simplicity, we just leak once per name.
-        let name = self.callback.name();
-        // SAFETY: We need a &str with 'static lifetime for the trait.
-        // Tools are long-lived so this small leak is acceptable.
-        Box::leak(name.into_boxed_str())
+        &self.cached_name
     }
 
     fn description(&self) -> &str {
-        let desc = self.callback.description();
-        Box::leak(desc.into_boxed_str())
+        &self.cached_description
     }
 
     fn parameters_schema(&self) -> serde_json::Value {


### PR DESCRIPTION
## 📋 Summary

Fixes a memory leak in `CallbackToolAdapter` where `Box::leak()` was called on **every** invocation of `name()` and `description()`, causing unbounded heap growth in long-running processes using FFI-registered tools.

The fix caches the name and description as owned `String` fields initialized once in `new()`.

## 🔗 Related Issues

Closes #874

---

## 🧠 Context

`CallbackToolAdapter` wraps a foreign `FfiToolCallback` (from Python/Swift/Kotlin) into the kernel `Tool` trait. The `Tool` trait requires `name() -> &str` and `description() -> &str`, but the callback returns owned `String`s.

The previous code used `Box::leak()` to convert the owned `String` into `&'static str`. The comment claimed "we just leak once per name" but there was **no caching** — every call leaked a new allocation.

The `mofa-plugins` crate already solved this same problem correctly for `RhaiPlugin` by caching metadata in a struct field (see `rhai_runtime/plugin.rs:223`). This PR applies the same pattern.

---

## 🛠️ Changes

- Added `cached_name: String` and `cached_description: String` fields to `CallbackToolAdapter`
- Initialize both fields once in `new()` by calling the callback
- `name()` now returns `&self.cached_name` instead of `Box::leak(...)`
- `description()` now returns `&self.cached_description` instead of `Box::leak(...)`

**1 file changed, 13 insertions, 11 deletions.**

---

## 🧪 How you Tested

1. `cargo build` — all 709 crates compiled successfully, 0 errors
2. `cargo test --workspace` — all tests passed, 0 failures
3. Verified the fix compiles cleanly with no new warnings

---

## 📸 Screenshots / Logs (if applicable)

```
$ cargo test --workspace
...
test result: ok. (all tests passed across all crates)
```

---

## ⚠️ Breaking Changes

- [x] No breaking changes

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [ ] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [x] Public APIs documented
- [x] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---

## 🧩 Additional Notes for Reviewers

- The `cached_name` and `cached_description` fields are initialized once during construction. Tool metadata is inherently static, so caching is the correct approach.
- No new tests were added since the change is to an internal FFI adapter struct with no public API change — existing tests verify compilation and tool registration.