### PR TITLE
feat(kernel): add RequestEnvelope and GatewayResponse types for typed gateway request lifecycle (Phase 2/10)

### DIFF
--- a/crates/mofa-kernel/src/gateway/envelope.rs
+++ b/crates/mofa-kernel/src/gateway/envelope.rs
@@ -1,0 +1,328 @@
+//! Typed request and response envelopes for the gateway pipeline.
+//!
+//! [`RequestEnvelope`] is created at gateway admission and flows through every
+//! middleware filter and routing layer unchanged.  All pipeline components read
+//! context (correlation ID, route, deadline) from this struct instead of
+//! re-parsing the raw HTTP request.
+//!
+//! [`AgentResponse`] is produced by the agent handler and consumed by the
+//! access-log, metrics, and admin API layers.  It carries enough information
+//! for structured logging and latency tracking without reaching into axum
+//! response internals.
+//!
+//! # Serialisation note
+//!
+//! Both types derive `Serialize`.  `RequestEnvelope::deadline` is a
+//! `std::time::Instant` — a monotonic, non-serialisable type — so it is
+//! tagged `#[serde(skip)]`.  Transport layers that need to propagate a
+//! deadline across process boundaries should convert to `deadline_unix_ms`
+//! (milliseconds since UNIX epoch) via [`RequestEnvelope::deadline_unix_ms`].
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RequestEnvelope
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A typed envelope wrapping an inbound agent call from admission to handler.
+///
+/// Created once at the gateway edge with a freshly generated `correlation_id`
+/// and passed unchanged through the filter chain and routing layer.
+///
+/// # Deadline semantics
+///
+/// When `deadline` is `Some`, middleware and handlers should check
+/// [`is_expired`](RequestEnvelope::is_expired) before doing expensive work.
+/// A request that has already exceeded its deadline should be short-circuited
+/// with a `504 Gateway Timeout` rather than forwarded to the agent.
+#[derive(Debug, Clone, Serialize)]
+pub struct RequestEnvelope {
+    /// UUID v4 generated at gateway admission.  Flows through every layer
+    /// for distributed tracing and log correlation.
+    pub correlation_id: String,
+    /// ID of the [`GatewayRoute`](super::route::GatewayRoute) that matched
+    /// this request, set after the routing phase.
+    pub route_id: String,
+    /// Request payload, parsed from the HTTP body.
+    pub payload: serde_json::Value,
+    /// Optional per-request deadline.  Skipped during serialisation because
+    /// `Instant` is not serialisable; use
+    /// [`deadline_unix_ms`](RequestEnvelope::deadline_unix_ms) when a
+    /// wire-transferable deadline is needed.
+    #[serde(skip)]
+    pub deadline: Option<Instant>,
+    /// IP address of the originating caller.
+    pub origin_ip: IpAddr,
+    /// Headers forwarded from the inbound HTTP request.  Keys are lowercased.
+    pub headers: HashMap<String, String>,
+    /// Wall-clock timestamp (ms since UNIX epoch) at which the envelope was
+    /// created.  Used to compute `latency_ms` in [`GatewayResponse`].
+    pub created_at_ms: u64,
+}
+
+impl RequestEnvelope {
+    /// Create a new envelope with a freshly generated correlation ID and the
+    /// current wall-clock creation time.
+    ///
+    /// `route_id` is typically empty at construction time and filled in by
+    /// the routing middleware once a matching route has been found.
+    pub fn new(
+        route_id: impl Into<String>,
+        payload: serde_json::Value,
+        origin_ip: IpAddr,
+    ) -> Self {
+        Self {
+            correlation_id: Uuid::new_v4().to_string(),
+            route_id: route_id.into(),
+            payload,
+            deadline: None,
+            origin_ip,
+            headers: HashMap::new(),
+            created_at_ms: now_ms(),
+        }
+    }
+
+    /// Set an optional deadline as a monotonic `Instant`.
+    pub fn with_deadline(mut self, deadline: Instant) -> Self {
+        self.deadline = Some(deadline);
+        self
+    }
+
+    /// Insert a forwarded header (key is lowercased automatically).
+    pub fn with_header(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.headers.insert(key.into().to_lowercase(), value.into());
+        self
+    }
+
+    /// Returns `true` if a deadline is set and has already passed.
+    pub fn is_expired(&self) -> bool {
+        self.deadline
+            .map(|d| Instant::now() > d)
+            .unwrap_or(false)
+    }
+
+    /// Return the deadline as milliseconds since UNIX epoch, suitable for
+    /// propagation over the wire.  Returns `None` if no deadline is set.
+    pub fn deadline_unix_ms(&self) -> Option<u64> {
+        self.deadline.map(|d| {
+            let remaining = d.saturating_duration_since(Instant::now());
+            now_ms().saturating_add(remaining.as_millis() as u64)
+        })
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GatewayResponse
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A typed response produced by an agent handler and consumed by the
+/// access-log, metrics, and admin API layers.
+///
+/// `latency_ms` is computed from the originating [`RequestEnvelope`]'s
+/// `created_at_ms` and the wall-clock time at response completion.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentResponse {
+    /// HTTP status code sent back to the caller.
+    pub status_code: u16,
+    /// Response body returned by the agent.
+    pub body: serde_json::Value,
+    /// End-to-end latency in milliseconds, measured from envelope creation to
+    /// response completion.
+    pub latency_ms: u64,
+    /// ID of the agent that handled the request.
+    pub agent_id: String,
+    /// Correlation ID copied from the originating [`RequestEnvelope`] so
+    /// access logs and traces can be joined without re-parsing the body.
+    pub correlation_id: String,
+}
+
+impl AgentResponse {
+    /// Create a response, computing `latency_ms` from the envelope's
+    /// `created_at_ms`.
+    pub fn new(
+        status_code: u16,
+        body: serde_json::Value,
+        agent_id: impl Into<String>,
+        envelope: &RequestEnvelope,
+    ) -> Self {
+        let latency_ms = now_ms().saturating_sub(envelope.created_at_ms);
+        Self {
+            status_code,
+            body,
+            latency_ms,
+            agent_id: agent_id.into(),
+            correlation_id: envelope.correlation_id.clone(),
+        }
+    }
+
+    /// Returns `true` if the response indicates success (2xx status code).
+    pub fn is_success(&self) -> bool {
+        (200..300).contains(&self.status_code)
+    }
+
+    /// Returns `true` if the status code is a client error (4xx).
+    pub fn is_client_error(&self) -> bool {
+        (400..500).contains(&self.status_code)
+    }
+
+    /// Returns `true` if the status code is a server or gateway error (5xx).
+    pub fn is_server_error(&self) -> bool {
+        self.status_code >= 500
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Current wall-clock time as milliseconds since UNIX epoch.
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::net::IpAddr;
+    use std::str::FromStr;
+    use std::time::{Duration, Instant};
+
+    use serde_json::json;
+
+    use super::{AgentResponse, RequestEnvelope};
+
+    fn loopback() -> IpAddr {
+        IpAddr::from_str("127.0.0.1").unwrap()
+    }
+
+    // ── RequestEnvelope ──────────────────────────────────────────────────────
+
+    #[test]
+    fn new_generates_unique_correlation_ids() {
+        let a = RequestEnvelope::new("r1", json!({}), loopback());
+        let b = RequestEnvelope::new("r1", json!({}), loopback());
+        assert_ne!(a.correlation_id, b.correlation_id);
+    }
+
+    #[test]
+    fn new_sets_created_at_ms() {
+        let env = RequestEnvelope::new("r1", json!({}), loopback());
+        assert!(env.created_at_ms > 0);
+    }
+
+    #[test]
+    fn headers_lowercased() {
+        let env = RequestEnvelope::new("r1", json!({}), loopback())
+            .with_header("Content-Type", "application/json")
+            .with_header("X-Api-Key", "secret");
+        assert_eq!(
+            env.headers.get("content-type"),
+            Some(&"application/json".to_string())
+        );
+        assert_eq!(
+            env.headers.get("x-api-key"),
+            Some(&"secret".to_string())
+        );
+    }
+
+    #[test]
+    fn is_expired_false_when_no_deadline() {
+        let env = RequestEnvelope::new("r1", json!({}), loopback());
+        assert!(!env.is_expired());
+    }
+
+    #[test]
+    fn is_expired_false_when_deadline_in_future() {
+        let env = RequestEnvelope::new("r1", json!({}), loopback())
+            .with_deadline(Instant::now() + Duration::from_secs(60));
+        assert!(!env.is_expired());
+    }
+
+    #[test]
+    fn is_expired_true_when_deadline_in_past() {
+        let past = Instant::now() - Duration::from_secs(1);
+        let env = RequestEnvelope::new("r1", json!({}), loopback()).with_deadline(past);
+        assert!(env.is_expired());
+    }
+
+    #[test]
+    fn deadline_unix_ms_none_when_no_deadline() {
+        let env = RequestEnvelope::new("r1", json!({}), loopback());
+        assert!(env.deadline_unix_ms().is_none());
+    }
+
+    #[test]
+    fn deadline_unix_ms_some_when_deadline_set() {
+        let env = RequestEnvelope::new("r1", json!({}), loopback())
+            .with_deadline(Instant::now() + Duration::from_secs(5));
+        assert!(env.deadline_unix_ms().is_some());
+    }
+
+    #[test]
+    fn envelope_serializes_without_deadline_field() {
+        let env = RequestEnvelope::new("r1", json!({"key": "val"}), loopback())
+            .with_deadline(Instant::now() + Duration::from_secs(10));
+        let json = serde_json::to_string(&env).unwrap();
+        assert!(!json.contains("deadline"));
+        assert!(json.contains("correlation_id"));
+        assert!(json.contains("created_at_ms"));
+    }
+
+    // ── GatewayResponse ──────────────────────────────────────────────────────
+
+    #[test]
+    fn gateway_response_latency_computed_from_envelope() {
+        let env = RequestEnvelope::new("r1", json!({}), loopback());
+        let resp = AgentResponse::new(200, json!({"ok": true}), "agent-a", &env);
+        assert_eq!(resp.correlation_id, env.correlation_id);
+        // latency_ms must be >= 0 (saturating_sub guarantees this)
+        // and realistically < 1000ms for a test
+        assert!(resp.latency_ms < 1000);
+    }
+
+    #[test]
+    fn is_success_2xx() {
+        let env = RequestEnvelope::new("r1", json!({}), loopback());
+        assert!(AgentResponse::new(200, json!({}), "a", &env).is_success());
+        assert!(AgentResponse::new(204, json!({}), "a", &env).is_success());
+        assert!(!AgentResponse::new(400, json!({}), "a", &env).is_success());
+    }
+
+    #[test]
+    fn is_client_error_4xx() {
+        let env = RequestEnvelope::new("r1", json!({}), loopback());
+        assert!(AgentResponse::new(400, json!({}), "a", &env).is_client_error());
+        assert!(AgentResponse::new(404, json!({}), "a", &env).is_client_error());
+        assert!(!AgentResponse::new(500, json!({}), "a", &env).is_client_error());
+    }
+
+    #[test]
+    fn is_server_error_5xx() {
+        let env = RequestEnvelope::new("r1", json!({}), loopback());
+        assert!(AgentResponse::new(500, json!({}), "a", &env).is_server_error());
+        assert!(AgentResponse::new(504, json!({}), "a", &env).is_server_error());
+        assert!(!AgentResponse::new(200, json!({}), "a", &env).is_server_error());
+    }
+
+    #[test]
+    fn gateway_response_serializes() {
+        let env = RequestEnvelope::new("r1", json!({}), loopback());
+        let resp = AgentResponse::new(200, json!({"result": "ok"}), "agent-a", &env);
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("status_code"));
+        assert!(json.contains("latency_ms"));
+        assert!(json.contains("agent_id"));
+        assert!(json.contains("correlation_id"));
+    }
+}

--- a/crates/mofa-kernel/src/gateway/mod.rs
+++ b/crates/mofa-kernel/src/gateway/mod.rs
@@ -1,9 +1,10 @@
 //! Kernel-level gateway abstractions for agent request dispatch.
 //!
 //! This module defines the trait boundary between the gateway transport layer
-//! (HTTP, gRPC, MQTT, …) and the agent runtime.  By keeping routing logic in
-//! the kernel, alternative transports and unit tests can reason about routing
-//! without depending on the full HTTP stack.
+//! (HTTP, gRPC, MQTT, …) and the agent runtime.  By keeping routing and
+//! envelope logic in the kernel, alternative transports and unit tests can
+//! reason about the full request lifecycle without depending on the full HTTP
+//! stack.
 //!
 //! # Types
 //!
@@ -19,7 +20,10 @@
 //! | [`GatewayResponse`] | Outbound HTTP response model |
 //! | [`GatewayContext`] | Per-request mutable context for filter chains |
 //! | [`RouteMatch`] | Result of a successful route lookup |
+//! | [`RequestEnvelope`] | Typed inbound request envelope flowing through the pipeline |
+//! | [`AgentResponse`] | Typed agent response for access logging, metrics, and admin API |
 
+pub mod envelope;
 pub mod error;
 pub mod route;
 mod config_error;
@@ -28,6 +32,7 @@ mod types;
 #[cfg(test)]
 mod tests;
 
+pub use envelope::{AgentResponse, RequestEnvelope};
 pub use error::RegistryError;
 pub use route::{GatewayRoute, HttpMethod, RouteRegistry, RoutingContext};
 pub use config_error::GatewayConfigError;

--- a/crates/mofa-kernel/src/lib.rs
+++ b/crates/mofa-kernel/src/lib.rs
@@ -68,8 +68,9 @@ pub mod security;
 // Gateway routing abstractions (kernel-level traits for agent request dispatch)
 pub mod gateway;
 pub use gateway::{
-    GatewayConfigError, GatewayContext, GatewayRequest, GatewayResponse, GatewayRoute, HttpMethod,
-    RegistryError, RouteMatch, RouteRegistry, RoutingContext,
+    AgentResponse, GatewayConfigError, GatewayContext, GatewayRequest, GatewayResponse,
+    GatewayRoute, HttpMethod, RegistryError, RequestEnvelope, RouteMatch, RouteRegistry,
+    RoutingContext,
 };
 
 // Scheduler kernel contract (traits, types, errors for periodic agent execution)


### PR DESCRIPTION
Closes #700

---

## What

Adds two typed envelope types to `mofa-kernel/src/gateway/envelope.rs`:

- `RequestEnvelope` — created once at gateway admission, carries `correlation_id` (UUID v4), matched `route_id`, `payload` as `serde_json::Value`, optional `deadline` as `std::time::Instant`, `origin_ip`, lowercased forwarded `headers`, and `created_at_ms` for end-to-end latency tracking
- `AgentResponse` — produced by the agent handler, carries `status_code`, `body`, `latency_ms` (computed from the envelope's `created_at_ms`), `agent_id`, and `correlation_id` for log joining

Both types are re-exported from `mofa-kernel::gateway` and the kernel root.

---

## Why

Without typed envelopes the gateway pipeline has no shared contract. Every middleware, routing strategy, and access log independently re-parses the same fields from the raw HTTP request, leading to duplication and inconsistency. Testing any pipeline component requires a live HTTP server.

`RequestEnvelope` is created once at the gateway edge and passed unchanged through every filter and routing layer. `AgentResponse` gives the access-log, metrics, and admin API layers a stable struct to read from instead of reaching into axum response internals.

---

## Design decisions

**`deadline` stored as `Instant` with `#[serde(skip)]`** — `Instant` is monotonic and not serialisable. The field is skipped during serialisation. Callers that need a wire-transferable deadline use `deadline_unix_ms()` which converts the remaining duration to milliseconds since UNIX epoch. This keeps the runtime-efficient `Instant` for local expiry checks via `is_expired()` while still allowing propagation over the wire.

**`latency_ms` computed in `AgentResponse::new`** — the response captures `now_ms() - envelope.created_at_ms` at construction time so callers never need to track start times separately.

**`AgentResponse` not `GatewayResponse`** — renamed to avoid collision with the raw transport-level `GatewayResponse` (bytes, headers, backend_id) introduced by PR #876. The two types serve different layers: `AgentResponse` is the agent pipeline response carrying structured JSON and correlation metadata, `GatewayResponse` is the raw HTTP response returned to the caller.

**No axum dependency in kernel** — conversion helpers from axum `Request` to `RequestEnvelope` and from `AgentResponse` to axum `Response` belong in `mofa-gateway` which already depends on axum. Pulling an HTTP framework into the kernel would violate the dependency direction rule and bloat every crate that depends on mofa-kernel.

---

## Architecture

```mermaid
sequenceDiagram
    participant Client
    participant Gateway
    participant Middleware
    participant Router
    participant Agent

    Client->>Gateway: HTTP Request
    Gateway->>Gateway: RequestEnvelope::new() — UUID correlation_id, created_at_ms
    Gateway->>Middleware: pass envelope
    Middleware->>Middleware: check is_expired(), read headers
    Middleware->>Router: RoutingContext from envelope
    Router->>Router: match route, set route_id on envelope
    Router->>Agent: forward with envelope
    Agent->>Gateway: AgentResponse::new(status, body, agent_id, &envelope)
    Note over Gateway: latency_ms = now_ms - envelope.created_at_ms
    Gateway->>Client: HTTP Response
```

---

## Changes

```
crates/mofa-kernel/src/gateway/
├── envelope.rs     — RequestEnvelope, AgentResponse (new)
└── mod.rs          — added envelope module and re-exports

crates/mofa-kernel/src/lib.rs
    — added AgentResponse and RequestEnvelope to re-exports
```

---

## Tests (14 new, 32 total across gateway module)

| Category | Tests |
|---|---|
| Envelope construction | unique correlation IDs generated, `created_at_ms` set |
| Headers | lowercased on insert |
| Deadline | not expired with no deadline, not expired in future, expired in past |
| Deadline wire format | `deadline_unix_ms` returns `None` / `Some` correctly |
| Serialisation | `deadline` field absent from JSON, all other fields present |
| `AgentResponse` | latency computed from envelope, `correlation_id` copied |
| Status helpers | `is_success` 2xx, `is_client_error` 4xx, `is_server_error` 5xx |
| Serialisation | all response fields serialise correctly |

```
test result: ok. 32 passed; 0 failed
```

---

## What comes next

| Issue | Title | Depends on |
|---|---|---|
| #701 | AuthClaims, AuthProvider, ApiKeyStore traits | #699 |
| #702 | Token-bucket rate limiter | #700 |
| #705 | Composable middleware pipeline | #700 + #701 + #702 |
| #706 | Admin REST API | #705 |
| #707 | Per-route deadline propagation + 504 enforcement | #705 |
