### PR TITLE
fix(plugins): implement real OpenAI-compatible streaming in OpenAIClient

### DIFF
--- a/crates/mofa-plugins/Cargo.toml
+++ b/crates/mofa-plugins/Cargo.toml
@@ -60,6 +60,10 @@ futures = "0.3"
 [lints]
 workspace = true
 
+[dev-dependencies]
+# HTTP mock server for offline unit tests — not compiled into the final binary.
+wiremock = "0.6"
+
 [features]
 default = []
 rodio = ["dep:rodio"]

--- a/crates/mofa-plugins/src/lib.rs
+++ b/crates/mofa-plugins/src/lib.rs
@@ -142,16 +142,65 @@ impl OpenAIClient {
 #[async_trait::async_trait]
 impl LLMClient for OpenAIClient {
     async fn generate(&self, prompt: &str) -> PluginResult<String> {
-        // 模拟实现，实际应调用 OpenAI API
-        // Mock implementation, should call OpenAI API in reality
+        let api_key = self
+            .config
+            .api_key
+            .as_deref()
+            .ok_or_else(|| PluginError::InitFailed("api_key not configured".into()))?;
+        let base_url = self
+            .config
+            .base_url
+            .as_deref()
+            .unwrap_or("https://api.openai.com");
+
         debug!(
-            "OpenAI generating response for prompt: {}...",
+            "OpenAI generate: model={}, prompt={}...",
+            self.config.model,
             &prompt[..prompt.len().min(50)]
         );
-        Ok(format!(
-            "[{}] Generated response to: {}",
-            self.config.model, prompt
-        ))
+
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(self.config.timeout_secs))
+            .build()
+            .map_err(|e| PluginError::ExecutionFailed(e.to_string()))?;
+
+        let body = serde_json::json!({
+            "model": self.config.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": self.config.max_tokens,
+            "temperature": self.config.temperature,
+            "stream": false
+        });
+
+        let resp = client
+            .post(format!("{}/v1/chat/completions", base_url))
+            .bearer_auth(api_key)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| PluginError::ExecutionFailed(e.to_string()))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(PluginError::ExecutionFailed(format!(
+                "HTTP {}: {}",
+                status, text
+            )));
+        }
+
+        let json: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| PluginError::ExecutionFailed(e.to_string()))?;
+
+        let content = json["choices"][0]["message"]["content"]
+            .as_str()
+            .unwrap_or("")
+            .to_string();
+
+        debug!("OpenAI generate: received {} chars", content.len());
+        Ok(content)
     }
 
     async fn generate_stream(
@@ -159,43 +208,224 @@ impl LLMClient for OpenAIClient {
         prompt: &str,
         callback: Box<dyn Fn(String) + Send + Sync>,
     ) -> PluginResult<String> {
-        // 模拟流式生成 TODO
-        // Mock stream generation TODO
-        // Stub: simulates word-level streaming with inter-token spacing.
-        // Replace with a real SSE/delta streaming call (e.g. via `async-openai`)
-        // once live credentials and an HTTP client are wired in.
-        let response = format!("[{}] Stream response to: {}", self.config.model, prompt);
-        let words: Vec<&str> = response.split_whitespace().collect();
-        let len = words.len();
-        for (i, word) in words.iter().enumerate() {
-            let chunk = if i + 1 < len {
-                format!("{} ", word) // preserve trailing space between tokens
-            } else {
-                word.to_string()
-            };
-            callback(chunk);
-            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        use futures::StreamExt;
+
+        let api_key = self
+            .config
+            .api_key
+            .as_deref()
+            .ok_or_else(|| PluginError::InitFailed("api_key not configured".into()))?;
+        let base_url = self
+            .config
+            .base_url
+            .as_deref()
+            .unwrap_or("https://api.openai.com");
+
+        debug!(
+            "OpenAI generate_stream: model={}, prompt={}...",
+            self.config.model,
+            &prompt[..prompt.len().min(50)]
+        );
+
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(self.config.timeout_secs))
+            .build()
+            .map_err(|e| PluginError::ExecutionFailed(e.to_string()))?;
+
+        let body = serde_json::json!({
+            "model": self.config.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": self.config.max_tokens,
+            "temperature": self.config.temperature,
+            "stream": true
+        });
+
+        let resp = client
+            .post(format!("{}/v1/chat/completions", base_url))
+            .bearer_auth(api_key)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| PluginError::ExecutionFailed(e.to_string()))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(PluginError::ExecutionFailed(format!(
+                "HTTP {}: {}",
+                status, text
+            )));
         }
