### PR TITLE
feat(testing): add test report generator with builder, formatters

### DIFF
--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -6,9 +6,14 @@
 pub mod backend;
 pub mod bus;
 pub mod clock;
+pub mod report;
 pub mod tools;
 
 pub use backend::MockLLMBackend;
 pub use bus::MockAgentBus;
 pub use clock::{Clock, MockClock, SystemClock};
+pub use report::{
+    JsonFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,
+    TextFormatter,
+};
 pub use tools::MockTool;

--- a/tests/src/report/builder.rs
+++ b/tests/src/report/builder.rs
@@ -1,0 +1,80 @@
+//! Fluent builder for collecting test results into a [`TestReport`].
+
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Instant;
+
+use crate::clock::{Clock, SystemClock};
+use crate::report::types::{TestCaseResult, TestReport, TestStatus};
+
+/// Collects [`TestCaseResult`]s and produces a [`TestReport`].
+pub struct TestReportBuilder {
+    suite_name: String,
+    clock: Arc<dyn Clock>,
+    results: Vec<TestCaseResult>,
+    suite_start: Instant,
+}
+
+impl TestReportBuilder {
+    /// Create a new builder for the named suite.
+    pub fn new(suite_name: impl Into<String>) -> Self {
+        Self {
+            suite_name: suite_name.into(),
+            clock: Arc::new(SystemClock),
+            results: Vec::new(),
+            suite_start: Instant::now(),
+        }
+    }
+
+    /// Inject a [`Clock`] implementation used for the report timestamp.
+    pub fn with_clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.clock = clock;
+        self
+    }
+
+    /// Run an async test closure and record its outcome.
+    ///
+    /// If the closure returns `Ok(())` the test is marked [`TestStatus::Passed`].
+    /// If it returns `Err(msg)` the test is marked [`TestStatus::Failed`] with
+    /// the error message captured.
+    pub async fn record<F, Fut>(mut self, name: impl Into<String>, f: F) -> Self
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<(), String>>,
+    {
+        let name = name.into();
+        let start = Instant::now();
+        let outcome = f().await;
+        let duration = start.elapsed();
+
+        let (status, error) = match outcome {
+            Ok(()) => (TestStatus::Passed, None),
+            Err(msg) => (TestStatus::Failed, Some(msg)),
+        };
+
+        self.results.push(TestCaseResult {
+            name,
+            status,
+            duration,
+            error,
+            metadata: Vec::new(),
+        });
+        self
+    }
+
+    /// Manually add a pre-built result.
+    pub fn add_result(mut self, result: TestCaseResult) -> Self {
+        self.results.push(result);
+        self
+    }
+
+    /// Consume the builder and produce a [`TestReport`].
+    pub fn build(self) -> TestReport {
+        TestReport {
+            suite_name: self.suite_name,
+            total_duration: self.suite_start.elapsed(),
+            timestamp: self.clock.now_millis(),
+            results: self.results,
+        }
+    }
+}

