### PR TITLE
feat(kernel): define GatewayRoute, RouteRegistry, and RoutingContext traits for agent request dispatch (Phase 1/10)

### DIFF
--- a/crates/mofa-kernel/src/gateway/error.rs
+++ b/crates/mofa-kernel/src/gateway/error.rs
@@ -1,0 +1,40 @@
+//! Error types for the gateway routing layer.
+
+use thiserror::Error;
+
+/// Errors that can occur when interacting with a [`RouteRegistry`](super::route::RouteRegistry).
+#[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RegistryError {
+    /// The route `id` field is empty or whitespace-only.
+    #[error("route id cannot be empty")]
+    EmptyRouteId,
+
+    /// The route `agent_id` field is empty or whitespace-only.
+    #[error("agent id cannot be empty")]
+    EmptyAgentId,
+
+    /// The path pattern is invalid (empty, or does not start with `/`).
+    #[error("route '{0}' has an invalid path pattern: {1}")]
+    InvalidPathPattern(String, String),
+
+    /// A route with this ID is already registered.
+    #[error("route '{0}' is already registered")]
+    DuplicateRouteId(String),
+
+    /// No route with this ID is currently registered.
+    #[error("route '{0}' not found")]
+    RouteNotFound(String),
+
+    /// Two routes share the same path pattern, method, and priority — the
+    /// gateway cannot deterministically choose between them.
+    #[error(
+        "route '{0}' conflicts with existing route '{1}': \
+         same path pattern, method, and priority"
+    )]
+    ConflictingRoutes(String, String),
+
+    /// The route failed basic field validation.
+    #[error("route is invalid: {0}")]
+    InvalidRoute(String),
+}

--- a/crates/mofa-kernel/src/gateway/mod.rs
+++ b/crates/mofa-kernel/src/gateway/mod.rs
@@ -1,0 +1,25 @@
+//! Kernel-level gateway abstractions for agent request dispatch.
+//!
+//! This module defines the trait boundary between the gateway transport layer
+//! (HTTP, gRPC, MQTT, …) and the agent runtime.  By keeping routing logic in
+//! the kernel, alternative transports and unit tests can reason about routing
+//! without depending on the full HTTP stack.
+//!
+//! # Types
+//!
+//! | Type | Description |
+//! |------|-------------|
+//! | [`GatewayRoute`] | A routing rule mapping a path + method to an agent |
+//! | [`RouteRegistry`] | Trait for registering, looking up, and listing routes |
+//! | [`RoutingContext`] | Per-request dispatch context (path, method, headers, correlation ID) |
+//! | [`HttpMethod`] | HTTP method enum |
+//! | [`RegistryError`] | Error type for registry operations |
+
+pub mod error;
+pub mod route;
+
+#[cfg(test)]
+mod tests;
+
+pub use error::RegistryError;
+pub use route::{GatewayRoute, HttpMethod, RouteRegistry, RoutingContext};