-        Ok(response)
+
+        // Parse the Server-Sent Events (SSE) stream.
+        // Each event line has the form:  data: <json>
+        // The stream ends with:          data: [DONE]
+        let mut full_response = String::new();
+        let mut byte_stream = resp.bytes_stream();
+        let mut line_buf = String::new();
+
+        while let Some(chunk) = byte_stream.next().await {
+            let bytes = chunk.map_err(|e| PluginError::ExecutionFailed(e.to_string()))?;
+            // Lossy conversion: invalid UTF-8 sequences (sometimes from some compatible APIs)
+            // are replaced with U+FFFD rather than failing the whole stream.
+            line_buf.push_str(&String::from_utf8_lossy(&bytes));
+
+            // Process every complete newline-terminated SSE line.
+            while let Some(newline_pos) = line_buf.find('\n') {
+                let raw_line = line_buf[..newline_pos].trim_end_matches('\r').to_string();
+                line_buf.drain(..=newline_pos);
+
+                if let Some(data) = raw_line.strip_prefix("data: ") {
+                    if data == "[DONE]" {
+                        break;
+                    }
+                    // Extract delta content token; skip malformed lines silently.
+                    if let Ok(json) = serde_json::from_str::<serde_json::Value>(data) {
+                        if let Some(token) = json["choices"][0]["delta"]["content"].as_str() {
+                            if !token.is_empty() {
+                                callback(token.to_string());
+                                full_response.push_str(token);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        debug!(
+            "OpenAI generate_stream: streamed {} chars total",
+            full_response.len()
+        );
+        Ok(full_response)
     }
 
     async fn chat(&self, messages: Vec<ChatMessage>) -> PluginResult<String> {
-        let last_message = messages.last().map(|m| m.content.as_str()).unwrap_or("");
-        debug!("OpenAI chat with {} messages", messages.len());
-        Ok(format!(
-            "[{}] Chat response to: {}",
-            self.config.model, last_message
-        ))
+        let api_key = self
+            .config
+            .api_key
+            .as_deref()
+            .ok_or_else(|| PluginError::InitFailed("api_key not configured".into()))?;
+        let base_url = self
+            .config
+            .base_url
+            .as_deref()
+            .unwrap_or("https://api.openai.com");
+
+        debug!(
+            "OpenAI chat: model={}, {} messages",
+            self.config.model,
+            messages.len()
+        );
+
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(self.config.timeout_secs))
+            .build()
+            .map_err(|e| PluginError::ExecutionFailed(e.to_string()))?;
+
+        // Convert ChatMessage vec to the OpenAI messages JSON array.
+        let api_messages: Vec<serde_json::Value> = messages
+            .iter()
+            .map(|m| serde_json::json!({"role": m.role, "content": m.content}))
+            .collect();
+
+        let body = serde_json::json!({
+            "model": self.config.model,
+            "messages": api_messages,
+            "max_tokens": self.config.max_tokens,
+            "temperature": self.config.temperature,
+            "stream": false
+        });
+
+        let resp = client
+            .post(format!("{}/v1/chat/completions", base_url))
+            .bearer_auth(api_key)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| PluginError::ExecutionFailed(e.to_string()))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(PluginError::ExecutionFailed(format!(
+                "HTTP {}: {}",
+                status, text
+            )));
+        }
+
+        let json: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| PluginError::ExecutionFailed(e.to_string()))?;
+
+        let content = json["choices"][0]["message"]["content"]
+            .as_str()
+            .unwrap_or("")
+            .to_string();
+
+        Ok(content)
     }
 
     async fn embedding(&self, text: &str) -> PluginResult<Vec<f32>> {
-        // 模拟嵌入向量
-        // Mock embedding vector
+        let api_key = self
+            .config
+            .api_key
+            .as_deref()
+            .ok_or_else(|| PluginError::InitFailed("api_key not configured".into()))?;
+        let base_url = self
+            .config
+            .base_url
+            .as_deref()
+            .unwrap_or("https://api.openai.com");
+
         debug!(
-            "OpenAI generating embedding for text: {}...",
+            "OpenAI embedding: model=text-embedding-ada-002, text={}...",
             &text[..text.len().min(50)]
         );
-        Ok(vec![0.1, 0.2, 0.3, 0.4, 0.5])
+
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(self.config.timeout_secs))
+            .build()
+            .map_err(|e| PluginError::ExecutionFailed(e.to_string()))?;
+
+        let body = serde_json::json!({
+            "model": "text-embedding-ada-002",
+            "input": text
+        });
+
+        let resp = client
+            .post(format!("{}/v1/embeddings", base_url))
+            .bearer_auth(api_key)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| PluginError::ExecutionFailed(e.to_string()))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let err_body = resp.text().await.unwrap_or_default();
+            return Err(PluginError::ExecutionFailed(format!(
+                "HTTP {}: {}",
+                status, err_body
+            )));
+        }
+
+        let json: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| PluginError::ExecutionFailed(e.to_string()))?;
+
+        // Extract the embedding vector from data[0].embedding.
+        let embedding: Vec<f32> = json["data"][0]["embedding"]
+            .as_array()
+            .ok_or_else(|| {
+                PluginError::ExecutionFailed("embedding field missing or not an array".into())
+            })?
+            .iter()
+            .filter_map(|v| v.as_f64().map(|f| f as f32))
+            .collect();
+
+        Ok(embedding)
     }
 }
 
