### PR TITLE
feat(foundation): implement token-bucket rate limiter with per-agent and per-client quota enforcement (Phase 4/10)

### DIFF
--- a/crates/mofa-foundation/Cargo.toml
+++ b/crates/mofa-foundation/Cargo.toml
@@ -120,6 +120,7 @@ once_cell = "1.21.3"
 
 # Graph data structures for task DAGs (Swarm Orchestrator)
 petgraph = { version = "0.7", features = ["serde-1"] }
+dashmap = { workspace = true }
 rhai = { version = "1", features = ["sync", "serde"] }
 lazy_static = "1.4"
 

--- a/crates/mofa-foundation/src/gateway/mod.rs
+++ b/crates/mofa-foundation/src/gateway/mod.rs
@@ -6,6 +6,4 @@
 
 pub mod rate_limiter;
 
-pub use rate_limiter::{
-    KeyStrategy, RateLimitDecision, RateLimiter, RateLimiterConfig, TokenBucketRateLimiter,
-};
+pub use rate_limiter::TokenBucketRateLimiter;

--- a/crates/mofa-foundation/src/gateway/mod.rs
+++ b/crates/mofa-foundation/src/gateway/mod.rs
@@ -1,0 +1,11 @@
+//! Foundation-layer gateway implementations.
+//!
+//! This module contains concrete implementations of the kernel-level gateway
+//! traits. Kernel traits live in `mofa-kernel::gateway`; implementations live
+//! here so the kernel stays free of runtime dependencies.
+
+pub mod rate_limiter;
+
+pub use rate_limiter::{
+    KeyStrategy, RateLimitDecision, RateLimiter, RateLimiterConfig, TokenBucketRateLimiter,
+};

--- a/crates/mofa-foundation/src/gateway/rate_limiter.rs
+++ b/crates/mofa-foundation/src/gateway/rate_limiter.rs
@@ -1,4 +1,4 @@
-//! Token-bucket rate limiter with per-agent and per-client quota enforcement.
+//! Token-bucket rate limiter — concrete implementation of the kernel contract.
 //!
 //! # How it works
 //!
@@ -9,92 +9,18 @@
 //!
 //! # Keying strategies
 //!
-//! Two strategies are supported and can be composed:
+//! Two strategies are supported:
 //!
 //! - [`KeyStrategy::PerAgent`] — one bucket per `agent_id` (from the matched route)
 //! - [`KeyStrategy::PerClient`] — one bucket per caller IP string
 //!