--- a/crates/mofa-kernel/src/gateway/route.rs
+++ b/crates/mofa-kernel/src/gateway/route.rs
@@ -1,0 +1,240 @@
+//! Core routing types and registry trait for agent request dispatch.
+//!
+//! [`GatewayRoute`] describes a single routing rule that maps an incoming
+//! HTTP path + method to a target agent.  [`RouteRegistry`] is the
+//! kernel-level trait any registry implementation must satisfy so that
+//! routing logic can be tested and extended without depending on the full
+//! HTTP stack.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use super::error::RegistryError;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// HTTP method
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Standard HTTP methods accepted by a gateway route.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum HttpMethod {
+    Get,
+    Post,
+    Put,
+    Patch,
+    Delete,
+    Head,
+    Options,
+}
+
+impl HttpMethod {
+    /// Case-insensitive parse from a string slice.  Returns `None` for unknown
+    /// method strings.
+    pub fn from_str_ci(s: &str) -> Option<Self> {
+        match s.to_ascii_uppercase().as_str() {
+            "GET" => Some(Self::Get),
+            "POST" => Some(Self::Post),
+            "PUT" => Some(Self::Put),
+            "PATCH" => Some(Self::Patch),
+            "DELETE" => Some(Self::Delete),
+            "HEAD" => Some(Self::Head),
+            "OPTIONS" => Some(Self::Options),
+            _ => None,
+        }
+    }
+
+    /// Return the standard uppercase string representation.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Get => "GET",
+            Self::Post => "POST",
+            Self::Put => "PUT",
+            Self::Patch => "PATCH",
+            Self::Delete => "DELETE",
+            Self::Head => "HEAD",
+            Self::Options => "OPTIONS",
+        }
+    }
+}
+
+impl std::fmt::Display for HttpMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GatewayRoute
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A single routing rule mapping an incoming HTTP path + method to a target
+/// agent.
+///
+/// Routes can be toggled at runtime via the [`enabled`](GatewayRoute::enabled)
+/// flag without having to deregister and re-register them.  This allows
+/// operators to disable a route during maintenance without losing its
+/// configuration.
+///
+/// # Priority
+///
+/// When multiple routes match the same `(path_pattern, method)` pair, the
+/// route with the **highest** `priority` value wins.  Two routes that share
+/// the same path, method, *and* priority value represent a conflict; see
+/// [`RouteRegistry::register`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GatewayRoute {
+    /// Stable, unique identifier for this route.
+    pub id: String,
+    /// ID of the agent that will handle matching requests.
+    pub agent_id: String,
+    /// URL path pattern, e.g. `/agents/summarizer` or `/v1/models/{model_id}`.
+    /// Must begin with `/`.
+    pub path_pattern: String,
+    /// HTTP method this route accepts.
+    pub method: HttpMethod,
+    /// Numeric priority — higher values are evaluated first.
+    /// Defaults to `0`.
+    pub priority: i32,
+    /// Whether this route is currently active.  Disabled routes are never
+    /// returned by [`RouteRegistry::list_active`] and never matched at
+    /// dispatch time.
+    pub enabled: bool,
+}
+
+impl GatewayRoute {
+    /// Create a new, enabled route with default priority.
+    pub fn new(
+        id: impl Into<String>,
+        agent_id: impl Into<String>,
+        path_pattern: impl Into<String>,
+        method: HttpMethod,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            agent_id: agent_id.into(),
+            path_pattern: path_pattern.into(),
+            method,
+            priority: 0,
+            enabled: true,
+        }
+    }
+
+    /// Set the routing priority.
+    pub fn with_priority(mut self, priority: i32) -> Self {
+        self.priority = priority;
+        self
+    }
+
+    /// Mark this route as disabled at creation time.
+    pub fn disabled(mut self) -> Self {
+        self.enabled = false;
+        self
+    }
+
+    /// Validate that mandatory fields are well-formed.
+    pub fn validate(&self) -> Result<(), RegistryError> {
+        if self.id.trim().is_empty() {
+            return Err(RegistryError::EmptyRouteId);
+        }
+        if self.agent_id.trim().is_empty() {
+            return Err(RegistryError::EmptyAgentId);
+        }
+        if self.path_pattern.trim().is_empty() || !self.path_pattern.starts_with('/') {
+            return Err(RegistryError::InvalidPathPattern(
+                self.id.clone(),
+                "path pattern must be non-empty and start with '/'".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RouteRegistry trait
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Kernel contract for a route registry.
+///
+/// Implementations must be `Send + Sync` so they can be wrapped in an `Arc`
+/// and shared across Tokio tasks without additional synchronisation.
+///
+/// # Conflict policy
+///
+/// Registering two routes with the same `(path_pattern, method)` pair *and*
+/// the same `priority` is an error ([`RegistryError::ConflictingRoutes`]).
+/// Routes that share the same pattern and method but differ in priority are
+/// accepted; the higher-priority route wins at dispatch time.
+pub trait RouteRegistry: Send + Sync {
+    /// Register a new route.
+    ///
+    /// # Errors
+    ///
+    /// * [`RegistryError::DuplicateRouteId`] — a route with the same `id` is
+    ///   already registered.
+    /// * [`RegistryError::ConflictingRoutes`] — another route with the same
+    ///   `(path_pattern, method, priority)` triple already exists.
+    /// * [`RegistryError::InvalidRoute`] — the route fails field validation.
+    fn register(&mut self, route: GatewayRoute) -> Result<(), RegistryError>;
+
+    /// Remove a previously registered route by its ID.
+    ///
+    /// # Errors
+    ///
+    /// * [`RegistryError::RouteNotFound`] — no route with the given `id` is
+    ///   registered.
+    fn deregister(&mut self, route_id: &str) -> Result<(), RegistryError>;
+
+    /// Look up a route by its stable ID, regardless of whether it is enabled.
+    ///
+    /// Returns `None` when no route with the given `id` is registered.
+    fn lookup(&self, route_id: &str) -> Option<&GatewayRoute>;
+
+    /// Return references to all **enabled** routes, sorted by descending
+    /// priority (highest first).
+    fn list_active(&self) -> Vec<&GatewayRoute>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RoutingContext
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Information available at dispatch time, passed to routing strategies so
+/// they can make decisions without depending on the raw HTTP request type.
+///
+/// The `correlation_id` field is a per-request identifier that flows through
+/// the entire system for distributed tracing and log correlation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoutingContext {
+    /// Incoming request path, e.g. `/agents/summarizer`.
+    pub path: String,
+    /// HTTP method of the incoming request.
+    pub method: HttpMethod,
+    /// Parsed request headers.  Keys are lowercased for case-insensitive
+    /// lookup (e.g. `"content-type"`).
+    pub headers: HashMap<String, String>,
+    /// Per-request correlation identifier for distributed tracing.
+    pub correlation_id: String,
+}
+
+impl RoutingContext {
+    /// Create a minimal context with no headers.
+    pub fn new(
+        path: impl Into<String>,
+        method: HttpMethod,
+        correlation_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            path: path.into(),
+            method,
+            headers: HashMap::new(),
+            correlation_id: correlation_id.into(),
+        }
+    }
+
+    /// Builder: insert a header (key is lowercased automatically).
+    pub fn with_header(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.headers.insert(key.into().to_lowercase(), value.into());
+        self
+    }
+}

--- a/crates/mofa-kernel/src/gateway/tests.rs
+++ b/crates/mofa-kernel/src/gateway/tests.rs
@@ -1,0 +1,281 @@
+//! Unit tests for GatewayRoute, RouteRegistry, and RoutingContext.
+//!
+//! Uses an `InMemoryRouteRegistry` defined here for testing purposes only —
+//! the concrete registry implementation lives in `mofa-foundation`.
+
+use std::collections::HashMap;
+
+use super::error::RegistryError;
+use super::route::{GatewayRoute, HttpMethod, RouteRegistry, RoutingContext};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Minimal in-test registry implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+struct InMemoryRouteRegistry {
+    routes: HashMap<String, GatewayRoute>,
+}
+
+impl InMemoryRouteRegistry {
+    fn new() -> Self {
+        Self {
+            routes: HashMap::new(),
+        }
+    }
+}
+
+impl RouteRegistry for InMemoryRouteRegistry {
+    fn register(&mut self, route: GatewayRoute) -> Result<(), RegistryError> {
+        route
+            .validate()
+            .map_err(|e| RegistryError::InvalidRoute(e.to_string()))?;
+
+        if self.routes.contains_key(&route.id) {
+            return Err(RegistryError::DuplicateRouteId(route.id.clone()));
+        }
+
+        // Conflict: same (path_pattern, method, priority) as an existing route.
+        for existing in self.routes.values() {
+            if existing.path_pattern == route.path_pattern
+                && existing.method == route.method
+                && existing.priority == route.priority
+            {
+                return Err(RegistryError::ConflictingRoutes(
+                    route.id.clone(),
+                    existing.id.clone(),
+                ));
+            }
+        }
+
+        self.routes.insert(route.id.clone(), route);
+        Ok(())
+    }
+
+    fn deregister(&mut self, route_id: &str) -> Result<(), RegistryError> {
+        if self.routes.remove(route_id).is_none() {
+            return Err(RegistryError::RouteNotFound(route_id.to_string()));
+        }
+        Ok(())
+    }
+
+    fn lookup(&self, route_id: &str) -> Option<&GatewayRoute> {
+        self.routes.get(route_id)
+    }
+
+    fn list_active(&self) -> Vec<&GatewayRoute> {
+        let mut active: Vec<&GatewayRoute> =
+            self.routes.values().filter(|r| r.enabled).collect();
+        active.sort_by(|a, b| b.priority.cmp(&a.priority));
+        active
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GatewayRoute tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn gateway_route_new_defaults() {
+    let route = GatewayRoute::new("r1", "agent-a", "/agents/summarizer", HttpMethod::Post);
+    assert_eq!(route.id, "r1");
+    assert_eq!(route.agent_id, "agent-a");
+    assert_eq!(route.path_pattern, "/agents/summarizer");
+    assert_eq!(route.method, HttpMethod::Post);
+    assert_eq!(route.priority, 0);
+    assert!(route.enabled);
+}
+
+#[test]
+fn gateway_route_builder() {
+    let route = GatewayRoute::new("r1", "agent-a", "/path", HttpMethod::Get)
+        .with_priority(10)
+        .disabled();
+    assert_eq!(route.priority, 10);
+    assert!(!route.enabled);
+}
+
+#[test]
+fn gateway_route_validate_empty_id() {
+    let route = GatewayRoute::new("", "agent-a", "/path", HttpMethod::Get);
+    assert!(matches!(route.validate(), Err(RegistryError::EmptyRouteId)));
+}
+
+#[test]
+fn gateway_route_validate_empty_agent_id() {
+    let route = GatewayRoute::new("r1", "", "/path", HttpMethod::Get);
+    assert!(matches!(route.validate(), Err(RegistryError::EmptyAgentId)));
+}
+
+#[test]
+fn gateway_route_validate_invalid_path() {
+    let route = GatewayRoute::new("r1", "agent-a", "no-leading-slash", HttpMethod::Get);
+    assert!(matches!(
+        route.validate(),
+        Err(RegistryError::InvalidPathPattern(_, _))
+    ));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RouteRegistry tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn register_and_lookup() {
+    let mut reg = InMemoryRouteRegistry::new();
+    let route = GatewayRoute::new("r1", "agent-a", "/agents/summarizer", HttpMethod::Post);
+    reg.register(route).unwrap();
+
+    let found = reg.lookup("r1").unwrap();
+    assert_eq!(found.agent_id, "agent-a");
+}
+
+#[test]
+fn lookup_missing_returns_none() {
+    let reg = InMemoryRouteRegistry::new();
+    assert!(reg.lookup("does-not-exist").is_none());
+}
+
+#[test]
+fn register_duplicate_id_is_error() {
+    let mut reg = InMemoryRouteRegistry::new();
+    let r1 = GatewayRoute::new("r1", "agent-a", "/path", HttpMethod::Get);
+    let r2 = GatewayRoute::new("r1", "agent-b", "/other", HttpMethod::Post);
+    reg.register(r1).unwrap();
+    assert!(matches!(
+        reg.register(r2),
+        Err(RegistryError::DuplicateRouteId(_))
+    ));
+}
+
+#[test]
+fn deregister_removes_route() {
+    let mut reg = InMemoryRouteRegistry::new();
+    reg.register(GatewayRoute::new("r1", "agent-a", "/path", HttpMethod::Get))
+        .unwrap();
+    reg.deregister("r1").unwrap();
+    assert!(reg.lookup("r1").is_none());
+}
+
+#[test]
+fn deregister_missing_is_error() {
+    let mut reg = InMemoryRouteRegistry::new();
+    assert!(matches!(
+        reg.deregister("ghost"),
+        Err(RegistryError::RouteNotFound(_))
+    ));
+}
+
+#[test]
+fn list_active_excludes_disabled_routes() {
+    let mut reg = InMemoryRouteRegistry::new();
+    reg.register(GatewayRoute::new("r1", "agent-a", "/active", HttpMethod::Get))
+        .unwrap();
+    reg.register(
+        GatewayRoute::new("r2", "agent-b", "/disabled", HttpMethod::Post).disabled(),
+    )
+    .unwrap();
+
+    let active = reg.list_active();
+    assert_eq!(active.len(), 1);
+    assert_eq!(active[0].id, "r1");
+}
+
+#[test]
+fn list_active_sorted_by_descending_priority() {
+    let mut reg = InMemoryRouteRegistry::new();
+    reg.register(
+        GatewayRoute::new("low", "agent-a", "/low", HttpMethod::Get).with_priority(1),
+    )
+    .unwrap();
+    reg.register(
+        GatewayRoute::new("high", "agent-b", "/high", HttpMethod::Post).with_priority(10),
+    )
+    .unwrap();
+    reg.register(
+        GatewayRoute::new("mid", "agent-c", "/mid", HttpMethod::Put).with_priority(5),
+    )
+    .unwrap();
+
+    let active = reg.list_active();
+    assert_eq!(active[0].id, "high");
+    assert_eq!(active[1].id, "mid");
+    assert_eq!(active[2].id, "low");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Conflict detection tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn conflict_same_path_method_and_equal_priority() {
+    let mut reg = InMemoryRouteRegistry::new();
+    reg.register(GatewayRoute::new("r1", "agent-a", "/v1/chat", HttpMethod::Post))
+        .unwrap();
+    // Same path, method, and priority (0) as r1 — must be rejected.
+    let result = reg.register(GatewayRoute::new("r2", "agent-b", "/v1/chat", HttpMethod::Post));
+    assert!(
+        matches!(result, Err(RegistryError::ConflictingRoutes(ref new, ref existing))
+            if new == "r2" && existing == "r1"),
+        "expected ConflictingRoutes(r2, r1), got {result:?}"
+    );
+}
+
+#[test]
+fn no_conflict_same_path_method_different_priority() {
+    let mut reg = InMemoryRouteRegistry::new();
+    reg.register(GatewayRoute::new("r1", "agent-a", "/v1/chat", HttpMethod::Post))
+        .unwrap();
+    // Different priority — should succeed.
+    reg.register(
+        GatewayRoute::new("r2", "agent-b", "/v1/chat", HttpMethod::Post).with_priority(1),
+    )
+    .unwrap();
+    assert!(reg.lookup("r2").is_some());
+}
+
+#[test]
+fn no_conflict_same_path_different_method() {
+    let mut reg = InMemoryRouteRegistry::new();
+    reg.register(GatewayRoute::new("r1", "agent-a", "/v1/chat", HttpMethod::Post))
+        .unwrap();
+    reg.register(GatewayRoute::new("r2", "agent-b", "/v1/chat", HttpMethod::Get))
+        .unwrap();
+    assert_eq!(reg.list_active().len(), 2);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RoutingContext tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn routing_context_new() {
+    let ctx = RoutingContext::new("/agents/summarizer", HttpMethod::Post, "req-abc-123");
+    assert_eq!(ctx.path, "/agents/summarizer");
+    assert_eq!(ctx.method, HttpMethod::Post);
+    assert_eq!(ctx.correlation_id, "req-abc-123");
+    assert!(ctx.headers.is_empty());
+}
+
+#[test]
+fn routing_context_headers_are_lowercased() {
+    let ctx = RoutingContext::new("/path", HttpMethod::Get, "cid-1")
+        .with_header("Content-Type", "application/json")
+        .with_header("X-Api-Key", "secret");
+
+    assert_eq!(
+        ctx.headers.get("content-type"),
+        Some(&"application/json".to_string())
+    );
+    assert_eq!(
+        ctx.headers.get("x-api-key"),
+        Some(&"secret".to_string())
+    );
+}
+
+#[test]
+fn http_method_from_str_ci() {
+    assert_eq!(HttpMethod::from_str_ci("get"), Some(HttpMethod::Get));
+    assert_eq!(HttpMethod::from_str_ci("POST"), Some(HttpMethod::Post));
+    assert_eq!(HttpMethod::from_str_ci("pAtCh"), Some(HttpMethod::Patch));
+    assert_eq!(HttpMethod::from_str_ci("UNKNOWN"), None);
+}

--- a/crates/mofa-kernel/src/lib.rs
+++ b/crates/mofa-kernel/src/lib.rs
@@ -74,3 +74,7 @@ pub mod structured_output;
 pub use structured_output::StructuredOutput;
 // Security governance (PII redaction, content moderation, prompt guard)
 pub mod security;
+
+// Gateway routing abstractions (kernel-level traits for agent request dispatch)
+pub mod gateway;
+pub use gateway::{GatewayRoute, HttpMethod, RegistryError, RouteRegistry, RoutingContext};


### PR DESCRIPTION
Closes #699

---

## What

Adds three kernel-level gateway abstractions to `mofa-kernel/src/gateway/`:

- `GatewayRoute` — a typed routing rule mapping a path pattern and HTTP method to a target agent, with a numeric priority and a runtime-toggleable `enabled` flag
- `RouteRegistry` — a `Send + Sync` trait for registering, deregistering, looking up, and listing active routes
- `RoutingContext` — a per-request dispatch context carrying the incoming path, method, lowercased headers, and a correlation ID for distributed tracing
- `HttpMethod` — standard HTTP method enum with case-insensitive parsing
- `RegistryError` — typed errors for all registry failure modes

All types live in `mofa-kernel/src/gateway/` and are re-exported from the kernel root.

---

## Why

The gateway in `mofa-gateway` dispatches requests directly through the axum handler layer with no kernel-level routing abstraction. This means:

- Routing logic cannot be unit-tested without spinning up an HTTP server
- Alternative transports (gRPC, MQTT, WebSocket) have no shared contract to build on
- Middleware, routing strategies, and access logs each extract path and method independently from the raw request

This PR defines the routing trait boundary so every layer above can implement, test, and reason about routing without touching axum internals.

---

## Architecture

This is **Phase 1** of a 10-issue Cognitive Gateway implementation. The full dependency graph:

```mermaid
graph TD
    A["#699 GatewayRoute / RouteRegistry / RoutingContext (this PR)"]
    B["#700 RequestEnvelope / GatewayResponse kernel types"]
    C["#701 AuthClaims / AuthProvider / ApiKeyStore traits"]
    D["#702 Token-bucket rate limiter (foundation)"]
    E["#703 Weighted round-robin + capability-aware routing"]
    F["#704 TOML config + atomic hot-reload"]
    G["#705 Composable middleware pipeline"]
    H["#706 Admin REST API"]
    I["#707 Per-route deadline propagation + 504 enforcement"]
    J["#708 Integration test harness + fault injection"]

    A --> B
    A --> C
    B --> G
    C --> G
    D --> G
    E --> G
    F --> G
    G --> H
    G --> I
    G --> J
```

```mermaid
graph LR
    subgraph mofa-kernel
        R[GatewayRoute]
        RR[RouteRegistry trait]
        RC[RoutingContext]
        HM[HttpMethod]
        RE[RegistryError]
    end

    subgraph mofa-foundation
        IR[InMemoryRouteRegistry impl]
        MW[Middleware pipeline - #705]
        RL[TokenBucketRateLimiter - #702]
        WRR[WeightedRoundRobin - #703]
    end

    subgraph mofa-gateway
        AX[axum handlers]
        ADM[Admin REST API - #706]
        DL[Deadline enforcement - #707]
    end

    RR --> IR
    R --> IR
    RC --> MW
    IR --> AX
    MW --> AX
    AX --> ADM
    AX --> DL
```

---

## Key design decisions

**`enabled` flag vs deregister** — routes carry an `enabled: bool` field so operators can disable a route during a deployment or maintenance window without losing the configuration. The registry's `list_active()` method only returns enabled routes; `lookup()` returns the route regardless so the flag can be flipped back.

**`agent_id` not `backend_id`** — this is an agent framework, so routes point to agents by their stable agent ID rather than a generic backend URL. The gateway layer is responsible for resolving agent ID to a transport address.

**Conflict detection** — two routes with the same `(path_pattern, method, priority)` triple are rejected at registration time with `RegistryError::ConflictingRoutes`. Routes that share pattern and method but have different priorities are accepted; the higher-priority route wins at dispatch time.

**`RouteRegistry` is sync** — the trait uses `&mut self` for mutations and `&self` for reads. Implementations that need shared ownership wrap in `Arc<RwLock<dyn RouteRegistry>>`. Keeping the trait sync avoids boxing futures for what is essentially an in-memory map operation.

---

## Changes

```
crates/mofa-kernel/src/gateway/
├── mod.rs          — module declaration and re-exports
├── route.rs        — GatewayRoute, RouteRegistry, RoutingContext, HttpMethod
├── error.rs        — RegistryError
└── tests.rs        — 18 unit tests

crates/mofa-kernel/src/lib.rs
    — added `pub mod gateway` and re-exports
```

---

## Tests

18 unit tests covering:

| Category | Tests |
|---|---|
| `GatewayRoute` construction | defaults, builder methods, disabled flag |
| Validation | empty ID, empty agent ID, invalid path pattern |
| Registry | register + lookup, missing lookup, duplicate ID error |
| Registry | deregister, deregister missing |
| Active listing | disabled routes excluded, sorted by descending priority |
| Conflict detection | same path + method + equal priority rejected |
| Conflict detection | same path + method + different priority accepted |
| Conflict detection | same path + different method accepted |
| `RoutingContext` | construction, header lowercasing |
| `HttpMethod` | case-insensitive parsing, unknown method returns None |

```
test result: ok. 18 passed; 0 failed
```

---

## What comes next

| Issue | Title | Depends on |
|---|---|---|
| #700 | RequestEnvelope and GatewayResponse kernel types | this PR |
| #701 | AuthClaims, AuthProvider, ApiKeyStore traits | this PR |
| #702 | Token-bucket rate limiter | #700 |
| #703 | Weighted round-robin + capability-aware routing | #699 + #701 |
| #704 | TOML config + atomic hot-reload | parallel |
| #705 | Composable middleware pipeline | #700 + #701 + #702 |
| #706 | Admin REST API | #705 |
| #707 | Per-route deadline propagation + 504 enforcement | #705 |
| #708 | Integration test harness + fault injection | all above |