--- a/tests/src/report/format.rs
+++ b/tests/src/report/format.rs
@@ -1,0 +1,104 @@
+//! Formatters that render a [`TestReport`] to a string.
+
+use crate::report::types::{TestReport, TestStatus};
+
+/// Converts a [`TestReport`] into a displayable string.
+pub trait ReportFormatter: Send + Sync {
+    fn format(&self, report: &TestReport) -> String;
+}
+
+/// Renders a report as a JSON object.
+pub struct JsonFormatter;
+
+impl ReportFormatter for JsonFormatter {
+    fn format(&self, report: &TestReport) -> String {
+        let results: Vec<serde_json::Value> = report
+            .results
+            .iter()
+            .map(|r| {
+                let mut obj = serde_json::json!({
+                    "name": r.name,
+                    "status": r.status.to_string(),
+                    "duration_ms": r.duration.as_millis() as u64,
+                });
+                if let Some(err) = &r.error {
+                    obj["error"] = serde_json::Value::String(err.clone());
+                }
+                if !r.metadata.is_empty() {
+                    let meta: serde_json::Map<String, serde_json::Value> = r
+                        .metadata
+                        .iter()
+                        .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+                        .collect();
+                    obj["metadata"] = serde_json::Value::Object(meta);
+                }
+                obj
+            })
+            .collect();
+
+        let total = report.total();
+        let passed = report.passed();
+        let failed = report.failed();
+        let skipped = report.skipped();
+        let pass_rate = report.pass_rate();
+
+        let root = serde_json::json!({
+            "suite": report.suite_name,
+            "timestamp": report.timestamp,
+            "total_duration_ms": report.total_duration.as_millis() as u64,
+            "summary": {
+                "total": total,
+                "passed": passed,
+                "failed": failed,
+                "skipped": skipped,
+                "pass_rate": pass_rate,
+            },
+            "results": results,
+        });
+
+        serde_json::to_string_pretty(&root).expect("report serialisation should not fail")
+    }
+}
+
+/// Renders a report as a human-readable text block.
+pub struct TextFormatter;
+
+impl ReportFormatter for TextFormatter {
+    fn format(&self, report: &TestReport) -> String {
+        let mut buf = String::new();
+
+        buf.push_str(&format!("=== {} ===\n", report.suite_name));
+
+        for r in &report.results {
+            let icon = match r.status {
+                TestStatus::Passed => "+",
+                TestStatus::Failed => "x",
+                TestStatus::Skipped => "-",
+            };
+            buf.push_str(&format!(
+                "[{}] {} .. {}ms\n",
+                icon,
+                r.name,
+                r.duration.as_millis()
+            ));
+            if let Some(err) = &r.error {
+                buf.push_str(&format!("     error: {}\n", err));
+            }
+        }
+
+        buf.push_str(&format!(
+            "\nTotal: {} | Passed: {} | Failed: {} | Skipped: {}\n",
+            report.total(),
+            report.passed(),
+            report.failed(),
+            report.skipped(),
+        ));
+        buf.push_str(&format!(
+            "Pass rate: {:.1}% | Duration: {}ms\n",
+            report.pass_rate() * 100.0,
+            report.total_duration.as_millis(),
+        ));
+
+        buf
+    }
+}

--- a/tests/src/report/mod.rs
+++ b/tests/src/report/mod.rs
@@ -1,0 +1,9 @@
+//! Test report generation: collect results, compute stats, format output.
+
+mod builder;
+mod format;
+mod types;
+
+pub use builder::TestReportBuilder;
+pub use format::{JsonFormatter, ReportFormatter, TextFormatter};
+pub use types::{TestCaseResult, TestReport, TestStatus};

