### PR TITLE
feat(kernel): Gateway Microkernel Layer — Router and Filter Trait Contracts (Task 12 Phase 2/5)

### DIFF
--- a/crates/mofa-kernel/src/gateway/filter.rs
+++ b/crates/mofa-kernel/src/gateway/filter.rs
@@ -1,0 +1,127 @@
+//! Gateway filter trait and filter-chain types.
+//!
+//! A filter chain is an ordered list of [`GatewayFilter`] instances applied
+//! to every request and response.  Filters are sorted by their declared
+//! [`FilterOrder`] and executed in ascending order on the request path
+//! (lowest value first) and descending order on the response path.
+//!
+//! ```text
+//! Request  ──► PreAuth ──► Auth ──► RateLimit ──► Transform ──► Logging
+//!                  (upstream / backend call happens here)
+//! Response ◄── Logging ◄── Transform ◄── RateLimit ◄── Auth ◄── PreAuth
+//! ```
+
+use super::config_error::GatewayConfigError;
+use super::types::{GatewayContext, GatewayResponse};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Filter ordering
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Numeric ordering slot for a filter in the chain.
+///
+/// The well-known slots below act as guidelines; any `u32` value is accepted
+/// so implementors can slot in custom filters between the standard phases.
+/// Filters with equal order values are executed in registration order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct FilterOrder(pub u32);
+
+impl FilterOrder {
+    /// Executes before all authentication logic (e.g. request ID injection).
+    pub const PRE_AUTH: FilterOrder = FilterOrder(0);
+    /// Authentication filter slot (API key, JWT, OAuth 2.0).
+    pub const AUTH: FilterOrder = FilterOrder(100);
+    /// Rate-limiting / throttling slot.
+    pub const RATE_LIMIT: FilterOrder = FilterOrder(200);
+    /// Request / response body transformation slot.
+    pub const TRANSFORM: FilterOrder = FilterOrder(300);
+    /// Audit logging slot — runs after all transformations.
+    pub const LOGGING: FilterOrder = FilterOrder(400);
+    /// Post-processing, metrics recording, etc.
+    pub const POST_PROCESS: FilterOrder = FilterOrder(500);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Filter action
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Instruction returned by [`GatewayFilter::on_request`] controlling what
+/// the gateway does with the request after the filter runs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FilterAction {
+    /// Pass the (possibly modified) request to the next filter or backend.
+    Continue,
+    /// Short-circuit the chain and return a synthetic error response with the
+    /// given HTTP status code (as a raw `u16` — callers should ensure validity)
+    /// and body string.
+    Reject(u16, String),
+    /// Short-circuit and redirect the caller to a different path.
+    Redirect(String),
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GatewayFilter trait
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Kernel contract for a single filter in the gateway pipeline.
+///
+/// Implementations must be `Send + Sync` so they can be shared across Tokio
+/// tasks without additional synchronization by the caller.
+#[async_trait]
+pub trait GatewayFilter: Send + Sync {
+    /// Stable, human-readable identifier for this filter (used in logs).
+    fn name(&self) -> &str;
+
+    /// Position in the filter chain.  Lower values execute first on the
+    /// request path.
+    fn order(&self) -> FilterOrder;
+
+    /// Called with the inbound request *before* it is forwarded to the backend.
+    ///
+    /// Implementations may mutate `ctx` (e.g. add authentication claims to
+    /// `ctx.auth_principal`, remove sensitive headers, …).  Return
+    /// [`FilterAction::Continue`] to proceed, or a `Reject`/`Redirect` variant
+    /// to short-circuit the chain.
+    async fn on_request(&self, ctx: &mut GatewayContext) -> Result<FilterAction, GatewayConfigError>;
+
+    /// Called with the backend response *before* it is returned to the caller.
+    ///
+    /// Implementations may mutate `resp` (e.g. strip internal headers, append
+    /// cache-control metadata, record latency metrics, …).
+    async fn on_response(
+        &self,
+        ctx: &GatewayContext,
+        resp: &mut GatewayResponse,
+    ) -> Result<(), GatewayConfigError>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FilterChainConfig
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Ordered list of filter names that make up a named filter chain.
+///
+/// This is the *configuration* representation (list of string names).  The
+/// runtime binds names to concrete [`GatewayFilter`] implementations during
+/// startup.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FilterChainConfig {
+    /// Human-readable name for this chain (used in logs and metrics).
+    pub name: String,
+    /// Ordered filter names.  Must not be empty — validated by gateway config
+    /// validation.
+    pub filter_names: Vec<String>,
+}
+
+impl FilterChainConfig {
+    /// Create a new chain config with the given name and filter list.
+    pub fn new(name: impl Into<String>, filter_names: Vec<String>) -> Self {
+        Self {
+            name: name.into(),
+            filter_names,
+        }
+    }
+}

--- a/crates/mofa-kernel/src/gateway/mod.rs
+++ b/crates/mofa-kernel/src/gateway/mod.rs
@@ -19,11 +19,19 @@
 //! | [`GatewayResponse`] | Outbound HTTP response model |
 //! | [`GatewayContext`] | Per-request mutable context for filter chains |
 //! | [`RouteMatch`] | Result of a successful route lookup |
+//! | [`RouteConfig`] | Route definition used by [`GatewayRouter`] |
+//! | [`GatewayRouter`] | Trait for path-based request routing |
+//! | [`GatewayFilter`] | Trait for request/response filter pipeline |
+//! | [`FilterOrder`] | Numeric ordering slot for filters |
+//! | [`FilterAction`] | Continue / Reject / Redirect action from a filter |
+//! | [`FilterChainConfig`] | Named ordered list of filter names |
 
 pub mod error;
 pub mod route;
 mod config_error;
 mod types;
+mod router;
+mod filter;
 
 #[cfg(test)]
 mod tests;
@@ -32,3 +40,5 @@ pub use error::RegistryError;
 pub use route::{GatewayRoute, HttpMethod, RouteRegistry, RoutingContext};
 pub use config_error::GatewayConfigError;
 pub use types::{GatewayContext, GatewayRequest, GatewayResponse, RouteMatch};
+pub use router::{GatewayRouter, RouteConfig};
+pub use filter::{FilterAction, FilterChainConfig, FilterOrder, GatewayFilter};

--- a/crates/mofa-kernel/src/gateway/router.rs
+++ b/crates/mofa-kernel/src/gateway/router.rs
@@ -1,0 +1,126 @@
+//! Gateway router trait and configuration types.
+//!
+//! The [`GatewayRouter`] trait is the single kernel-level abstraction for
+//! request routing.  Implementations (e.g. a trie-based router in
+//! `mofa-gateway`) are registered against routes at startup and looked up
+//! on every inbound request.
+
+use super::config_error::GatewayConfigError;
+use super::route::HttpMethod;
+use super::types::RouteMatch;
+use serde::{Deserialize, Serialize};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Route configuration
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A single routing rule mapping a path pattern + method set to a backend.
+///
+/// Path patterns follow the `{param}` template syntax used by axum 0.8+:
+/// ```text
+/// /v1/chat/completions          — exact path
+/// /v1/models/{model_id}         — captures `model_id`
+/// /v1/agents/{agent_id}/invoke  — captures `agent_id`
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RouteConfig {
+    /// Unique stable identifier for this route.
+    pub id: String,
+    /// URL path template.  Must begin with `/`.
+    pub path_pattern: String,
+    /// Accepted HTTP methods.  An empty vec means *all* methods are accepted.
+    pub methods: Vec<HttpMethod>,
+    /// Id of the backend this route forwards to.
+    pub backend_id: String,
+    /// Per-route request timeout in milliseconds (overrides gateway default).
+    /// A value of `0` means "use the gateway default".
+    pub timeout_ms: u64,
+    /// Routing priority: higher values are evaluated first when multiple
+    /// patterns match the same path.
+    pub priority: i32,
+}
+
+impl RouteConfig {
+    /// Create a minimal route with just id, path_pattern, and backend_id.
+    pub fn new(
+        id: impl Into<String>,
+        path_pattern: impl Into<String>,
+        backend_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            path_pattern: path_pattern.into(),
+            methods: Vec::new(),
+            backend_id: backend_id.into(),
+            timeout_ms: 0,
+            priority: 0,
+        }
+    }
+
+    /// Builder: restrict to specific HTTP methods.
+    pub fn with_methods(mut self, methods: Vec<HttpMethod>) -> Self {
+        self.methods = methods;
+        self
+    }
+
+    /// Builder: set a per-route timeout.
+    pub fn with_timeout_ms(mut self, ms: u64) -> Self {
+        self.timeout_ms = ms;
+        self
+    }
+
+    /// Builder: set routing priority (higher = evaluated first).
+    pub fn with_priority(mut self, priority: i32) -> Self {
+        self.priority = priority;
+        self
+    }
+
+    /// Basic sanity checks run during gateway config validation.
+    pub(crate) fn validate(&self) -> Result<(), GatewayConfigError> {
+        if self.id.trim().is_empty() {
+            return Err(GatewayConfigError::EmptyRouteId);
+        }
+        if self.path_pattern.trim().is_empty() {
+            return Err(GatewayConfigError::InvalidPathPattern(
+                self.id.clone(),
+                "path pattern cannot be empty".to_string(),
+            ));
+        }
+        if !self.path_pattern.starts_with('/') {
+            return Err(GatewayConfigError::InvalidPathPattern(
+                self.id.clone(),
+                "path pattern must start with '/'".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Router trait
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Kernel contract for request routing.
+///
+/// Implementations receive [`RouteConfig`] entries at startup (via
+/// [`register`](GatewayRouter::register)) and resolve incoming
+/// (path, method) pairs to a [`RouteMatch`] at request time.
+///
+/// The trait is intentionally synchronous: route lookups must be O(depth)
+/// in a trie — no I/O, no allocation on the hot path.
+pub trait GatewayRouter: Send + Sync {
+    /// Register a new route.  Returns [`GatewayConfigError::DuplicateRoute`] if
+    /// a route with the same `id` is already registered.
+    fn register(&mut self, route: RouteConfig) -> Result<(), GatewayConfigError>;
+
+    /// Resolve a request `(path, method)` to the best matching route.
+    /// Returns `None` when no route matches.
+    fn resolve(&self, path: &str, method: &HttpMethod) -> Option<RouteMatch>;
+
+    /// Return a snapshot of all registered routes, sorted by descending priority.
+    fn routes(&self) -> Vec<&RouteConfig>;
+
+    /// Remove a previously registered route.
+    /// Returns [`GatewayConfigError::RouteNotFound`] if the id is not registered.
+    fn deregister(&mut self, route_id: &str) -> Result<(), GatewayConfigError>;
+}

--- a/crates/mofa-kernel/src/lib.rs
+++ b/crates/mofa-kernel/src/lib.rs
@@ -67,6 +67,7 @@ pub mod security;
 // Gateway routing abstractions (kernel-level traits for agent request dispatch)
 pub mod gateway;
 pub use gateway::{
-    GatewayConfigError, GatewayContext, GatewayRequest, GatewayResponse, GatewayRoute, HttpMethod,
-    RegistryError, RouteMatch, RouteRegistry, RoutingContext,
+    FilterAction, FilterChainConfig, FilterOrder, GatewayConfigError, GatewayContext, GatewayFilter,
+    GatewayRequest, GatewayResponse, GatewayRoute, GatewayRouter, HttpMethod, RegistryError,
+    RouteConfig, RouteMatch, RouteRegistry, RoutingContext,
 };


### PR DESCRIPTION
**Types exist. Now let's define what they're actually supposed to do.**

---

### Phase 2 adds the routing and filtering contracts — the behavioural backbone of the gateway layer.

- `GatewayRouter` and `GatewayFilter` are now defined as kernel-level traits.
- Any crate can implement its own router or filter without touching business logic.
- Route config gets a full builder API with validation — no more silent misconfiguration at startup.

---

### Architecture
<img width="1380" height="929" alt="image" src="https://github.com/user-attachments/assets/d481988c-f52e-4cc8-8669-7068c684d2b9" />


### Background

Phase 1 (#876) introduced the data types — requests, responses, errors. But types alone don't define behaviour. This phase defines *what the gateway does* with those types: how it routes a request, how it filters it, and in what order.

Previously (#774), routing and filtering logic was buried inside concrete structs in `mofa-gateway`. Swapping them out, testing them in isolation, or reusing them in another crate was not possible. These traits fix that.

---

### What's in this commit

- **`GatewayRouter` trait**: `register()`, `resolve()` returns `RouteMatch`, `routes()`, `deregister()`
- **`RouteConfig`**: route descriptor with id, path pattern, methods, backend id, timeout, priority — builder API with `validate()`
- **`GatewayFilter` async trait**: `name()`, `order()` returns `FilterOrder`, `on_request()`, `on_response()`
- **`FilterOrder` constants**: PRE_AUTH=0, AUTH=100, RATE_LIMIT=200, TRANSFORM=300, LOGGING=400, POST_PROCESS=500
- **`FilterAction` enum**: `Continue`, `Reject(status, message)`, `Redirect(url)`
- **`FilterChainConfig`**: ordered list of filter names
- **Trait definitions only — no implementations.** Implementations land in Phase 4 (`mofa-gateway`).

---

### Tests / Examples

No tests at this stage — these are pure trait definitions with no runtime logic. Tests land in Phase 4 when the implementations are introduced.

---

**Stacked PR series:** #876 -> #882 -> #883 -> #884 -> #885  
*Base: `feat/task12-phase1-types-errors` (post-#876)*
