### PR TITLE
feat(gateway): Gateway Microkernel Layer — OpenAI Backend Proxy and Capability Registry (Task 12 Phase 5/5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5924,6 +5924,7 @@ dependencies = [
  "prost",
  "prost-types",
  "rand 0.8.5",
+ "reqwest",
  "rocksdb",
  "serde",
  "serde_json",

--- a/crates/mofa-gateway/Cargo.toml
+++ b/crates/mofa-gateway/Cargo.toml
@@ -44,6 +44,7 @@ prometheus = { version = "0.13", default-features = false }
 tower = "0.5"
 hyper = { version = "1.8", features = ["full"] }
 hyper-util = "0.1"
+reqwest = { workspace = true, features = ["json"] }
 
 # Utilities
 dashmap = "5.5"

--- a/crates/mofa-gateway/src/backend/mod.rs
+++ b/crates/mofa-gateway/src/backend/mod.rs
@@ -1,0 +1,7 @@
+//! Backend module.
+
+mod openai;
+mod registry;
+
+pub use openai::OpenAiBackend;
+pub use registry::InMemoryCapabilityRegistry;

--- a/crates/mofa-gateway/src/backend/openai.rs
+++ b/crates/mofa-gateway/src/backend/openai.rs
@@ -1,0 +1,130 @@
+//! OpenAI-compatible backend proxy.
+//!
+//! [`OpenAiBackend`] forwards requests to any OpenAI-compatible completion
+//! endpoint (OpenAI, Azure OpenAI, local LLMs running Ollama / llama.cpp,
+//! etc.) and relays the response body verbatim.
+//!
+//! The proxy is intentionally transparent: it does not parse or modify the
+//! request/response JSON, which means it is forward-compatible with new
+//! model parameters without code changes.
+
+use crate::error::{GatewayError, GatewayResult};
+use mofa_kernel::gateway::{GatewayRequest, GatewayResponse};
+use reqwest::Client;
+use std::time::Duration;
+use tracing::{debug, instrument};
+
+/// Proxies requests to an OpenAI-compatible REST API endpoint.
+pub struct OpenAiBackend {
+    backend_id: String,
+    base_url: String,
+    api_key: Option<String>,
+    client: Client,
+}
+
+impl OpenAiBackend {
+    /// Create a new backend proxy.
+    ///
+    /// - `backend_id`: registry id (used in metrics and error messages).
+    /// - `base_url`:  base URL, e.g. `https://api.openai.com`.
+    /// - `api_key`:   optional API key.  When `None` the gateway relies on the
+    ///   caller to supply its own credentials via `Authorization` header.
+    pub fn new(
+        backend_id: impl Into<String>,
+        base_url: impl Into<String>,
+        api_key: Option<String>,
+    ) -> Self {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(120))
+            .build()
+            .expect("failed to build reqwest client");
+
+        Self {
+            backend_id: backend_id.into(),
+            base_url: base_url.into().trim_end_matches('/').to_string(),
+            api_key,
+            client,
+        }
+    }
+
+    /// Forward `req` to `{base_url}{req.path}` and return a [`GatewayResponse`].
+    #[instrument(skip(self, req), fields(backend = %self.backend_id, path = %req.path))]
+    pub async fn forward(&self, req: &GatewayRequest) -> GatewayResult<GatewayResponse> {
+        let url = format!("{}{}", self.base_url, req.path);
+        debug!(url = %url, "forwarding to OpenAI-compatible backend");
+
+        let start = std::time::Instant::now();
+
+        // Match on a reference to avoid moving out of the borrowed GatewayRequest.
+        let mut builder = match &req.method {
+            mofa_kernel::gateway::HttpMethod::Post => self.client.post(&url),
+            mofa_kernel::gateway::HttpMethod::Get => self.client.get(&url),
+            mofa_kernel::gateway::HttpMethod::Put => self.client.put(&url),
+            mofa_kernel::gateway::HttpMethod::Delete => self.client.delete(&url),
+            mofa_kernel::gateway::HttpMethod::Patch => self.client.patch(&url),
+            _ => self.client.post(&url), // HEAD/OPTIONS: fall back to POST for proxy
+        };
+
+        // Forward headers from the original request, except `host`.
+        for (key, value) in &req.headers {
+            if key == "host" || key == "content-length" {
+                continue;
+            }
+            builder = builder.header(key, value);
+        }
+
+        // Inject backend API key if configured, overriding any caller-supplied key.
+        if let Some(key) = &self.api_key {
+            builder = builder.header("authorization", format!("Bearer {}", key));
+        }
+
+        // Send body if present.
+        if !req.body.is_empty() {
+            builder = builder
+                .header("content-type", "application/json")
+                .body(req.body.clone());
+        }
+
+        let upstream_resp = builder.send().await.map_err(|e| {
+            GatewayError::AgentOperationFailed(format!(
+                "network error for backend '{}': {}",
+                self.backend_id, e
+            ))
+        })?;
+
+        let latency_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+        let status = upstream_resp.status().as_u16();
+
+        // Collect response headers.
+        let mut headers = std::collections::HashMap::new();
+        for (name, value) in upstream_resp.headers() {
+            if let Ok(v) = value.to_str() {
+                headers.insert(name.to_string(), v.to_string());
+            }
+        }
+
+        let body = upstream_resp.bytes().await.map_err(|e| {
+            GatewayError::AgentOperationFailed(format!(
+                "network error for backend '{}': {}",
+                self.backend_id, e
+            ))
+        })?;
+
+        // Surface 5xx responses as errors; 4xx are proxied transparently so
+        // callers can inspect the structured error body (e.g. OpenAI 429 JSON).
+        if status >= 500 {
+            return Err(GatewayError::AgentOperationFailed(format!(
+                "upstream '{}' returned HTTP {}: {}",
+                self.backend_id,
+                status,
+                String::from_utf8_lossy(&body)
+            )));
+        }
+
+        let mut resp = GatewayResponse::new(status, &self.backend_id);
+        resp.headers = headers;
+        resp.body = body.to_vec();
+        resp.latency_ms = latency_ms;
+        Ok(resp)
+    }
+}

--- a/crates/mofa-gateway/src/backend/registry.rs
+++ b/crates/mofa-gateway/src/backend/registry.rs
@@ -1,0 +1,117 @@
+//! In-memory [`CapabilityRegistry`] implementation.
+
+use mofa_kernel::gateway::{
+    BackendHealth, BackendKind, CapabilityDescriptor, CapabilityRegistry, GatewayConfigError,
+};
+use std::collections::HashMap;
+
+/// [`CapabilityRegistry`] backed by a simple `HashMap`.
+///
+/// Suitable for single-node deployments.  Distributed/service-mesh
+/// implementations belong in separate plugin crates.
+#[derive(Default)]
+pub struct InMemoryCapabilityRegistry {
+    store: HashMap<String, CapabilityDescriptor>,
+}
+
+impl InMemoryCapabilityRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl CapabilityRegistry for InMemoryCapabilityRegistry {
+    fn register(&mut self, descriptor: CapabilityDescriptor) -> Result<(), GatewayConfigError> {
+        if self.store.contains_key(&descriptor.id) {
+            return Err(GatewayConfigError::DuplicateBackend(descriptor.id));
+        }
+        self.store.insert(descriptor.id.clone(), descriptor);
+        Ok(())
+    }
+
+    fn lookup(&self, id: &str) -> Option<&CapabilityDescriptor> {
+        self.store.get(id)
+    }
+
+    fn list_by_kind(&self, kind: &BackendKind) -> Vec<&CapabilityDescriptor> {
+        self.store.values().filter(|d| &d.kind == kind).collect()
+    }
+
+    fn list_all(&self) -> Vec<&CapabilityDescriptor> {
+        self.store.values().collect()
+    }
+
+    fn deregister(&mut self, id: &str) -> Result<(), GatewayConfigError> {
+        self.store
+            .remove(id)
+            .map(|_| ())
+            .ok_or_else(|| GatewayConfigError::BackendNotFound(id.to_string()))
+    }
+
+    fn update_health(&mut self, id: &str, health: BackendHealth) -> Result<(), GatewayConfigError> {
+        self.store
+            .get_mut(id)
+            .map(|d| d.health = health)
+            .ok_or_else(|| GatewayConfigError::BackendNotFound(id.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn openai() -> CapabilityDescriptor {
+        CapabilityDescriptor::new("openai", BackendKind::LlmOpenAI, "https://api.openai.com")
+    }
+
+    #[test]
+    fn register_and_lookup() {
+        let mut reg = InMemoryCapabilityRegistry::new();
+        reg.register(openai()).unwrap();
+        assert!(reg.lookup("openai").is_some());
+        assert!(reg.lookup("unknown").is_none());
+    }
+
+    #[test]
+    fn duplicate_register_returns_error() {
+        let mut reg = InMemoryCapabilityRegistry::new();
+        reg.register(openai()).unwrap();
+        assert!(matches!(
+            reg.register(openai()),
+            Err(GatewayConfigError::DuplicateBackend(_))
+        ));
+    }
+
+    #[test]
+    fn list_by_kind_filters_correctly() {
+        let mut reg = InMemoryCapabilityRegistry::new();
+        reg.register(openai()).unwrap();
+        reg.register(CapabilityDescriptor::new(
+            "ha-hub",
+            BackendKind::IoT,
+            "http://homeassistant.local:8123",
+        ))
+        .unwrap();
+
+        assert_eq!(reg.list_by_kind(&BackendKind::LlmOpenAI).len(), 1);
+        assert_eq!(reg.list_by_kind(&BackendKind::IoT).len(), 1);
+        assert_eq!(reg.list_by_kind(&BackendKind::McpTool).len(), 0);
+    }
+
+    #[test]
+    fn deregister_removes_entry() {
+        let mut reg = InMemoryCapabilityRegistry::new();
+        reg.register(openai()).unwrap();
+        reg.deregister("openai").unwrap();
+        assert!(reg.lookup("openai").is_none());
+    }
+
+    #[test]
+    fn update_health_reflects_new_state() {
+        let mut reg = InMemoryCapabilityRegistry::new();
+        reg.register(openai()).unwrap();
+        reg.update_health("openai", BackendHealth::Healthy).unwrap();
+        assert_eq!(reg.lookup("openai").unwrap().health, BackendHealth::Healthy);
+    }
+}

--- a/crates/mofa-gateway/src/lib.rs
+++ b/crates/mofa-gateway/src/lib.rs
@@ -87,6 +87,7 @@ pub mod types;
 // Task 12: Cognitive Gateway — kernel trait implementations
 pub mod router;
 pub mod filter;
+pub mod backend;
 
 // Re-export main types
 pub use control_plane::{ControlPlane, ControlPlaneConfig};
@@ -94,5 +95,6 @@ pub use error::{ControlPlaneError, GatewayError, GatewayResult};
 pub use gateway::{Gateway, GatewayConfig};
 pub use router::TrieRouter;
 pub use filter::FilterPipeline;
+pub use backend::{InMemoryCapabilityRegistry, OpenAiBackend};
 pub use server::{GatewayServer, ServerConfig};
 pub use types::*;


### PR DESCRIPTION
**Route it. Filter it. Now forward it — to any OpenAI-compatible endpoint.**

---

### Phase 5 closes the loop: a working backend proxy and a runtime capability registry.

- `OpenAiBackend` is a transparent HTTP proxy for OpenAI, Azure OpenAI, Ollama, llama.cpp — anything OpenAI-compatible.
- `InMemoryCapabilityRegistry` gives single-node deployments a ready-to-use registry with zero setup.
- 5 tests — all pass.

---

### Architecture
<img width="1373" height="575" alt="image" src="https://github.com/user-attachments/assets/b98c8d6a-ca18-499f-9dbb-693960138b01" />


### Background

Phases 1-4 gave us the full kernel contract and the routing/filtering implementations. But there was no actual *backend* — nothing that takes a routed, filtered request and forwards it somewhere. Phase 5 adds that final piece.

`OpenAiBackend` is intentionally thin: it forwards headers, injects the API key, and proxies the response body verbatim. It surfaces 5xx as errors and passes 4xx through transparently so callers see structured error bodies (e.g. OpenAI 429 JSON). No magic, no transformation — just a reliable proxy.

`InMemoryCapabilityRegistry` is the reference runtime implementation. For distributed or service-mesh deployments, drop-in replacements can be written as separate plugin crates against the `CapabilityRegistry` trait from Phase 3.

---

### What's in this commit

- **`OpenAiBackend`** (`mofa-gateway`): transparent HTTP proxy for any OpenAI-compatible API endpoint. Forwards headers, injects API key, proxies response verbatim.
- **`InMemoryCapabilityRegistry`** (`mofa-gateway`): implements `CapabilityRegistry` using `HashMap`. Reference implementation for single-node deployments.
- Adds `reqwest` workspace dependency for HTTP forwarding.

---

### Tests

5 tests: `register_and_lookup`, `duplicate_register_returns_error`, `list_by_kind_filters_correctly`, `deregister_removes_entry`, `update_health_reflects_new_state`. All pass.

---

**Stacked PR series:** #876 -> #882 -> #883 -> #884 -> #885  
*Base: `feat/task12-phase4-router-filters` (post-#884)*
