### PR TITLE
feat(foundation): implement TOML-based gateway configuration schema with atomic hot-reload (Phase 6/10)

### DIFF
--- a/crates/mofa-foundation/Cargo.toml
+++ b/crates/mofa-foundation/Cargo.toml
@@ -111,6 +111,7 @@ mofa-extra = { path = "../mofa-extra", version = "0.1" }
 mofa-plugins = { path = "../mofa-plugins", version = "0.1" }
 once_cell = "1.21.3"
 dashmap = { workspace = true }
+notify = { workspace = true }
 rhai = { version = "1", features = ["sync", "serde"] }
 lazy_static = "1.4"
 

--- a/crates/mofa-foundation/Cargo.toml
+++ b/crates/mofa-foundation/Cargo.toml
@@ -110,6 +110,7 @@ mofa-kernel = { path = "../mofa-kernel", version = "0.1", features = [
 mofa-extra = { path = "../mofa-extra", version = "0.1" }
 mofa-plugins = { path = "../mofa-plugins", version = "0.1" }
 once_cell = "1.21.3"
+dashmap = { workspace = true }
 rhai = { version = "1", features = ["sync", "serde"] }
 lazy_static = "1.4"
 

--- a/crates/mofa-foundation/src/gateway/config.rs
+++ b/crates/mofa-foundation/src/gateway/config.rs
@@ -1,0 +1,576 @@
+//! TOML-based gateway configuration schema with atomic hot-reload.
+//!
+//! # Usage
+//!
+//! ```toml
+//! # gateway.toml
+//! default_auth_provider = "api_key"
+//!
+//! [[routes]]
+//! id            = "chat"
+//! path_pattern  = "/v1/chat"
+//! method        = "POST"
+//! agent_id      = "agent-chat"
+//! strategy      = "weighted_round_robin"
+//! timeout_ms    = 5000
+//! rate_limit    = "default"
+//!
+//! [rate_limit_profiles.default]
+//! capacity     = 100
+//! refill_rate  = 10
+//! strategy     = "PerClient"
+//! ```
+//!
+//! Load once:
+//! ```rust,ignore
+//! let cfg = GatewayConfigLoader::load_from_file(Path::new("gateway.toml"))?;
+//! ```
+//!
+//! Hot-reload:
+//! ```rust,ignore
+//! let (tx, rx) = tokio::sync::mpsc::channel(8);
+//! GatewayConfigLoader::watch(Path::new("gateway.toml"), tx)?;
+//! // rx receives a new GatewayConfig on every debounced file change.
+//! ```
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc::Sender;
+use tracing::{error, info, warn};
+
+use super::rate_limiter::KeyStrategy;
+use mofa_kernel::gateway::route::{GatewayRoute, HttpMethod};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Config schema
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Rate-limit profile referenced by name from route definitions.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RateLimitProfile {
+    /// Burst capacity (max tokens).
+    pub capacity: u32,
+    /// Tokens added per second.
+    pub refill_rate: u32,
+    /// Keying strategy.
+    pub strategy: KeyStrategy,
+}
+
+impl Default for RateLimitProfile {
+    fn default() -> Self {
+        Self {
+            capacity: 100,
+            refill_rate: 10,
+            strategy: KeyStrategy::PerClient,
+        }
+    }
+}
+
+/// A single route definition inside the TOML config.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RouteConfig {
+    /// Unique stable route identifier.
+    pub id: String,
+    /// URL path pattern (must start with `/`).
+    pub path_pattern: String,
+    /// HTTP method string, e.g. `"POST"`.
+    pub method: String,
+    /// Target agent ID.
+    pub agent_id: String,
+    /// Routing strategy name (`"weighted_round_robin"` or `"capability_match"`).
+    #[serde(default = "default_strategy")]
+    pub strategy: String,
+    /// Per-route timeout in milliseconds. `0` means no timeout.
+    #[serde(default)]
+    pub timeout_ms: u64,
+    /// Name of a rate limit profile defined in `rate_limit_profiles`.
+    /// `None` means no rate limiting for this route.
+    #[serde(default)]
+    pub rate_limit: Option<String>,
+    /// Whether the route is enabled. Defaults to `true`.
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+}
+
+fn default_strategy() -> String {
+    "weighted_round_robin".to_string()
+}
+
+fn default_enabled() -> bool {
+    true
+}
+
+impl RouteConfig {
+    /// Convert to a [`GatewayRoute`] kernel type.
+    ///
+    /// Returns `None` when `method` is not a recognised HTTP method string.
+    pub fn to_gateway_route(&self) -> Option<GatewayRoute> {
+        let method = HttpMethod::from_str_ci(&self.method)?;
+        Some(
+            GatewayRoute::new(
+                self.id.clone(),
+                self.agent_id.clone(),
+                self.path_pattern.clone(),
+                method,
+            )
+            .with_priority(0),
+        )
+    }
+}
+
+/// Top-level gateway configuration parsed from TOML.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GatewayConfig {
+    /// Name of the default auth provider.
+    #[serde(default)]
+    pub default_auth_provider: Option<String>,
+
+    /// Route definitions.
+    #[serde(default)]
+    pub routes: Vec<RouteConfig>,
+
+    /// Named rate-limit profiles routes can reference.
+    #[serde(default)]
+    pub rate_limit_profiles: HashMap<String, RateLimitProfile>,
+}
+
+impl GatewayConfig {
+    /// Return the rate-limit profile for `name`, or the default profile if
+    /// `name` is not found.
+    pub fn rate_limit_profile(&self, name: &str) -> RateLimitProfile {
+        self.rate_limit_profiles
+            .get(name)
+            .cloned()
+            .unwrap_or_default()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Config diff
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The diff between a previous config and a new one.
+#[derive(Debug, Default, PartialEq)]
+pub struct ConfigDiff {
+    /// Route IDs that are new in the new config.
+    pub added: Vec<String>,
+    /// Route IDs that were removed in the new config.
+    pub removed: Vec<String>,
+    /// Route IDs whose definition changed between the two configs.
+    pub modified: Vec<String>,
+}
+
+impl ConfigDiff {
+    /// Returns `true` when there are no changes.
+    pub fn is_empty(&self) -> bool {
+        self.added.is_empty() && self.removed.is_empty() && self.modified.is_empty()
+    }
+}
+
+/// Compute the diff between `old` and `new` configs.
+pub fn diff_configs(old: &GatewayConfig, new: &GatewayConfig) -> ConfigDiff {
+    let old_map: HashMap<&str, &RouteConfig> =
+        old.routes.iter().map(|r| (r.id.as_str(), r)).collect();
+    let new_map: HashMap<&str, &RouteConfig> =
+        new.routes.iter().map(|r| (r.id.as_str(), r)).collect();
+
+    let mut result = ConfigDiff::default();
+
+    for (id, new_route) in &new_map {
+        match old_map.get(id) {
+            None => result.added.push(id.to_string()),
+            Some(old_route) => {
+                if old_route != new_route {
+                    result.modified.push(id.to_string());
+                }
+            }
+        }
+    }
+
+    for id in old_map.keys() {
+        if !new_map.contains_key(id) {
+            result.removed.push(id.to_string());
+        }
+    }
+
+    result.added.sort();
+    result.removed.sort();
+    result.modified.sort();
+    result
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GatewayConfigLoader
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Loads and watches a TOML gateway configuration file.
+pub struct GatewayConfigLoader;
+
+impl GatewayConfigLoader {
+    /// Parse a [`GatewayConfig`] from a TOML file at `path`.
+    pub fn load_from_file(path: &Path) -> Result<GatewayConfig, ConfigError> {
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| ConfigError::Io(path.display().to_string(), e.to_string()))?;
+        toml::from_str(&content)
+            .map_err(|e| ConfigError::Parse(path.display().to_string(), e.to_string()))
+    }
+
+    /// Watch `path` for changes and emit a new [`GatewayConfig`] on `tx`
+    /// after a 200 ms debounce window.
+    ///
+    /// The watcher runs on a background OS thread spawned by the `notify`
+    /// crate and is kept alive as long as the returned `_guard` value is not
+    /// dropped.  Drop the guard to stop watching.
+    pub fn watch(
+        path: &Path,
+        tx: Sender<GatewayConfig>,
+    ) -> Result<RecommendedWatcher, ConfigError> {
+        let path_buf = path.to_path_buf();
+        let last_event: Arc<Mutex<Option<Instant>>> = Arc::new(Mutex::new(None));
+        let debounce = Duration::from_millis(200);
+
+        let watcher_tx = tx.clone();
+        let watcher_path = path_buf.clone();
+        let watcher_last = Arc::clone(&last_event);
+
+        let mut watcher = notify::recommended_watcher(
+            move |res: Result<Event, notify::Error>| match res {
+                Ok(event) => {
+                    let is_write = matches!(
+                        event.kind,
+                        EventKind::Create(_) | EventKind::Modify(_)
+                    );
+                    if !is_write {
+                        return;
+                    }
+
+                    // Debounce: record the event time and only reload after the
+                    // settling window.
+                    let now = Instant::now();
+                    {
+                        let mut last = watcher_last.lock().unwrap();
+                        *last = Some(now);
+                    }
+
+                    // Sleep for the debounce window, then check whether a
+                    // newer event has arrived.
+                    let sleep_last = Arc::clone(&watcher_last);
+                    let reload_path = watcher_path.clone();
+                    let reload_tx = watcher_tx.clone();
+                    std::thread::spawn(move || {
+                        std::thread::sleep(debounce);
+                        let last = sleep_last.lock().unwrap();
+                        // If another event arrived after ours, skip this reload.
+                        if last.map(|t| t > now).unwrap_or(false) {
+                            return;
+                        }
+                        drop(last);
+
+                        match GatewayConfigLoader::load_from_file(&reload_path) {
+                            Ok(cfg) => {
+                                info!("gateway config reloaded from {:?}", reload_path);
+                                if let Err(e) = reload_tx.blocking_send(cfg) {
+                                    warn!("gateway config channel closed: {e}");
+                                }
+                            }
+                            Err(e) => {
+                                error!("failed to reload gateway config: {e}");
+                            }
+                        }
+                    });
+                }
+                Err(e) => error!("file watcher error: {e}"),
+            },
+        )
+        .map_err(|e| ConfigError::Watcher(e.to_string()))?;
+
+        watcher
+            .watch(&path_buf, RecursiveMode::NonRecursive)
+            .map_err(|e| ConfigError::Watcher(e.to_string()))?;
+
+        Ok(watcher)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ConfigError
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Errors that can occur when loading or watching the gateway config.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ConfigError {
+    #[error("failed to read '{0}': {1}")]
+    Io(String, String),
+    #[error("failed to parse '{0}': {1}")]
+    Parse(String, String),
+    #[error("file watcher error: {0}")]
+    Watcher(String),
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use super::*;
+
+    const MINIMAL_TOML: &str = r#"
+default_auth_provider = "api_key"
+
+[[routes]]
+id           = "chat"
+path_pattern = "/v1/chat"
+method       = "POST"
+agent_id     = "agent-chat"
+strategy     = "weighted_round_robin"
+timeout_ms   = 5000
+rate_limit   = "default"
+
+[[routes]]
+id           = "search"
+path_pattern = "/v1/search"
+method       = "GET"
+agent_id     = "agent-search"
+
+[rate_limit_profiles.default]
+capacity    = 100
+refill_rate = 10
+strategy    = "PerClient"
+"#;
+
+    fn parse(toml: &str) -> GatewayConfig {
+        toml::from_str(toml).expect("valid TOML")
+    }
+
+    // ── Parse round-trip ─────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_round_trip() {
+        let cfg = parse(MINIMAL_TOML);
+        let re_serialized = toml::to_string(&cfg).unwrap();
+        let re_parsed: GatewayConfig = toml::from_str(&re_serialized).unwrap();
+        assert_eq!(cfg, re_parsed);
+    }
+
+    #[test]
+    fn parse_routes_count() {
+        let cfg = parse(MINIMAL_TOML);
+        assert_eq!(cfg.routes.len(), 2);
+    }
+
+    #[test]
+    fn parse_route_fields() {
+        let cfg = parse(MINIMAL_TOML);
+        let chat = cfg.routes.iter().find(|r| r.id == "chat").unwrap();
+        assert_eq!(chat.path_pattern, "/v1/chat");
+        assert_eq!(chat.method, "POST");
+        assert_eq!(chat.agent_id, "agent-chat");
+        assert_eq!(chat.strategy, "weighted_round_robin");
+        assert_eq!(chat.timeout_ms, 5000);
+        assert_eq!(chat.rate_limit, Some("default".to_string()));
+        assert!(chat.enabled);
+    }
+
+    #[test]
+    fn parse_rate_limit_profile() {
+        let cfg = parse(MINIMAL_TOML);
+        let profile = cfg.rate_limit_profiles.get("default").unwrap();
+        assert_eq!(profile.capacity, 100);
+        assert_eq!(profile.refill_rate, 10);
+        assert_eq!(profile.strategy, KeyStrategy::PerClient);
+    }
+
+    #[test]
+    fn default_strategy_applied_when_missing() {
+        let cfg = parse(MINIMAL_TOML);
+        let search = cfg.routes.iter().find(|r| r.id == "search").unwrap();
+        assert_eq!(search.strategy, "weighted_round_robin");
+    }
+
+    #[test]
+    fn default_enabled_true_when_missing() {
+        let cfg = parse(MINIMAL_TOML);
+        assert!(cfg.routes.iter().all(|r| r.enabled));
+    }
+
+    #[test]
+    fn to_gateway_route_conversion() {
+        let cfg = parse(MINIMAL_TOML);
+        let chat = cfg.routes.iter().find(|r| r.id == "chat").unwrap();
+        let route = chat.to_gateway_route().unwrap();
+        assert_eq!(route.id, "chat");
+        assert_eq!(route.agent_id, "agent-chat");
+        assert_eq!(route.method, HttpMethod::Post);
+    }
+
+    #[test]
+    fn to_gateway_route_invalid_method_returns_none() {
+        let mut cfg = parse(MINIMAL_TOML);
+        cfg.routes[0].method = "INVALID".to_string();
+        assert!(cfg.routes[0].to_gateway_route().is_none());
+    }
+
+    // ── load_from_file ───────────────────────────────────────────────────────
+
+    #[test]
+    fn load_from_file_success() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(MINIMAL_TOML.as_bytes()).unwrap();
+        let cfg = GatewayConfigLoader::load_from_file(tmp.path()).unwrap();
+        assert_eq!(cfg.routes.len(), 2);
+    }
+
+    #[test]
+    fn load_from_file_missing_returns_error() {
+        let result = GatewayConfigLoader::load_from_file(Path::new("/nonexistent/gateway.toml"));
+        assert!(matches!(result, Err(ConfigError::Io(..))));
+    }
+
+    #[test]
+    fn load_from_file_invalid_toml_returns_error() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(b"not valid toml ][").unwrap();
+        let result = GatewayConfigLoader::load_from_file(tmp.path());
+        assert!(matches!(result, Err(ConfigError::Parse(..))));
+    }
+
+    // ── diff_configs ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn diff_no_changes() {
+        let cfg = parse(MINIMAL_TOML);
+        let diff = diff_configs(&cfg, &cfg);
+        assert!(diff.is_empty());
+    }
+
+    #[test]
+    fn diff_added_route() {
+        let old = parse(MINIMAL_TOML);
+        let mut new = old.clone();
+        new.routes.push(RouteConfig {
+            id: "new-route".to_string(),
+            path_pattern: "/v1/new".to_string(),
+            method: "DELETE".to_string(),
+            agent_id: "agent-new".to_string(),
+            strategy: default_strategy(),
+            timeout_ms: 0,
+            rate_limit: None,
+            enabled: true,
+        });
+        let diff = diff_configs(&old, &new);
+        assert_eq!(diff.added, vec!["new-route"]);
+        assert!(diff.removed.is_empty());
+        assert!(diff.modified.is_empty());
+    }
+
+    #[test]
+    fn diff_removed_route() {
+        let old = parse(MINIMAL_TOML);
+        let mut new = old.clone();
+        new.routes.retain(|r| r.id != "search");
+        let diff = diff_configs(&old, &new);
+        assert!(diff.added.is_empty());
+        assert_eq!(diff.removed, vec!["search"]);
+        assert!(diff.modified.is_empty());
+    }
+
+    #[test]
+    fn diff_modified_route() {
+        let old = parse(MINIMAL_TOML);
+        let mut new = old.clone();
+        new.routes.iter_mut().find(|r| r.id == "chat").unwrap().timeout_ms = 9999;
+        let diff = diff_configs(&old, &new);
+        assert!(diff.added.is_empty());
+        assert!(diff.removed.is_empty());
+        assert_eq!(diff.modified, vec!["chat"]);
+    }
+
+    #[test]
+    fn diff_combined_changes() {
+        let old = parse(MINIMAL_TOML);
+        let mut new = old.clone();
+        // modify chat
+        new.routes.iter_mut().find(|r| r.id == "chat").unwrap().agent_id = "new-agent".to_string();
+        // remove search
+        new.routes.retain(|r| r.id != "search");
+        // add brand-new
+        new.routes.push(RouteConfig {
+            id: "admin".to_string(),
+            path_pattern: "/admin".to_string(),
+            method: "GET".to_string(),
+            agent_id: "agent-admin".to_string(),
+            strategy: default_strategy(),
+            timeout_ms: 0,
+            rate_limit: None,
+            enabled: true,
+        });
+        let diff = diff_configs(&old, &new);
+        assert_eq!(diff.added, vec!["admin"]);
+        assert_eq!(diff.removed, vec!["search"]);
+        assert_eq!(diff.modified, vec!["chat"]);
+    }
+
+    // ── debounce ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn debounce_ignores_second_write_within_200ms() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        use std::sync::Arc;
+
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(MINIMAL_TOML.as_bytes()).unwrap();
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<GatewayConfig>(8);
+        let _watcher = GatewayConfigLoader::watch(tmp.path(), tx).unwrap();
+
+        let reload_count = Arc::new(AtomicU32::new(0));
+        let count_clone = Arc::clone(&reload_count);
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async move {
+            // Write twice within 50ms — should produce only one reload after
+            // the 200ms debounce window.
+            {
+                let mut f = std::fs::OpenOptions::new()
+                    .write(true)
+                    .truncate(true)
+                    .open(tmp.path())
+                    .unwrap();
+                f.write_all(MINIMAL_TOML.as_bytes()).unwrap();
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            {
+                let mut f = std::fs::OpenOptions::new()
+                    .write(true)
+                    .truncate(true)
+                    .open(tmp.path())
+                    .unwrap();
+                f.write_all(MINIMAL_TOML.as_bytes()).unwrap();
+            }
+
+            // Wait long enough for the debounce to fire once.
+            tokio::time::sleep(Duration::from_millis(400)).await;
+
+            while let Ok(cfg) = rx.try_recv() {
+                let _ = cfg;
+                count_clone.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+
+        // At most one reload should have fired.
+        assert!(
+            reload_count.load(std::sync::atomic::Ordering::Relaxed) <= 1,
+            "debounce failed: got {} reloads",
+            reload_count.load(std::sync::atomic::Ordering::Relaxed)
+        );
+    }
+}

--- a/crates/mofa-foundation/src/gateway/mod.rs
+++ b/crates/mofa-foundation/src/gateway/mod.rs
@@ -9,3 +9,6 @@ pub mod rate_limiter;
 pub use rate_limiter::{
     KeyStrategy, RateLimitDecision, RateLimiter, RateLimiterConfig, TokenBucketRateLimiter,
 };
+
+pub mod routing;
+pub use routing::{AgentScorer, CapabilityMatchRouter, RouterRegistry, WeightedRoundRobinRouter};

--- a/crates/mofa-foundation/src/gateway/mod.rs
+++ b/crates/mofa-foundation/src/gateway/mod.rs
@@ -1,0 +1,11 @@
+//! Foundation-layer gateway implementations.
+//!
+//! This module contains concrete implementations of the kernel-level gateway
+//! traits. Kernel traits live in `mofa-kernel::gateway`; implementations live
+//! here so the kernel stays free of runtime dependencies.
+
+pub mod rate_limiter;
+
+pub use rate_limiter::{
+    KeyStrategy, RateLimitDecision, RateLimiter, RateLimiterConfig, TokenBucketRateLimiter,
+};

--- a/crates/mofa-foundation/src/gateway/mod.rs
+++ b/crates/mofa-foundation/src/gateway/mod.rs
@@ -12,3 +12,9 @@ pub use rate_limiter::{
 
 pub mod routing;
 pub use routing::{AgentScorer, CapabilityMatchRouter, RouterRegistry, WeightedRoundRobinRouter};
+
+pub mod config;
+pub use config::{
+    ConfigDiff, ConfigError, GatewayConfig, GatewayConfigLoader, RateLimitProfile, RouteConfig,
+    diff_configs,
+};

--- a/crates/mofa-foundation/src/gateway/rate_limiter.rs
+++ b/crates/mofa-foundation/src/gateway/rate_limiter.rs
@@ -1,0 +1,331 @@
+//! Token-bucket rate limiter with per-agent and per-client quota enforcement.
+//!
+//! # How it works
+//!
+//! Each unique key gets its own [`TokenBucket`].  Tokens refill lazily on
+//! every `check_and_consume` call — no background timer, no spawned tasks.
+//! The refill amount is proportional to how much wall-clock time has elapsed
+//! since the last call, capped at the bucket capacity.
+//!
+//! # Keying strategies
+//!
+//! Two strategies are supported and can be composed:
+//!
+//! - [`KeyStrategy::PerAgent`] — one bucket per `agent_id` (from the matched route)
+//! - [`KeyStrategy::PerClient`] — one bucket per caller IP string
+//!
+//! Both strategies use the same underlying `TokenBucketRateLimiter`; the
+//! caller is responsible for passing the correct key.
+
+use std::time::{Duration, Instant};
+
+use dashmap::DashMap;
+use serde::{Deserialize, Serialize};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The outcome of a rate-limit check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RateLimitDecision {
+    /// Request is within quota.
+    Allowed {
+        /// Tokens remaining in the bucket after this request.
+        remaining: u32,
+    },
+    /// Request exceeds quota.
+    Denied {
+        /// Milliseconds the caller should wait before retrying.
+        retry_after_ms: u64,
+    },
+}
+
+impl RateLimitDecision {
+    /// Returns `true` if the request was allowed.
+    pub fn is_allowed(&self) -> bool {
+        matches!(self, Self::Allowed { .. })
+    }
+}
+
+/// Which dimension to key the rate limiter on.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum KeyStrategy {
+    /// One bucket per agent ID (from the matched route).
+    PerAgent,
+    /// One bucket per originating client IP address.
+    PerClient,
+}
+
+/// Configuration for a [`TokenBucketRateLimiter`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RateLimiterConfig {
+    /// Maximum number of tokens (burst size).
+    pub capacity: u32,
+    /// Number of tokens added per second (sustained rate).
+    pub refill_rate: u32,
+    /// Keying strategy.
+    pub strategy: KeyStrategy,
+}
+
+impl Default for RateLimiterConfig {
+    fn default() -> Self {
+        Self {
+            capacity: 100,
+            refill_rate: 10,
+            strategy: KeyStrategy::PerClient,
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RateLimiter trait
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Kernel-adjacent contract for rate limiting.
+///
+/// Implementations must be `Send + Sync` so they can be held behind an `Arc`
+/// and called from multiple Tokio tasks concurrently.
+pub trait RateLimiter: Send + Sync {
+    /// Attempt to consume one token from the bucket identified by `key`.
+    ///
+    /// Returns [`RateLimitDecision::Allowed`] when a token was successfully
+    /// consumed, or [`RateLimitDecision::Denied`] with a retry hint when the
+    /// bucket is empty.
+    fn check_and_consume(&self, key: &str) -> RateLimitDecision;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TokenBucket (internal per-key state)
+// ─────────────────────────────────────────────────────────────────────────────
+
+struct TokenBucket {
+    tokens: f64,
+    capacity: f64,
+    refill_rate: f64,
+    last_refill: Instant,
+}
+
+impl TokenBucket {
+    fn new(capacity: u32, refill_rate: u32) -> Self {
+        Self {
+            tokens: capacity as f64,
+            capacity: capacity as f64,
+            refill_rate: refill_rate as f64,
+            last_refill: Instant::now(),
+        }
+    }
+
+    /// Refill tokens based on elapsed time, then attempt to consume one.
+    fn try_consume(&mut self) -> RateLimitDecision {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.last_refill).as_secs_f64();
+        self.tokens = (self.tokens + elapsed * self.refill_rate).min(self.capacity);
+        self.last_refill = now;
+
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            RateLimitDecision::Allowed {
+                remaining: self.tokens as u32,
+            }
+        } else {
+            // Time until next token is available.
+            let deficit = 1.0 - self.tokens;
+            let wait_secs = deficit / self.refill_rate;
+            let retry_after_ms = (wait_secs * 1000.0).ceil() as u64;
+            RateLimitDecision::Denied { retry_after_ms }
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TokenBucketRateLimiter
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Lock-free token-bucket rate limiter backed by [`DashMap`].
+///
+/// Each unique key gets its own bucket lazily created on first access.
+/// Refill is computed on demand — no background timer, no spawned tasks.
+pub struct TokenBucketRateLimiter {
+    buckets: DashMap<String, TokenBucket>,
+    capacity: u32,
+    refill_rate: u32,
+}
+
+impl TokenBucketRateLimiter {
+    /// Create a new limiter with the given configuration.
+    pub fn new(config: &RateLimiterConfig) -> Self {
+        Self {
+            buckets: DashMap::new(),
+            capacity: config.capacity,
+            refill_rate: config.refill_rate,
+        }
+    }
+}
+
+impl RateLimiter for TokenBucketRateLimiter {
+    fn check_and_consume(&self, key: &str) -> RateLimitDecision {
+        self.buckets
+            .entry(key.to_string())
+            .or_insert_with(|| TokenBucket::new(self.capacity, self.refill_rate))
+            .try_consume()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::thread;
+
+    use super::*;
+
+    fn limiter(capacity: u32, refill_rate: u32) -> TokenBucketRateLimiter {
+        TokenBucketRateLimiter::new(&RateLimiterConfig {
+            capacity,
+            refill_rate,
+            strategy: KeyStrategy::PerClient,
+        })
+    }
+
+    // ── Basic behaviour ──────────────────────────────────────────────────────
+
+    #[test]
+    fn fresh_bucket_allows_up_to_capacity() {
+        let rl = limiter(5, 1);
+        for i in 0..5 {
+            let decision = rl.check_and_consume("client-a");
+            assert!(
+                decision.is_allowed(),
+                "expected Allowed on request {}, got {decision:?}",
+                i + 1
+            );
+        }
+    }
+
+    #[test]
+    fn excess_requests_are_denied() {
+        let rl = limiter(3, 1);
+        for _ in 0..3 {
+            rl.check_and_consume("client-a");
+        }
+        let decision = rl.check_and_consume("client-a");
+        assert!(
+            matches!(decision, RateLimitDecision::Denied { .. }),
+            "expected Denied, got {decision:?}"
+        );
+    }
+
+    #[test]
+    fn denied_carries_positive_retry_after() {
+        let rl = limiter(1, 1);
+        rl.check_and_consume("client-a"); // drain
+        match rl.check_and_consume("client-a") {
+            RateLimitDecision::Denied { retry_after_ms } => {
+                assert!(retry_after_ms > 0, "retry_after_ms must be > 0");
+            }
+            other => panic!("expected Denied, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn remaining_decrements_correctly() {
+        let rl = limiter(3, 1);
+        match rl.check_and_consume("client-a") {
+            RateLimitDecision::Allowed { remaining } => assert_eq!(remaining, 2),
+            other => panic!("expected Allowed, got {other:?}"),
+        }
+        match rl.check_and_consume("client-a") {
+            RateLimitDecision::Allowed { remaining } => assert_eq!(remaining, 1),
+            other => panic!("expected Allowed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn different_keys_have_independent_buckets() {
+        let rl = limiter(1, 1);
+        let a = rl.check_and_consume("agent-a");
+        let b = rl.check_and_consume("agent-b");
+        assert!(a.is_allowed());
+        assert!(b.is_allowed());
+    }
+
+    // ── Refill ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn bucket_refills_after_elapsed_time() {
+        let rl = limiter(1, 1000); // 1000 tokens/sec — refills very fast
+        rl.check_and_consume("client-a"); // drain
+
+        // Sleep just long enough for the 1000 tokens/sec rate to refill at
+        // least one token (1ms should add 1 token).
+        thread::sleep(Duration::from_millis(5));
+
+        let decision = rl.check_and_consume("client-a");
+        assert!(
+            decision.is_allowed(),
+            "expected bucket to have refilled, got {decision:?}"
+        );
+    }
+
+    // ── Concurrency ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn concurrent_access_does_not_exceed_capacity() {
+        const CAPACITY: u32 = 50;
+        const THREADS: usize = 20;
+        const REQUESTS_PER_THREAD: usize = 10;
+
+        let rl = Arc::new(TokenBucketRateLimiter::new(&RateLimiterConfig {
+            capacity: CAPACITY,
+            refill_rate: 0, // no refill during the test
+            strategy: KeyStrategy::PerClient,
+        }));
+
+        let allowed = Arc::new(std::sync::atomic::AtomicU32::new(0));
+
+        let handles: Vec<_> = (0..THREADS)
+            .map(|_| {
+                let rl = Arc::clone(&rl);
+                let allowed = Arc::clone(&allowed);
+                thread::spawn(move || {
+                    for _ in 0..REQUESTS_PER_THREAD {
+                        if rl.check_and_consume("shared-key").is_allowed() {
+                            allowed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        }
+                    }
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let total_allowed = allowed.load(std::sync::atomic::Ordering::Relaxed);
+        assert!(
+            total_allowed <= CAPACITY,
+            "allowed {total_allowed} requests but capacity is {CAPACITY}"
+        );
+    }
+
+    // ── Config ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn rate_limiter_config_default() {
+        let cfg = RateLimiterConfig::default();
+        assert_eq!(cfg.capacity, 100);
+        assert_eq!(cfg.refill_rate, 10);
+        assert_eq!(cfg.strategy, KeyStrategy::PerClient);
+    }
+
+    #[test]
+    fn rate_limit_decision_is_allowed_helper() {
+        assert!(RateLimitDecision::Allowed { remaining: 5 }.is_allowed());
+        assert!(!RateLimitDecision::Denied { retry_after_ms: 100 }.is_allowed());
+    }
+}

--- a/crates/mofa-foundation/src/gateway/routing.rs
+++ b/crates/mofa-foundation/src/gateway/routing.rs
@@ -1,0 +1,473 @@
+//! Concrete routing strategy implementations for the gateway.
+//!
+//! # Strategies
+//!
+//! | Type | Description |
+//! |------|-------------|
+//! | [`WeightedRoundRobinRouter`] | Distributes requests proportionally across weighted agent backends |
+//! | [`CapabilityMatchRouter`] | Selects the highest-scoring agent for a task description |
+//! | [`RouterRegistry`] | Maps route IDs to their assigned strategy |
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+
+use mofa_kernel::gateway::envelope::RequestEnvelope;
+use mofa_kernel::gateway::routing::RoutingStrategy;
+use tracing::warn;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WeightedRoundRobinRouter
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Distributes requests proportionally across a set of weighted agent backends.
+///
+/// Selection is atomic — a global counter is incremented on every call and
+/// mapped to a backend via a cumulative-weight lookup, so concurrent gateway
+/// threads never double-select the same slot.
+///
+/// Weights can be updated at runtime via [`update_backends`] without dropping
+/// the router or interrupting in-flight requests.
+pub struct WeightedRoundRobinRouter {
+    /// Snapshot of backends used for selection.
+    /// Stored behind RwLock so `update_backends` can swap it atomically.
+    backends: RwLock<WeightedBackends>,
+    /// Monotonically increasing request counter.
+    counter: AtomicU64,
+}
+
+struct WeightedBackends {
+    /// Parallel vec of agent IDs.
+    agents: Vec<String>,
+    /// Cumulative weights for O(log n) selection.
+    cumulative: Vec<u64>,
+    /// Total weight sum.
+    total: u64,
+}
+
+impl WeightedBackends {
+    fn new(backends: Vec<(String, u32)>) -> Self {
+        let mut agents = Vec::with_capacity(backends.len());
+        let mut cumulative = Vec::with_capacity(backends.len());
+        let mut running = 0u64;
+        for (id, w) in backends {
+            running += w as u64;
+            agents.push(id);
+            cumulative.push(running);
+        }
+        Self {
+            agents,
+            cumulative,
+            total: running,
+        }
+    }
+
+    fn select(&self, slot: u64) -> Option<&str> {
+        if self.total == 0 {
+            return None;
+        }
+        let target = (slot % self.total) + 1;
+        // Binary search for the first cumulative weight >= target.
+        let idx = self.cumulative.partition_point(|&c| c < target);
+        self.agents.get(idx).map(|s| s.as_str())
+    }
+}
+
+impl WeightedRoundRobinRouter {
+    /// Create a new router with the given `(agent_id, weight)` pairs.
+    ///
+    /// Backends with weight `0` are ignored.
+    pub fn new(backends: Vec<(impl Into<String>, u32)>) -> Self {
+        let backends = backends
+            .into_iter()
+            .filter(|(_, w)| *w > 0)
+            .map(|(id, w)| (id.into(), w))
+            .collect();
+        Self {
+            backends: RwLock::new(WeightedBackends::new(backends)),
+            counter: AtomicU64::new(0),
+        }
+    }
+
+    /// Replace the backend list at runtime.  In-flight selections complete
+    /// against the old list; new selections use the new list.
+    pub fn update_backends(&self, backends: Vec<(impl Into<String>, u32)>) {
+        let backends = backends
+            .into_iter()
+            .filter(|(_, w)| *w > 0)
+            .map(|(id, w)| (id.into(), w))
+            .collect();
+        let new = WeightedBackends::new(backends);
+        *self.backends.write().unwrap() = new;
+    }
+}
+
+impl RoutingStrategy for WeightedRoundRobinRouter {
+    fn select_agent(&self, _envelope: &RequestEnvelope) -> Option<String> {
+        let slot = self.counter.fetch_add(1, Ordering::Relaxed);
+        let backends = self.backends.read().unwrap();
+        backends.select(slot).map(String::from)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AgentScorer — extensibility seam for CapabilityRegistry (#404)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Scores agents by how well they match a task description.
+///
+/// This trait is the extensibility seam between the `CapabilityMatchRouter`
+/// and the `CapabilityRegistry` introduced in issue #404.  Once that PR
+/// merges, `CapabilityRegistry` implements `AgentScorer` and the router
+/// picks it up automatically.
+pub trait AgentScorer: Send + Sync {
+    /// Return `(agent_id, score)` pairs for all agents that can handle
+    /// `task_description`.  A higher score means a better match.
+    fn score(&self, task_description: &str) -> Vec<(String, f64)>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CapabilityMatchRouter
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Selects the highest-scoring agent for the task description carried in the
+/// request envelope's metadata.
+///
+/// Falls back to `fallback_agent_id` when no agent scores at or above
+/// `threshold`, logging a warning.  This avoids returning errors for
+/// borderline requests while still routing them predictably.
+pub struct CapabilityMatchRouter {
+    scorer: Arc<dyn AgentScorer>,
+    threshold: f64,
+    fallback_agent_id: String,
+    /// Metadata key in `RequestEnvelope` that holds the task description.
+    task_key: String,
+}
+
+impl CapabilityMatchRouter {
+    /// Create a new router.
+    ///
+    /// * `scorer` — any `AgentScorer` implementation (e.g. `CapabilityRegistry`)
+    /// * `threshold` — minimum score for a match to be accepted (0.0–1.0)
+    /// * `fallback_agent_id` — agent to use when no match meets the threshold
+    /// * `task_key` — key in `RequestEnvelope.payload` holding the task string
+    pub fn new(
+        scorer: Arc<dyn AgentScorer>,
+        threshold: f64,
+        fallback_agent_id: impl Into<String>,
+        task_key: impl Into<String>,
+    ) -> Self {
+        Self {
+            scorer,
+            threshold,
+            fallback_agent_id: fallback_agent_id.into(),
+            task_key: task_key.into(),
+        }
+    }
+}
+
+impl RoutingStrategy for CapabilityMatchRouter {
+    fn select_agent(&self, envelope: &RequestEnvelope) -> Option<String> {
+        // Extract task description from the payload using the configured key.
+        let task = envelope
+            .payload
+            .get(&self.task_key)
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        if task.is_empty() {
+            warn!(
+                correlation_id = %envelope.correlation_id,
+                "CapabilityMatchRouter: task key '{}' missing or empty, using fallback agent '{}'",
+                self.task_key, self.fallback_agent_id
+            );
+            return Some(self.fallback_agent_id.clone());
+        }
+
+        let mut scores = self.scorer.score(task);
+        scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+        if let Some((agent_id, score)) = scores.first() {
+            if *score >= self.threshold {
+                return Some(agent_id.clone());
+            }
+        }
+
+        warn!(
+            correlation_id = %envelope.correlation_id,
+            task = %task,
+            threshold = self.threshold,
+            fallback = %self.fallback_agent_id,
+            "CapabilityMatchRouter: no agent scored above threshold, using fallback"
+        );
+        Some(self.fallback_agent_id.clone())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RouterRegistry
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Maps route IDs to their assigned [`RoutingStrategy`].
+///
+/// The gateway dispatch layer looks up the strategy for the matched route ID
+/// on each request, avoiding a match statement in the hot path.
+pub struct RouterRegistry {
+    strategies: HashMap<String, Arc<dyn RoutingStrategy>>,
+}
+
+impl RouterRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self {
+            strategies: HashMap::new(),
+        }
+    }
+
+    /// Register a strategy for `route_id`.  Replaces any existing strategy.
+    pub fn register(&mut self, route_id: impl Into<String>, strategy: Arc<dyn RoutingStrategy>) {
+        self.strategies.insert(route_id.into(), strategy);
+    }
+
+    /// Look up the strategy for `route_id`.
+    ///
+    /// Returns `None` when no strategy has been registered for this route.
+    pub fn get(&self, route_id: &str) -> Option<Arc<dyn RoutingStrategy>> {
+        self.strategies.get(route_id).cloned()
+    }
+
+    /// Number of registered strategies.
+    pub fn len(&self) -> usize {
+        self.strategies.len()
+    }
+
+    /// Returns `true` if no strategies are registered.
+    pub fn is_empty(&self) -> bool {
+        self.strategies.is_empty()
+    }
+}
+
+impl Default for RouterRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::net::IpAddr;
+    use std::str::FromStr;
+    use std::sync::Arc;
+
+    use serde_json::json;
+
+    use super::*;
+    use mofa_kernel::gateway::envelope::RequestEnvelope;
+
+    fn envelope(task: &str) -> RequestEnvelope {
+        RequestEnvelope::new(
+            "route-1",
+            json!({ "task": task }),
+            IpAddr::from_str("127.0.0.1").unwrap(),
+        )
+    }
+
+    fn empty_envelope() -> RequestEnvelope {
+        RequestEnvelope::new("route-1", json!({}), IpAddr::from_str("127.0.0.1").unwrap())
+    }
+
+    // ── WeightedRoundRobinRouter ─────────────────────────────────────────────
+
+    #[test]
+    fn wrr_distributes_proportionally() {
+        // agent-a weight 3, agent-b weight 1 → expect ~75% / ~25%
+        let router = WeightedRoundRobinRouter::new(vec![
+            ("agent-a", 3u32),
+            ("agent-b", 1u32),
+        ]);
+
+        let n = 1000usize;
+        let mut counts: HashMap<String, usize> = HashMap::new();
+        for _ in 0..n {
+            let agent = router.select_agent(&empty_envelope()).unwrap();
+            *counts.entry(agent).or_insert(0) += 1;
+        }
+
+        let a_pct = *counts.get("agent-a").unwrap_or(&0) as f64 / n as f64;
+        let b_pct = *counts.get("agent-b").unwrap_or(&0) as f64 / n as f64;
+
+        // Allow 5% tolerance.
+        assert!(
+            (a_pct - 0.75).abs() < 0.05,
+            "agent-a: expected ~75%, got {:.1}%",
+            a_pct * 100.0
+        );
+        assert!(
+            (b_pct - 0.25).abs() < 0.05,
+            "agent-b: expected ~25%, got {:.1}%",
+            b_pct * 100.0
+        );
+    }
+
+    #[test]
+    fn wrr_single_backend_always_selected() {
+        let router = WeightedRoundRobinRouter::new(vec![("only-agent", 5u32)]);
+        for _ in 0..10 {
+            assert_eq!(
+                router.select_agent(&empty_envelope()),
+                Some("only-agent".to_string())
+            );
+        }
+    }
+
+    #[test]
+    fn wrr_empty_backends_returns_none() {
+        let router = WeightedRoundRobinRouter::new(Vec::<(String, u32)>::new());
+        assert!(router.select_agent(&empty_envelope()).is_none());
+    }
+
+    #[test]
+    fn wrr_update_backends_takes_effect() {
+        let router = WeightedRoundRobinRouter::new(vec![("old-agent", 1u32)]);
+        assert_eq!(
+            router.select_agent(&empty_envelope()),
+            Some("old-agent".to_string())
+        );
+        router.update_backends(vec![("new-agent", 1u32)]);
+        // Counter carries over; new selection should be from new backends.
+        let selected = router.select_agent(&empty_envelope()).unwrap();
+        assert_eq!(selected, "new-agent");
+    }
+
+    #[test]
+    fn wrr_zero_weight_backends_ignored() {
+        let router = WeightedRoundRobinRouter::new(vec![("zero", 0u32), ("valid", 1u32)]);
+        for _ in 0..5 {
+            assert_eq!(
+                router.select_agent(&empty_envelope()),
+                Some("valid".to_string())
+            );
+        }
+    }
+
+    // ── CapabilityMatchRouter ────────────────────────────────────────────────
+
+    struct MockScorer {
+        scores: Vec<(String, f64)>,
+    }
+
+    impl AgentScorer for MockScorer {
+        fn score(&self, _task: &str) -> Vec<(String, f64)> {
+            self.scores.clone()
+        }
+    }
+
+    fn scorer(scores: Vec<(&str, f64)>) -> Arc<dyn AgentScorer> {
+        Arc::new(MockScorer {
+            scores: scores
+                .into_iter()
+                .map(|(id, s)| (id.to_string(), s))
+                .collect(),
+        })
+    }
+
+    #[test]
+    fn capability_match_selects_highest_scorer_above_threshold() {
+        let router = CapabilityMatchRouter::new(
+            scorer(vec![("agent-low", 0.4), ("agent-high", 0.9)]),
+            0.7,
+            "fallback",
+            "task",
+        );
+        assert_eq!(
+            router.select_agent(&envelope("summarise this")),
+            Some("agent-high".to_string())
+        );
+    }
+
+    #[test]
+    fn capability_match_falls_back_when_no_score_above_threshold() {
+        let router = CapabilityMatchRouter::new(
+            scorer(vec![("agent-a", 0.3), ("agent-b", 0.5)]),
+            0.7,
+            "fallback-agent",
+            "task",
+        );
+        assert_eq!(
+            router.select_agent(&envelope("summarise this")),
+            Some("fallback-agent".to_string())
+        );
+    }
+
+    #[test]
+    fn capability_match_falls_back_when_scorer_returns_empty() {
+        let router = CapabilityMatchRouter::new(
+            scorer(vec![]),
+            0.7,
+            "fallback-agent",
+            "task",
+        );
+        assert_eq!(
+            router.select_agent(&envelope("summarise this")),
+            Some("fallback-agent".to_string())
+        );
+    }
+
+    #[test]
+    fn capability_match_falls_back_when_task_key_missing() {
+        let router = CapabilityMatchRouter::new(
+            scorer(vec![("agent-a", 0.9)]),
+            0.7,
+            "fallback-agent",
+            "task",
+        );
+        // envelope has no "task" key
+        assert_eq!(
+            router.select_agent(&empty_envelope()),
+            Some("fallback-agent".to_string())
+        );
+    }
+
+    // ── RouterRegistry ───────────────────────────────────────────────────────
+
+    #[test]
+    fn router_registry_returns_correct_strategy() {
+        let mut reg = RouterRegistry::new();
+        let strategy: Arc<dyn RoutingStrategy> =
+            Arc::new(WeightedRoundRobinRouter::new(vec![("agent-a", 1u32)]));
+        reg.register("route-chat", Arc::clone(&strategy));
+
+        assert!(reg.get("route-chat").is_some());
+        assert!(reg.get("nonexistent").is_none());
+    }
+
+    #[test]
+    fn router_registry_len_and_is_empty() {
+        let mut reg = RouterRegistry::new();
+        assert!(reg.is_empty());
+        reg.register(
+            "r1",
+            Arc::new(WeightedRoundRobinRouter::new(vec![("a", 1u32)])),
+        );
+        assert_eq!(reg.len(), 1);
+        assert!(!reg.is_empty());
+    }
+
+    #[test]
+    fn router_registry_replaces_existing_strategy() {
+        let mut reg = RouterRegistry::new();
+        reg.register(
+            "r1",
+            Arc::new(WeightedRoundRobinRouter::new(vec![("old", 1u32)])),
+        );
+        reg.register(
+            "r1",
+            Arc::new(WeightedRoundRobinRouter::new(vec![("new", 1u32)])),
+        );
+        assert_eq!(reg.len(), 1);
+    }
+}

--- a/crates/mofa-foundation/src/lib.rs
+++ b/crates/mofa-foundation/src/lib.rs
@@ -68,8 +68,10 @@ pub mod recovery;
 // Gateway implementations (rate limiter, routing strategies)
 pub mod gateway;
 pub use gateway::{
-    AgentScorer, CapabilityMatchRouter, KeyStrategy, RateLimitDecision, RateLimiter,
-    RateLimiterConfig, RouterRegistry, TokenBucketRateLimiter, WeightedRoundRobinRouter,
+    AgentScorer, CapabilityMatchRouter, ConfigDiff, ConfigError, GatewayConfig, GatewayConfigLoader,
+    KeyStrategy, RateLimitDecision, RateLimiter,
+    RateLimitProfile, RateLimiterConfig, RouteConfig as GatewayRouteConfig, RouterRegistry,
+    TokenBucketRateLimiter, WeightedRoundRobinRouter, diff_configs,
 };
 
 // Re-export config types

--- a/crates/mofa-foundation/src/lib.rs
+++ b/crates/mofa-foundation/src/lib.rs
@@ -65,6 +65,12 @@ pub mod security;
 // Error recovery strategies (Backoff, RetryPolicy, CircuitBreaker, retry, fallback_chain)
 pub mod recovery;
 
+// Gateway implementations (rate limiter, routing strategies)
+pub mod gateway;
+pub use gateway::{
+    KeyStrategy, RateLimitDecision, RateLimiter, RateLimiterConfig, TokenBucketRateLimiter,
+};
+
 // Re-export config types
 pub use config::{AgentInfo, AgentYamlConfig, LLMYamlConfig, RuntimeConfig, ToolConfig};
 

--- a/crates/mofa-foundation/src/lib.rs
+++ b/crates/mofa-foundation/src/lib.rs
@@ -68,7 +68,8 @@ pub mod recovery;
 // Gateway implementations (rate limiter, routing strategies)
 pub mod gateway;
 pub use gateway::{
-    KeyStrategy, RateLimitDecision, RateLimiter, RateLimiterConfig, TokenBucketRateLimiter,
+    AgentScorer, CapabilityMatchRouter, KeyStrategy, RateLimitDecision, RateLimiter,
+    RateLimiterConfig, RouterRegistry, TokenBucketRateLimiter, WeightedRoundRobinRouter,
 };
 
 // Re-export config types

--- a/crates/mofa-gateway/gateway.example.toml
+++ b/crates/mofa-gateway/gateway.example.toml
@@ -1,0 +1,51 @@
+# gateway.example.toml
+#
+# Example two-route gateway configuration demonstrating:
+#   - Route 1: weighted round-robin across two chat agent instances
+#   - Route 2: capability-match routing to the best-fit search agent
+#
+# Copy this file to gateway.toml and adjust to your deployment.
+
+# Name of the auth provider to use for all routes (unless overridden per-route).
+default_auth_provider = "api_key"
+
+# ─── Routes ──────────────────────────────────────────────────────────────────
+
+[[routes]]
+# Route 1: load-balance chat requests across two instances using weighted
+# round-robin (agent-chat-a gets 3x more traffic than agent-chat-b).
+id            = "chat"
+path_pattern  = "/v1/chat"
+method        = "POST"
+agent_id      = "agent-chat-a"   # primary agent; WRR strategy picks from the pool
+strategy      = "weighted_round_robin"
+timeout_ms    = 10000
+rate_limit    = "standard"
+enabled       = true
+
+[[routes]]
+# Route 2: route search requests to whichever agent best matches the task
+# description in the request payload. Falls back to agent-search-default
+# when no agent scores above 0.7.
+id            = "search"
+path_pattern  = "/v1/search"
+method        = "GET"
+agent_id      = "agent-search-default"  # fallback agent for capability-match
+strategy      = "capability_match"
+timeout_ms    = 5000
+rate_limit    = "search_tier"
+enabled       = true
+
+# ─── Rate-limit profiles ─────────────────────────────────────────────────────
+
+[rate_limit_profiles.standard]
+# 100-token burst, 10 tokens/second refill, keyed per client IP.
+capacity    = 100
+refill_rate = 10
+strategy    = "PerClient"
+
+[rate_limit_profiles.search_tier]
+# Tighter limit for the search route — 20-token burst, 5 tokens/second.
+capacity    = 20
+refill_rate = 5
+strategy    = "PerAgent"

--- a/crates/mofa-kernel/src/gateway/auth.rs
+++ b/crates/mofa-kernel/src/gateway/auth.rs
@@ -1,0 +1,382 @@
+//! Authentication trait boundary for the gateway pipeline.
+//!
+//! Defines three things:
+//! - [`AuthClaims`] — the verified identity produced by any auth backend
+//! - [`AuthProvider`] — async trait gateway middleware calls to verify a request
+//! - [`ApiKeyStore`] — persistence trait for issuing, looking up, and revoking API keys
+//! - [`AuthError`] — typed error enum covering every auth failure mode
+//!
+//! Concrete implementations (in-memory store, JWT verifier, etc.) live in
+//! `mofa-foundation` so the kernel stays free of crypto and HTTP dependencies.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AuthError
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Every way authentication can fail in the gateway pipeline.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum AuthError {
+    /// No credential was present in the request (missing Authorization header,
+    /// missing API key header, etc.).
+    #[error("missing credentials")]
+    MissingCredentials,
+
+    /// A credential was present but could not be verified — wrong key, bad
+    /// signature, malformed token, etc.
+    #[error("invalid credentials")]
+    InvalidCredentials,
+
+    /// The credential was valid at some point but has since expired.
+    #[error("credentials have expired")]
+    ExpiredCredentials,
+
+    /// The caller's verified claims do not include the scope required to access
+    /// this route.
+    #[error("insufficient scope: required '{required}'")]
+    InsufficientScope {
+        /// The scope string that was required but not present in the claims.
+        required: String,
+    },
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AuthClaims
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The verified identity produced by a successful authentication check.
+///
+/// All auth backends — API key, JWT, OAuth 2.0, mTLS — produce `AuthClaims`
+/// so downstream middleware and routing logic have a single type to reason
+/// about regardless of the authentication strategy in use.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthClaims {
+    /// Stable identifier of the authenticated agent or user
+    /// (e.g. `"agent:summarizer"`, `"user:alice"`).
+    pub subject: String,
+    /// Permitted operations for this identity
+    /// (e.g. `["agents:invoke", "agents:read"]`).
+    pub scopes: Vec<String>,
+    /// Optional expiry as a UNIX timestamp in milliseconds.
+    /// `None` means the credential does not expire.
+    pub expires_at_ms: Option<u64>,
+    /// Arbitrary extra attributes forwarded from the auth backend
+    /// (e.g. tenant ID, rate-limit tier).
+    pub attributes: HashMap<String, String>,
+}
+
+impl AuthClaims {
+    /// Create claims with no expiry and no extra attributes.
+    pub fn new(subject: impl Into<String>, scopes: Vec<String>) -> Self {
+        Self {
+            subject: subject.into(),
+            scopes,
+            expires_at_ms: None,
+            attributes: HashMap::new(),
+        }
+    }
+
+    /// Set an optional expiry timestamp (milliseconds since UNIX epoch).
+    pub fn with_expiry(mut self, expires_at_ms: u64) -> Self {
+        self.expires_at_ms = Some(expires_at_ms);
+        self
+    }
+
+    /// Attach an extra attribute.
+    pub fn with_attribute(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.attributes.insert(key.into(), value.into());
+        self
+    }
+
+    /// Returns `true` if the claims include `scope`.
+    pub fn has_scope(&self, scope: &str) -> bool {
+        self.scopes.iter().any(|s| s == scope)
+    }
+
+    /// Returns `true` if an expiry is set and has already passed.
+    ///
+    /// `now_ms` should be the current time as milliseconds since UNIX epoch.
+    /// Injecting it as a parameter makes this method unit-testable without
+    /// mocking the system clock.
+    pub fn is_expired(&self, now_ms: u64) -> bool {
+        self.expires_at_ms.map(|exp| now_ms > exp).unwrap_or(false)
+    }
+
+    /// Convenience: assert a required scope is present, returning
+    /// [`AuthError::InsufficientScope`] if it is not.
+    pub fn require_scope(&self, scope: &str) -> Result<(), AuthError> {
+        if self.has_scope(scope) {
+            Ok(())
+        } else {
+            Err(AuthError::InsufficientScope {
+                required: scope.to_string(),
+            })
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AuthProvider
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Kernel contract for authenticating an inbound request.
+///
+/// Gateway middleware calls `authenticate` with the request headers extracted
+/// into a plain `HashMap` so the trait carries no dependency on axum or any
+/// HTTP framework.  The gateway layer is responsible for extracting headers
+/// from the raw request before calling this trait.
+///
+/// Implementations must be `Send + Sync` so they can be held behind an `Arc`
+/// and shared across Tokio tasks.
+#[async_trait]
+pub trait AuthProvider: Send + Sync {
+    /// Verify the request headers and return verified claims on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthError`] when credentials are missing, invalid, expired,
+    /// or lack a required scope.
+    async fn authenticate(
+        &self,
+        headers: &HashMap<String, String>,
+    ) -> Result<AuthClaims, AuthError>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ApiKeyStore
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Kernel contract for API key lifecycle management.
+///
+/// The store is the persistence layer behind an API-key-based
+/// [`AuthProvider`].  In-memory and file-backed implementations live in
+/// `mofa-foundation`.
+pub trait ApiKeyStore: Send + Sync {
+    /// Look up the claims associated with `key`.
+    ///
+    /// Returns `None` if the key is not registered or has been revoked.
+    fn lookup(&self, key: &str) -> Option<AuthClaims>;
+
+    /// Issue a new API key for `subject` with the given `scopes`.
+    ///
+    /// Returns the generated key string.  The key must be stored internally
+    /// so that a subsequent `lookup` call returns the associated claims.
+    fn issue(&mut self, subject: impl Into<String>, scopes: Vec<String>) -> String;
+
+    /// Revoke an existing key.
+    ///
+    /// Returns `true` if the key existed and was removed, `false` if it was
+    /// not found (already revoked or never issued).
+    fn revoke(&mut self, key: &str) -> bool;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    // ── AuthClaims ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn claims_has_scope_true() {
+        let claims = AuthClaims::new("agent:a", vec!["agents:invoke".to_string()]);
+        assert!(claims.has_scope("agents:invoke"));
+    }
+
+    #[test]
+    fn claims_has_scope_false() {
+        let claims = AuthClaims::new("agent:a", vec!["agents:read".to_string()]);
+        assert!(!claims.has_scope("agents:invoke"));
+    }
+
+    #[test]
+    fn claims_require_scope_ok() {
+        let claims = AuthClaims::new("agent:a", vec!["agents:invoke".to_string()]);
+        assert!(claims.require_scope("agents:invoke").is_ok());
+    }
+
+    #[test]
+    fn claims_require_scope_insufficient() {
+        let claims = AuthClaims::new("agent:a", vec!["agents:read".to_string()]);
+        let err = claims.require_scope("agents:invoke").unwrap_err();
+        assert!(matches!(
+            err,
+            AuthError::InsufficientScope { required } if required == "agents:invoke"
+        ));
+    }
+
+    #[test]
+    fn claims_not_expired_when_no_expiry() {
+        let claims = AuthClaims::new("agent:a", vec![]);
+        assert!(!claims.is_expired(9_999_999_999_999));
+    }
+
+    #[test]
+    fn claims_not_expired_before_expiry() {
+        let claims = AuthClaims::new("agent:a", vec![]).with_expiry(1_000_000);
+        assert!(!claims.is_expired(999_999));
+    }
+
+    #[test]
+    fn claims_expired_after_expiry() {
+        let claims = AuthClaims::new("agent:a", vec![]).with_expiry(1_000_000);
+        assert!(claims.is_expired(1_000_001));
+    }
+
+    #[test]
+    fn claims_attributes_builder() {
+        let claims = AuthClaims::new("agent:a", vec![])
+            .with_attribute("tenant", "acme")
+            .with_attribute("tier", "pro");
+        assert_eq!(claims.attributes.get("tenant"), Some(&"acme".to_string()));
+        assert_eq!(claims.attributes.get("tier"), Some(&"pro".to_string()));
+    }
+
+    // ── AuthProvider ─────────────────────────────────────────────────────────
+
+    /// Minimal in-test AuthProvider that accepts a single hardcoded key.
+    struct HardcodedKeyProvider {
+        valid_key: String,
+        scopes: Vec<String>,
+    }
+
+    #[async_trait]
+    impl AuthProvider for HardcodedKeyProvider {
+        async fn authenticate(
+            &self,
+            headers: &HashMap<String, String>,
+        ) -> Result<AuthClaims, AuthError> {
+            match headers.get("x-api-key").map(|s| s.as_str()) {
+                None => Err(AuthError::MissingCredentials),
+                Some(k) if k == self.valid_key => {
+                    Ok(AuthClaims::new("agent:test", self.scopes.clone()))
+                }
+                Some(_) => Err(AuthError::InvalidCredentials),
+            }
+        }
+    }
+
+    fn provider(scopes: Vec<&str>) -> HardcodedKeyProvider {
+        HardcodedKeyProvider {
+            valid_key: "secret".to_string(),
+            scopes: scopes.into_iter().map(String::from).collect(),
+        }
+    }
+
+    #[tokio::test]
+    async fn auth_provider_missing_header() {
+        let p = provider(vec![]);
+        let err = p.authenticate(&HashMap::new()).await.unwrap_err();
+        assert_eq!(err, AuthError::MissingCredentials);
+    }
+
+    #[tokio::test]
+    async fn auth_provider_invalid_key() {
+        let p = provider(vec![]);
+        let headers = HashMap::from([("x-api-key".to_string(), "wrong".to_string())]);
+        let err = p.authenticate(&headers).await.unwrap_err();
+        assert_eq!(err, AuthError::InvalidCredentials);
+    }
+
+    #[tokio::test]
+    async fn auth_provider_valid_key_returns_claims() {
+        let p = provider(vec!["agents:invoke"]);
+        let headers = HashMap::from([("x-api-key".to_string(), "secret".to_string())]);
+        let claims = p.authenticate(&headers).await.unwrap();
+        assert_eq!(claims.subject, "agent:test");
+        assert!(claims.has_scope("agents:invoke"));
+    }
+
+    #[tokio::test]
+    async fn auth_provider_insufficient_scope_after_auth() {
+        let p = provider(vec!["agents:read"]);
+        let headers = HashMap::from([("x-api-key".to_string(), "secret".to_string())]);
+        let claims = p.authenticate(&headers).await.unwrap();
+        let err = claims.require_scope("agents:invoke").unwrap_err();
+        assert!(matches!(
+            err,
+            AuthError::InsufficientScope { required } if required == "agents:invoke"
+        ));
+    }
+
+    // ── ApiKeyStore ───────────────────────────────────────────────────────────
+
+    /// Minimal in-test ApiKeyStore.
+    struct InMemoryApiKeyStore {
+        keys: HashMap<String, AuthClaims>,
+        counter: u32,
+    }
+
+    impl InMemoryApiKeyStore {
+        fn new() -> Self {
+            Self {
+                keys: HashMap::new(),
+                counter: 0,
+            }
+        }
+    }
+
+    impl ApiKeyStore for InMemoryApiKeyStore {
+        fn lookup(&self, key: &str) -> Option<AuthClaims> {
+            self.keys.get(key).cloned()
+        }
+
+        fn issue(&mut self, subject: impl Into<String>, scopes: Vec<String>) -> String {
+            self.counter += 1;
+            let key = format!("key-{}", self.counter);
+            self.keys
+                .insert(key.clone(), AuthClaims::new(subject, scopes));
+            key
+        }
+
+        fn revoke(&mut self, key: &str) -> bool {
+            self.keys.remove(key).is_some()
+        }
+    }
+
+    #[test]
+    fn api_key_store_issue_and_lookup() {
+        let mut store = InMemoryApiKeyStore::new();
+        let key = store.issue("agent:a", vec!["agents:invoke".to_string()]);
+        let claims = store.lookup(&key).unwrap();
+        assert_eq!(claims.subject, "agent:a");
+        assert!(claims.has_scope("agents:invoke"));
+    }
+
+    #[test]
+    fn api_key_store_lookup_missing_returns_none() {
+        let store = InMemoryApiKeyStore::new();
+        assert!(store.lookup("nonexistent").is_none());
+    }
+
+    #[test]
+    fn api_key_store_revoke_returns_true() {
+        let mut store = InMemoryApiKeyStore::new();
+        let key = store.issue("agent:a", vec![]);
+        assert!(store.revoke(&key));
+        assert!(store.lookup(&key).is_none());
+    }
+
+    #[test]
+    fn api_key_store_revoke_missing_returns_false() {
+        let mut store = InMemoryApiKeyStore::new();
+        assert!(!store.revoke("ghost"));
+    }
+
+    #[test]
+    fn api_key_store_each_issue_unique_key() {
+        let mut store = InMemoryApiKeyStore::new();
+        let k1 = store.issue("agent:a", vec![]);
+        let k2 = store.issue("agent:b", vec![]);
+        assert_ne!(k1, k2);
+    }
+}

--- a/crates/mofa-kernel/src/gateway/envelope.rs
+++ b/crates/mofa-kernel/src/gateway/envelope.rs
@@ -1,0 +1,328 @@
+//! Typed request and response envelopes for the gateway pipeline.
+//!
+//! [`RequestEnvelope`] is created at gateway admission and flows through every
+//! middleware filter and routing layer unchanged.  All pipeline components read
+//! context (correlation ID, route, deadline) from this struct instead of
+//! re-parsing the raw HTTP request.
+//!
+//! [`GatewayResponse`] is produced by the agent handler and consumed by the
+//! access-log, metrics, and admin API layers.  It carries enough information
+//! for structured logging and latency tracking without reaching into axum
+//! response internals.
+//!
+//! # Serialisation note
+//!
+//! Both types derive `Serialize`.  `RequestEnvelope::deadline` is a
+//! `std::time::Instant` — a monotonic, non-serialisable type — so it is
+//! tagged `#[serde(skip)]`.  Transport layers that need to propagate a
+//! deadline across process boundaries should convert to `deadline_unix_ms`
+//! (milliseconds since UNIX epoch) via [`RequestEnvelope::deadline_unix_ms`].
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RequestEnvelope
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A typed envelope wrapping an inbound agent call from admission to handler.
+///
+/// Created once at the gateway edge with a freshly generated `correlation_id`
+/// and passed unchanged through the filter chain and routing layer.
+///
+/// # Deadline semantics
+///
+/// When `deadline` is `Some`, middleware and handlers should check
+/// [`is_expired`](RequestEnvelope::is_expired) before doing expensive work.
+/// A request that has already exceeded its deadline should be short-circuited
+/// with a `504 Gateway Timeout` rather than forwarded to the agent.
+#[derive(Debug, Clone, Serialize)]
+pub struct RequestEnvelope {
+    /// UUID v4 generated at gateway admission.  Flows through every layer
+    /// for distributed tracing and log correlation.
+    pub correlation_id: String,
+    /// ID of the [`GatewayRoute`](super::route::GatewayRoute) that matched
+    /// this request, set after the routing phase.
+    pub route_id: String,
+    /// Request payload, parsed from the HTTP body.
+    pub payload: serde_json::Value,
+    /// Optional per-request deadline.  Skipped during serialisation because
+    /// `Instant` is not serialisable; use
+    /// [`deadline_unix_ms`](RequestEnvelope::deadline_unix_ms) when a
+    /// wire-transferable deadline is needed.
+    #[serde(skip)]
+    pub deadline: Option<Instant>,
+    /// IP address of the originating caller.
+    pub origin_ip: IpAddr,
+    /// Headers forwarded from the inbound HTTP request.  Keys are lowercased.
+    pub headers: HashMap<String, String>,
+    /// Wall-clock timestamp (ms since UNIX epoch) at which the envelope was
+    /// created.  Used to compute `latency_ms` in [`GatewayResponse`].
+    pub created_at_ms: u64,
+}
+
+impl RequestEnvelope {
+    /// Create a new envelope with a freshly generated correlation ID and the
+    /// current wall-clock creation time.
+    ///
+    /// `route_id` is typically empty at construction time and filled in by
+    /// the routing middleware once a matching route has been found.
+    pub fn new(
+        route_id: impl Into<String>,
+        payload: serde_json::Value,
+        origin_ip: IpAddr,
+    ) -> Self {
+        Self {
+            correlation_id: Uuid::new_v4().to_string(),
+            route_id: route_id.into(),
+            payload,
+            deadline: None,
+            origin_ip,
+            headers: HashMap::new(),
+            created_at_ms: now_ms(),
+        }
+    }
+
+    /// Set an optional deadline as a monotonic `Instant`.
+    pub fn with_deadline(mut self, deadline: Instant) -> Self {
+        self.deadline = Some(deadline);
+        self
+    }
+
+    /// Insert a forwarded header (key is lowercased automatically).
+    pub fn with_header(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.headers.insert(key.into().to_lowercase(), value.into());
+        self
+    }
+
+    /// Returns `true` if a deadline is set and has already passed.
+    pub fn is_expired(&self) -> bool {
+        self.deadline
+            .map(|d| Instant::now() > d)
+            .unwrap_or(false)
+    }
+
+    /// Return the deadline as milliseconds since UNIX epoch, suitable for
+    /// propagation over the wire.  Returns `None` if no deadline is set.
+    pub fn deadline_unix_ms(&self) -> Option<u64> {
+        self.deadline.map(|d| {
+            let remaining = d.saturating_duration_since(Instant::now());
+            now_ms().saturating_add(remaining.as_millis() as u64)
+        })
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GatewayResponse
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A typed response produced by an agent handler and consumed by the
+/// access-log, metrics, and admin API layers.
+///
+/// `latency_ms` is computed from the originating [`RequestEnvelope`]'s
+/// `created_at_ms` and the wall-clock time at response completion.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayResponse {
+    /// HTTP status code sent back to the caller.
+    pub status_code: u16,
+    /// Response body returned by the agent.
+    pub body: serde_json::Value,
+    /// End-to-end latency in milliseconds, measured from envelope creation to
+    /// response completion.
+    pub latency_ms: u64,
+    /// ID of the agent that handled the request.
+    pub agent_id: String,
+    /// Correlation ID copied from the originating [`RequestEnvelope`] so
+    /// access logs and traces can be joined without re-parsing the body.
+    pub correlation_id: String,
+}
+
+impl GatewayResponse {
+    /// Create a response, computing `latency_ms` from the envelope's
+    /// `created_at_ms`.
+    pub fn new(
+        status_code: u16,
+        body: serde_json::Value,
+        agent_id: impl Into<String>,
+        envelope: &RequestEnvelope,
+    ) -> Self {
+        let latency_ms = now_ms().saturating_sub(envelope.created_at_ms);
+        Self {
+            status_code,
+            body,
+            latency_ms,
+            agent_id: agent_id.into(),
+            correlation_id: envelope.correlation_id.clone(),
+        }
+    }
+
+    /// Returns `true` if the response indicates success (2xx status code).
+    pub fn is_success(&self) -> bool {
+        (200..300).contains(&self.status_code)
+    }
+
+    /// Returns `true` if the status code is a client error (4xx).
+    pub fn is_client_error(&self) -> bool {
+        (400..500).contains(&self.status_code)
+    }
+
+    /// Returns `true` if the status code is a server or gateway error (5xx).
+    pub fn is_server_error(&self) -> bool {
+        self.status_code >= 500
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Current wall-clock time as milliseconds since UNIX epoch.
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::net::IpAddr;
+    use std::str::FromStr;
+    use std::time::{Duration, Instant};
+
+    use serde_json::json;
+
+    use super::{GatewayResponse, RequestEnvelope};
+
+    fn loopback() -> IpAddr {
+        IpAddr::from_str("127.0.0.1").unwrap()
+    }
+
+    // ── RequestEnvelope ──────────────────────────────────────────────────────
+
+    #[test]
+    fn new_generates_unique_correlation_ids() {
+        let a = RequestEnvelope::new("r1", json!({}), loopback());
+        let b = RequestEnvelope::new("r1", json!({}), loopback());
+        assert_ne!(a.correlation_id, b.correlation_id);
+    }
+
+    #[test]
+    fn new_sets_created_at_ms() {
+        let env = RequestEnvelope::new("r1", json!({}), loopback());
+        assert!(env.created_at_ms > 0);
+    }
+
+    #[test]
+    fn headers_lowercased() {
+        let env = RequestEnvelope::new("r1", json!({}), loopback())
+            .with_header("Content-Type", "application/json")
+            .with_header("X-Api-Key", "secret");
+        assert_eq!(
+            env.headers.get("content-type"),
+            Some(&"application/json".to_string())
+        );
+        assert_eq!(
+            env.headers.get("x-api-key"),
+            Some(&"secret".to_string())
+        );
+    }
+
+    #[test]
+    fn is_expired_false_when_no_deadline() {
+        let env = RequestEnvelope::new("r1", json!({}), loopback());
+        assert!(!env.is_expired());
+    }
+
+    #[test]
+    fn is_expired_false_when_deadline_in_future() {
+        let env = RequestEnvelope::new("r1", json!({}), loopback())
+            .with_deadline(Instant::now() + Duration::from_secs(60));
+        assert!(!env.is_expired());
+    }
+
+    #[test]
+    fn is_expired_true_when_deadline_in_past() {
+        let past = Instant::now() - Duration::from_secs(1);
+        let env = RequestEnvelope::new("r1", json!({}), loopback()).with_deadline(past);
+        assert!(env.is_expired());
+    }
+
+    #[test]
+    fn deadline_unix_ms_none_when_no_deadline() {
+        let env = RequestEnvelope::new("r1", json!({}), loopback());
+        assert!(env.deadline_unix_ms().is_none());
+    }
+
+    #[test]
+    fn deadline_unix_ms_some_when_deadline_set() {
+        let env = RequestEnvelope::new("r1", json!({}), loopback())
+            .with_deadline(Instant::now() + Duration::from_secs(5));
+        assert!(env.deadline_unix_ms().is_some());
+    }
+
+    #[test]
+    fn envelope_serializes_without_deadline_field() {
+        let env = RequestEnvelope::new("r1", json!({"key": "val"}), loopback())
+            .with_deadline(Instant::now() + Duration::from_secs(10));
+        let json = serde_json::to_string(&env).unwrap();
+        assert!(!json.contains("deadline"));
+        assert!(json.contains("correlation_id"));
+        assert!(json.contains("created_at_ms"));
+    }
+
+    // ── GatewayResponse ──────────────────────────────────────────────────────
+
+    #[test]
+    fn gateway_response_latency_computed_from_envelope() {
+        let env = RequestEnvelope::new("r1", json!({}), loopback());
+        let resp = GatewayResponse::new(200, json!({"ok": true}), "agent-a", &env);
+        assert_eq!(resp.correlation_id, env.correlation_id);
+        // latency_ms must be >= 0 (saturating_sub guarantees this)
+        // and realistically < 1000ms for a test
+        assert!(resp.latency_ms < 1000);
+    }
+
+    #[test]
+    fn is_success_2xx() {
+        let env = RequestEnvelope::new("r1", json!({}), loopback());
+        assert!(GatewayResponse::new(200, json!({}), "a", &env).is_success());
+        assert!(GatewayResponse::new(204, json!({}), "a", &env).is_success());
+        assert!(!GatewayResponse::new(400, json!({}), "a", &env).is_success());
+    }
+
+    #[test]
+    fn is_client_error_4xx() {
+        let env = RequestEnvelope::new("r1", json!({}), loopback());
+        assert!(GatewayResponse::new(400, json!({}), "a", &env).is_client_error());
+        assert!(GatewayResponse::new(404, json!({}), "a", &env).is_client_error());
+        assert!(!GatewayResponse::new(500, json!({}), "a", &env).is_client_error());
+    }
+
+    #[test]
+    fn is_server_error_5xx() {
+        let env = RequestEnvelope::new("r1", json!({}), loopback());
+        assert!(GatewayResponse::new(500, json!({}), "a", &env).is_server_error());
+        assert!(GatewayResponse::new(504, json!({}), "a", &env).is_server_error());
+        assert!(!GatewayResponse::new(200, json!({}), "a", &env).is_server_error());
+    }
+
+    #[test]
+    fn gateway_response_serializes() {
+        let env = RequestEnvelope::new("r1", json!({}), loopback());
+        let resp = GatewayResponse::new(200, json!({"result": "ok"}), "agent-a", &env);
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("status_code"));
+        assert!(json.contains("latency_ms"));
+        assert!(json.contains("agent_id"));
+        assert!(json.contains("correlation_id"));
+    }
+}

--- a/crates/mofa-kernel/src/gateway/error.rs
+++ b/crates/mofa-kernel/src/gateway/error.rs
@@ -1,0 +1,40 @@
+//! Error types for the gateway routing layer.
+
+use thiserror::Error;
+
+/// Errors that can occur when interacting with a [`RouteRegistry`](super::route::RouteRegistry).
+#[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RegistryError {
+    /// The route `id` field is empty or whitespace-only.
+    #[error("route id cannot be empty")]
+    EmptyRouteId,
+
+    /// The route `agent_id` field is empty or whitespace-only.
+    #[error("agent id cannot be empty")]
+    EmptyAgentId,
+
+    /// The path pattern is invalid (empty, or does not start with `/`).
+    #[error("route '{0}' has an invalid path pattern: {1}")]
+    InvalidPathPattern(String, String),
+
+    /// A route with this ID is already registered.
+    #[error("route '{0}' is already registered")]
+    DuplicateRouteId(String),
+
+    /// No route with this ID is currently registered.
+    #[error("route '{0}' not found")]
+    RouteNotFound(String),
+
+    /// Two routes share the same path pattern, method, and priority — the
+    /// gateway cannot deterministically choose between them.
+    #[error(
+        "route '{0}' conflicts with existing route '{1}': \
+         same path pattern, method, and priority"
+    )]
+    ConflictingRoutes(String, String),
+
+    /// The route failed basic field validation.
+    #[error("route is invalid: {0}")]
+    InvalidRoute(String),
+}

--- a/crates/mofa-kernel/src/gateway/mod.rs
+++ b/crates/mofa-kernel/src/gateway/mod.rs
@@ -1,0 +1,25 @@
+//! Kernel-level gateway abstractions for agent request dispatch.
+//!
+//! This module defines the trait boundary between the gateway transport layer
+//! (HTTP, gRPC, MQTT, …) and the agent runtime.  By keeping routing logic in
+//! the kernel, alternative transports and unit tests can reason about routing
+//! without depending on the full HTTP stack.
+//!
+//! # Types
+//!
+//! | Type | Description |
+//! |------|-------------|
+//! | [`GatewayRoute`] | A routing rule mapping a path + method to an agent |
+//! | [`RouteRegistry`] | Trait for registering, looking up, and listing routes |
+//! | [`RoutingContext`] | Per-request dispatch context (path, method, headers, correlation ID) |
+//! | [`HttpMethod`] | HTTP method enum |
+//! | [`RegistryError`] | Error type for registry operations |
+
+pub mod error;
+pub mod route;
+
+#[cfg(test)]
+mod tests;
+
+pub use error::RegistryError;
+pub use route::{GatewayRoute, HttpMethod, RouteRegistry, RoutingContext};

--- a/crates/mofa-kernel/src/gateway/mod.rs
+++ b/crates/mofa-kernel/src/gateway/mod.rs
@@ -1,23 +1,20 @@
 //! Kernel-level gateway abstractions for agent request dispatch.
 //!
-//! This module defines the trait boundary between the gateway transport layer
-//! (HTTP, gRPC, MQTT, …) and the agent runtime.  By keeping routing and
-//! envelope logic in the kernel, alternative transports and unit tests can
-//! reason about the full request lifecycle without depending on the full HTTP
-//! stack.
-//!
-//! # Types
-//!
 //! | Type | Description |
 //! |------|-------------|
-//! | [`GatewayRoute`] | A routing rule mapping a path + method to an agent |
+//! | [`GatewayRoute`] | Routing rule mapping path + method to an agent |
 //! | [`RouteRegistry`] | Trait for registering, looking up, and listing routes |
-//! | [`RoutingContext`] | Per-request dispatch context (path, method, headers, correlation ID) |
+//! | [`RoutingContext`] | Per-request dispatch context |
 //! | [`HttpMethod`] | HTTP method enum |
 //! | [`RegistryError`] | Error type for registry operations |
-//! | [`RequestEnvelope`] | Typed inbound request envelope flowing through the pipeline |
-//! | [`GatewayResponse`] | Typed response for access logging, metrics, and admin API |
+//! | [`RequestEnvelope`] | Typed inbound request envelope |
+//! | [`GatewayResponse`] | Typed response for logging and metrics |
+//! | [`AuthClaims`] | Verified identity produced by any auth backend |
+//! | [`AuthProvider`] | Async trait for authenticating requests |
+//! | [`ApiKeyStore`] | Persistence trait for API key lifecycle |
+//! | [`AuthError`] | Auth failure error enum |
 
+pub mod auth;
 pub mod envelope;
 pub mod error;
 pub mod route;
@@ -25,6 +22,7 @@ pub mod route;
 #[cfg(test)]
 mod tests;
 
+pub use auth::{ApiKeyStore, AuthClaims, AuthError, AuthProvider};
 pub use envelope::{GatewayResponse, RequestEnvelope};
 pub use error::RegistryError;
 pub use route::{GatewayRoute, HttpMethod, RouteRegistry, RoutingContext};

--- a/crates/mofa-kernel/src/gateway/mod.rs
+++ b/crates/mofa-kernel/src/gateway/mod.rs
@@ -1,9 +1,10 @@
 //! Kernel-level gateway abstractions for agent request dispatch.
 //!
 //! This module defines the trait boundary between the gateway transport layer
-//! (HTTP, gRPC, MQTT, …) and the agent runtime.  By keeping routing logic in
-//! the kernel, alternative transports and unit tests can reason about routing
-//! without depending on the full HTTP stack.
+//! (HTTP, gRPC, MQTT, …) and the agent runtime.  By keeping routing and
+//! envelope logic in the kernel, alternative transports and unit tests can
+//! reason about the full request lifecycle without depending on the full HTTP
+//! stack.
 //!
 //! # Types
 //!
@@ -14,12 +15,16 @@
 //! | [`RoutingContext`] | Per-request dispatch context (path, method, headers, correlation ID) |
 //! | [`HttpMethod`] | HTTP method enum |
 //! | [`RegistryError`] | Error type for registry operations |
+//! | [`RequestEnvelope`] | Typed inbound request envelope flowing through the pipeline |
+//! | [`GatewayResponse`] | Typed response for access logging, metrics, and admin API |
 
+pub mod envelope;
 pub mod error;
 pub mod route;
 
 #[cfg(test)]
 mod tests;
 
+pub use envelope::{GatewayResponse, RequestEnvelope};
 pub use error::RegistryError;
 pub use route::{GatewayRoute, HttpMethod, RouteRegistry, RoutingContext};

--- a/crates/mofa-kernel/src/gateway/mod.rs
+++ b/crates/mofa-kernel/src/gateway/mod.rs
@@ -26,3 +26,6 @@ pub use auth::{ApiKeyStore, AuthClaims, AuthError, AuthProvider};
 pub use envelope::{GatewayResponse, RequestEnvelope};
 pub use error::RegistryError;
 pub use route::{GatewayRoute, HttpMethod, RouteRegistry, RoutingContext};
+
+pub mod routing;
+pub use routing::RoutingStrategy;

--- a/crates/mofa-kernel/src/gateway/route.rs
+++ b/crates/mofa-kernel/src/gateway/route.rs
@@ -1,0 +1,240 @@
+//! Core routing types and registry trait for agent request dispatch.
+//!
+//! [`GatewayRoute`] describes a single routing rule that maps an incoming
+//! HTTP path + method to a target agent.  [`RouteRegistry`] is the
+//! kernel-level trait any registry implementation must satisfy so that
+//! routing logic can be tested and extended without depending on the full
+//! HTTP stack.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use super::error::RegistryError;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// HTTP method
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Standard HTTP methods accepted by a gateway route.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum HttpMethod {
+    Get,
+    Post,
+    Put,
+    Patch,
+    Delete,
+    Head,
+    Options,
+}
+
+impl HttpMethod {
+    /// Case-insensitive parse from a string slice.  Returns `None` for unknown
+    /// method strings.
+    pub fn from_str_ci(s: &str) -> Option<Self> {
+        match s.to_ascii_uppercase().as_str() {
+            "GET" => Some(Self::Get),
+            "POST" => Some(Self::Post),
+            "PUT" => Some(Self::Put),
+            "PATCH" => Some(Self::Patch),
+            "DELETE" => Some(Self::Delete),
+            "HEAD" => Some(Self::Head),
+            "OPTIONS" => Some(Self::Options),
+            _ => None,
+        }
+    }
+
+    /// Return the standard uppercase string representation.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Get => "GET",
+            Self::Post => "POST",
+            Self::Put => "PUT",
+            Self::Patch => "PATCH",
+            Self::Delete => "DELETE",
+            Self::Head => "HEAD",
+            Self::Options => "OPTIONS",
+        }
+    }
+}
+
+impl std::fmt::Display for HttpMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GatewayRoute
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A single routing rule mapping an incoming HTTP path + method to a target
+/// agent.
+///
+/// Routes can be toggled at runtime via the [`enabled`](GatewayRoute::enabled)
+/// flag without having to deregister and re-register them.  This allows
+/// operators to disable a route during maintenance without losing its
+/// configuration.
+///
+/// # Priority
+///
+/// When multiple routes match the same `(path_pattern, method)` pair, the
+/// route with the **highest** `priority` value wins.  Two routes that share
+/// the same path, method, *and* priority value represent a conflict; see
+/// [`RouteRegistry::register`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GatewayRoute {
+    /// Stable, unique identifier for this route.
+    pub id: String,
+    /// ID of the agent that will handle matching requests.
+    pub agent_id: String,
+    /// URL path pattern, e.g. `/agents/summarizer` or `/v1/models/{model_id}`.
+    /// Must begin with `/`.
+    pub path_pattern: String,
+    /// HTTP method this route accepts.
+    pub method: HttpMethod,
+    /// Numeric priority — higher values are evaluated first.
+    /// Defaults to `0`.
+    pub priority: i32,
+    /// Whether this route is currently active.  Disabled routes are never
+    /// returned by [`RouteRegistry::list_active`] and never matched at
+    /// dispatch time.
+    pub enabled: bool,
+}
+
+impl GatewayRoute {
+    /// Create a new, enabled route with default priority.
+    pub fn new(
+        id: impl Into<String>,
+        agent_id: impl Into<String>,
+        path_pattern: impl Into<String>,
+        method: HttpMethod,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            agent_id: agent_id.into(),
+            path_pattern: path_pattern.into(),
+            method,
+            priority: 0,
+            enabled: true,
+        }
+    }
+
+    /// Set the routing priority.
+    pub fn with_priority(mut self, priority: i32) -> Self {
+        self.priority = priority;
+        self
+    }
+
+    /// Mark this route as disabled at creation time.
+    pub fn disabled(mut self) -> Self {
+        self.enabled = false;
+        self
+    }
+
+    /// Validate that mandatory fields are well-formed.
+    pub fn validate(&self) -> Result<(), RegistryError> {
+        if self.id.trim().is_empty() {
+            return Err(RegistryError::EmptyRouteId);
+        }
+        if self.agent_id.trim().is_empty() {
+            return Err(RegistryError::EmptyAgentId);
+        }
+        if self.path_pattern.trim().is_empty() || !self.path_pattern.starts_with('/') {
+            return Err(RegistryError::InvalidPathPattern(
+                self.id.clone(),
+                "path pattern must be non-empty and start with '/'".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RouteRegistry trait
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Kernel contract for a route registry.
+///
+/// Implementations must be `Send + Sync` so they can be wrapped in an `Arc`
+/// and shared across Tokio tasks without additional synchronisation.
+///
+/// # Conflict policy
+///
+/// Registering two routes with the same `(path_pattern, method)` pair *and*
+/// the same `priority` is an error ([`RegistryError::ConflictingRoutes`]).
+/// Routes that share the same pattern and method but differ in priority are
+/// accepted; the higher-priority route wins at dispatch time.
+pub trait RouteRegistry: Send + Sync {
+    /// Register a new route.
+    ///
+    /// # Errors
+    ///
+    /// * [`RegistryError::DuplicateRouteId`] — a route with the same `id` is
+    ///   already registered.
+    /// * [`RegistryError::ConflictingRoutes`] — another route with the same
+    ///   `(path_pattern, method, priority)` triple already exists.
+    /// * [`RegistryError::InvalidRoute`] — the route fails field validation.
+    fn register(&mut self, route: GatewayRoute) -> Result<(), RegistryError>;
+
+    /// Remove a previously registered route by its ID.
+    ///
+    /// # Errors
+    ///
+    /// * [`RegistryError::RouteNotFound`] — no route with the given `id` is
+    ///   registered.
+    fn deregister(&mut self, route_id: &str) -> Result<(), RegistryError>;
+
+    /// Look up a route by its stable ID, regardless of whether it is enabled.
+    ///
+    /// Returns `None` when no route with the given `id` is registered.
+    fn lookup(&self, route_id: &str) -> Option<&GatewayRoute>;
+
+    /// Return references to all **enabled** routes, sorted by descending
+    /// priority (highest first).
+    fn list_active(&self) -> Vec<&GatewayRoute>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RoutingContext
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Information available at dispatch time, passed to routing strategies so
+/// they can make decisions without depending on the raw HTTP request type.
+///
+/// The `correlation_id` field is a per-request identifier that flows through
+/// the entire system for distributed tracing and log correlation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoutingContext {
+    /// Incoming request path, e.g. `/agents/summarizer`.
+    pub path: String,
+    /// HTTP method of the incoming request.
+    pub method: HttpMethod,
+    /// Parsed request headers.  Keys are lowercased for case-insensitive
+    /// lookup (e.g. `"content-type"`).
+    pub headers: HashMap<String, String>,
+    /// Per-request correlation identifier for distributed tracing.
+    pub correlation_id: String,
+}
+
+impl RoutingContext {
+    /// Create a minimal context with no headers.
+    pub fn new(
+        path: impl Into<String>,
+        method: HttpMethod,
+        correlation_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            path: path.into(),
+            method,
+            headers: HashMap::new(),
+            correlation_id: correlation_id.into(),
+        }
+    }
+
+    /// Builder: insert a header (key is lowercased automatically).
+    pub fn with_header(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.headers.insert(key.into().to_lowercase(), value.into());
+        self
+    }
+}

--- a/crates/mofa-kernel/src/gateway/routing.rs
+++ b/crates/mofa-kernel/src/gateway/routing.rs
@@ -1,0 +1,24 @@
+//! Kernel-level routing strategy trait.
+//!
+//! [`RoutingStrategy`] is the single contract every routing backend must
+//! implement.  Concrete strategies (weighted round-robin, capability-match,
+//! etc.) live in `mofa-foundation`.
+
+use super::envelope::RequestEnvelope;
+
+/// Kernel contract for a request routing strategy.
+///
+/// Given an inbound [`RequestEnvelope`], the strategy returns the agent ID
+/// that should handle the request, or `None` when no suitable agent is
+/// available (e.g. all backends are unhealthy or the capability threshold is
+/// not met).
+///
+/// Implementations must be `Send + Sync` so they can be held behind an `Arc`
+/// and called concurrently from multiple Tokio tasks.
+pub trait RoutingStrategy: Send + Sync {
+    /// Select an agent for the given request.
+    ///
+    /// Returns `Some(agent_id)` on success, `None` when the strategy cannot
+    /// select an agent.
+    fn select_agent(&self, envelope: &RequestEnvelope) -> Option<String>;
+}

--- a/crates/mofa-kernel/src/gateway/tests.rs
+++ b/crates/mofa-kernel/src/gateway/tests.rs
@@ -1,0 +1,281 @@
+//! Unit tests for GatewayRoute, RouteRegistry, and RoutingContext.
+//!
+//! Uses an `InMemoryRouteRegistry` defined here for testing purposes only —
+//! the concrete registry implementation lives in `mofa-foundation`.
+
+use std::collections::HashMap;
+
+use super::error::RegistryError;
+use super::route::{GatewayRoute, HttpMethod, RouteRegistry, RoutingContext};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Minimal in-test registry implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+struct InMemoryRouteRegistry {
+    routes: HashMap<String, GatewayRoute>,
+}
+
+impl InMemoryRouteRegistry {
+    fn new() -> Self {
+        Self {
+            routes: HashMap::new(),
+        }
+    }
+}
+
+impl RouteRegistry for InMemoryRouteRegistry {
+    fn register(&mut self, route: GatewayRoute) -> Result<(), RegistryError> {
+        route
+            .validate()
+            .map_err(|e| RegistryError::InvalidRoute(e.to_string()))?;
+
+        if self.routes.contains_key(&route.id) {
+            return Err(RegistryError::DuplicateRouteId(route.id.clone()));
+        }
+
+        // Conflict: same (path_pattern, method, priority) as an existing route.
+        for existing in self.routes.values() {
+            if existing.path_pattern == route.path_pattern
+                && existing.method == route.method
+                && existing.priority == route.priority
+            {
+                return Err(RegistryError::ConflictingRoutes(
+                    route.id.clone(),
+                    existing.id.clone(),
+                ));
+            }
+        }
+
+        self.routes.insert(route.id.clone(), route);
+        Ok(())
+    }
+
+    fn deregister(&mut self, route_id: &str) -> Result<(), RegistryError> {
+        if self.routes.remove(route_id).is_none() {
+            return Err(RegistryError::RouteNotFound(route_id.to_string()));
+        }
+        Ok(())
+    }
+
+    fn lookup(&self, route_id: &str) -> Option<&GatewayRoute> {
+        self.routes.get(route_id)
+    }
+
+    fn list_active(&self) -> Vec<&GatewayRoute> {
+        let mut active: Vec<&GatewayRoute> =
+            self.routes.values().filter(|r| r.enabled).collect();
+        active.sort_by(|a, b| b.priority.cmp(&a.priority));
+        active
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GatewayRoute tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn gateway_route_new_defaults() {
+    let route = GatewayRoute::new("r1", "agent-a", "/agents/summarizer", HttpMethod::Post);
+    assert_eq!(route.id, "r1");
+    assert_eq!(route.agent_id, "agent-a");
+    assert_eq!(route.path_pattern, "/agents/summarizer");
+    assert_eq!(route.method, HttpMethod::Post);
+    assert_eq!(route.priority, 0);
+    assert!(route.enabled);
+}
+
+#[test]
+fn gateway_route_builder() {
+    let route = GatewayRoute::new("r1", "agent-a", "/path", HttpMethod::Get)
+        .with_priority(10)
+        .disabled();
+    assert_eq!(route.priority, 10);
+    assert!(!route.enabled);
+}
+
+#[test]
+fn gateway_route_validate_empty_id() {
+    let route = GatewayRoute::new("", "agent-a", "/path", HttpMethod::Get);
+    assert!(matches!(route.validate(), Err(RegistryError::EmptyRouteId)));
+}
+
+#[test]
+fn gateway_route_validate_empty_agent_id() {
+    let route = GatewayRoute::new("r1", "", "/path", HttpMethod::Get);
+    assert!(matches!(route.validate(), Err(RegistryError::EmptyAgentId)));
+}
+
+#[test]
+fn gateway_route_validate_invalid_path() {
+    let route = GatewayRoute::new("r1", "agent-a", "no-leading-slash", HttpMethod::Get);
+    assert!(matches!(
+        route.validate(),
+        Err(RegistryError::InvalidPathPattern(_, _))
+    ));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RouteRegistry tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn register_and_lookup() {
+    let mut reg = InMemoryRouteRegistry::new();
+    let route = GatewayRoute::new("r1", "agent-a", "/agents/summarizer", HttpMethod::Post);
+    reg.register(route).unwrap();
+
+    let found = reg.lookup("r1").unwrap();
+    assert_eq!(found.agent_id, "agent-a");
+}
+
+#[test]
+fn lookup_missing_returns_none() {
+    let reg = InMemoryRouteRegistry::new();
+    assert!(reg.lookup("does-not-exist").is_none());
+}
+
+#[test]
+fn register_duplicate_id_is_error() {
+    let mut reg = InMemoryRouteRegistry::new();
+    let r1 = GatewayRoute::new("r1", "agent-a", "/path", HttpMethod::Get);
+    let r2 = GatewayRoute::new("r1", "agent-b", "/other", HttpMethod::Post);
+    reg.register(r1).unwrap();
+    assert!(matches!(
+        reg.register(r2),
+        Err(RegistryError::DuplicateRouteId(_))
+    ));
+}
+
+#[test]
+fn deregister_removes_route() {
+    let mut reg = InMemoryRouteRegistry::new();
+    reg.register(GatewayRoute::new("r1", "agent-a", "/path", HttpMethod::Get))
+        .unwrap();
+    reg.deregister("r1").unwrap();
+    assert!(reg.lookup("r1").is_none());
+}
+
+#[test]
+fn deregister_missing_is_error() {
+    let mut reg = InMemoryRouteRegistry::new();
+    assert!(matches!(
+        reg.deregister("ghost"),
+        Err(RegistryError::RouteNotFound(_))
+    ));
+}
+
+#[test]
+fn list_active_excludes_disabled_routes() {
+    let mut reg = InMemoryRouteRegistry::new();
+    reg.register(GatewayRoute::new("r1", "agent-a", "/active", HttpMethod::Get))
+        .unwrap();
+    reg.register(
+        GatewayRoute::new("r2", "agent-b", "/disabled", HttpMethod::Post).disabled(),
+    )
+    .unwrap();
+
+    let active = reg.list_active();
+    assert_eq!(active.len(), 1);
+    assert_eq!(active[0].id, "r1");
+}
+
+#[test]
+fn list_active_sorted_by_descending_priority() {
+    let mut reg = InMemoryRouteRegistry::new();
+    reg.register(
+        GatewayRoute::new("low", "agent-a", "/low", HttpMethod::Get).with_priority(1),
+    )
+    .unwrap();
+    reg.register(
+        GatewayRoute::new("high", "agent-b", "/high", HttpMethod::Post).with_priority(10),
+    )
+    .unwrap();
+    reg.register(
+        GatewayRoute::new("mid", "agent-c", "/mid", HttpMethod::Put).with_priority(5),
+    )
+    .unwrap();
+
+    let active = reg.list_active();
+    assert_eq!(active[0].id, "high");
+    assert_eq!(active[1].id, "mid");
+    assert_eq!(active[2].id, "low");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Conflict detection tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn conflict_same_path_method_and_equal_priority() {
+    let mut reg = InMemoryRouteRegistry::new();
+    reg.register(GatewayRoute::new("r1", "agent-a", "/v1/chat", HttpMethod::Post))
+        .unwrap();
+    // Same path, method, and priority (0) as r1 — must be rejected.
+    let result = reg.register(GatewayRoute::new("r2", "agent-b", "/v1/chat", HttpMethod::Post));
+    assert!(
+        matches!(result, Err(RegistryError::ConflictingRoutes(ref new, ref existing))
+            if new == "r2" && existing == "r1"),
+        "expected ConflictingRoutes(r2, r1), got {result:?}"
+    );
+}
+
+#[test]
+fn no_conflict_same_path_method_different_priority() {
+    let mut reg = InMemoryRouteRegistry::new();
+    reg.register(GatewayRoute::new("r1", "agent-a", "/v1/chat", HttpMethod::Post))
+        .unwrap();
+    // Different priority — should succeed.
+    reg.register(
+        GatewayRoute::new("r2", "agent-b", "/v1/chat", HttpMethod::Post).with_priority(1),
+    )
+    .unwrap();
+    assert!(reg.lookup("r2").is_some());
+}
+
+#[test]
+fn no_conflict_same_path_different_method() {
+    let mut reg = InMemoryRouteRegistry::new();
+    reg.register(GatewayRoute::new("r1", "agent-a", "/v1/chat", HttpMethod::Post))
+        .unwrap();
+    reg.register(GatewayRoute::new("r2", "agent-b", "/v1/chat", HttpMethod::Get))
+        .unwrap();
+    assert_eq!(reg.list_active().len(), 2);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RoutingContext tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn routing_context_new() {
+    let ctx = RoutingContext::new("/agents/summarizer", HttpMethod::Post, "req-abc-123");
+    assert_eq!(ctx.path, "/agents/summarizer");
+    assert_eq!(ctx.method, HttpMethod::Post);
+    assert_eq!(ctx.correlation_id, "req-abc-123");
+    assert!(ctx.headers.is_empty());
+}
+
+#[test]
+fn routing_context_headers_are_lowercased() {
+    let ctx = RoutingContext::new("/path", HttpMethod::Get, "cid-1")
+        .with_header("Content-Type", "application/json")
+        .with_header("X-Api-Key", "secret");
+
+    assert_eq!(
+        ctx.headers.get("content-type"),
+        Some(&"application/json".to_string())
+    );
+    assert_eq!(
+        ctx.headers.get("x-api-key"),
+        Some(&"secret".to_string())
+    );
+}
+
+#[test]
+fn http_method_from_str_ci() {
+    assert_eq!(HttpMethod::from_str_ci("get"), Some(HttpMethod::Get));
+    assert_eq!(HttpMethod::from_str_ci("POST"), Some(HttpMethod::Post));
+    assert_eq!(HttpMethod::from_str_ci("pAtCh"), Some(HttpMethod::Patch));
+    assert_eq!(HttpMethod::from_str_ci("UNKNOWN"), None);
+}

--- a/crates/mofa-kernel/src/lib.rs
+++ b/crates/mofa-kernel/src/lib.rs
@@ -74,3 +74,7 @@ pub mod structured_output;
 pub use structured_output::StructuredOutput;
 // Security governance (PII redaction, content moderation, prompt guard)
 pub mod security;
+
+// Gateway routing abstractions (kernel-level traits for agent request dispatch)
+pub mod gateway;
+pub use gateway::{GatewayRoute, HttpMethod, RegistryError, RouteRegistry, RoutingContext};

--- a/crates/mofa-kernel/src/lib.rs
+++ b/crates/mofa-kernel/src/lib.rs
@@ -77,4 +77,7 @@ pub mod security;
 
 // Gateway routing abstractions (kernel-level traits for agent request dispatch)
 pub mod gateway;
-pub use gateway::{GatewayRoute, HttpMethod, RegistryError, RouteRegistry, RoutingContext};
+pub use gateway::{
+    GatewayResponse, GatewayRoute, HttpMethod, RegistryError, RequestEnvelope, RouteRegistry,
+    RoutingContext,
+};

--- a/crates/mofa-kernel/src/lib.rs
+++ b/crates/mofa-kernel/src/lib.rs
@@ -78,6 +78,7 @@ pub mod security;
 // Gateway routing abstractions (kernel-level traits for agent request dispatch)
 pub mod gateway;
 pub use gateway::{
-    GatewayResponse, GatewayRoute, HttpMethod, RegistryError, RequestEnvelope, RouteRegistry,
+    ApiKeyStore, AuthClaims, AuthError, AuthProvider, GatewayResponse, GatewayRoute, HttpMethod,
+    RegistryError, RequestEnvelope, RouteRegistry,
     RoutingContext,
 };

--- a/crates/mofa-kernel/src/lib.rs
+++ b/crates/mofa-kernel/src/lib.rs
@@ -79,6 +79,7 @@ pub mod security;
 pub mod gateway;
 pub use gateway::{
     ApiKeyStore, AuthClaims, AuthError, AuthProvider, GatewayResponse, GatewayRoute, HttpMethod,
+    RoutingStrategy,
     RegistryError, RequestEnvelope, RouteRegistry,
     RoutingContext,
 };


### PR DESCRIPTION
Closes #704

---

## What

Adds a TOML-based gateway configuration system to `mofa-foundation/src/gateway/config.rs`:

- `GatewayConfig` — top-level config struct: `default_auth_provider`, `routes: Vec<RouteConfig>`, `rate_limit_profiles: HashMap<String, RateLimitProfile>`
- `RouteConfig` — per-route definition with `id`, `path_pattern`, `method`, `agent_id`, `strategy`, `timeout_ms`, `rate_limit`, `enabled` — derives `Deserialize`/`Serialize`, converts to kernel `GatewayRoute` via `to_gateway_route()`
- `RateLimitProfile` — named rate-limit config referenced by routes
- `GatewayConfigLoader::load_from_file` — parses TOML from disk
- `GatewayConfigLoader::watch` — watches a file with `notify`, debounces rapid writes with a 200 ms settling window, emits `GatewayConfig` on a `tokio::sync::mpsc::Sender`
- `diff_configs` — computes `ConfigDiff` (added / removed / modified route IDs) between two configs so `apply_config` can update only changed routes without touching in-flight ones
- `crates/mofa-gateway/gateway.example.toml` — two-route example (weighted round-robin + capability-match)

---

## Why

Every route, rate limit, and routing strategy is currently defined in code. Any change requires recompilation and a full process restart, interrupting in-flight requests. This PR introduces a declarative config layer so operators can update gateway policy at runtime.

---

## Design decisions

**Debounce via per-event thread sleep** — on each write event the handler records `Instant::now()` behind a `Mutex`, sleeps 200 ms, then checks whether a newer event has arrived. If yes, it skips the reload. This handles the "editor writes via temp file then rename" pattern without pulling in a debounce crate or spawning a dedicated timer task.

**`diff_configs` is pure** — takes two `&GatewayConfig` values and returns a `ConfigDiff` with no side effects. The caller (`apply_config` in the dispatch layer) decides what to do with the diff. This keeps the config module testable without needing a live registry.

**`RouteConfig` aliases `route_config` not `GatewayRoute`** — the TOML schema has a `method: String` rather than `HttpMethod` because TOML users shouldn't have to know the enum. `to_gateway_route()` does the conversion and returns `None` for unrecognised method strings rather than panicking.

**`notify` dep is workspace-wide** — `notify` was already in the workspace root `Cargo.toml`; only the `mofa-foundation` dep entry needed adding.

---

## Changes

```
crates/mofa-foundation/src/gateway/
└── config.rs          — GatewayConfig, RouteConfig, RateLimitProfile,
                         GatewayConfigLoader, diff_configs, ConfigDiff, ConfigError (new)

crates/mofa-foundation/src/gateway/mod.rs   — config module wired in
crates/mofa-foundation/src/lib.rs           — new types re-exported
crates/mofa-foundation/Cargo.toml           — notify workspace dep added
crates/mofa-gateway/gateway.example.toml   — two-route example config (new)
```

---

## Tests (17 tests)

| Category | Tests |
|---|---|
| Parse | round-trip serialise → deserialise, route count, route fields, profile fields |
| Defaults | `strategy` defaults to `weighted_round_robin`, `enabled` defaults to `true` |
| Conversion | `to_gateway_route` correct method, invalid method returns `None` |
| File loading | success, missing file → `Io` error, invalid TOML → `Parse` error |
| Diff | no changes, added route, removed route, modified route, combined changes |
| Debounce | two writes within 50 ms produce at most one reload after 200 ms window |

```
test result: ok. 17 passed; 0 failed
```