--- a/tests/src/report/types.rs
+++ b/tests/src/report/types.rs
@@ -1,0 +1,97 @@
+//! Core data types for test reports.
+
+use std::time::Duration;
+
+/// Outcome of a single test case.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TestStatus {
+    Passed,
+    Failed,
+    Skipped,
+}
+
+impl std::fmt::Display for TestStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Passed => write!(f, "passed"),
+            Self::Failed => write!(f, "failed"),
+            Self::Skipped => write!(f, "skipped"),
+        }
+    }
+}
+
+/// Result of a single test case execution.
+#[derive(Debug, Clone)]
+pub struct TestCaseResult {
+    pub name: String,
+    pub status: TestStatus,
+    pub duration: Duration,
+    pub error: Option<String>,
+    pub metadata: Vec<(String, String)>,
+}
+
+/// Aggregated report for a test suite.
+#[derive(Debug, Clone)]
+pub struct TestReport {
+    pub suite_name: String,
+    pub results: Vec<TestCaseResult>,
+    pub total_duration: Duration,
+    pub timestamp: u64,
+}
+
+impl TestReport {
+    /// Total number of test cases.
+    pub fn total(&self) -> usize {
+        self.results.len()
+    }
+
+    /// Number of passed test cases.
+    pub fn passed(&self) -> usize {
+        self.results
+            .iter()
+            .filter(|r| r.status == TestStatus::Passed)
+            .count()
+    }
+
+    /// Number of failed test cases.
+    pub fn failed(&self) -> usize {
+        self.results
+            .iter()
+            .filter(|r| r.status == TestStatus::Failed)
+            .count()
+    }
+
+    /// Number of skipped test cases.
+    pub fn skipped(&self) -> usize {
+        self.results
+            .iter()
+            .filter(|r| r.status == TestStatus::Skipped)
+            .count()
+    }
+
+    /// Pass rate as a fraction in `[0.0, 1.0]`. Returns `1.0` for an empty suite.
+    pub fn pass_rate(&self) -> f64 {
+        let total = self.total();
+        if total == 0 {
+            return 1.0;
+        }
+        self.passed() as f64 / total as f64
+    }
+
+    /// The `n` slowest test cases, sorted by descending duration.
+    pub fn slowest(&self, n: usize) -> Vec<&TestCaseResult> {
+        let mut sorted: Vec<&TestCaseResult> = self.results.iter().collect();
+        sorted.sort_by(|a, b| b.duration.cmp(&a.duration));
+        sorted.truncate(n);
+        sorted
+    }
+
+    /// All test cases that failed.
+    pub fn failures(&self) -> Vec<&TestCaseResult> {
+        self.results
+            .iter()
+            .filter(|r| r.status == TestStatus::Failed)
+            .collect()
+    }
+}