@@ -492,10 +722,9 @@ impl ToolPlugin {
     /// 调用工具
     /// Call tool
     pub async fn call_tool(&mut self, call: ToolCall) -> PluginResult<ToolResult> {
-        let tool = self
-            .tools
-            .get(&call.name)
-            .ok_or_else(|| PluginError::ExecutionFailed(format!("Tool not found: {}", call.name)))?;
+        let tool = self.tools.get(&call.name).ok_or_else(|| {
+            PluginError::ExecutionFailed(format!("Tool not found: {}", call.name))
+        })?;
 
         // 验证参数
         // Validate arguments
@@ -572,8 +801,9 @@ impl AgentPlugin for ToolPlugin {
     async fn execute(&mut self, input: String) -> PluginResult<String> {
         // 解析输入为工具调用
         // Parse input as tool call
-        let call: ToolCall = serde_json::from_str(&input)
-            .map_err(|e| PluginError::ExecutionFailed(format!("Invalid tool call format: {}", e)))?;
+        let call: ToolCall = serde_json::from_str(&input).map_err(|e| {
+            PluginError::ExecutionFailed(format!("Invalid tool call format: {}", e))
+        })?;
         let result = self.call_tool(call).await?;
         serde_json::to_string(&result)
             .map_err(|e| PluginError::ExecutionFailed(format!("Failed to serialize result: {}", e)))
@@ -1145,7 +1375,10 @@ impl PluginManager {
         let mut plugins = self.plugins.write().await;
 
         if plugins.contains_key(&plugin_id) {
-            return Err(PluginError::Other(format!("Plugin {} already registered", plugin_id)));
+            return Err(PluginError::Other(format!(
+                "Plugin {} already registered",
+                plugin_id
+            )));
         }
 
         let entry = PluginEntry {
@@ -1358,13 +1591,46 @@ impl PluginManager {
 mod tests {
     use super::*;
 
+    // -------------------------------------------------------------------------
+    // A simple mock LLM client for use in plugin lifecycle tests.
+    // It echoes the prompt back so tests can assert on the response content
+    // without needing a real API key or network connection.
+    // -------------------------------------------------------------------------
+    struct MockLLMClient;
+
+    #[async_trait::async_trait]
+    impl LLMClient for MockLLMClient {
+        async fn generate(&self, prompt: &str) -> PluginResult<String> {
+            Ok(format!("[mock] {}", prompt))
+        }
+
+        async fn generate_stream(
+            &self,
+            prompt: &str,
+            callback: Box<dyn Fn(String) + Send + Sync>,
+        ) -> PluginResult<String> {
+            let response = format!("[mock] {}", prompt);
+            callback(response.clone());
+            Ok(response)
+        }
+
+        async fn chat(&self, messages: Vec<ChatMessage>) -> PluginResult<String> {
+            let last = messages.last().map(|m| m.content.as_str()).unwrap_or("");
+            Ok(format!("[mock] {}", last))
+        }
+
+        async fn embedding(&self, _text: &str) -> PluginResult<Vec<f32>> {
+            Ok(vec![0.1, 0.2, 0.3])
+        }
+    }
+
     #[tokio::test]
     async fn test_plugin_manager() {
         let manager = PluginManager::new("test_agent");
 
-        // 注册 LLM 插件
-        // Register LLM plugin
-        let llm = LLMPlugin::new("llm_001");
+        // Register LLM plugin — inject MockLLMClient so the test does not
+        // require a real API key or network connection.
+        let llm = LLMPlugin::new("llm_001").with_client(MockLLMClient);
         manager.register(llm).await.unwrap();
 
         // 注册存储插件
@@ -1419,7 +1685,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_llm_plugin() {
-        let mut llm = LLMPlugin::new("llm_test");
+        // Inject MockLLMClient so this lifecycle test does not need a real
+        // API key. The client is set before load/init to bypass init_plugin's
+        // default OpenAIClient creation.
+        let mut llm = LLMPlugin::new("llm_test").with_client(MockLLMClient);
         let ctx = PluginContext::new("test_agent");
 
         llm.load(&ctx).await.unwrap();
@@ -1643,7 +1912,6 @@ mod tests {
         let value: Option<i32> = ctx.get_state("counter").await;
         assert_eq!(value, Some(42));
 
-        // 测试配置
         // Test configuration
         let mut config = PluginConfig::new();
         config.set("timeout", 30);
@@ -1651,5 +1919,214 @@ mod tests {
 
         assert_eq!(config.get_i64("timeout"), Some(30));
         assert_eq!(config.get_bool("enabled"), Some(true));
+    }
+}
+
+// ============================================================================
+// OpenAIClient unit tests
+// Tests for the real HTTP-backed LLMClient implementation.
+// All tests in this module are fully offline — wiremock spins up a local server.
+// ============================================================================
+#[cfg(test)]
+mod openai_client_tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    // Build a minimal LLMPluginConfig pointing at the given mock server URI.
+    fn test_config(base_url: String) -> LLMPluginConfig {
+        LLMPluginConfig {
+            model: "gpt-3.5-turbo".to_string(),
+            api_key: Some("test-api-key".to_string()),
+            base_url: Some(base_url),
+            max_tokens: 100,
+            temperature: 0.7,
+            timeout_secs: 10,
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 1: generate() and generate_stream() return Err when api_key is None.
+    // No network call should be attempted.
+    // -------------------------------------------------------------------------
+    #[tokio::test]
+    async fn test_openai_client_missing_api_key_returns_err() {
+        let config = LLMPluginConfig {
+            api_key: None,
+            ..Default::default()
+        };
+        let client = OpenAIClient::new(config);
+
+        let gen_result = client.generate("hello").await;
+        assert!(
+            gen_result.is_err(),
+            "generate() must fail when api_key is None"
+        );
+        assert!(
+            gen_result.unwrap_err().to_string().contains("api_key"),
+            "error message should mention api_key"
+        );
+
+        let stream_result = client.generate_stream("hello", Box::new(|_| {})).await;
+        assert!(
+            stream_result.is_err(),
+            "generate_stream() must fail when api_key is None"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 2: generate_stream() correctly:
+    //   - connects to the (mocked) endpoint
+    //   - calls the callback once per delta token
+    //   - returns the fully accumulated string
+    // -------------------------------------------------------------------------
+    #[tokio::test]
+    async fn test_generate_stream_real_sse_accumulates_chunks() {
+        let server = MockServer::start().await;
+
+        // A minimal two-token SSE stream followed by [DONE].
+        let sse_body = concat!(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}\n\n",
+            "data: [DONE]\n\n",
+        );
+
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+            .mount(&server)
+            .await;
+
+        let client = OpenAIClient::new(test_config(server.uri()));
+
+        // Use Arc<Mutex<>> so the closure satisfies Fn (not FnMut) while still
+        // collecting tokens. The trait signature requires Fn, not FnMut.
+        let received_chunks = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let chunks_for_cb = received_chunks.clone();
+
+        let result = client
+            .generate_stream(
+                "Say hello",
+                Box::new(move |chunk| {
+                    chunks_for_cb.lock().unwrap().push(chunk);
+                }),
+            )
+            .await
+            .expect("generate_stream should succeed against the mock server");
+
+        let final_chunks = received_chunks.lock().unwrap().clone();
+        assert_eq!(result, "Hello world", "accumulated response must match");
+        assert_eq!(
+            final_chunks,
+            vec!["Hello", " world"],
+            "callback must be called once per SSE delta token"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 3: generate() correctly extracts choices[0].message.content from a
+    // standard non-streaming chat completion response.
+    // -------------------------------------------------------------------------
+    #[tokio::test]
+    async fn test_generate_non_streaming_returns_content() {
+        let server = MockServer::start().await;
+
+        let response_body = serde_json::json!({
+            "choices": [{
+                "message": {"role": "assistant", "content": "42 is the answer."},
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12}
+        });
+
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+            .mount(&server)
+            .await;
+
+        let client = OpenAIClient::new(test_config(server.uri()));
+
+        let result = client
+            .generate("What is the answer?")
+            .await
+            .expect("generate should succeed against the mock server");
+
+        assert_eq!(result, "42 is the answer.");
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 4: Non-2xx HTTP status codes are propagated as Err(ExecutionFailed).
+    // -------------------------------------------------------------------------
+    #[tokio::test]
+    async fn test_openai_client_http_error_propagated() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(401)
+                    .set_body_string("{\"error\":{\"message\":\"Incorrect API key\"}}"),
+            )
+            .mount(&server)
+            .await;
+
+        let client = OpenAIClient::new(test_config(server.uri()));
+
+        let result = client.generate("hello").await;
+        assert!(result.is_err(), "generate() must return Err on HTTP 401");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("401"),
+            "error message should contain the HTTP status code, got: {err_msg}"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 5: Live round-trip against a real OpenAI-compatible endpoint.
+    // Marked #[ignore] — never runs in CI.
+    // Run manually:
+    //   $env:OPENAI_API_KEY="sk-..."
+    //   cargo test -p mofa-plugins test_live_openai_stream -- --ignored --nocapture
+    // -------------------------------------------------------------------------
+    #[tokio::test]
+    #[ignore = "requires OPENAI_API_KEY env var and live network access"]
+    async fn test_live_openai_stream() {
+        let api_key =
+            std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set to run this test");
+        let base_url = std::env::var("OPENAI_BASE_URL")
+            .unwrap_or_else(|_| "https://api.openai.com".to_string());
+
+        let config = LLMPluginConfig {
+            model: "gpt-3.5-turbo".to_string(),
+            api_key: Some(api_key),
+            base_url: Some(base_url),
+            max_tokens: 32,
+            temperature: 0.0,
+            timeout_secs: 30,
+        };
+        let client = OpenAIClient::new(config);
+
+        // Use Arc<Mutex<>> so the closure satisfies Fn (not FnMut) while collecting.
+        let chunks = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let chunks_for_cb = chunks.clone();
+
+        let full = client
+            .generate_stream(
+                "Reply with exactly: Hello from MoFA",
+                Box::new(move |c| {
+                    print!("{c}");
+                    chunks_for_cb.lock().unwrap().push(c);
+                }),
+            )
+            .await
+            .expect("live stream must succeed");
+
+        println!("\nFull response: {full}");
+        assert!(!full.is_empty(), "live response must not be empty");
+        assert!(
+            !chunks.lock().unwrap().is_empty(),
+            "at least one chunk must be received"
+        );
     }
 }


### PR DESCRIPTION
## Summary 
fix issue##606
Replace the hardcoded stubs in `OpenAIClient` with real HTTP calls to any
OpenAI-compatible REST API. `generate_stream()` now correctly sends a streaming
request, parses incoming SSE `data:` lines, and delivers each delta token to
the caller via the callback as it arrives from the server.

All four stub methods are fixed for a coherent, production-ready client.

## Motivation
Closes #606

The stub silently returned fabricated responses and split a local string
word-by-word with a 20ms artificial delay — making the entire streaming API
completely unusable in production. Any agent, workflow, or multi-agent chain
calling `generate_stream()` received fake data with zero API contact.

## Files Changed

| File | Change |
|---|---|
| `crates/mofa-plugins/src/lib.rs` | Replace 4 stub methods, add `MockLLMClient`, add 5 new tests |
| `crates/mofa-plugins/Cargo.toml` | Add `wiremock = "0.6"` to `[dev-dependencies]` only |

## Method-by-method Changes

| Method | Before (broken) | After (real) |
|---|---|---|
| `generate()` | Returns mock string | POST `/v1/chat/completions`, extracts `choices[0].message.content` |
| `generate_stream()` | Splits local string with 20ms sleep | POST with `stream: true`, parses SSE `data:` lines, calls callback per token |
| `chat()` | Returns mock string | POST `/v1/chat/completions` with full messages array |
| `embedding()` | Returns `[0.1, 0.2, 0.3, 0.4, 0.5]` | POST `/v1/embeddings`, extracts `data[0].embedding` |

## Key Design Decisions

- **No `async-openai` in `mofa-plugins`** — `mofa-foundation` already owns that dependency. The plugins layer uses `reqwest` (already present in `Cargo.toml`) for lightweight REST calls. No new runtime dependencies introduced.
- **Default `base_url` = `"https://api.openai.com"`** — compatible with Ollama, LM Studio, vLLM, and Azure proxy by just changing `base_url` in config.
- **Lossy UTF-8** — SSE byte chunks use `from_utf8_lossy` to tolerate compatible APIs that send non-UTF-8 data, consistent with `mofa-foundation`'s own `openai.rs`.
- **No `unwrap()` in production code** — all error paths use `?` or `map_err(...)` per `CLAUDE.md` rules.
- **`MockLLMClient`** injected into 2 pre-existing lifecycle tests that previously relied on stub output — keeps them deterministic and offline, no API key required.

## Tests Added

All new tests are fully offline (`openai_client_tests` module, wiremock spins up a local HTTP server — no real API key needed in CI).

| Test | What it verifies |
|---|---|
| `test_openai_client_missing_api_key_returns_err` | `generate()` and `generate_stream()` return `Err` immediately when `api_key` is `None` — no network call made |
| `test_generate_stream_real_sse_accumulates_chunks` | Wiremock serves a 2-token SSE stream; callback called twice, return value = `"Hello world"` |
| `test_generate_non_streaming_returns_content` | Wiremock serves standard chat completion JSON; asserts content extracted correctly |
| `test_openai_client_http_error_propagated` | Wiremock returns 401; asserts `Err` contains HTTP status in message |
| `test_live_openai_stream` *(#[ignore])* | Full round-trip — run manually with `OPENAI_API_KEY` set, never runs in CI |

## Verification
```
cargo fmt -p mofa-plugins                              → EXIT 0 ✅
cargo check -p mofa-plugins                            → EXIT 0 ✅
cargo test -p mofa-plugins                             → EXIT 0 ✅  (126 passed, 0 failed, 1 ignored)
cargo clippy --workspace --all-features -- -D errors   → EXIT 0 ✅
cargo build --examples                                 → EXIT 0 ✅
cargo doc --workspace --no-deps --all-features         → EXIT 0 ✅
```

## Checklist
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-features -- -D errors` passes
- [x] `cargo test --workspace --all-features` passes
- [x] `cargo build --examples` succeeds
- [x] `cargo doc --workspace --no-deps --all-features` succeeds
- [x] Architecture layer rules respected — no `async-openai` in `mofa-plugins`
- [x] No secrets committed — `api_key` read from `LLMPluginConfig`, filled by caller from env vars
- [x] All comments in English
- [x] No `unwrap()` in production code