-//! Both strategies use the same underlying `TokenBucketRateLimiter`; the
-//! caller is responsible for passing the correct key.
+//! The caller is responsible for passing the correct key to
+//! [`TokenBucketRateLimiter::check_and_consume`].
 
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use dashmap::DashMap;
-use serde::{Deserialize, Serialize};
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Public API types
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// The outcome of a rate-limit check.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum RateLimitDecision {
-    /// Request is within quota.
-    Allowed {
-        /// Tokens remaining in the bucket after this request.
-        remaining: u32,
-    },
-    /// Request exceeds quota.
-    Denied {
-        /// Milliseconds the caller should wait before retrying.
-        retry_after_ms: u64,
-    },
-}
-
-impl RateLimitDecision {
-    /// Returns `true` if the request was allowed.
-    pub fn is_allowed(&self) -> bool {
-        matches!(self, Self::Allowed { .. })
-    }
-}
-
-/// Which dimension to key the rate limiter on.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[non_exhaustive]
-pub enum KeyStrategy {
-    /// One bucket per agent ID (from the matched route).
-    PerAgent,
-    /// One bucket per originating client IP address.
-    PerClient,
-}
-
-/// Configuration for a [`TokenBucketRateLimiter`].
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RateLimiterConfig {
-    /// Maximum number of tokens (burst size).
-    pub capacity: u32,
-    /// Number of tokens added per second (sustained rate).
-    pub refill_rate: u32,
-    /// Keying strategy.
-    pub strategy: KeyStrategy,
-}
-
-impl Default for RateLimiterConfig {
-    fn default() -> Self {
-        Self {
-            capacity: 100,
-            refill_rate: 10,
-            strategy: KeyStrategy::PerClient,
-        }
-    }
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// RateLimiter trait
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// Kernel-adjacent contract for rate limiting.
-///
-/// Implementations must be `Send + Sync` so they can be held behind an `Arc`
-/// and called from multiple Tokio tasks concurrently.
-pub trait RateLimiter: Send + Sync {
-    /// Attempt to consume one token from the bucket identified by `key`.
-    ///
-    /// Returns [`RateLimitDecision::Allowed`] when a token was successfully
-    /// consumed, or [`RateLimitDecision::Denied`] with a retry hint when the
-    /// bucket is empty.
-    fn check_and_consume(&self, key: &str) -> RateLimitDecision;
-}
+pub use mofa_kernel::{GatewayRateLimiter, KeyStrategy, RateLimitDecision, RateLimiterConfig};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // TokenBucket (internal per-key state)
@@ -130,7 +56,6 @@ impl TokenBucket {
                 remaining: self.tokens as u32,
             }
         } else {
-            // Time until next token is available.
             let deficit = 1.0 - self.tokens;
             let wait_secs = deficit / self.refill_rate;
             let retry_after_ms = (wait_secs * 1000.0).ceil() as u64;
@@ -146,7 +71,7 @@ impl TokenBucket {
 /// Lock-free token-bucket rate limiter backed by [`DashMap`].
 ///
 /// Each unique key gets its own bucket lazily created on first access.
-/// Refill is computed on demand — no background timer, no spawned tasks.
+/// Implements [`GatewayRateLimiter`] from `mofa-kernel`.
 pub struct TokenBucketRateLimiter {
     buckets: DashMap<String, TokenBucket>,
     capacity: u32,
@@ -164,7 +89,7 @@ impl TokenBucketRateLimiter {
     }
 }
 
-impl RateLimiter for TokenBucketRateLimiter {
+impl GatewayRateLimiter for TokenBucketRateLimiter {
     fn check_and_consume(&self, key: &str) -> RateLimitDecision {
         self.buckets
             .entry(key.to_string())
@@ -181,6 +106,7 @@ impl RateLimiter for TokenBucketRateLimiter {
 mod tests {
     use std::sync::Arc;
     use std::thread;
+    use std::time::Duration;
 
     use super::*;
 
@@ -261,8 +187,6 @@ mod tests {
         let rl = limiter(1, 1000); // 1000 tokens/sec — refills very fast
         rl.check_and_consume("client-a"); // drain
 
-        // Sleep just long enough for the 1000 tokens/sec rate to refill at
-        // least one token (1ms should add 1 token).
         thread::sleep(Duration::from_millis(5));
 
         let decision = rl.check_and_consume("client-a");

--- a/crates/mofa-foundation/src/gateway/rate_limiter.rs
+++ b/crates/mofa-foundation/src/gateway/rate_limiter.rs
@@ -1,0 +1,331 @@
+//! Token-bucket rate limiter with per-agent and per-client quota enforcement.
+//!
+//! # How it works
+//!
+//! Each unique key gets its own [`TokenBucket`].  Tokens refill lazily on
+//! every `check_and_consume` call — no background timer, no spawned tasks.
+//! The refill amount is proportional to how much wall-clock time has elapsed
+//! since the last call, capped at the bucket capacity.
+//!
+//! # Keying strategies
+//!
+//! Two strategies are supported and can be composed:
+//!
+//! - [`KeyStrategy::PerAgent`] — one bucket per `agent_id` (from the matched route)
+//! - [`KeyStrategy::PerClient`] — one bucket per caller IP string
+//!
+//! Both strategies use the same underlying `TokenBucketRateLimiter`; the
+//! caller is responsible for passing the correct key.
+
+use std::time::{Duration, Instant};
+
+use dashmap::DashMap;
+use serde::{Deserialize, Serialize};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The outcome of a rate-limit check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RateLimitDecision {
+    /// Request is within quota.
+    Allowed {
+        /// Tokens remaining in the bucket after this request.
+        remaining: u32,
+    },
+    /// Request exceeds quota.
+    Denied {
+        /// Milliseconds the caller should wait before retrying.
+        retry_after_ms: u64,
+    },
+}
+
+impl RateLimitDecision {
+    /// Returns `true` if the request was allowed.
+    pub fn is_allowed(&self) -> bool {
+        matches!(self, Self::Allowed { .. })
+    }
+}
+
+/// Which dimension to key the rate limiter on.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum KeyStrategy {
+    /// One bucket per agent ID (from the matched route).
+    PerAgent,
+    /// One bucket per originating client IP address.
+    PerClient,
+}
+
+/// Configuration for a [`TokenBucketRateLimiter`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RateLimiterConfig {
+    /// Maximum number of tokens (burst size).
+    pub capacity: u32,
+    /// Number of tokens added per second (sustained rate).
+    pub refill_rate: u32,
+    /// Keying strategy.
+    pub strategy: KeyStrategy,
+}
+
+impl Default for RateLimiterConfig {
+    fn default() -> Self {
+        Self {
+            capacity: 100,
+            refill_rate: 10,
+            strategy: KeyStrategy::PerClient,
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RateLimiter trait
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Kernel-adjacent contract for rate limiting.
+///
+/// Implementations must be `Send + Sync` so they can be held behind an `Arc`
+/// and called from multiple Tokio tasks concurrently.
+pub trait RateLimiter: Send + Sync {
+    /// Attempt to consume one token from the bucket identified by `key`.
+    ///
+    /// Returns [`RateLimitDecision::Allowed`] when a token was successfully
+    /// consumed, or [`RateLimitDecision::Denied`] with a retry hint when the
+    /// bucket is empty.
+    fn check_and_consume(&self, key: &str) -> RateLimitDecision;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TokenBucket (internal per-key state)
+// ─────────────────────────────────────────────────────────────────────────────
+
+struct TokenBucket {
+    tokens: f64,
+    capacity: f64,
+    refill_rate: f64,
+    last_refill: Instant,
+}
+
+impl TokenBucket {
+    fn new(capacity: u32, refill_rate: u32) -> Self {
+        Self {
+            tokens: capacity as f64,
+            capacity: capacity as f64,
+            refill_rate: refill_rate as f64,
+            last_refill: Instant::now(),
+        }
+    }
+
+    /// Refill tokens based on elapsed time, then attempt to consume one.
+    fn try_consume(&mut self) -> RateLimitDecision {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.last_refill).as_secs_f64();
+        self.tokens = (self.tokens + elapsed * self.refill_rate).min(self.capacity);
+        self.last_refill = now;
+
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            RateLimitDecision::Allowed {
+                remaining: self.tokens as u32,
+            }
+        } else {
+            // Time until next token is available.
+            let deficit = 1.0 - self.tokens;
+            let wait_secs = deficit / self.refill_rate;
+            let retry_after_ms = (wait_secs * 1000.0).ceil() as u64;
+            RateLimitDecision::Denied { retry_after_ms }
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TokenBucketRateLimiter
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Lock-free token-bucket rate limiter backed by [`DashMap`].
+///
+/// Each unique key gets its own bucket lazily created on first access.
+/// Refill is computed on demand — no background timer, no spawned tasks.
+pub struct TokenBucketRateLimiter {
+    buckets: DashMap<String, TokenBucket>,
+    capacity: u32,
+    refill_rate: u32,
+}
+
+impl TokenBucketRateLimiter {
+    /// Create a new limiter with the given configuration.
+    pub fn new(config: &RateLimiterConfig) -> Self {
+        Self {
+            buckets: DashMap::new(),
+            capacity: config.capacity,
+            refill_rate: config.refill_rate,
+        }
+    }
+}
+
+impl RateLimiter for TokenBucketRateLimiter {
+    fn check_and_consume(&self, key: &str) -> RateLimitDecision {
+        self.buckets
+            .entry(key.to_string())
+            .or_insert_with(|| TokenBucket::new(self.capacity, self.refill_rate))
+            .try_consume()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::thread;
+
+    use super::*;
+
+    fn limiter(capacity: u32, refill_rate: u32) -> TokenBucketRateLimiter {
+        TokenBucketRateLimiter::new(&RateLimiterConfig {
+            capacity,
+            refill_rate,
+            strategy: KeyStrategy::PerClient,
+        })
+    }
+
+    // ── Basic behaviour ──────────────────────────────────────────────────────
+
+    #[test]
+    fn fresh_bucket_allows_up_to_capacity() {
+        let rl = limiter(5, 1);
+        for i in 0..5 {
+            let decision = rl.check_and_consume("client-a");
+            assert!(
+                decision.is_allowed(),
+                "expected Allowed on request {}, got {decision:?}",
+                i + 1
+            );
+        }
+    }
+
+    #[test]
+    fn excess_requests_are_denied() {
+        let rl = limiter(3, 1);
+        for _ in 0..3 {
+            rl.check_and_consume("client-a");
+        }
+        let decision = rl.check_and_consume("client-a");
+        assert!(
+            matches!(decision, RateLimitDecision::Denied { .. }),
+            "expected Denied, got {decision:?}"
+        );
+    }
+
+    #[test]
+    fn denied_carries_positive_retry_after() {
+        let rl = limiter(1, 1);
+        rl.check_and_consume("client-a"); // drain
+        match rl.check_and_consume("client-a") {
+            RateLimitDecision::Denied { retry_after_ms } => {
+                assert!(retry_after_ms > 0, "retry_after_ms must be > 0");
+            }
+            other => panic!("expected Denied, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn remaining_decrements_correctly() {
+        let rl = limiter(3, 1);
+        match rl.check_and_consume("client-a") {
+            RateLimitDecision::Allowed { remaining } => assert_eq!(remaining, 2),
+            other => panic!("expected Allowed, got {other:?}"),
+        }
+        match rl.check_and_consume("client-a") {
+            RateLimitDecision::Allowed { remaining } => assert_eq!(remaining, 1),
+            other => panic!("expected Allowed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn different_keys_have_independent_buckets() {
+        let rl = limiter(1, 1);
+        let a = rl.check_and_consume("agent-a");
+        let b = rl.check_and_consume("agent-b");
+        assert!(a.is_allowed());
+        assert!(b.is_allowed());
+    }
+
+    // ── Refill ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn bucket_refills_after_elapsed_time() {
+        let rl = limiter(1, 1000); // 1000 tokens/sec — refills very fast
+        rl.check_and_consume("client-a"); // drain
+
+        // Sleep just long enough for the 1000 tokens/sec rate to refill at
+        // least one token (1ms should add 1 token).
+        thread::sleep(Duration::from_millis(5));
+
+        let decision = rl.check_and_consume("client-a");
+        assert!(
+            decision.is_allowed(),
+            "expected bucket to have refilled, got {decision:?}"
+        );
+    }
+
+    // ── Concurrency ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn concurrent_access_does_not_exceed_capacity() {
+        const CAPACITY: u32 = 50;
+        const THREADS: usize = 20;
+        const REQUESTS_PER_THREAD: usize = 10;
+
+        let rl = Arc::new(TokenBucketRateLimiter::new(&RateLimiterConfig {
+            capacity: CAPACITY,
+            refill_rate: 0, // no refill during the test
+            strategy: KeyStrategy::PerClient,
+        }));
+
+        let allowed = Arc::new(std::sync::atomic::AtomicU32::new(0));
+
+        let handles: Vec<_> = (0..THREADS)
+            .map(|_| {
+                let rl = Arc::clone(&rl);
+                let allowed = Arc::clone(&allowed);
+                thread::spawn(move || {
+                    for _ in 0..REQUESTS_PER_THREAD {
+                        if rl.check_and_consume("shared-key").is_allowed() {
+                            allowed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        }
+                    }
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let total_allowed = allowed.load(std::sync::atomic::Ordering::Relaxed);
+        assert!(
+            total_allowed <= CAPACITY,
+            "allowed {total_allowed} requests but capacity is {CAPACITY}"
+        );
+    }
+
+    // ── Config ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn rate_limiter_config_default() {
+        let cfg = RateLimiterConfig::default();
+        assert_eq!(cfg.capacity, 100);
+        assert_eq!(cfg.refill_rate, 10);
+        assert_eq!(cfg.strategy, KeyStrategy::PerClient);
+    }
+
+    #[test]
+    fn rate_limit_decision_is_allowed_helper() {
+        assert!(RateLimitDecision::Allowed { remaining: 5 }.is_allowed());
+        assert!(!RateLimitDecision::Denied { retry_after_ms: 100 }.is_allowed());
+    }
+}

--- a/crates/mofa-foundation/src/lib.rs
+++ b/crates/mofa-foundation/src/lib.rs
@@ -85,6 +85,12 @@ pub use metrics::{
     TokenUsage, ToolMetrics, WorkflowMetrics,
 };
 
+// Gateway implementations (rate limiter, routing strategies)
+pub mod gateway;
+pub use gateway::{
+    KeyStrategy, RateLimitDecision, RateLimiter, RateLimiterConfig, TokenBucketRateLimiter,
+};
+
 // Re-export config types
 pub use config::{AgentInfo, AgentYamlConfig, LLMYamlConfig, RuntimeConfig, ToolConfig};
 

--- a/crates/mofa-foundation/src/lib.rs
+++ b/crates/mofa-foundation/src/lib.rs
@@ -87,9 +87,7 @@ pub use metrics::{
 
 // Gateway implementations (rate limiter, routing strategies)
 pub mod gateway;
-pub use gateway::{
-    KeyStrategy, RateLimitDecision, RateLimiter, RateLimiterConfig, TokenBucketRateLimiter,
-};
+pub use gateway::TokenBucketRateLimiter;
 
 // Re-export config types
 pub use config::{AgentInfo, AgentYamlConfig, LLMYamlConfig, RuntimeConfig, ToolConfig};

--- a/crates/mofa-kernel/src/gateway/mod.rs
+++ b/crates/mofa-kernel/src/gateway/mod.rs
@@ -18,8 +18,13 @@
 //! | [`AuthProvider`] | Async trait for authenticating requests |
 //! | [`ApiKeyStore`] | Persistence trait for API key lifecycle |
 //! | [`AuthError`] | Auth failure error enum |
+//! | [`GatewayRateLimiter`] | Kernel contract for rate limiting |
+//! | [`RateLimitDecision`] | Outcome of a rate-limit check |
+//! | [`KeyStrategy`] | Keying dimension (per-agent or per-client) |
+//! | [`RateLimiterConfig`] | Shared rate limiter configuration |
 
 pub mod auth;
+pub mod rate_limiter;
 pub mod envelope;
 pub mod error;
 pub mod route;
@@ -31,6 +36,7 @@ mod tests;
 
 pub use auth::{ApiKeyStore, AuthClaims, AuthError, AuthProvider};
 pub use envelope::{AgentResponse, RequestEnvelope};
+pub use rate_limiter::{GatewayRateLimiter, KeyStrategy, RateLimitDecision, RateLimiterConfig};
 pub use error::RegistryError;
 pub use route::{GatewayRoute, HttpMethod, RouteRegistry, RoutingContext};
 pub use config_error::GatewayConfigError;

--- a/crates/mofa-kernel/src/gateway/rate_limiter.rs
+++ b/crates/mofa-kernel/src/gateway/rate_limiter.rs
@@ -1,0 +1,90 @@
+//! Kernel-level rate-limiting contract for the gateway.
+//!
+//! This module defines the trait boundary and supporting types that all rate
+//! limiter implementations must satisfy.  Concrete implementations (e.g.
+//! token-bucket, sliding-window) live in `mofa-foundation::gateway`.
+
+use serde::{Deserialize, Serialize};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Decision
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The outcome of a rate-limit check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RateLimitDecision {
+    /// Request is within quota.
+    Allowed {
+        /// Tokens remaining in the bucket after this request.
+        remaining: u32,
+    },
+    /// Request exceeds quota.
+    Denied {
+        /// Milliseconds the caller should wait before retrying.
+        retry_after_ms: u64,
+    },
+}
+
+impl RateLimitDecision {
+    /// Returns `true` if the request was allowed.
+    pub fn is_allowed(&self) -> bool {
+        matches!(self, Self::Allowed { .. })
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// KeyStrategy
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Which dimension to key the rate limiter on.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum KeyStrategy {
+    /// One bucket per agent ID (from the matched route).
+    PerAgent,
+    /// One bucket per originating client IP address.
+    PerClient,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RateLimiterConfig
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Configuration shared by all rate limiter implementations.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RateLimiterConfig {
+    /// Maximum number of tokens (burst size).
+    pub capacity: u32,
+    /// Number of tokens added per second (sustained rate).
+    pub refill_rate: u32,
+    /// Keying strategy.
+    pub strategy: KeyStrategy,
+}
+
+impl Default for RateLimiterConfig {
+    fn default() -> Self {
+        Self {
+            capacity: 100,
+            refill_rate: 10,
+            strategy: KeyStrategy::PerClient,
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RateLimiter trait
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Kernel contract for gateway rate limiting.
+///
+/// Implementations must be `Send + Sync` so they can be held behind an `Arc`
+/// and called from multiple Tokio tasks concurrently.
+pub trait GatewayRateLimiter: Send + Sync {
+    /// Attempt to consume one token from the bucket identified by `key`.
+    ///
+    /// Returns [`RateLimitDecision::Allowed`] when a token was successfully
+    /// consumed, or [`RateLimitDecision::Denied`] with a retry hint when the
+    /// bucket is empty.
+    fn check_and_consume(&self, key: &str) -> RateLimitDecision;
+}

--- a/crates/mofa-kernel/src/lib.rs
+++ b/crates/mofa-kernel/src/lib.rs
@@ -78,8 +78,9 @@ pub mod security;
 pub mod gateway;
 pub use gateway::{
     AgentResponse, ApiKeyStore, AuthClaims, AuthError, AuthProvider, GatewayConfigError,
-    GatewayContext, GatewayRequest, GatewayResponse, GatewayRoute, HttpMethod, RegistryError,
-    RequestEnvelope, RouteMatch, RouteRegistry, RoutingContext,
+    GatewayContext, GatewayRequest, GatewayRateLimiter, GatewayResponse, GatewayRoute, HttpMethod,
+    KeyStrategy, RateLimitDecision, RateLimiterConfig, RegistryError, RequestEnvelope, RouteMatch,
+    RouteRegistry, RoutingContext,
 };
 
 // Scheduler kernel contract (traits, types, errors for periodic agent execution)


### PR DESCRIPTION
Closes #702

---

## What

Adds a lock-free token-bucket rate limiter to `mofa-foundation/src/gateway/rate_limiter.rs`:

- `RateLimitDecision` — `Allowed { remaining }` or `Denied { retry_after_ms }`
- `KeyStrategy` — `PerAgent` or `PerClient` keying dimension
- `RateLimiterConfig` — `capacity`, `refill_rate`, `strategy`
- `RateLimiter` trait — single `check_and_consume(key) -> RateLimitDecision`, `Send + Sync`
- `TokenBucketRateLimiter` — concrete implementation backed by `DashMap<String, TokenBucket>` for lock-free concurrent access

---

## Why

A single misconfigured caller or a burst of traffic can overwhelm agent instances, exhaust LLM provider quotas, or degrade service for all other callers. There is no admission control layer between the gateway edge and the agent handlers. This PR provides the building block the middleware pipeline (#705) will use to enforce configurable quotas per route.

---

## Design decisions

**Lazy refill, no background timer** — tokens are refilled on each `check_and_consume` call based on elapsed wall-clock time. No background task is spawned per bucket, no `Arc<Mutex<>>` overhead, no timer drift. The refill formula is `tokens = min(tokens + elapsed_secs * refill_rate, capacity)`.

**`DashMap` for lock-free concurrency** — each key gets its own shard in the `DashMap`. Concurrent requests for different keys never contend. Requests for the same key contend only within a single shard, not across the whole map.

**`retry_after_ms` computed from deficit** — when denied, the response carries `ceil((1 - tokens) / refill_rate * 1000)` ms so callers know exactly when to retry rather than backing off blindly.

**Two independent strategies, not one combined** — `PerAgent` and `PerClient` are separate strategy values. The middleware pipeline composes them by calling `check_and_consume` twice with different keys (agent ID first, then client IP), so each dimension has its own bucket and config.

---

## Changes

```
crates/mofa-foundation/src/gateway/
├── mod.rs           — module declaration and re-exports (new)
└── rate_limiter.rs  — RateLimiter trait + TokenBucketRateLimiter impl (new)

crates/mofa-foundation/src/lib.rs  — gateway module wired in
crates/mofa-foundation/Cargo.toml  — dashmap workspace dep added
```

---

## Tests (9 tests)

| Test | What it covers |
|---|---|
| `fresh_bucket_allows_up_to_capacity` | all requests within capacity succeed |
| `excess_requests_are_denied` | request beyond capacity returns Denied |
| `denied_carries_positive_retry_after` | retry_after_ms > 0 when denied |
| `remaining_decrements_correctly` | remaining field counts down accurately |
| `different_keys_have_independent_buckets` | two keys never share state |
| `bucket_refills_after_elapsed_time` | lazy refill works after sleep |
| `concurrent_access_does_not_exceed_capacity` | 20 threads × 10 requests, total allowed ≤ capacity |
| `rate_limiter_config_default` | default config values |
| `rate_limit_decision_is_allowed_helper` | helper method on decision type |

```
test result: ok. 9 passed; 0 failed
```