--- a/tests/tests/report_tests.rs
+++ b/tests/tests/report_tests.rs
@@ -1,0 +1,321 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use mofa_testing::{
+    JsonFormatter, MockClock, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder,
+    TestStatus, TextFormatter,
+};
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+fn make_result(name: &str, status: TestStatus, ms: u64, error: Option<&str>) -> TestCaseResult {
+    TestCaseResult {
+        name: name.to_string(),
+        status,
+        duration: Duration::from_millis(ms),
+        error: error.map(String::from),
+        metadata: Vec::new(),
+    }
+}
+
+fn mixed_report() -> TestReport {
+    TestReport {
+        suite_name: "mixed".into(),
+        results: vec![
+            make_result("a", TestStatus::Passed, 10, None),
+            make_result("b", TestStatus::Failed, 50, Some("boom")),
+            make_result("c", TestStatus::Passed, 30, None),
+            make_result("d", TestStatus::Skipped, 0, None),
+            make_result("e", TestStatus::Failed, 20, Some("oops")),
+        ],
+        total_duration: Duration::from_millis(110),
+        timestamp: 1000,
+    }
+}
+
+// ===========================================================================
+// TestStatus
+// ===========================================================================
+
+#[test]
+fn status_display() {
+    assert_eq!(TestStatus::Passed.to_string(), "passed");
+    assert_eq!(TestStatus::Failed.to_string(), "failed");
+    assert_eq!(TestStatus::Skipped.to_string(), "skipped");
+}
+
+#[test]
+fn status_equality() {
+    assert_eq!(TestStatus::Passed, TestStatus::Passed);
+    assert_ne!(TestStatus::Passed, TestStatus::Failed);
+}
+
+// ===========================================================================
+// TestReport summary methods
+// ===========================================================================
+
+#[test]
+fn report_counts() {
+    let r = mixed_report();
+    assert_eq!(r.total(), 5);
+    assert_eq!(r.passed(), 2);
+    assert_eq!(r.failed(), 2);
+    assert_eq!(r.skipped(), 1);
+}
+
+#[test]
+fn pass_rate_mixed() {
+    let r = mixed_report();
+    let rate = r.pass_rate();
+    assert!((rate - 0.4).abs() < f64::EPSILON);
+}
+
+#[test]
+fn pass_rate_all_pass() {
+    let r = TestReport {
+        suite_name: "ok".into(),
+        results: vec![
+            make_result("x", TestStatus::Passed, 1, None),
+            make_result("y", TestStatus::Passed, 2, None),
+        ],
+        total_duration: Duration::ZERO,
+        timestamp: 0,
+    };
+    assert!((r.pass_rate() - 1.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn pass_rate_all_fail() {
+    let r = TestReport {
+        suite_name: "bad".into(),
+        results: vec![make_result("z", TestStatus::Failed, 1, Some("err"))],
+        total_duration: Duration::ZERO,
+        timestamp: 0,
+    };
+    assert!((r.pass_rate()).abs() < f64::EPSILON);
+}
+
+#[test]
+fn pass_rate_empty() {
+    let r = TestReport {
+        suite_name: "empty".into(),
+        results: vec![],
+        total_duration: Duration::ZERO,
+        timestamp: 0,
+    };
+    assert!((r.pass_rate() - 1.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn slowest_returns_descending() {
+    let r = mixed_report();
+    let top = r.slowest(3);
+    assert_eq!(top.len(), 3);
+    assert_eq!(top[0].name, "b"); // 50ms
+    assert_eq!(top[1].name, "c"); // 30ms
+    assert_eq!(top[2].name, "e"); // 20ms
+}
+
+#[test]
+fn slowest_more_than_total() {
+    let r = mixed_report();
+    let top = r.slowest(100);
+    assert_eq!(top.len(), 5);
+}
+
+#[test]
+fn failures_returns_only_failed() {
+    let r = mixed_report();
+    let fails = r.failures();
+    assert_eq!(fails.len(), 2);
+    assert!(fails.iter().all(|f| f.status == TestStatus::Failed));
+    assert_eq!(fails[0].name, "b");
+    assert_eq!(fails[1].name, "e");
+}
+
+#[test]
+fn failures_empty_when_all_pass() {
+    let r = TestReport {
+        suite_name: "ok".into(),
+        results: vec![make_result("x", TestStatus::Passed, 1, None)],
+        total_duration: Duration::ZERO,
+        timestamp: 0,
+    };
+    assert!(r.failures().is_empty());
+}
+
+// ===========================================================================
+// TestReportBuilder
+// ===========================================================================
+
+#[tokio::test]
+async fn builder_record_passing() {
+    let report = TestReportBuilder::new("pass-suite")
+        .record("ok_test", || async { Ok(()) })
+        .await
+        .build();
+
+    assert_eq!(report.suite_name, "pass-suite");
+    assert_eq!(report.total(), 1);
+    assert_eq!(report.results[0].status, TestStatus::Passed);
+    assert!(report.results[0].error.is_none());
+}
+
+#[tokio::test]
+async fn builder_record_failure() {
+    let report = TestReportBuilder::new("fail-suite")
+        .record("bad_test", || async { Err("kaboom".into()) })
+        .await
+        .build();
+
+    assert_eq!(report.failed(), 1);
+    assert_eq!(report.results[0].error.as_deref(), Some("kaboom"));
+}
+
+#[tokio::test]
+async fn builder_add_result_skipped() {
+    let report = TestReportBuilder::new("skip-suite")
+        .add_result(make_result("skipped_one", TestStatus::Skipped, 0, None))
+        .build();
+
+    assert_eq!(report.skipped(), 1);
+}
+
+#[tokio::test]
+async fn builder_empty_suite() {
+    let report = TestReportBuilder::new("empty").build();
+    assert_eq!(report.total(), 0);
+    assert!((report.pass_rate() - 1.0).abs() < f64::EPSILON);
+}
+
+#[tokio::test]
+async fn builder_with_mock_clock() {
+    let clock = Arc::new(MockClock::starting_at(Duration::from_millis(42_000)));
+    let report = TestReportBuilder::new("clocked").with_clock(clock).build();
+
+    assert_eq!(report.timestamp, 42_000);
+}
+
+#[tokio::test]
+async fn builder_mixed_record_and_add() {
+    let report = TestReportBuilder::new("combo")
+        .record("auto_pass", || async { Ok(()) })
+        .await
+        .add_result(make_result(
+            "manual_fail",
+            TestStatus::Failed,
+            5,
+            Some("err"),
+        ))
+        .record("auto_fail", || async { Err("nope".into()) })
+        .await
+        .add_result(make_result("manual_skip", TestStatus::Skipped, 0, None))
+        .build();
+
+    assert_eq!(report.total(), 4);
+    assert_eq!(report.passed(), 1);
+    assert_eq!(report.failed(), 2);
+    assert_eq!(report.skipped(), 1);
+}
+
+// ===========================================================================
+// JsonFormatter
+// ===========================================================================
+
+#[test]
+fn json_formatter_valid_json() {
+    let r = mixed_report();
+    let output = JsonFormatter.format(&r);
+    let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
+
+    assert_eq!(parsed["suite"], "mixed");
+    assert_eq!(parsed["timestamp"], 1000);
+    assert_eq!(parsed["summary"]["total"], 5);
+    assert_eq!(parsed["summary"]["passed"], 2);
+    assert_eq!(parsed["summary"]["failed"], 2);
+    assert_eq!(parsed["summary"]["skipped"], 1);
+
+    let results = parsed["results"].as_array().expect("results array");
+    assert_eq!(results.len(), 5);
+    assert_eq!(results[0]["name"], "a");
+    assert_eq!(results[0]["status"], "passed");
+    assert_eq!(results[1]["error"], "boom");
+}
+
+#[test]
+fn json_formatter_empty_report() {
+    let r = TestReport {
+        suite_name: "empty".into(),
+        results: vec![],
+        total_duration: Duration::ZERO,
+        timestamp: 0,
+    };
+    let output = JsonFormatter.format(&r);
+    let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
+    assert_eq!(parsed["summary"]["total"], 0);
+    assert_eq!(parsed["results"].as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn json_formatter_includes_metadata() {
+    let mut tc = make_result("meta_test", TestStatus::Passed, 5, None);
+    tc.metadata.push(("key".into(), "val".into()));
+    let r = TestReport {
+        suite_name: "m".into(),
+        results: vec![tc],
+        total_duration: Duration::from_millis(5),
+        timestamp: 0,
+    };
+    let output = JsonFormatter.format(&r);
+    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+    assert_eq!(parsed["results"][0]["metadata"]["key"], "val");
+}
+
+// ===========================================================================
+// TextFormatter
+// ===========================================================================
+
+#[test]
+fn text_formatter_contains_test_names() {
+    let r = mixed_report();
+    let output = TextFormatter.format(&r);
+    assert!(output.contains("=== mixed ==="));
+    assert!(output.contains("a"));
+    assert!(output.contains("b"));
+    assert!(output.contains("boom"));
+}
+
+#[test]
+fn text_formatter_status_icons() {
+    let r = mixed_report();
+    let output = TextFormatter.format(&r);
+    assert!(output.contains("[+]"));
+    assert!(output.contains("[x]"));
+    assert!(output.contains("[-]"));
+}
+
+#[test]
+fn text_formatter_summary_line() {
+    let r = mixed_report();
+    let output = TextFormatter.format(&r);
+    assert!(output.contains("Total: 5"));
+    assert!(output.contains("Passed: 2"));
+    assert!(output.contains("Failed: 2"));
+    assert!(output.contains("Skipped: 1"));
+    assert!(output.contains("Pass rate: 40.0%"));
+}
+
+#[test]
+fn text_formatter_empty_report() {
+    let r = TestReport {
+        suite_name: "empty".into(),
+        results: vec![],
+        total_duration: Duration::ZERO,
+        timestamp: 0,
+    };
+    let output = TextFormatter.format(&r);
+    assert!(output.contains("Total: 0"));
+    assert!(output.contains("Pass rate: 100.0%"));
+}


### PR DESCRIPTION
## feat(testing): Test Report Generator for `mofa-testing`

fixes #894 
### Summary

Adds a structured test report generation system to `mofa-testing` — collect test results, compute stats, and output as JSON or human-readable text. Builds directly on the mocks from #486 and the failure injection / `MockClock` from #888.

### Motivation

The testing crate now has mocks (#486) and failure injection (#888), but no structured way to **collect and report** outcomes. Test results are scattered across stdout with no machine-readable format, no timing data, no aggregated stats, and no CI-friendly output. This PR closes that gap.

### What's New

| Component | Description |
|-----------|-------------|
| `TestStatus` | `#[non_exhaustive]` enum: `Passed`, `Failed`, `Skipped` with `Display` impl |
| `TestCaseResult` | Name, status, duration, optional error, key-value metadata |
| `TestReport` | Suite name, results vec, total duration, timestamp + summary methods |
| `TestReportBuilder` | Fluent API: `new()` → `with_clock()` → `record()` / `add_result()` → `build()` |
| `ReportFormatter` trait | `fn format(&self, report: &TestReport) -> String` |
| `JsonFormatter` | Pretty-printed JSON with suite, summary, and per-test results |
| `TextFormatter` | Human-readable block with status icons, durations, and summary line |

### How It Builds on #486 and #888

```
PR #486 (Mocks)          PR #888 (Failure Injection + MockClock)
    │                           │
    │  MockLLMBackend           │  fail_next, fail_on, rate limiting
    │  MockTool                 │  add_response_sequence
    │  MockAgentBus             │  MockClock
    │                           │
    └───────────┬───────────────┘
                │
                ▼
        This PR (Report Generator)
                │
    TestReportBuilder.record() wraps mock-driven test closures
    Uses MockClock for deterministic timestamps
    Failure injection creates both pass/fail scenarios for stats
```





**Report stats:**
```rust
report.total()     // 3
report.passed()    // 1
report.failed()    // 1
report.skipped()   // 1
report.pass_rate() // 0.333...
report.slowest(2)  // top 2 slowest, descending
report.failures()  // only failed cases
```

**Formatters:**
```rust
let json = JsonFormatter.format(&report);   // valid JSON with summary + results
let text = TextFormatter.format(&report);   // human-readable with icons
```

### Test Results

```
running 24 tests  (report_tests.rs)
test builder_add_result_skipped ......... ok
test builder_empty_suite ................ ok
test builder_mixed_record_and_add ....... ok
test builder_record_failure ............. ok
test builder_record_passing ............. ok
test builder_with_mock_clock ............ ok
test failures_empty_when_all_pass ....... ok
test failures_returns_only_failed ....... ok
test json_formatter_empty_report ........ ok
test json_formatter_includes_metadata ... ok
test json_formatter_valid_json .......... ok
test pass_rate_all_fail ................. ok
test pass_rate_all_pass ................. ok
test pass_rate_empty .................... ok
test pass_rate_mixed .................... ok
test report_counts ...................... ok
test slowest_more_than_total ............ ok
test slowest_returns_descending ......... ok
test status_display ..................... ok
test status_equality .................... ok
test text_formatter_contains_test_names . ok
test text_formatter_empty_report ........ ok
test text_formatter_status_icons ........ ok
test text_formatter_summary_line ........ ok

test result: ok. 24 passed; 0 failed
```

**Full crate: 71/71 tests pass** (15 integration + 32 failure injection + 24 report)

### Verification Checklist

- [x] `cargo check -p mofa-testing` — clean
- [x] `cargo clippy -p mofa-testing -- -W dead_code -W unused_imports -W unused_variables` — 0 warnings
- [x] `cargo fmt -p mofa-testing -- --check` — clean
- [x] `cargo test -p mofa-testing` — 71/71 pass
- [x] Rebased on latest `upstream/main` (`deff9683`) — zero conflicts
- [x] Only touches `tests/` directory — no changes to core crates
- [x] All existing 47 tests unchanged and passing
- [x] Public enum `TestStatus` has `#[non_exhaustive]`
- [x] No new dependencies added (`serde_json` already in Cargo.toml)
