### PR TITLE
fix: cache regexes, add #[non_exhaustive]

### DIFF
--- a/crates/mofa-foundation/src/agent/components/tool.rs
+++ b/crates/mofa-foundation/src/agent/components/tool.rs
@@ -26,6 +26,7 @@ use std::sync::Arc;
 ///
 /// Foundation-specific extension for tool categorization
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum ToolCategory {
     /// File operations (read, write, edit)
     File,

--- a/crates/mofa-foundation/src/prompt/builder.rs
+++ b/crates/mofa-foundation/src/prompt/builder.rs
@@ -174,10 +174,9 @@ impl PromptBuilder {
 
         // 查找所有变量
         // Find all variables
-        let re = regex::Regex::new(r"\{(\w+)\}").unwrap();
         let mut missing = Vec::new();
 
-        for cap in re.captures_iter(content) {
+        for cap in super::regex::VARIABLE_PLACEHOLDER_RE.captures_iter(content) {
             let var_name = &cap[1];
             if let Some(value) = self.variables.get(var_name) {
                 let placeholder = format!("{{{}}}", var_name);
@@ -280,11 +279,10 @@ impl PromptBuilder {
     /// 获取所有需要的变量名
     /// Get all required variable names
     pub fn required_variables(&self) -> Vec<String> {
-        let re = regex::Regex::new(r"\{(\w+)\}").unwrap();
         let mut vars = std::collections::HashSet::new();
 
         for entry in &self.messages {
-            for cap in re.captures_iter(&entry.content) {
+            for cap in super::regex::VARIABLE_PLACEHOLDER_RE.captures_iter(&entry.content) {
                 vars.insert(cap[1].to_string());
             }
         }

--- a/crates/mofa-foundation/src/prompt/mod.rs
+++ b/crates/mofa-foundation/src/prompt/mod.rs
@@ -22,6 +22,7 @@
 mod builder;
 mod hot_reload;
 mod memory_store;
+mod regex;
 mod plugin;
 mod presets;
 mod registry;

--- a/crates/mofa-foundation/src/prompt/regex.rs
+++ b/crates/mofa-foundation/src/prompt/regex.rs
@@ -1,0 +1,10 @@
+//! Cached regex patterns for prompt variable substitution.
+//!
+//! Per project standards: regex objects with high compilation costs MUST be
+//! cached using LazyLock or OnceLock.
+
+use std::sync::LazyLock;
+
+/// Cached regex for template variable placeholders: `{var_name}`
+pub(crate) static VARIABLE_PLACEHOLDER_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"\{(\w+)\}").unwrap());

--- a/crates/mofa-foundation/src/prompt/template.rs
+++ b/crates/mofa-foundation/src/prompt/template.rs
@@ -372,10 +372,9 @@ impl PromptTemplate {
     /// 获取模板中所有变量名（从内容中解析）
     /// Get all template variable names (parse from content)
     pub fn extract_variables(&self) -> Vec<String> {
-        let re = regex::Regex::new(r"\{(\w+)\}").unwrap();
         let mut vars = std::collections::HashSet::new();
 
-        for cap in re.captures_iter(&self.content) {
+        for cap in super::regex::VARIABLE_PLACEHOLDER_RE.captures_iter(&self.content) {
             vars.insert(cap[1].to_string());
         }
 
@@ -441,14 +440,13 @@ impl PromptTemplate {
 
         // 然后处理模板中存在但未在 variables 中预定义的变量
         // Then handle variables in template not predefined in variables
-        let re = regex::Regex::new(r"\{(\w+)\}").unwrap();
         let defined_vars: std::collections::HashSet<_> =
             self.variables.iter().map(|v| v.name.as_str()).collect();
 
         // 收集所有未定义但在模板中出现的变量
         // Collect all undefined variables appearing in template
         let mut missing = Vec::new();
-        for cap in re.captures_iter(&result.clone()) {
+        for cap in super::regex::VARIABLE_PLACEHOLDER_RE.captures_iter(&result.clone()) {
             let var_name = &cap[1];
             if !defined_vars.contains(var_name) {
                 if let Some(&value) = vars.get(var_name) {
@@ -509,11 +507,10 @@ impl PromptTemplate {
 
         // 检查模板中的未定义变量
         // Check undefined variables in template
-        let re = regex::Regex::new(r"\{(\w+)\}").unwrap();
         let defined_vars: std::collections::HashSet<_> =
             self.variables.iter().map(|v| v.name.as_str()).collect();
 
-        for cap in re.captures_iter(&self.content) {
+        for cap in super::regex::VARIABLE_PLACEHOLDER_RE.captures_iter(&self.content) {
             let var_name = &cap[1];
             // 如果变量未在预定义列表中，且未在提供的变量中
             // If variable not in predefined list and not in provided variables

--- a/crates/mofa-kernel/src/config/mod.rs
+++ b/crates/mofa-kernel/src/config/mod.rs
@@ -14,6 +14,15 @@ use config::{Config as Cfg, Environment, File, FileFormat};
 use regex::Regex;
 use serde::de::DeserializeOwned;
 use std::path::Path;
+use std::sync::LazyLock;
+
+/// Cached regex for braced env var syntax: `${VAR_NAME}`
+static ENV_VAR_BRACED_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}").unwrap());
+
+/// Cached regex for simple env var syntax: `$VAR_NAME`
+static ENV_VAR_SIMPLE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\$([A-Za-z_][A-Za-z0-9_]*)\b").unwrap());
 
 /// Configuration format detection error
 #[derive(Debug, thiserror::Error)]
@@ -94,8 +103,7 @@ pub fn substitute_env_vars(content: &str) -> String {
     let mut result = content.to_string();
 
     // Match ${VAR_NAME} pattern (braced syntax - higher priority)
-    let re_braced = Regex::new(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}").unwrap();
-    result = re_braced
+    result = ENV_VAR_BRACED_RE
         .replace_all(&result, |caps: &regex::Captures| {
             let var_name = &caps[1];
             std::env::var(var_name).unwrap_or_else(|_| caps[0].to_string())
@@ -104,8 +112,7 @@ pub fn substitute_env_vars(content: &str) -> String {
 
     // Match $VAR_NAME pattern (non-braced, but only if not already substituted)
     // This regex matches $ followed by a valid identifier name
-    let re_simple = Regex::new(r"\$([A-Za-z_][A-Za-z0-9_]*)\b").unwrap();
-    result = re_simple
+    result = ENV_VAR_SIMPLE_RE
         .replace_all(&result, |caps: &regex::Captures| {
             let var_name = &caps[1];
             std::env::var(var_name).unwrap_or_else(|_| caps[0].to_string())

--- a/crates/mofa-monitoring/src/dashboard/prometheus.rs
+++ b/crates/mofa-monitoring/src/dashboard/prometheus.rs
@@ -13,6 +13,12 @@ use tracing::{debug, warn};
 
 const OTHER_LABEL_VALUE: &str = "__other__";
 
+/// Default cardinality limits for exported label dimensions.
+const DEFAULT_AGENT_ID_LIMIT: usize = 100;
+const DEFAULT_WORKFLOW_ID_LIMIT: usize = 100;
+const DEFAULT_PLUGIN_OR_TOOL_LIMIT: usize = 100;
+const DEFAULT_PROVIDER_MODEL_LIMIT: usize = 50;
+
 /// Cardinality limits for exported label dimensions.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
@@ -30,10 +36,10 @@ pub struct CardinalityLimits {
 impl Default for CardinalityLimits {
     fn default() -> Self {
         Self {
-            agent_id: 100,
-            workflow_id: 100,
-            plugin_or_tool: 100,
-            provider_model: 50,
+            agent_id: DEFAULT_AGENT_ID_LIMIT,
+            workflow_id: DEFAULT_WORKFLOW_ID_LIMIT,
+            plugin_or_tool: DEFAULT_PLUGIN_OR_TOOL_LIMIT,
+            provider_model: DEFAULT_PROVIDER_MODEL_LIMIT,
         }
     }
 }

--- a/crates/mofa-plugins/src/skill/parser.rs
+++ b/crates/mofa-plugins/src/skill/parser.rs
@@ -6,6 +6,12 @@ use mofa_kernel::plugin::{PluginError, PluginResult};
 use regex::Regex;
 use std::fs;
 use std::path::Path;
+use std::sync::LazyLock;
+
+/// Cached regex for SKILL.md YAML frontmatter parsing.
+/// Use [\s\S]*? instead of .*? to match newlines in YAML content.
+static FRONTMATTER_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$").unwrap());
 
 /// SKILL.md 解析器
 /// SKILL.md parser
@@ -15,10 +21,7 @@ impl SkillParser {
     /// 解析 YAML frontmatter
     /// Parse YAML frontmatter
     pub fn parse_frontmatter(content: &str) -> PluginResult<(SkillMetadata, String)> {
-        // Use [\s\S]*? instead of .*? to match newlines in YAML content
-        let frontmatter_regex = Regex::new(r"^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$").unwrap();
-
-        if let Some(caps) = frontmatter_regex.captures(content) {
+        if let Some(caps) = FRONTMATTER_RE.captures(content) {
             let yaml = &caps[1];
             let markdown = &caps[2];
 


### PR DESCRIPTION
# refactor: align with project coding standards (regex caching, non_exhaustive, constants)

## Summary

Addresses code quality and maintainability issues identified during codebase review. Changes align with MoFA project standards documented in `.cursorrules` and `CLAUDE.md`.

## Changes

### 1. Regex Caching (Performance)

Per project standards: *"Objects with high compilation costs like regular expressions MUST be cached using LazyLock or OnceLock"*

- **mofa-kernel** (`config/mod.rs`): Cache `ENV_VAR_BRACED_RE` and `ENV_VAR_SIMPLE_RE` for `${VAR}` and `$VAR` substitution instead of compiling on every `substitute_env_vars()` call
- **mofa-foundation** (`prompt/`): Add shared `VARIABLE_PLACEHOLDER_RE` in new `regex.rs` module; use in `template.rs` and `builder.rs` for `{var_name}` placeholder parsing
- **mofa-plugins** (`skill/parser.rs`): Cache `FRONTMATTER_RE` for SKILL.md YAML frontmatter parsing

### 2. API Stability (`#[non_exhaustive]`)

Per project standards: *"MUST add the #[non_exhaustive] attribute to public enums"*

- **mofa-foundation** (`agent/components/tool.rs`): Add `#[non_exhaustive]` to `ToolCategory` enum for backward-compatible future extensibility

### 3. Named Constants (Code Quality)

Per project standards: *"Replace hard-coded values with named constants"*

- **mofa-monitoring** (`dashboard/prometheus.rs`): Replace magic numbers in `CardinalityLimits::default()` with named constants (`DEFAULT_AGENT_ID_LIMIT`, `DEFAULT_WORKFLOW_ID_LIMIT`, `DEFAULT_PLUGIN_OR_TOOL_LIMIT`, `DEFAULT_PROVIDER_MODEL_LIMIT`)

## Files Changed

| Crate | File | Change |
|-------|------|--------|
| mofa-kernel | `config/mod.rs` | LazyLock-cached env var regexes |
| mofa-foundation | `prompt/regex.rs` | **New** – shared variable placeholder regex |
| mofa-foundation | `prompt/mod.rs` | Add `mod regex` |
| mofa-foundation | `prompt/template.rs` | Use cached regex |
| mofa-foundation | `prompt/builder.rs` | Use cached regex |
| mofa-foundation | `agent/components/tool.rs` | `#[non_exhaustive]` on `ToolCategory` |
| mofa-plugins | `skill/parser.rs` | LazyLock-cached frontmatter regex |
| mofa-monitoring | `dashboard/prometheus.rs` | Named constants for cardinality limits |

## Testing

- `cargo build` succeeds
- No behavioral changes; existing tests remain valid
