### PR TITLE
feat(kernel): Gateway Microkernel Layer — Capability Registry and Config Validation (Task 12 Phase 3/5)

### DIFF
--- a/crates/mofa-kernel/src/gateway/capability.rs
+++ b/crates/mofa-kernel/src/gateway/capability.rs
@@ -1,0 +1,182 @@
+//! Backend capability registry — kernel contract.
+//!
+//! The [`CapabilityRegistry`] trait is the single kernel-level abstraction for
+//! discovering and managing the backend targets that the gateway can forward
+//! requests to.  Concrete implementations (in-memory, service-mesh, Consul …)
+//! live in `mofa-gateway` or plugin crates.
+
+use super::config_error::GatewayConfigError;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Backend kind
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Classifies what *type* of service a backend represents.
+///
+/// This drives capability-matching logic: an LLM route must not be forwarded
+/// to an IoT backend, for example.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum BackendKind {
+    /// OpenAI-compatible completion / embedding endpoint.
+    LlmOpenAI,
+    /// Anthropic Claude API endpoint.
+    LlmAnthropic,
+    /// Generic OpenAI-compatible endpoint (e.g. local LLM, Azure OpenAI).
+    LlmCompatible,
+    /// MCP (Model Context Protocol) tool server.
+    McpTool,
+    /// Agent-to-Agent (A2A) communication target.
+    A2AAgent,
+    /// IoT hub / device endpoint.
+    IoT,
+    /// Arbitrary HTTP service.
+    Http,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Health status
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Last-known health state of a backend, updated by health-check polling.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[non_exhaustive]
+pub enum BackendHealth {
+    /// Backend is responding normally.
+    Healthy,
+    /// Backend is responding but with elevated latency or partial errors.
+    Degraded(String),
+    /// Backend is not responding or returning errors.
+    Unhealthy(String),
+    /// Health has not yet been checked since registration.
+    #[default]
+    Unknown,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CapabilityDescriptor
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Full description of a backend registered in the capability registry.
+///
+/// All registered backends have a unique `id`.  The `kind` field drives
+/// routing rules; `endpoint` is the URL the gateway will forward to.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CapabilityDescriptor {
+    /// Unique stable identifier (must not be empty).
+    pub id: String,
+    /// Classification of this backend.
+    pub kind: BackendKind,
+    /// Base URL for forwarding (e.g. `https://api.openai.com`).
+    pub endpoint: String,
+    /// Optional health-check path appended to `endpoint`
+    /// (e.g. `/health` → `GET {endpoint}/health`).
+    pub health_check_path: Option<String>,
+    /// Arbitrary key-value metadata (model names, regions, labels, …).
+    pub metadata: HashMap<String, serde_json::Value>,
+    /// Last-known health state (updated by the health-check loop).
+    #[serde(default)]
+    pub health: BackendHealth,
+}
+
+impl CapabilityDescriptor {
+    /// Construct a minimal descriptor.
+    pub fn new(
+        id: impl Into<String>,
+        kind: BackendKind,
+        endpoint: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            kind,
+            endpoint: endpoint.into(),
+            health_check_path: None,
+            metadata: HashMap::new(),
+            health: BackendHealth::Unknown,
+        }
+    }
+
+    /// Builder: set the health-check path.
+    pub fn with_health_check(mut self, path: impl Into<String>) -> Self {
+        self.health_check_path = Some(path.into());
+        self
+    }
+
+    /// Builder: attach arbitrary metadata.
+    pub fn with_metadata(
+        mut self,
+        key: impl Into<String>,
+        value: serde_json::Value,
+    ) -> Self {
+        self.metadata.insert(key.into(), value);
+        self
+    }
+
+    /// Basic sanity checks run during gateway config validation.
+    pub(crate) fn validate(&self) -> Result<(), GatewayConfigError> {
+        if self.id.trim().is_empty() {
+            return Err(GatewayConfigError::EmptyBackendId);
+        }
+        if self.endpoint.trim().is_empty() {
+            return Err(GatewayConfigError::InvalidEndpoint(
+                self.id.clone(),
+                "endpoint URI cannot be empty".to_string(),
+            ));
+        }
+        if !self.endpoint.starts_with("http://") && !self.endpoint.starts_with("https://") {
+            return Err(GatewayConfigError::InvalidEndpoint(
+                self.id.clone(),
+                format!(
+                    "endpoint '{}' must start with http:// or https://",
+                    self.endpoint
+                ),
+            ));
+        }
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CapabilityRegistry trait
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Kernel contract for the backend capability registry.
+///
+/// This trait is intentionally **synchronous** and scoped to in-memory
+/// implementations.  I/O-backed registries (e.g. service-mesh, Consul)
+/// should wrap an internal async layer and expose a sync facade that
+/// reads from a locally-cached snapshot.
+pub trait CapabilityRegistry: Send + Sync {
+    /// Register a new backend.
+    ///
+    /// Returns [`GatewayConfigError::DuplicateBackend`] if a descriptor with
+    /// the same `id` already exists.
+    fn register(&mut self, descriptor: CapabilityDescriptor) -> Result<(), GatewayConfigError>;
+
+    /// Look up a backend by its unique id.  Returns `None` if not found.
+    fn lookup(&self, id: &str) -> Option<&CapabilityDescriptor>;
+
+    /// Return all backends of a specific [`BackendKind`].
+    fn list_by_kind(&self, kind: &BackendKind) -> Vec<&CapabilityDescriptor>;
+
+    /// Return all registered backends.
+    fn list_all(&self) -> Vec<&CapabilityDescriptor>;
+
+    /// Remove a backend by id.
+    ///
+    /// Returns [`GatewayConfigError::BackendNotFound`] if the id is not
+    /// registered.
+    fn deregister(&mut self, id: &str) -> Result<(), GatewayConfigError>;
+
+    /// Update the health state of a registered backend.
+    ///
+    /// Returns [`GatewayConfigError::BackendNotFound`] if the id is not
+    /// registered.
+    fn update_health(
+        &mut self,
+        id: &str,
+        health: BackendHealth,
+    ) -> Result<(), GatewayConfigError>;
+}

--- a/crates/mofa-kernel/src/gateway/mod.rs
+++ b/crates/mofa-kernel/src/gateway/mod.rs
@@ -25,6 +25,12 @@
 //! | [`FilterOrder`] | Numeric ordering slot for filters |
 //! | [`FilterAction`] | Continue / Reject / Redirect action from a filter |
 //! | [`FilterChainConfig`] | Named ordered list of filter names |
+//! | [`BackendKind`] | Classification of a backend service |
+//! | [`BackendHealth`] | Last-known health state of a backend |
+//! | [`CapabilityDescriptor`] | Full description of a registered backend |
+//! | [`CapabilityRegistry`] | Trait for backend discovery and management |
+//! | [`GatewayConfig`] | Top-level gateway configuration container |
+//! | [`RateLimitConfig`] | Token-bucket rate-limit parameters |
 
 pub mod error;
 pub mod route;
@@ -32,6 +38,8 @@ mod config_error;
 mod types;
 mod router;
 mod filter;
+mod capability;
+mod validation;
 
 #[cfg(test)]
 mod tests;
@@ -42,3 +50,5 @@ pub use config_error::GatewayConfigError;
 pub use types::{GatewayContext, GatewayRequest, GatewayResponse, RouteMatch};
 pub use router::{GatewayRouter, RouteConfig};
 pub use filter::{FilterAction, FilterChainConfig, FilterOrder, GatewayFilter};
+pub use capability::{BackendHealth, BackendKind, CapabilityDescriptor, CapabilityRegistry};
+pub use validation::{GatewayConfig, RateLimitConfig};

--- a/crates/mofa-kernel/src/gateway/validation.rs
+++ b/crates/mofa-kernel/src/gateway/validation.rs
@@ -1,0 +1,426 @@
+//! Gateway configuration container and structural validation.
+//!
+//! [`GatewayConfig`] aggregates the three configuration dimensions
+//! (routes, backends, global settings) and exposes a single
+//! [`GatewayConfig::validate`] method that checks all structural invariants
+//! *before* any runtime resources are allocated.
+//!
+//! This mirrors the `MessageGraph::validate()` / `MessageGraph::compile()`
+//! pattern established in `mofa-kernel::message_graph`.
+
+use super::capability::CapabilityDescriptor;
+use super::config_error::GatewayConfigError;
+use super::filter::FilterChainConfig;
+use super::router::RouteConfig;
+use std::collections::HashSet;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RateLimitConfig
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Simple token-bucket rate-limit parameters.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RateLimitConfig {
+    /// Sustained token refill rate (tokens per second).
+    pub rate_per_second: u32,
+    /// Maximum burst capacity (must be >= `rate_per_second`).
+    pub burst_capacity: u32,
+}
+
+impl RateLimitConfig {
+    /// Create a new rate-limit config.
+    pub fn new(rate_per_second: u32, burst_capacity: u32) -> Self {
+        Self {
+            rate_per_second,
+            burst_capacity,
+        }
+    }
+
+    fn validate(&self) -> Result<(), GatewayConfigError> {
+        if self.burst_capacity < self.rate_per_second {
+            return Err(GatewayConfigError::InvalidRateLimit);
+        }
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GatewayConfig
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Top-level gateway configuration.
+///
+/// Call [`validate()`](Self::validate) to check all structural invariants
+/// before passing this config to the gateway runtime.
+#[derive(Debug, Clone)]
+pub struct GatewayConfig {
+    /// Unique identifier for this gateway instance.
+    pub id: String,
+    /// All route definitions.
+    pub routes: Vec<RouteConfig>,
+    /// All registered backend descriptors.
+    pub backends: Vec<CapabilityDescriptor>,
+    /// Optional filter chain configuration.
+    pub filter_chain: Option<FilterChainConfig>,
+    /// Global default request timeout in milliseconds (must be > 0).
+    pub request_timeout_ms: u64,
+    /// Optional global rate-limit configuration.
+    pub rate_limit: Option<RateLimitConfig>,
+}
+
+impl GatewayConfig {
+    /// Construct a minimal config with only a gateway id.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            routes: Vec::new(),
+            backends: Vec::new(),
+            filter_chain: None,
+            request_timeout_ms: 30_000,
+            rate_limit: None,
+        }
+    }
+
+    /// Builder: add a route.
+    pub fn with_route(mut self, route: RouteConfig) -> Self {
+        self.routes.push(route);
+        self
+    }
+
+    /// Builder: add a backend.
+    pub fn with_backend(mut self, backend: CapabilityDescriptor) -> Self {
+        self.backends.push(backend);
+        self
+    }
+
+    /// Builder: set the filter chain.
+    pub fn with_filter_chain(mut self, chain: FilterChainConfig) -> Self {
+        self.filter_chain = Some(chain);
+        self
+    }
+
+    /// Builder: set the global request timeout.
+    pub fn with_timeout_ms(mut self, ms: u64) -> Self {
+        self.request_timeout_ms = ms;
+        self
+    }
+
+    /// Builder: set the rate-limit config.
+    pub fn with_rate_limit(mut self, rl: RateLimitConfig) -> Self {
+        self.rate_limit = Some(rl);
+        self
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Validation
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Validate all structural invariants of this configuration.
+    ///
+    /// Returns `Ok(())` if the configuration is structurally sound and can be
+    /// used to initialise the gateway runtime.  Returns the *first* detected
+    /// [`GatewayConfigError`] otherwise.
+    ///
+    /// Checks performed (in order):
+    /// 1. Gateway id is non-empty.
+    /// 2. At least one route is defined.
+    /// 3. At least one backend is defined.
+    /// 4. Global `request_timeout_ms` is non-zero.
+    /// 5. Each backend passes its own [`CapabilityDescriptor::validate()`] check.
+    /// 6. No two backends share the same id.
+    /// 7. Each route passes its own [`RouteConfig::validate()`] check.
+    /// 8. No two routes share the same id.
+    /// 9. Every route's `backend_id` refers to a declared backend.
+    /// 10. If a filter chain is present, it is non-empty.
+    /// 11. If a rate-limit config is present, burst >= rate.
+    pub fn validate(&self) -> Result<(), GatewayConfigError> {
+        // ── 1. Gateway id ────────────────────────────────────────────────────
+        if self.id.trim().is_empty() {
+            return Err(GatewayConfigError::EmptyGatewayId);
+        }
+
+        // ── 2. At least one route ────────────────────────────────────────────
+        if self.routes.is_empty() {
+            return Err(GatewayConfigError::NoRoutes);
+        }
+
+        // ── 3. At least one backend ──────────────────────────────────────────
+        if self.backends.is_empty() {
+            return Err(GatewayConfigError::NoBackends);
+        }
+
+        // ── 4. Global timeout is non-zero ────────────────────────────────────
+        if self.request_timeout_ms == 0 {
+            return Err(GatewayConfigError::InvalidTimeout);
+        }
+
+        // ── Build backend id lookup set ──────────────────────────────────────
+        let mut backend_ids: HashSet<&str> = HashSet::new();
+
+        // ── 5 + 6. Validate each backend, check for duplicates ──────────────
+        for backend in &self.backends {
+            backend.validate()?;
+            if !backend_ids.insert(backend.id.as_str()) {
+                return Err(GatewayConfigError::DuplicateBackend(backend.id.clone()));
+            }
+        }
+
+        // ── 7 + 8 + 9. Validate each route ──────────────────────────────────
+        let mut route_ids: HashSet<&str> = HashSet::new();
+        for route in &self.routes {
+            route.validate()?;
+            if !route_ids.insert(route.id.as_str()) {
+                return Err(GatewayConfigError::DuplicateRoute(route.id.clone()));
+            }
+            if !backend_ids.contains(route.backend_id.as_str()) {
+                return Err(GatewayConfigError::UnknownBackend(
+                    route.id.clone(),
+                    route.backend_id.clone(),
+                ));
+            }
+        }
+
+        // ── 10. Filter chain must be non-empty if present ───────────────────
+        if self
+            .filter_chain
+            .as_ref()
+            .is_some_and(|chain| chain.filter_names.is_empty())
+        {
+            return Err(GatewayConfigError::EmptyFilterChain);
+        }
+
+        // ── 11. Rate-limit burst >= rate ─────────────────────────────────────
+        if let Some(rl) = &self.rate_limit {
+            rl.validate()?;
+        }
+
+        Ok(())
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gateway::capability::{BackendKind, CapabilityDescriptor};
+    use crate::gateway::filter::FilterChainConfig;
+    use crate::gateway::router::RouteConfig;
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    fn openai_backend() -> CapabilityDescriptor {
+        CapabilityDescriptor::new("openai", BackendKind::LlmOpenAI, "https://api.openai.com")
+    }
+
+    fn chat_route() -> RouteConfig {
+        RouteConfig::new("chat", "/v1/chat/completions", "openai")
+    }
+
+    fn valid_config() -> GatewayConfig {
+        GatewayConfig::new("gateway-test")
+            .with_backend(openai_backend())
+            .with_route(chat_route())
+    }
+
+    // ── Happy path ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn valid_config_passes_validation() {
+        assert!(valid_config().validate().is_ok());
+    }
+
+    #[test]
+    fn valid_config_with_filter_chain_passes() {
+        let chain =
+            FilterChainConfig::new("default", vec!["auth".to_string(), "log".to_string()]);
+        let cfg = valid_config().with_filter_chain(chain);
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn valid_config_with_rate_limit_passes() {
+        let rl = RateLimitConfig::new(100, 200);
+        let cfg = valid_config().with_rate_limit(rl);
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn multiple_routes_and_backends_pass() {
+        let anthropic = CapabilityDescriptor::new(
+            "anthropic",
+            BackendKind::LlmAnthropic,
+            "https://api.anthropic.com",
+        );
+        let models_route = RouteConfig::new("models", "/v1/models", "anthropic");
+        let cfg = valid_config()
+            .with_backend(anthropic)
+            .with_route(models_route);
+        assert!(cfg.validate().is_ok());
+    }
+
+    // ── Identity errors ──────────────────────────────────────────────────────
+
+    #[test]
+    fn empty_gateway_id_returns_error() {
+        let cfg = GatewayConfig::new("")
+            .with_backend(openai_backend())
+            .with_route(chat_route());
+        assert_eq!(cfg.validate(), Err(GatewayConfigError::EmptyGatewayId));
+    }
+
+    #[test]
+    fn whitespace_only_gateway_id_returns_error() {
+        let cfg = GatewayConfig::new("   ")
+            .with_backend(openai_backend())
+            .with_route(chat_route());
+        assert_eq!(cfg.validate(), Err(GatewayConfigError::EmptyGatewayId));
+    }
+
+    // ── Route errors ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn no_routes_returns_error() {
+        let cfg = GatewayConfig::new("gw").with_backend(openai_backend());
+        assert_eq!(cfg.validate(), Err(GatewayConfigError::NoRoutes));
+    }
+
+    #[test]
+    fn duplicate_route_id_returns_error() {
+        let cfg = GatewayConfig::new("gw")
+            .with_backend(openai_backend())
+            .with_route(chat_route())
+            .with_route(chat_route()); // same id
+        assert_eq!(
+            cfg.validate(),
+            Err(GatewayConfigError::DuplicateRoute("chat".to_string()))
+        );
+    }
+
+    #[test]
+    fn route_with_empty_id_returns_error() {
+        let bad_route = RouteConfig::new("", "/v1/chat/completions", "openai");
+        let cfg = GatewayConfig::new("gw")
+            .with_backend(openai_backend())
+            .with_route(bad_route);
+        assert_eq!(cfg.validate(), Err(GatewayConfigError::EmptyRouteId));
+    }
+
+    #[test]
+    fn route_path_missing_leading_slash_returns_error() {
+        let bad_route = RouteConfig::new("chat", "v1/chat/completions", "openai");
+        let cfg = GatewayConfig::new("gw")
+            .with_backend(openai_backend())
+            .with_route(bad_route);
+        assert!(matches!(
+            cfg.validate(),
+            Err(GatewayConfigError::InvalidPathPattern(ref id, _)) if id == "chat"
+        ));
+    }
+
+    #[test]
+    fn route_referencing_unknown_backend_returns_error() {
+        let route = RouteConfig::new("chat", "/v1/chat/completions", "nonexistent-backend");
+        let cfg = GatewayConfig::new("gw")
+            .with_backend(openai_backend())
+            .with_route(route);
+        assert!(matches!(
+            cfg.validate(),
+            Err(GatewayConfigError::UnknownBackend(ref rid, ref bid))
+                if rid == "chat" && bid == "nonexistent-backend"
+        ));
+    }
+
+    // ── Backend errors ───────────────────────────────────────────────────────
+
+    #[test]
+    fn no_backends_returns_error() {
+        let cfg = GatewayConfig::new("gw").with_route(chat_route());
+        assert_eq!(cfg.validate(), Err(GatewayConfigError::NoBackends));
+    }
+
+    #[test]
+    fn duplicate_backend_id_returns_error() {
+        let cfg = GatewayConfig::new("gw")
+            .with_backend(openai_backend())
+            .with_backend(openai_backend()) // same id
+            .with_route(chat_route());
+        assert_eq!(
+            cfg.validate(),
+            Err(GatewayConfigError::DuplicateBackend("openai".to_string()))
+        );
+    }
+
+    #[test]
+    fn backend_with_empty_id_returns_error() {
+        let bad =
+            CapabilityDescriptor::new("", BackendKind::LlmOpenAI, "https://api.openai.com");
+        let cfg = GatewayConfig::new("gw")
+            .with_backend(bad)
+            .with_route(chat_route());
+        assert_eq!(cfg.validate(), Err(GatewayConfigError::EmptyBackendId));
+    }
+
+    #[test]
+    fn backend_with_empty_endpoint_returns_error() {
+        let bad = CapabilityDescriptor::new("openai", BackendKind::LlmOpenAI, "");
+        let cfg = GatewayConfig::new("gw")
+            .with_backend(bad)
+            .with_route(chat_route());
+        assert!(matches!(
+            cfg.validate(),
+            Err(GatewayConfigError::InvalidEndpoint(ref id, _)) if id == "openai"
+        ));
+    }
+
+    #[test]
+    fn backend_endpoint_without_http_scheme_returns_error() {
+        let bad =
+            CapabilityDescriptor::new("openai", BackendKind::LlmOpenAI, "ftp://badscheme.com");
+        let cfg = GatewayConfig::new("gw")
+            .with_backend(bad)
+            .with_route(chat_route());
+        assert!(matches!(
+            cfg.validate(),
+            Err(GatewayConfigError::InvalidEndpoint(ref id, _)) if id == "openai"
+        ));
+    }
+
+    // ── Timeout errors ───────────────────────────────────────────────────────
+
+    #[test]
+    fn zero_request_timeout_returns_error() {
+        let cfg = valid_config().with_timeout_ms(0);
+        assert_eq!(cfg.validate(), Err(GatewayConfigError::InvalidTimeout));
+    }
+
+    // ── Filter chain errors ──────────────────────────────────────────────────
+
+    #[test]
+    fn empty_filter_chain_returns_error() {
+        let chain = FilterChainConfig::new("default", vec![]);
+        let cfg = valid_config().with_filter_chain(chain);
+        assert_eq!(
+            cfg.validate(),
+            Err(GatewayConfigError::EmptyFilterChain)
+        );
+    }
+
+    // ── Rate limit errors ────────────────────────────────────────────────────
+
+    #[test]
+    fn burst_less_than_rate_returns_error() {
+        let rl = RateLimitConfig::new(100, 50); // burst < rate — invalid
+        let cfg = valid_config().with_rate_limit(rl);
+        assert_eq!(cfg.validate(), Err(GatewayConfigError::InvalidRateLimit));
+    }
+
+    #[test]
+    fn burst_equal_to_rate_passes() {
+        let rl = RateLimitConfig::new(100, 100); // burst == rate — valid
+        let cfg = valid_config().with_rate_limit(rl);
+        assert!(cfg.validate().is_ok());
+    }
+}

--- a/crates/mofa-kernel/src/lib.rs
+++ b/crates/mofa-kernel/src/lib.rs
@@ -67,7 +67,8 @@ pub mod security;
 // Gateway routing abstractions (kernel-level traits for agent request dispatch)
 pub mod gateway;
 pub use gateway::{
-    FilterAction, FilterChainConfig, FilterOrder, GatewayConfigError, GatewayContext, GatewayFilter,
-    GatewayRequest, GatewayResponse, GatewayRoute, GatewayRouter, HttpMethod, RegistryError,
-    RouteConfig, RouteMatch, RouteRegistry, RoutingContext,
+    BackendHealth, BackendKind, CapabilityDescriptor, CapabilityRegistry, FilterAction,
+    FilterChainConfig, FilterOrder, GatewayConfig, GatewayConfigError, GatewayContext,
+    GatewayFilter, GatewayRequest, GatewayResponse, GatewayRoute, GatewayRouter, HttpMethod,
+    RateLimitConfig, RegistryError, RouteConfig, RouteMatch, RouteRegistry, RoutingContext,
 };


### PR DESCRIPTION
**What backends exist? Are they healthy? Is this config even valid? Phase 3 answers all three.**

---

### Phase 3 adds capability discovery, backend health tracking, and config validation — the safety net before anything runs.

- The kernel now knows *what* backends exist and what kind they are (LLM, MCP, IoT, HTTP, A2A).
- `GatewayConfig.validate()` catches 11 classes of misconfiguration at startup, not at runtime.
- 20 unit tests — all pass.

---

### Architecture
<img width="1060" height="649" alt="image" src="https://github.com/user-attachments/assets/cb912f4f-62d0-4e64-914a-0ca906e65beb" />


### Background

Phases 1 and 2 gave us the data models and the routing/filtering contracts. But neither phase answers a critical question: *how does the gateway know what backends it can forward to, and are they healthy?* That's the gap this phase closes.

Previously (#774), backend registration and health state were part of the monolithic control plane — no clean interface to query or update them from other crates. This phase extracts that into a `CapabilityRegistry` trait and a `CapabilityDescriptor` type, both in `mofa-kernel`.

---

### What's in this commit

- **`BackendKind` enum**: `LlmOpenAI`, `LlmAnthropic`, `LlmCompatible`, `McpTool`, `A2AAgent`, `IoT`, `Http`
- **`BackendHealth` enum**: `Healthy`, `Degraded(msg)`, `Unhealthy(msg)`, `Unknown`
- **`CapabilityDescriptor`**: full backend description — id, kind, endpoint, health check path, metadata, health state
- **`CapabilityRegistry` trait**: `register`, `lookup`, `list_by_kind`, `list_all`, `deregister`, `update_health`
- **`RateLimitConfig`**: `rate_per_second`, `burst_capacity`
- **`GatewayConfig`**: full gateway configuration with 11-step structural `validate()` covering empty IDs, duplicate routes, invalid endpoints, unknown backends, invalid rate limits, and more

---

### Tests

20 unit tests covering config validation edge cases. All pass.

---

**Stacked PR series:** #876 -> #882 -> #883 -> #884 -> #885  
*Base: `feat/task12-phase2-kernel-traits` (post-#882)*
