### PR TITLE
feat(testing): add failure injection, sequenced responses, rate limiting & MockClock to mofa-testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,6 +1748,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf 0.11.3",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
+dependencies = [
+ "parse-zoneinfo",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2820,6 +2842,12 @@ dependencies = [
  "rustc_version",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "deunicode"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "dialoguer"
@@ -4186,6 +4214,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags 2.11.0",
+ "ignore",
+ "walkdir",
+]
+
+[[package]]
 name = "goblin"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4464,6 +4516,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humansize"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "humantime"
@@ -4766,6 +4827,22 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -5698,6 +5775,7 @@ dependencies = [
  "futures",
  "hex",
  "indicatif",
+ "json5",
  "mofa-foundation",
  "mofa-kernel",
  "mofa-runtime",
@@ -5713,6 +5791,7 @@ dependencies = [
  "sqlx",
  "tar",
  "tempfile",
+ "tera",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
@@ -5983,6 +6062,20 @@ dependencies = [
 [[package]]
 name = "mofa-smith"
 version = "0.1.0"
+
+[[package]]
+name = "mofa-testing"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "mofa-foundation",
+ "mofa-kernel",
+ "serde",
+ "serde_json",
+ "tokio",
+]
 
 [[package]]
 name = "nanorand"
@@ -6718,6 +6811,15 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec 1.15.1",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "parse-zoneinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
+dependencies = [
+ "regex",
 ]
 
 [[package]]
@@ -9000,6 +9102,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slug"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
+dependencies = [
+ "deunicode",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9741,6 +9853,28 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tera"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8004bca281f2d32df3bacd59bc67b312cb4c70cea46cbd79dbe8ac5ed206722"
+dependencies = [
+ "chrono",
+ "chrono-tz",
+ "globwalk",
+ "humansize",
+ "lazy_static",
+ "percent-encoding",
+ "pest",
+ "pest_derive",
+ "rand 0.8.5",
+ "regex",
+ "serde",
+ "serde_json",
+ "slug",
+ "unicode-segmentation",
 ]
 
 [[package]]

--- a/tests/src/backend.rs
+++ b/tests/src/backend.rs
@@ -5,23 +5,33 @@ use mofa_foundation::orchestrator::{
     ModelOrchestrator, ModelProviderConfig, ModelType, OrchestratorError, OrchestratorResult,
     PoolStatistics,
 };
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 
+type ResponseSequences = Vec<(String, VecDeque<String>)>;
+
 /// Deterministic mock implementation of [`ModelOrchestrator`].
+///
+/// Supports first-match response rules, sequenced responses, failure injection,
+/// rate limiting, and call counting.
 pub struct MockLLMBackend {
-    /// Ordered response rules — first match wins
     responses: Arc<RwLock<Vec<(String, String)>>>,
-    /// Fallback when nothing matches
     fallback: String,
-    /// Registered model IDs
     registered: Arc<RwLock<HashSet<String>>>,
-    /// Loaded model IDs
     loaded: Arc<RwLock<HashSet<String>>>,
-    /// Memory threshold (bytes)
     memory_threshold: Arc<RwLock<u64>>,
-    /// Idle timeout (seconds)
     idle_timeout_secs: Arc<RwLock<u64>>,
+    failure_queue: Arc<RwLock<VecDeque<OrchestratorError>>>,
+    failure_patterns: Arc<RwLock<Vec<(String, OrchestratorError)>>>,
+    response_sequences: Arc<RwLock<ResponseSequences>>,
+    call_count: Arc<AtomicUsize>,
+    rate_limit: Arc<RwLock<Option<RateLimit>>>,
+}
+
+struct RateLimit {
+    max_calls: usize,
+    window_calls: usize,
 }
 
 impl Default for MockLLMBackend {
@@ -40,10 +50,15 @@ impl MockLLMBackend {
             loaded: Arc::new(RwLock::new(HashSet::new())),
             memory_threshold: Arc::new(RwLock::new(u64::MAX)),
             idle_timeout_secs: Arc::new(RwLock::new(300)),
+            failure_queue: Arc::new(RwLock::new(VecDeque::new())),
+            failure_patterns: Arc::new(RwLock::new(Vec::new())),
+            response_sequences: Arc::new(RwLock::new(Vec::new())),
+            call_count: Arc::new(AtomicUsize::new(0)),
+            rate_limit: Arc::new(RwLock::new(None)),
         }
     }
 
-    /// Append a response rule.  Order determines priority (first match wins).
+    /// Append a response rule. Order determines priority (first match wins).
     pub fn add_response(&self, prompt_substring: &str, response: &str) {
         self.responses
             .write()
@@ -56,8 +71,75 @@ impl MockLLMBackend {
         self.fallback = response.to_string();
     }
 
-    /// Look up the response for a given prompt (first-match semantics).
+    /// Queue errors to be returned by the next N `infer()` calls (FIFO).
+    pub fn fail_next(&self, count: usize, error: OrchestratorError) {
+        let mut queue = self.failure_queue.write().expect("lock poisoned");
+        for _ in 0..count {
+            queue.push_back(error.clone());
+        }
+    }
+
+    /// Fail any `infer()` call whose prompt contains the given substring.
+    pub fn fail_on(&self, prompt_substring: &str, error: OrchestratorError) {
+        self.failure_patterns
+            .write()
+            .expect("lock poisoned")
+            .push((prompt_substring.to_string(), error));
+    }
+
+    /// Add a sequence of responses for a prompt pattern.
+    /// Each matching call consumes the next value; the last value repeats forever.
+    pub fn add_response_sequence(&self, prompt_substring: &str, responses: Vec<&str>) {
+        let deque: VecDeque<String> = responses.into_iter().map(String::from).collect();
+        self.response_sequences
+            .write()
+            .expect("lock poisoned")
+            .push((prompt_substring.to_string(), deque));
+    }
+
+    /// Set a rate limit: after `max_calls` invocations, subsequent calls fail.
+    /// Call [`reset_rate_limit`] to clear the counter.
+    pub fn set_rate_limit(&self, max_calls: usize) {
+        *self.rate_limit.write().expect("lock poisoned") = Some(RateLimit {
+            max_calls,
+            window_calls: 0,
+        });
+    }
+
+    /// Reset the rate limit call counter without removing the limit.
+    pub fn reset_rate_limit(&self) {
+        if let Some(rl) = self.rate_limit.write().expect("lock poisoned").as_mut() {
+            rl.window_calls = 0;
+        }
+    }
+
+    /// Total number of `infer()` calls made.
+    pub fn call_count(&self) -> usize {
+        self.call_count.load(Ordering::Relaxed)
+    }
+
+    /// Reset the call counter to zero.
+    pub fn reset_call_count(&self) {
+        self.call_count.store(0, Ordering::Relaxed);
+    }
+
+    /// Look up the response for a given prompt.
+    /// Sequence responses take priority over static rules.
     fn resolve(&self, prompt: &str) -> String {
+        // Check sequences first
+        let mut seqs = self.response_sequences.write().expect("lock poisoned");
+        for (key, deque) in seqs.iter_mut() {
+            if prompt.contains(key.as_str()) {
+                if deque.len() > 1 {
+                    return deque.pop_front().expect("deque non-empty");
+                } else if let Some(last) = deque.front() {
+                    return last.clone();
+                }
+            }
+        }
+        drop(seqs);
+
+        // Then static rules
         let rules = self.responses.read().expect("lock poisoned");
         for (key, value) in rules.iter() {
             if prompt.contains(key.as_str()) {
@@ -85,10 +167,7 @@ impl ModelOrchestrator for MockLLMBackend {
     }
 
     async fn unregister_model(&self, model_id: &str) -> OrchestratorResult<()> {
-        self.loaded
-            .write()
-            .expect("lock poisoned")
-            .remove(model_id);
+        self.loaded.write().expect("lock poisoned").remove(model_id);
         self.registered
             .write()
             .expect("lock poisoned")
@@ -99,7 +178,12 @@ impl ModelOrchestrator for MockLLMBackend {
     // -- lifecycle -----------------------------------------------------------
 
     async fn load_model(&self, model_id: &str) -> OrchestratorResult<()> {
-        if !self.registered.read().expect("lock poisoned").contains(model_id) {
+        if !self
+            .registered
+            .read()
+            .expect("lock poisoned")
+            .contains(model_id)
+        {
             return Err(OrchestratorError::ModelNotFound(model_id.to_string()));
         }
         self.loaded
@@ -110,10 +194,7 @@ impl ModelOrchestrator for MockLLMBackend {
     }
 
     async fn unload_model(&self, model_id: &str) -> OrchestratorResult<()> {
-        self.loaded
-            .write()
-            .expect("lock poisoned")
-            .remove(model_id);
+        self.loaded.write().expect("lock poisoned").remove(model_id);
         Ok(())
     }
 
@@ -127,6 +208,40 @@ impl ModelOrchestrator for MockLLMBackend {
     // -- inference -----------------------------------------------------------
 
     async fn infer(&self, _model_id: &str, input: &str) -> OrchestratorResult<String> {
+        self.call_count.fetch_add(1, Ordering::Relaxed);
+
+        // 1. Drain failure queue (FIFO)
+        {
+            let mut queue = self.failure_queue.write().expect("lock poisoned");
+            if let Some(err) = queue.pop_front() {
+                return Err(err);
+            }
+        }
+
+        // 2. Check pattern-based failures
+        {
+            let patterns = self.failure_patterns.read().expect("lock poisoned");
+            for (key, err) in patterns.iter() {
+                if input.contains(key.as_str()) {
+                    return Err(err.clone());
+                }
+            }
+        }
+
+        // 3. Check rate limit
+        {
+            let mut rl = self.rate_limit.write().expect("lock poisoned");
+            if let Some(limit) = rl.as_mut() {
+                limit.window_calls += 1;
+                if limit.window_calls > limit.max_calls {
+                    return Err(OrchestratorError::Other(format!(
+                        "Rate limit exceeded: {} calls (max {})",
+                        limit.window_calls, limit.max_calls
+                    )));
+                }
+            }
+        }
+
         Ok(self.resolve(input))
     }
 

--- a/tests/src/bus.rs
+++ b/tests/src/bus.rs
@@ -2,16 +2,17 @@
 
 use mofa_kernel::bus::{AgentBus, BusError, CommunicationMode};
 use mofa_kernel::message::AgentMessage;
+use std::collections::VecDeque;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
 /// A message-bus spy that records all sent messages for later assertions.
+/// Supports failure injection via [`fail_next_send`](Self::fail_next_send).
 #[derive(Clone)]
 pub struct MockAgentBus {
-    /// The real bus implementation (delegates actual routing)
     pub inner: AgentBus,
-    /// Chronologically ordered capture of `(sender_id, mode, message)`
     pub captured_messages: Arc<RwLock<Vec<(String, CommunicationMode, AgentMessage)>>>,
+    failure_queue: Arc<RwLock<VecDeque<String>>>,
 }
 
 impl MockAgentBus {
@@ -20,21 +21,40 @@ impl MockAgentBus {
         Self {
             inner: AgentBus::new(),
             captured_messages: Arc::new(RwLock::new(Vec::new())),
+            failure_queue: Arc::new(RwLock::new(VecDeque::new())),
+        }
+    }
+
+    /// Queue send failures for the next N calls.
+    /// Each failure returns `BusError::SendFailed` with the given message.
+    pub async fn fail_next_send(&self, count: usize, error_msg: &str) {
+        let mut queue = self.failure_queue.write().await;
+        for _ in 0..count {
+            queue.push_back(error_msg.to_string());
         }
     }
 
     /// Send a message through the inner bus **and** record it.
+    /// If failures are queued, the message is still captured but the send returns an error.
     pub async fn send_and_capture(
         &self,
         sender_id: &str,
         mode: CommunicationMode,
         message: AgentMessage,
     ) -> Result<(), BusError> {
-        // Record first so assertions see the message even if send fails
-        self.captured_messages
-            .write()
-            .await
-            .push((sender_id.to_string(), mode.clone(), message.clone()));
+        self.captured_messages.write().await.push((
+            sender_id.to_string(),
+            mode.clone(),
+            message.clone(),
+        ));
+
+        // Check failure queue before delegating
+        {
+            let mut queue = self.failure_queue.write().await;
+            if let Some(err_msg) = queue.pop_front() {
+                return Err(BusError::SendFailed(err_msg));
+            }
+        }
 
         self.inner.send_message(sender_id, mode, &message).await
     }

--- a/tests/src/clock.rs
+++ b/tests/src/clock.rs
@@ -1,0 +1,90 @@
+//! Deterministic clock for testing time-dependent agent code.
+
+use std::sync::RwLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+/// Trait for injectable time sources.
+pub trait Clock: Send + Sync {
+    /// Returns the current time in milliseconds since an arbitrary epoch.
+    fn now_millis(&self) -> u64;
+}
+
+/// A mock clock with manually controlled time.
+///
+/// Time starts at zero and only advances when you call [`advance`](Self::advance),
+/// [`set`](Self::set), or enable [`set_auto_advance`](Self::set_auto_advance).
+pub struct MockClock {
+    current_ms: AtomicU64,
+    auto_advance_ms: RwLock<Option<u64>>,
+}
+
+impl Default for MockClock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MockClock {
+    /// Create a clock starting at time zero.
+    pub fn new() -> Self {
+        Self {
+            current_ms: AtomicU64::new(0),
+            auto_advance_ms: RwLock::new(None),
+        }
+    }
+
+    /// Create a clock starting at the given duration from epoch.
+    pub fn starting_at(start: Duration) -> Self {
+        Self {
+            current_ms: AtomicU64::new(start.as_millis() as u64),
+            auto_advance_ms: RwLock::new(None),
+        }
+    }
+
+    /// Advance the clock by the given duration.
+    pub fn advance(&self, duration: Duration) {
+        self.current_ms
+            .fetch_add(duration.as_millis() as u64, Ordering::Relaxed);
+    }
+
+    /// Set the clock to an exact time.
+    pub fn set(&self, duration: Duration) {
+        self.current_ms
+            .store(duration.as_millis() as u64, Ordering::Relaxed);
+    }
+
+    /// Enable auto-advance: each call to [`now_millis`](Clock::now_millis)
+    /// automatically moves time forward by the given step.
+    pub fn set_auto_advance(&self, step: Duration) {
+        *self.auto_advance_ms.write().expect("lock poisoned") = Some(step.as_millis() as u64);
+    }
+
+    /// Disable auto-advance.
+    pub fn clear_auto_advance(&self) {
+        *self.auto_advance_ms.write().expect("lock poisoned") = None;
+    }
+}
+
+impl Clock for MockClock {
+    fn now_millis(&self) -> u64 {
+        let current = self.current_ms.load(Ordering::Relaxed);
+        if let Some(step) = *self.auto_advance_ms.read().expect("lock poisoned") {
+            self.current_ms.fetch_add(step, Ordering::Relaxed);
+        }
+        current
+    }
+}
+
+/// A real-time clock backed by [`std::time::SystemTime`].
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now_millis(&self) -> u64 {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64
+    }
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,11 +1,14 @@
 //! MoFA Testing Framework
 //!
-//! Provides mock implementations and assertion utilities for testing.
+//! Provides mock implementations, failure injection, and deterministic time
+//! control for testing MoFA agents.
 
 pub mod backend;
 pub mod bus;
+pub mod clock;
 pub mod tools;
 
 pub use backend::MockLLMBackend;
 pub use bus::MockAgentBus;
+pub use clock::{Clock, MockClock, SystemClock};
 pub use tools::MockTool;

--- a/tests/src/tools.rs
+++ b/tests/src/tools.rs
@@ -4,20 +4,25 @@ use async_trait::async_trait;
 use mofa_foundation::agent::components::tool::{SimpleTool, ToolCategory};
 use mofa_kernel::agent::components::tool::{ToolInput, ToolResult};
 use serde_json::Value;
+use std::collections::VecDeque;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
 /// A mock tool that records calls and returns a configurable result.
+/// Supports failure injection via [`fail_next`](Self::fail_next),
+/// input-pattern failures via [`fail_on_input`](Self::fail_on_input),
+/// and sequenced results via [`add_result_sequence`](Self::add_result_sequence).
 #[derive(Clone)]
 pub struct MockTool {
     name: String,
     description: String,
     schema: Value,
     category: ToolCategory,
-    /// The result returned by every call to [`execute`](SimpleTool::execute).
     pub stubbed_result: Arc<RwLock<ToolResult>>,
-    /// Chronologically ordered inputs passed to this tool.
     pub call_history: Arc<RwLock<Vec<ToolInput>>>,
+    failure_queue: Arc<RwLock<VecDeque<String>>>,
+    failure_patterns: Arc<RwLock<Vec<(Value, String)>>>,
+    result_sequence: Arc<RwLock<VecDeque<ToolResult>>>,
 }
 
 impl MockTool {
@@ -32,6 +37,9 @@ impl MockTool {
                 "Mock execution default",
             ))),
             call_history: Arc::new(RwLock::new(Vec::new())),
+            failure_queue: Arc::new(RwLock::new(VecDeque::new())),
+            failure_patterns: Arc::new(RwLock::new(Vec::new())),
+            result_sequence: Arc::new(RwLock::new(VecDeque::new())),
         }
     }
 
@@ -48,6 +56,31 @@ impl MockTool {
     /// Number of times this tool has been executed.
     pub async fn call_count(&self) -> usize {
         self.call_history.read().await.len()
+    }
+
+    /// Queue failures for the next N calls.
+    pub async fn fail_next(&self, count: usize, error_msg: &str) {
+        let mut queue = self.failure_queue.write().await;
+        for _ in 0..count {
+            queue.push_back(error_msg.to_string());
+        }
+    }
+
+    /// Fail when input arguments match the given JSON value.
+    pub async fn fail_on_input(&self, input_pattern: Value, error_msg: &str) {
+        self.failure_patterns
+            .write()
+            .await
+            .push((input_pattern, error_msg.to_string()));
+    }
+
+    /// Add a sequence of results. Each call consumes the next entry;
+    /// when exhausted, falls back to `stubbed_result`.
+    pub async fn add_result_sequence(&self, results: Vec<ToolResult>) {
+        let mut seq = self.result_sequence.write().await;
+        for r in results {
+            seq.push_back(r);
+        }
     }
 }
 
@@ -66,7 +99,34 @@ impl SimpleTool for MockTool {
     }
 
     async fn execute(&self, input: ToolInput) -> ToolResult {
-        self.call_history.write().await.push(input);
+        self.call_history.write().await.push(input.clone());
+
+        // 1. Drain failure queue
+        {
+            let mut queue = self.failure_queue.write().await;
+            if let Some(err) = queue.pop_front() {
+                return ToolResult::failure(err);
+            }
+        }
+
+        // 2. Check input-pattern failures
+        {
+            let patterns = self.failure_patterns.read().await;
+            for (pattern, err) in patterns.iter() {
+                if input.arguments == *pattern {
+                    return ToolResult::failure(err);
+                }
+            }
+        }
+
+        // 3. Drain result sequence
+        {
+            let mut seq = self.result_sequence.write().await;
+            if let Some(result) = seq.pop_front() {
+                return result;
+            }
+        }
+
         self.stubbed_result.read().await.clone()
     }
 
@@ -82,7 +142,8 @@ macro_rules! assert_tool_called {
         use mofa_foundation::agent::components::tool::SimpleTool as _;
         let count = $tool.call_count().await;
         assert_eq!(
-            count, $expected_count,
+            count,
+            $expected_count,
             "Expected tool '{}' to be called {} time(s), but was called {} time(s)",
             $tool.name(),
             $expected_count,

--- a/tests/tests/failure_injection_tests.rs
+++ b/tests/tests/failure_injection_tests.rs
@@ -1,0 +1,535 @@
+//! Tests for failure injection, sequenced responses, rate limiting, and MockClock.
+
+use mofa_foundation::agent::components::tool::SimpleTool;
+use mofa_foundation::orchestrator::{
+    ModelOrchestrator, ModelProviderConfig, ModelType, OrchestratorError,
+};
+use mofa_kernel::agent::components::tool::{ToolInput, ToolResult};
+use mofa_kernel::bus::CommunicationMode;
+use mofa_kernel::message::AgentMessage;
+use mofa_testing::backend::MockLLMBackend;
+use mofa_testing::bus::MockAgentBus;
+use mofa_testing::clock::{Clock, MockClock};
+use mofa_testing::tools::MockTool;
+use serde_json::json;
+use std::collections::HashMap;
+use std::time::Duration;
+
+fn make_config(name: &str) -> ModelProviderConfig {
+    ModelProviderConfig {
+        model_name: name.into(),
+        model_path: "/mock".into(),
+        device: "cpu".into(),
+        model_type: ModelType::Llm,
+        max_context_length: None,
+        quantization: None,
+        extra_config: HashMap::new(),
+    }
+}
+
+// ===================================================================
+// MockLLMBackend — failure queue
+// ===================================================================
+
+#[tokio::test]
+async fn backend_fail_next_drains_fifo() {
+    let backend = MockLLMBackend::new();
+    backend.add_response("hi", "hello");
+    backend.register_model(make_config("m")).await.unwrap();
+    backend.load_model("m").await.unwrap();
+
+    backend.fail_next(2, OrchestratorError::InferenceFailed("boom".into()));
+
+    let r1 = backend.infer("m", "hi").await;
+    assert!(r1.is_err());
+    let r2 = backend.infer("m", "hi").await;
+    assert!(r2.is_err());
+    // Third call succeeds — queue drained
+    let r3 = backend.infer("m", "hi").await;
+    assert_eq!(r3.unwrap(), "hello");
+}
+
+#[tokio::test]
+async fn backend_fail_next_zero_is_noop() {
+    let backend = MockLLMBackend::new();
+    backend.add_response("x", "ok");
+    backend.register_model(make_config("m")).await.unwrap();
+    backend.load_model("m").await.unwrap();
+
+    backend.fail_next(0, OrchestratorError::InferenceFailed("unused".into()));
+    assert_eq!(backend.infer("m", "x").await.unwrap(), "ok");
+}
+
+// ===================================================================
+// MockLLMBackend — pattern-based failures
+// ===================================================================
+
+#[tokio::test]
+async fn backend_fail_on_pattern_match() {
+    let backend = MockLLMBackend::new();
+    backend.add_response("safe", "ok");
+    backend.register_model(make_config("m")).await.unwrap();
+    backend.load_model("m").await.unwrap();
+
+    backend.fail_on("danger", OrchestratorError::Other("blocked".into()));
+
+    let err = backend.infer("m", "this is danger zone").await;
+    assert!(err.is_err());
+
+    let ok = backend.infer("m", "safe input").await;
+    assert_eq!(ok.unwrap(), "ok");
+}
+
+#[tokio::test]
+async fn backend_fail_on_does_not_match_unrelated() {
+    let backend = MockLLMBackend::new();
+    backend.register_model(make_config("m")).await.unwrap();
+    backend.load_model("m").await.unwrap();
+
+    backend.fail_on("specific", OrchestratorError::Other("nope".into()));
+
+    let result = backend.infer("m", "something else").await;
+    assert!(result.is_ok());
+}
+
+// ===================================================================
+// MockLLMBackend — failure queue drains before pattern check
+// ===================================================================
+
+#[tokio::test]
+async fn backend_fail_next_takes_priority_over_fail_on() {
+    let backend = MockLLMBackend::new();
+    backend.register_model(make_config("m")).await.unwrap();
+    backend.load_model("m").await.unwrap();
+
+    backend.fail_on("anything", OrchestratorError::Other("pattern".into()));
+    backend.fail_next(1, OrchestratorError::InferenceFailed("queue".into()));
+
+    let err = backend.infer("m", "anything").await.unwrap_err();
+    match err {
+        OrchestratorError::InferenceFailed(msg) => assert_eq!(msg, "queue"),
+        other => panic!("expected InferenceFailed, got: {other}"),
+    }
+}
+
+// ===================================================================
+// MockLLMBackend — response sequences
+// ===================================================================
+
+#[tokio::test]
+async fn backend_response_sequence_returns_in_order() {
+    let backend = MockLLMBackend::new();
+    backend.register_model(make_config("m")).await.unwrap();
+    backend.load_model("m").await.unwrap();
+
+    backend.add_response_sequence("greet", vec!["Hi!", "Hello again!", "Still here."]);
+
+    assert_eq!(backend.infer("m", "greet me").await.unwrap(), "Hi!");
+    assert_eq!(
+        backend.infer("m", "greet me").await.unwrap(),
+        "Hello again!"
+    );
+    assert_eq!(backend.infer("m", "greet me").await.unwrap(), "Still here.");
+    // Last value repeats
+    assert_eq!(backend.infer("m", "greet me").await.unwrap(), "Still here.");
+}
+
+#[tokio::test]
+async fn backend_sequence_takes_priority_over_static_rule() {
+    let backend = MockLLMBackend::new();
+    backend.register_model(make_config("m")).await.unwrap();
+    backend.load_model("m").await.unwrap();
+
+    backend.add_response("hello", "static");
+    backend.add_response_sequence("hello", vec!["seq1", "seq2"]);
+
+    assert_eq!(backend.infer("m", "hello").await.unwrap(), "seq1");
+    assert_eq!(backend.infer("m", "hello").await.unwrap(), "seq2");
+    // After sequence exhausted (last repeats)
+    assert_eq!(backend.infer("m", "hello").await.unwrap(), "seq2");
+}
+
+#[tokio::test]
+async fn backend_unmatched_sequence_falls_through() {
+    let backend = MockLLMBackend::new();
+    backend.register_model(make_config("m")).await.unwrap();
+    backend.load_model("m").await.unwrap();
+
+    backend.add_response_sequence("greet", vec!["Hi!"]);
+    backend.add_response("other", "static");
+
+    assert_eq!(backend.infer("m", "other topic").await.unwrap(), "static");
+}
+
+// ===================================================================
+// MockLLMBackend — rate limiting
+// ===================================================================
+
+#[tokio::test]
+async fn backend_rate_limit_blocks_after_max_calls() {
+    let backend = MockLLMBackend::new();
+    backend.register_model(make_config("m")).await.unwrap();
+    backend.load_model("m").await.unwrap();
+
+    backend.set_rate_limit(3);
+
+    assert!(backend.infer("m", "1").await.is_ok());
+    assert!(backend.infer("m", "2").await.is_ok());
+    assert!(backend.infer("m", "3").await.is_ok());
+    // 4th call exceeds limit
+    let err = backend.infer("m", "4").await;
+    assert!(err.is_err());
+}
+
+#[tokio::test]
+async fn backend_rate_limit_reset_allows_more_calls() {
+    let backend = MockLLMBackend::new();
+    backend.register_model(make_config("m")).await.unwrap();
+    backend.load_model("m").await.unwrap();
+
+    backend.set_rate_limit(1);
+    assert!(backend.infer("m", "a").await.is_ok());
+    assert!(backend.infer("m", "b").await.is_err());
+
+    backend.reset_rate_limit();
+    assert!(backend.infer("m", "c").await.is_ok());
+}
+
+// ===================================================================
+// MockLLMBackend — call counter
+// ===================================================================
+
+#[tokio::test]
+async fn backend_call_count_tracks_all_invocations() {
+    let backend = MockLLMBackend::new();
+    backend.register_model(make_config("m")).await.unwrap();
+    backend.load_model("m").await.unwrap();
+
+    assert_eq!(backend.call_count(), 0);
+    let _ = backend.infer("m", "a").await;
+    let _ = backend.infer("m", "b").await;
+    assert_eq!(backend.call_count(), 2);
+}
+
+#[tokio::test]
+async fn backend_call_count_includes_failed_calls() {
+    let backend = MockLLMBackend::new();
+    backend.register_model(make_config("m")).await.unwrap();
+    backend.load_model("m").await.unwrap();
+
+    backend.fail_next(1, OrchestratorError::InferenceFailed("err".into()));
+    let _ = backend.infer("m", "a").await;
+
+    assert_eq!(backend.call_count(), 1);
+}
+
+#[tokio::test]
+async fn backend_call_count_reset() {
+    let backend = MockLLMBackend::new();
+    backend.register_model(make_config("m")).await.unwrap();
+    backend.load_model("m").await.unwrap();
+
+    let _ = backend.infer("m", "a").await;
+    assert_eq!(backend.call_count(), 1);
+
+    backend.reset_call_count();
+    assert_eq!(backend.call_count(), 0);
+}
+
+// ===================================================================
+// MockTool — failure queue
+// ===================================================================
+
+#[tokio::test]
+async fn tool_fail_next_returns_failures_then_succeeds() {
+    let tool = MockTool::new("t", "desc", json!({"type": "object"}));
+    tool.fail_next(2, "transient error").await;
+
+    let r1 = tool.execute(ToolInput::from_json(json!({}))).await;
+    assert!(!r1.success);
+    assert_eq!(r1.error.as_deref(), Some("transient error"));
+
+    let r2 = tool.execute(ToolInput::from_json(json!({}))).await;
+    assert!(!r2.success);
+
+    // Third call succeeds — queue drained
+    let r3 = tool.execute(ToolInput::from_json(json!({}))).await;
+    assert!(r3.success);
+}
+
+#[tokio::test]
+async fn tool_fail_next_zero_is_noop() {
+    let tool = MockTool::new("t", "desc", json!({"type": "object"}));
+    tool.fail_next(0, "unused").await;
+
+    let result = tool.execute(ToolInput::from_json(json!({}))).await;
+    assert!(result.success);
+}
+
+// ===================================================================
+// MockTool — input-pattern failures
+// ===================================================================
+
+#[tokio::test]
+async fn tool_fail_on_input_matches_exact_json() {
+    let tool = MockTool::new("t", "desc", json!({"type": "object"}));
+    tool.fail_on_input(json!({"action": "delete"}), "forbidden")
+        .await;
+
+    let bad = tool
+        .execute(ToolInput::from_json(json!({"action": "delete"})))
+        .await;
+    assert!(!bad.success);
+    assert_eq!(bad.error.as_deref(), Some("forbidden"));
+
+    let good = tool
+        .execute(ToolInput::from_json(json!({"action": "read"})))
+        .await;
+    assert!(good.success);
+}
+
+#[tokio::test]
+async fn tool_fail_on_input_records_call_even_on_failure() {
+    let tool = MockTool::new("t", "desc", json!({"type": "object"}));
+    tool.fail_on_input(json!({"x": 1}), "boom").await;
+
+    tool.execute(ToolInput::from_json(json!({"x": 1}))).await;
+    assert_eq!(tool.call_count().await, 1);
+}
+
+// ===================================================================
+// MockTool — result sequences
+// ===================================================================
+
+#[tokio::test]
+async fn tool_result_sequence_drains_then_falls_back() {
+    let tool = MockTool::new("t", "desc", json!({"type": "object"}));
+    tool.add_result_sequence(vec![
+        ToolResult::success_text("first"),
+        ToolResult::failure("transient"),
+        ToolResult::success_text("recovered"),
+    ])
+    .await;
+
+    let r1 = tool.execute(ToolInput::from_json(json!({}))).await;
+    assert!(r1.success);
+    assert_eq!(r1.output, json!("first"));
+
+    let r2 = tool.execute(ToolInput::from_json(json!({}))).await;
+    assert!(!r2.success);
+
+    let r3 = tool.execute(ToolInput::from_json(json!({}))).await;
+    assert!(r3.success);
+    assert_eq!(r3.output, json!("recovered"));
+
+    // Sequence exhausted — falls back to stubbed_result
+    let r4 = tool.execute(ToolInput::from_json(json!({}))).await;
+    assert!(r4.success);
+    assert_eq!(r4.output, json!("Mock execution default"));
+}
+
+#[tokio::test]
+async fn tool_fail_next_takes_priority_over_sequence() {
+    let tool = MockTool::new("t", "desc", json!({"type": "object"}));
+    tool.add_result_sequence(vec![ToolResult::success_text("seq")])
+        .await;
+    tool.fail_next(1, "queue wins").await;
+
+    let r = tool.execute(ToolInput::from_json(json!({}))).await;
+    assert!(!r.success);
+    assert_eq!(r.error.as_deref(), Some("queue wins"));
+
+    // Now sequence kicks in
+    let r2 = tool.execute(ToolInput::from_json(json!({}))).await;
+    assert_eq!(r2.output, json!("seq"));
+}
+
+// ===================================================================
+// MockTool — call history preserved across all modes
+// ===================================================================
+
+#[tokio::test]
+async fn tool_call_history_includes_all_invocations() {
+    let tool = MockTool::new("t", "desc", json!({"type": "object"}));
+    tool.fail_next(1, "err").await;
+
+    tool.execute(ToolInput::from_json(json!({"a": 1}))).await;
+    tool.execute(ToolInput::from_json(json!({"b": 2}))).await;
+
+    let history = tool.history().await;
+    assert_eq!(history.len(), 2);
+    assert_eq!(history[0].arguments, json!({"a": 1}));
+    assert_eq!(history[1].arguments, json!({"b": 2}));
+}
+
+// ===================================================================
+// MockAgentBus — failure queue
+// ===================================================================
+
+#[tokio::test]
+async fn bus_fail_next_send_returns_errors() {
+    let bus = MockAgentBus::new();
+    bus.fail_next_send(2, "channel closed").await;
+
+    let msg = AgentMessage::TaskRequest {
+        task_id: "t1".into(),
+        content: "ping".into(),
+    };
+    let mode = CommunicationMode::Broadcast;
+
+    let r1 = bus.send_and_capture("a", mode.clone(), msg.clone()).await;
+    assert!(r1.is_err());
+
+    let r2 = bus.send_and_capture("a", mode.clone(), msg.clone()).await;
+    assert!(r2.is_err());
+
+    // Messages are still captured even when send fails
+    assert_eq!(bus.message_count().await, 2);
+}
+
+#[tokio::test]
+async fn bus_fail_next_send_drains_then_proceeds() {
+    let bus = MockAgentBus::new();
+    bus.fail_next_send(1, "temporary").await;
+
+    let msg = AgentMessage::TaskRequest {
+        task_id: "t1".into(),
+        content: "ping".into(),
+    };
+    let mode = CommunicationMode::Broadcast;
+
+    let r1 = bus.send_and_capture("a", mode.clone(), msg.clone()).await;
+    assert!(r1.is_err());
+
+    // Second call — queue drained, proceeds to inner bus
+    // (inner bus may still error if no receiver, but that's a different error)
+    let _ = bus.send_and_capture("a", mode.clone(), msg.clone()).await;
+    assert_eq!(bus.message_count().await, 2);
+}
+
+#[tokio::test]
+async fn bus_fail_next_send_zero_is_noop() {
+    let bus = MockAgentBus::new();
+    bus.fail_next_send(0, "unused").await;
+
+    let msg = AgentMessage::TaskRequest {
+        task_id: "t1".into(),
+        content: "ping".into(),
+    };
+    // Should not inject a failure — proceeds directly to inner bus
+    let _ = bus
+        .send_and_capture("a", CommunicationMode::Broadcast, msg)
+        .await;
+    assert_eq!(bus.message_count().await, 1);
+}
+
+// ===================================================================
+// MockClock — basic operations
+// ===================================================================
+
+#[tokio::test]
+async fn clock_starts_at_zero() {
+    let clock = MockClock::new();
+    assert_eq!(clock.now_millis(), 0);
+}
+
+#[tokio::test]
+async fn clock_starting_at_custom_time() {
+    let clock = MockClock::starting_at(Duration::from_secs(100));
+    assert_eq!(clock.now_millis(), 100_000);
+}
+
+#[tokio::test]
+async fn clock_advance_adds_time() {
+    let clock = MockClock::new();
+    clock.advance(Duration::from_secs(30));
+    assert_eq!(clock.now_millis(), 30_000);
+    clock.advance(Duration::from_millis(500));
+    assert_eq!(clock.now_millis(), 30_500);
+}
+
+#[tokio::test]
+async fn clock_set_overrides_time() {
+    let clock = MockClock::new();
+    clock.advance(Duration::from_secs(100));
+    clock.set(Duration::from_secs(5));
+    assert_eq!(clock.now_millis(), 5_000);
+}
+
+// ===================================================================
+// MockClock — auto-advance
+// ===================================================================
+
+#[tokio::test]
+async fn clock_auto_advance_increments_on_each_read() {
+    let clock = MockClock::new();
+    clock.set_auto_advance(Duration::from_millis(100));
+
+    assert_eq!(clock.now_millis(), 0);
+    assert_eq!(clock.now_millis(), 100);
+    assert_eq!(clock.now_millis(), 200);
+}
+
+#[tokio::test]
+async fn clock_clear_auto_advance_stops_incrementing() {
+    let clock = MockClock::new();
+    clock.set_auto_advance(Duration::from_millis(50));
+
+    assert_eq!(clock.now_millis(), 0);
+    assert_eq!(clock.now_millis(), 50);
+
+    clock.clear_auto_advance();
+    assert_eq!(clock.now_millis(), 100);
+    assert_eq!(clock.now_millis(), 100); // no longer advancing
+}
+
+#[tokio::test]
+async fn clock_auto_advance_combines_with_manual_advance() {
+    let clock = MockClock::new();
+    clock.set_auto_advance(Duration::from_millis(10));
+
+    assert_eq!(clock.now_millis(), 0); // reads 0, then advances to 10
+    clock.advance(Duration::from_secs(1)); // jumps to 1010
+    assert_eq!(clock.now_millis(), 1010); // reads 1010, then advances to 1020
+    assert_eq!(clock.now_millis(), 1020);
+}
+
+// ===================================================================
+// MockClock — SystemClock (smoke test)
+// ===================================================================
+
+#[tokio::test]
+async fn system_clock_returns_nonzero() {
+    let clock = mofa_testing::SystemClock;
+    assert!(clock.now_millis() > 0);
+}
+
+// ===================================================================
+// Integration: failure injection + call counting together
+// ===================================================================
+
+#[tokio::test]
+async fn backend_combined_fail_next_and_rate_limit() {
+    let backend = MockLLMBackend::new();
+    backend.register_model(make_config("m")).await.unwrap();
+    backend.load_model("m").await.unwrap();
+
+    backend.fail_next(1, OrchestratorError::InferenceFailed("boom".into()));
+    backend.set_rate_limit(2);
+
+    // Call 1: fail_next fires (rate limit counter still increments)
+    let r1 = backend.infer("m", "a").await;
+    assert!(r1.is_err());
+
+    // Call 2, 3: rate limit allows (fail_next drained)
+    let r2 = backend.infer("m", "b").await;
+    assert!(r2.is_ok());
+    let r3 = backend.infer("m", "c").await;
+    assert!(r3.is_ok());
+
+    // Call 4: rate limit exceeded
+    let r4 = backend.infer("m", "d").await;
+    assert!(r4.is_err());
+
+    assert_eq!(backend.call_count(), 4);
+}

--- a/tests/tests/integration.rs
+++ b/tests/tests/integration.rs
@@ -1,7 +1,4 @@
 //! Integration tests for the mofa-testing framework.
-//!
-//! Covers MockLLMBackend, MockAgentBus, and MockTool to ensure
-//! all public APIs behave correctly and deterministically.
 
 use mofa_foundation::agent::components::tool::SimpleTool;
 use mofa_foundation::orchestrator::{ModelOrchestrator, ModelProviderConfig, ModelType};
@@ -38,7 +35,10 @@ async fn backend_infer_returns_matching_response() {
     let resp = backend.infer("test-llm", "say hello").await.unwrap();
     assert_eq!(resp, "Hi there!");
 
-    let resp = backend.infer("test-llm", "what is the weather?").await.unwrap();
+    let resp = backend
+        .infer("test-llm", "what is the weather?")
+        .await
+        .unwrap();
     assert_eq!(resp, "Sunny today.");
 }
 
@@ -82,7 +82,11 @@ async fn backend_register_load_unload_lifecycle() {
 
     backend.load_model("model-a").await.unwrap();
     assert!(backend.is_model_loaded("model-a"));
-    assert!(backend.list_loaded_models().contains(&"model-a".to_string()));
+    assert!(
+        backend
+            .list_loaded_models()
+            .contains(&"model-a".to_string())
+    );
 
     backend.unload_model("model-a").await.unwrap();
     assert!(!backend.is_model_loaded("model-a"));
@@ -225,9 +229,7 @@ async fn tool_custom_stub_result() {
     ))
     .await;
 
-    let result = tool
-        .execute(ToolInput::from_json(json!({"x": 1})))
-        .await;
+    let result = tool.execute(ToolInput::from_json(json!({"x": 1}))).await;
     assert!(!result.success);
 }
 


### PR DESCRIPTION
## feat(testing): Failure Injection, Sequenced Responses, Rate Limiting & MockClock for `mofa-testing`
closes #887 

### Summary

Extends the existing mock infrastructure in `mofa-testing`  which i made (introduced in [PR #486](https://github.com/mofa-org/mofa/pull/486)) with configurable failure modes, sequenced responses, rate limiting, call counting, and a deterministic `MockClock` — enabling error-path testing for production-grade agents.

### Motivation

PR #486 delivered `MockLLMBackend`, `MockTool`, and `MockAgentBus` for happy-path testing. However, real-world agents need to handle failures gracefully:

- **Retry logic** can't be tested when mocks always succeed
- **Timeout/rate-limit handling** has no way to be simulated
- **Multi-turn behavior** can't be validated with static single-value responses
- **Time-dependent code** using `SystemTime::now()` is non-deterministic in tests

This PR fills those gaps.

### Changes

**`MockLLMBackend` — Failure Injection + Sequences** (`tests/src/backend.rs`)
| Method | Purpose |
|--------|---------|
| `fail_next(count, error)` | Queue N errors to return from `infer()` (FIFO) |
| `fail_on(pattern, error)` | Fail when prompt contains pattern |
| `add_response_sequence(pattern, responses)` | Return different responses per call; last repeats |
| `set_rate_limit(max_calls)` / `reset_rate_limit()` | Fail after N calls |
| `call_count()` / `reset_call_count()` | Track total invocations |

Priority: fail_next → fail_on → rate_limit → sequence → static rule → fallback

**`MockTool` — Failure Injection** (`tests/src/tools.rs`)
| Method | Purpose |
|--------|---------|
| `fail_next(count, msg)` | Queue N failures |
| `fail_on_input(json_pattern, msg)` | Fail on exact JSON match |
| `add_result_sequence(results)` | Sequence of results; falls back to `stubbed_result` |

**`MockAgentBus` — Failure Injection** (`tests/src/bus.rs`)
| Method | Purpose |
|--------|---------|
| `fail_next_send(count, msg)` | Queue N `BusError::SendFailed` returns (message still captured) |

**`MockClock` — Deterministic Time** (`tests/src/clock.rs` — NEW)
| Method | Purpose |
|--------|---------|
| `new()` / `starting_at(duration)` | Create clock at zero or custom start |
| `advance(duration)` | Move time forward |
| `set(duration)` | Set exact time |
| `set_auto_advance(step)` | Auto-increment on each `now_millis()` read |
| `clear_auto_advance()` | Stop auto-incrementing |

Also provides `Clock` trait and `SystemClock` for production use.


### Test Results

```
Running tests\failure_injection_tests.rs — 32 tests
  backend_fail_next_drains_fifo .................. ok
  backend_fail_next_zero_is_noop ................. ok
  backend_fail_on_pattern_match .................. ok
  backend_fail_on_does_not_match_unrelated ....... ok
  backend_fail_next_takes_priority_over_fail_on .. ok
  backend_response_sequence_returns_in_order ..... ok
  backend_sequence_takes_priority_over_static .... ok
  backend_unmatched_sequence_falls_through ....... ok
  backend_rate_limit_blocks_after_max_calls ...... ok
  backend_rate_limit_reset_allows_more_calls ..... ok
  backend_call_count_tracks_all_invocations ...... ok
  backend_call_count_includes_failed_calls ....... ok
  backend_call_count_reset ....................... ok
  backend_combined_fail_next_and_rate_limit ...... ok
  tool_fail_next_returns_failures_then_succeeds .. ok
  tool_fail_next_zero_is_noop .................... ok
  tool_fail_on_input_matches_exact_json .......... ok
  tool_fail_on_input_records_call_even_on_failure  ok
  tool_result_sequence_drains_then_falls_back .... ok
  tool_fail_next_takes_priority_over_sequence .... ok
  tool_call_history_includes_all_invocations ..... ok
  bus_fail_next_send_returns_errors .............. ok
  bus_fail_next_send_drains_then_proceeds ........ ok
  bus_fail_next_send_zero_is_noop ................ ok
  clock_starts_at_zero ........................... ok
  clock_starting_at_custom_time .................. ok
  clock_advance_adds_time ........................ ok
  clock_set_overrides_time ....................... ok
  clock_auto_advance_increments_on_each_read ..... ok
  clock_clear_auto_advance_stops_incrementing .... ok
  clock_auto_advance_combines_with_manual ........ ok
  system_clock_returns_nonzero ................... ok

Running tests\integration.rs — 15 existing tests
  All 15 pass unchanged ✓

Total: 47 passed, 0 failed
```

### Verification

- [x] `cargo check -p mofa-testing` — compiles
- [x] `cargo clippy -p mofa-testing` — 0 warnings in mofa-testing
- [x] `cargo fmt -p mofa-testing -- --check` — clean
- [x] `cargo test -p mofa-testing` — 47/47 pass (32 new + 15 existing)
- [x] No new external dependencies
- [x] All existing tests backward compatible


