### PR TITLE
feat(gateway): implement admin REST API for live route inspection and dynamic agent registration (Phase 8/10)

### DIFF
--- a/crates/mofa-gateway/Cargo.toml
+++ b/crates/mofa-gateway/Cargo.toml
@@ -29,6 +29,7 @@ chrono.workspace = true
 
 # Local dependencies
 mofa-kernel = { path = "../mofa-kernel", version = "0.1", features = ["config"] }
+mofa-foundation = { path = "../mofa-foundation", version = "0.1" }
 mofa-runtime = { path = "../mofa-runtime", version = "0.1" }
 mofa-monitoring = { path = "../mofa-monitoring", version = "0.1", optional = true }
 

--- a/crates/mofa-gateway/src/admin/handlers.rs
+++ b/crates/mofa-gateway/src/admin/handlers.rs
@@ -235,7 +235,7 @@ pub fn admin_router() -> Router<Arc<AdminState>> {
     Router::new()
         .route("/admin/routes", get(list_routes).post(register_route))
         .route(
-            "/admin/routes/{id}",
+            "/admin/routes/:id",
             delete(deregister_route).patch(toggle_route),
         )
         .route("/admin/health", get(admin_health))

--- a/crates/mofa-gateway/src/admin/handlers.rs
+++ b/crates/mofa-gateway/src/admin/handlers.rs
@@ -1,0 +1,242 @@
+//! Admin API request handlers.
+
+use std::sync::Arc;
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::{HeaderMap, StatusCode},
+    response::IntoResponse,
+    routing::{delete, get, patch, post},
+    Router,
+};
+use serde_json::json;
+
+use mofa_kernel::gateway::route::GatewayRoute;
+
+use super::state::{AdminState, parse_method};
+use super::types::{AdminRouteEntry, GatewayHealthSummary, RegisterRouteRequest};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Auth guard
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Extract and verify the `X-Admin-Key` header.  Returns `Err(401)` on
+/// missing or invalid credentials.
+fn require_auth(
+    headers: &HeaderMap,
+    state: &AdminState,
+) -> Result<(), (StatusCode, axum::Json<serde_json::Value>)> {
+    let key = headers
+        .get("x-admin-key")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    if state.verify_key(key) {
+        Ok(())
+    } else {
+        Err((
+            StatusCode::UNAUTHORIZED,
+            Json(json!({ "error": { "code": "UNAUTHORIZED", "message": "invalid or missing X-Admin-Key" } })),
+        ))
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /admin/routes
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// List all registered routes with per-route request counts.
+pub async fn list_routes(
+    State(state): State<Arc<AdminState>>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    if let Err(e) = require_auth(&headers, &state) {
+        return e.into_response();
+    }
+
+    let entries: Vec<AdminRouteEntry> = state
+        .list_routes()
+        .into_iter()
+        .map(|(r, count)| AdminRouteEntry {
+            id: r.id,
+            path_pattern: r.path_pattern,
+            agent_id: r.agent_id,
+            method: r.method.to_string(),
+            priority: r.priority,
+            enabled: r.enabled,
+            requests_served: count,
+        })
+        .collect();
+
+    (StatusCode::OK, Json(entries)).into_response()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /admin/routes
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Register a new route at runtime.
+///
+/// Returns 201 on success, 409 if the route ID already exists, 422 if the
+/// request body is invalid.
+pub async fn register_route(
+    State(state): State<Arc<AdminState>>,
+    headers: HeaderMap,
+    Json(req): Json<RegisterRouteRequest>,
+) -> impl IntoResponse {
+    if let Err(e) = require_auth(&headers, &state) {
+        return e.into_response();
+    }
+
+    if req.id.trim().is_empty() {
+        return (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(json!({ "error": { "code": "INVALID_ROUTE", "message": "route id cannot be empty" } })),
+        )
+            .into_response();
+    }
+
+    if req.path_pattern.trim().is_empty() || !req.path_pattern.starts_with('/') {
+        return (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(json!({ "error": { "code": "INVALID_ROUTE", "message": "path_pattern must be non-empty and start with '/'" } })),
+        )
+            .into_response();
+    }
+
+    if req.agent_id.trim().is_empty() {
+        return (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(json!({ "error": { "code": "INVALID_ROUTE", "message": "agent_id cannot be empty" } })),
+        )
+            .into_response();
+    }
+
+    let method = parse_method(&req.method);
+    let mut route = GatewayRoute::new(&req.id, &req.agent_id, &req.path_pattern, method);
+    if !req.enabled {
+        route = route.disabled();
+    }
+
+    if !state.register_route(route) {
+        return (
+            StatusCode::CONFLICT,
+            Json(json!({ "error": { "code": "ROUTE_ALREADY_EXISTS", "message": format!("route '{}' is already registered", req.id) } })),
+        )
+            .into_response();
+    }
+
+    (
+        StatusCode::CREATED,
+        Json(json!({ "registered": req.id })),
+    )
+        .into_response()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DELETE /admin/routes/:id
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Deregister a route by ID.
+///
+/// In-flight requests on the deregistered route complete normally; new
+/// requests receive 404 immediately after this call returns.
+pub async fn deregister_route(
+    State(state): State<Arc<AdminState>>,
+    headers: HeaderMap,
+    Path(route_id): Path<String>,
+) -> impl IntoResponse {
+    if let Err(e) = require_auth(&headers, &state) {
+        return e.into_response();
+    }
+
+    if state.deregister_route(&route_id) {
+        (StatusCode::OK, Json(json!({ "deregistered": route_id }))).into_response()
+    } else {
+        (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": { "code": "ROUTE_NOT_FOUND", "message": format!("route '{}' not found", route_id) } })),
+        )
+            .into_response()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PATCH /admin/routes/:id
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Toggle a route's `enabled` flag at runtime without deregistering it.
+///
+/// Accepts `{"enabled": true}` or `{"enabled": false}`.
+/// Returns 200 on success, 404 if the route does not exist.
+pub async fn toggle_route(
+    State(state): State<Arc<AdminState>>,
+    headers: HeaderMap,
+    Path(route_id): Path<String>,
+    Json(body): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    if let Err(e) = require_auth(&headers, &state) {
+        return e.into_response();
+    }
+
+    let enabled = match body.get("enabled").and_then(|v| v.as_bool()) {
+        Some(v) => v,
+        None => {
+            return (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                Json(json!({ "error": { "code": "INVALID_BODY", "message": "body must be {\"enabled\": true|false}" } })),
+            )
+                .into_response();
+        }
+    };
+
+    if state.set_route_enabled(&route_id, enabled) {
+        (StatusCode::OK, Json(json!({ "id": route_id, "enabled": enabled }))).into_response()
+    } else {
+        (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": { "code": "ROUTE_NOT_FOUND", "message": format!("route '{}' not found", route_id) } })),
+        )
+            .into_response()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /admin/health
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Return a health summary of the gateway.
+pub async fn admin_health(
+    State(state): State<Arc<AdminState>>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    if let Err(e) = require_auth(&headers, &state) {
+        return e.into_response();
+    }
+
+    let summary = GatewayHealthSummary {
+        uptime_secs: state.uptime_secs(),
+        total_requests: state.total_requests(),
+        routes_count: state.routes_count(),
+        hot_reload_active: state.hot_reload_active(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    };
+
+    (StatusCode::OK, Json(summary)).into_response()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Router
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Build the admin router subtree.
+pub fn admin_router() -> Router<Arc<AdminState>> {
+    Router::new()
+        .route("/admin/routes", get(list_routes).post(register_route))
+        .route(
+            "/admin/routes/{id}",
+            delete(deregister_route).patch(toggle_route),
+        )
+        .route("/admin/health", get(admin_health))
+}

--- a/crates/mofa-gateway/src/admin/mod.rs
+++ b/crates/mofa-gateway/src/admin/mod.rs
@@ -1,0 +1,27 @@
+//! Admin REST API — live route management and gateway health.
+//!
+//! Bound on a separate port (default 9090) from the main agent-serving port
+//! so the admin surface can be firewalled independently.
+//!
+//! All endpoints require a valid `X-Admin-Key` header.
+//!
+//! # Endpoints
+//!
+//! | Method | Path | Description |
+//! |--------|------|-------------|
+//! | `GET`  | `/admin/routes` | List all registered routes with stats |
+//! | `POST` | `/admin/routes` | Register a new route at runtime |
+//! | `DELETE` | `/admin/routes/:id` | Deregister a route |
+//! | `GET`  | `/admin/health` | Gateway health summary |
+
+pub mod handlers;
+pub mod server;
+pub mod state;
+pub mod types;
+
+#[cfg(test)]
+mod tests;
+
+pub use server::{AdminServer, AdminServerConfig};
+pub use state::AdminState;
+pub use types::{AdminRouteEntry, GatewayHealthSummary, RegisterRouteRequest};

--- a/crates/mofa-gateway/src/admin/server.rs
+++ b/crates/mofa-gateway/src/admin/server.rs
@@ -1,0 +1,79 @@
+//! Admin HTTP server bound on a separate port.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::Router;
+use tracing::info;
+
+use super::handlers::admin_router;
+use super::state::AdminState;
+
+/// Configuration for the admin server.
+#[derive(Debug, Clone)]
+pub struct AdminServerConfig {
+    /// Bind host.
+    pub host: String,
+    /// Admin port (default 9090, separate from the main gateway port).
+    pub port: u16,
+    /// Admin API key required in `X-Admin-Key` header.
+    pub admin_key: String,
+}
+
+impl Default for AdminServerConfig {
+    fn default() -> Self {
+        Self {
+            host: "127.0.0.1".to_string(),
+            port: 9090,
+            admin_key: "changeme".to_string(),
+        }
+    }
+}
+
+impl AdminServerConfig {
+    pub fn new(admin_key: impl Into<String>) -> Self {
+        Self {
+            admin_key: admin_key.into(),
+            ..Default::default()
+        }
+    }
+
+    pub fn with_port(mut self, port: u16) -> Self {
+        self.port = port;
+        self
+    }
+
+    pub fn socket_addr(&self) -> SocketAddr {
+        format!("{}:{}", self.host, self.port)
+            .parse()
+            .unwrap_or_else(|_| SocketAddr::from(([127, 0, 0, 1], self.port)))
+    }
+}
+
+/// Admin REST API server bound on a dedicated port.
+pub struct AdminServer {
+    pub config: AdminServerConfig,
+    pub state: Arc<AdminState>,
+}
+
+impl AdminServer {
+    pub fn new(config: AdminServerConfig) -> Self {
+        let state = Arc::new(AdminState::new(config.admin_key.clone()));
+        Self { config, state }
+    }
+
+    /// Build the axum router without binding.  Useful for in-process tests.
+    pub fn build_router(&self) -> Router {
+        admin_router().with_state(Arc::clone(&self.state))
+    }
+
+    /// Start the admin server and block until it exits.
+    pub async fn start(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let addr = self.config.socket_addr();
+        info!("MoFA admin API starting on http://{}", addr);
+        let router = self.build_router();
+        let listener = tokio::net::TcpListener::bind(addr).await?;
+        axum::serve(listener, router).await?;
+        Ok(())
+    }
+}

--- a/crates/mofa-gateway/src/admin/state.rs
+++ b/crates/mofa-gateway/src/admin/state.rs
@@ -1,0 +1,161 @@
+//! Shared state for the admin API server.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+use std::time::Instant;
+
+use mofa_kernel::gateway::route::{GatewayRoute, HttpMethod};
+
+/// Per-route runtime statistics.
+#[derive(Debug, Default)]
+pub struct RouteStats {
+    pub requests_served: AtomicU64,
+}
+
+impl RouteStats {
+    pub fn increment(&self) {
+        self.requests_served.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn count(&self) -> u64 {
+        self.requests_served.load(Ordering::Relaxed)
+    }
+}
+
+/// Shared state for the admin API.
+///
+/// Held behind an `Arc` and shared across all admin request handlers.
+#[derive(Clone)]
+pub struct AdminState {
+    inner: Arc<AdminStateInner>,
+}
+
+struct AdminStateInner {
+    /// Live route registry: route_id → GatewayRoute.
+    routes: RwLock<HashMap<String, GatewayRoute>>,
+    /// Per-route request counters.
+    stats: RwLock<HashMap<String, Arc<RouteStats>>>,
+    /// Global request counter.
+    total_requests: AtomicU64,
+    /// Server start time for uptime computation.
+    started_at: Instant,
+    /// Whether the hot-reload watcher is active.
+    hot_reload_active: AtomicBool,
+    /// Admin API key checked on every request.
+    admin_key: String,
+}
+
+impl AdminState {
+    /// Create a new admin state with the given admin key.
+    pub fn new(admin_key: impl Into<String>) -> Self {
+        Self {
+            inner: Arc::new(AdminStateInner {
+                routes: RwLock::new(HashMap::new()),
+                stats: RwLock::new(HashMap::new()),
+                total_requests: AtomicU64::new(0),
+                started_at: Instant::now(),
+                hot_reload_active: AtomicBool::new(false),
+                admin_key: admin_key.into(),
+            }),
+        }
+    }
+
+    // ── Auth ─────────────────────────────────────────────────────────────────
+
+    /// Returns `true` if `key` matches the configured admin key.
+    pub fn verify_key(&self, key: &str) -> bool {
+        self.inner.admin_key == key
+    }
+
+    // ── Route registry ───────────────────────────────────────────────────────
+
+    /// Register a new route. Returns `false` if the ID already exists.
+    pub fn register_route(&self, route: GatewayRoute) -> bool {
+        let mut routes = self.inner.routes.write().unwrap();
+        if routes.contains_key(&route.id) {
+            return false;
+        }
+        let mut stats = self.inner.stats.write().unwrap();
+        stats.insert(route.id.clone(), Arc::new(RouteStats::default()));
+        routes.insert(route.id.clone(), route);
+        true
+    }
+
+    /// Deregister a route by ID. Returns `false` if not found.
+    pub fn deregister_route(&self, route_id: &str) -> bool {
+        let mut routes = self.inner.routes.write().unwrap();
+        if routes.remove(route_id).is_none() {
+            return false;
+        }
+        self.inner.stats.write().unwrap().remove(route_id);
+        true
+    }
+
+    /// Toggle the `enabled` flag on a registered route.
+    /// Returns `false` if the route ID does not exist.
+    pub fn set_route_enabled(&self, route_id: &str, enabled: bool) -> bool {
+        let mut routes = self.inner.routes.write().unwrap();
+        match routes.get_mut(route_id) {
+            Some(r) => {
+                r.enabled = enabled;
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Return a snapshot of all registered routes and their request counts.
+    pub fn list_routes(&self) -> Vec<(GatewayRoute, u64)> {
+        let routes = self.inner.routes.read().unwrap();
+        let stats = self.inner.stats.read().unwrap();
+        routes
+            .values()
+            .map(|r| {
+                let count = stats.get(&r.id).map(|s| s.count()).unwrap_or(0);
+                (r.clone(), count)
+            })
+            .collect()
+    }
+
+    /// Increment the request counter for a route and the global total.
+    pub fn record_request(&self, route_id: &str) {
+        self.inner.total_requests.fetch_add(1, Ordering::Relaxed);
+        if let Some(s) = self.inner.stats.read().unwrap().get(route_id) {
+            s.increment();
+        }
+    }
+
+    // ── Health ───────────────────────────────────────────────────────────────
+
+    /// Uptime in whole seconds since the admin state was created.
+    pub fn uptime_secs(&self) -> u64 {
+        self.inner.started_at.elapsed().as_secs()
+    }
+
+    /// Total requests served across all routes.
+    pub fn total_requests(&self) -> u64 {
+        self.inner.total_requests.load(Ordering::Relaxed)
+    }
+
+    /// Number of registered routes.
+    pub fn routes_count(&self) -> usize {
+        self.inner.routes.read().unwrap().len()
+    }
+
+    /// Mark the hot-reload watcher as active or inactive.
+    pub fn set_hot_reload_active(&self, active: bool) {
+        self.inner.hot_reload_active.store(active, Ordering::Relaxed);
+    }
+
+    /// Whether the hot-reload watcher is active.
+    pub fn hot_reload_active(&self) -> bool {
+        self.inner.hot_reload_active.load(Ordering::Relaxed)
+    }
+}
+
+/// Parse an HTTP method string into `HttpMethod`, case-insensitive.
+/// Falls back to `HttpMethod::Post` for unknown strings.
+pub fn parse_method(s: &str) -> HttpMethod {
+    HttpMethod::from_str_ci(s).unwrap_or(HttpMethod::Post)
+}

--- a/crates/mofa-gateway/src/admin/tests.rs
+++ b/crates/mofa-gateway/src/admin/tests.rs
@@ -1,0 +1,358 @@
+//! Integration tests for the admin API.
+//!
+//! Spins up the admin router in-process using tower's `oneshot`, drives it
+//! via axum test helpers, and verifies the full route lifecycle:
+//! register → inspect → serve → toggle → deregister → 404.
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use serde_json::{Value, json};
+    use tower::ServiceExt;
+
+    use mofa_kernel::gateway::route::{GatewayRoute, HttpMethod};
+
+    use crate::admin::handlers::admin_router;
+    use crate::admin::state::AdminState;
+
+    const ADMIN_KEY: &str = "test-key";
+
+    fn build_state() -> Arc<AdminState> {
+        Arc::new(AdminState::new(ADMIN_KEY))
+    }
+
+    fn build_app(state: Arc<AdminState>) -> axum::Router {
+        admin_router().with_state(state)
+    }
+
+    async fn json_body(body: axum::body::Body) -> Value {
+        let bytes = axum::body::to_bytes(body, usize::MAX).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+    }
+
+    // ── Auth guard ────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn missing_key_returns_401() {
+        let app = build_app(build_state());
+        let req = Request::builder()
+            .method("GET")
+            .uri("/admin/routes")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn wrong_key_returns_401() {
+        let app = build_app(build_state());
+        let req = Request::builder()
+            .method("GET")
+            .uri("/admin/routes")
+            .header("x-admin-key", "wrong")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // ── GET /admin/routes ─────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn list_routes_empty() {
+        let app = build_app(build_state());
+        let req = Request::builder()
+            .method("GET")
+            .uri("/admin/routes")
+            .header("x-admin-key", ADMIN_KEY)
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = json_body(resp.into_body()).await;
+        assert_eq!(body, json!([]));
+    }
+
+    // ── POST /admin/routes ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn register_route_success() {
+        let state = build_state();
+        let app = build_app(Arc::clone(&state));
+        let req = Request::builder()
+            .method("POST")
+            .uri("/admin/routes")
+            .header("x-admin-key", ADMIN_KEY)
+            .header("content-type", "application/json")
+            .body(Body::from(
+                json!({
+                    "id": "chat",
+                    "path_pattern": "/v1/chat",
+                    "agent_id": "agent-chat",
+                    "method": "POST"
+                })
+                .to_string(),
+            ))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        assert_eq!(state.routes_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn register_route_duplicate_returns_409() {
+        let state = build_state();
+        let app = build_app(Arc::clone(&state));
+
+        let body = json!({
+            "id": "chat",
+            "path_pattern": "/v1/chat",
+            "agent_id": "agent-chat",
+            "method": "POST"
+        })
+        .to_string();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/admin/routes")
+            .header("x-admin-key", ADMIN_KEY)
+            .header("content-type", "application/json")
+            .body(Body::from(body.clone()))
+            .unwrap();
+        app.clone().oneshot(req).await.unwrap();
+
+        let req2 = Request::builder()
+            .method("POST")
+            .uri("/admin/routes")
+            .header("x-admin-key", ADMIN_KEY)
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let resp = app.oneshot(req2).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn register_route_invalid_path_returns_422() {
+        let app = build_app(build_state());
+        let req = Request::builder()
+            .method("POST")
+            .uri("/admin/routes")
+            .header("x-admin-key", ADMIN_KEY)
+            .header("content-type", "application/json")
+            .body(Body::from(
+                json!({
+                    "id": "bad",
+                    "path_pattern": "no-leading-slash",
+                    "agent_id": "agent-a",
+                    "method": "GET"
+                })
+                .to_string(),
+            ))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    // ── PATCH /admin/routes/:id ───────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn toggle_route_disable_enable() {
+        let state = build_state();
+        state.register_route(GatewayRoute::new(
+            "chat",
+            "agent-chat",
+            "/v1/chat",
+            HttpMethod::Post,
+        ));
+
+        // Disable.
+        let app = build_app(Arc::clone(&state));
+        let req = Request::builder()
+            .method("PATCH")
+            .uri("/admin/routes/chat")
+            .header("x-admin-key", ADMIN_KEY)
+            .header("content-type", "application/json")
+            .body(Body::from(json!({ "enabled": false }).to_string()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Verify disabled.
+        let routes = state.list_routes();
+        assert_eq!(routes.len(), 1);
+        assert!(!routes[0].0.enabled);
+
+        // Re-enable.
+        let app = build_app(Arc::clone(&state));
+        let req = Request::builder()
+            .method("PATCH")
+            .uri("/admin/routes/chat")
+            .header("x-admin-key", ADMIN_KEY)
+            .header("content-type", "application/json")
+            .body(Body::from(json!({ "enabled": true }).to_string()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let routes = state.list_routes();
+        assert!(routes[0].0.enabled);
+    }
+
+    #[tokio::test]
+    async fn toggle_missing_route_returns_404() {
+        let app = build_app(build_state());
+        let req = Request::builder()
+            .method("PATCH")
+            .uri("/admin/routes/nonexistent")
+            .header("x-admin-key", ADMIN_KEY)
+            .header("content-type", "application/json")
+            .body(Body::from(json!({ "enabled": false }).to_string()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    // ── DELETE /admin/routes/:id ──────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn deregister_route_success() {
+        let state = build_state();
+        state.register_route(GatewayRoute::new(
+            "chat",
+            "agent-chat",
+            "/v1/chat",
+            HttpMethod::Post,
+        ));
+
+        let app = build_app(Arc::clone(&state));
+        let req = Request::builder()
+            .method("DELETE")
+            .uri("/admin/routes/chat")
+            .header("x-admin-key", ADMIN_KEY)
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(state.routes_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn deregister_missing_route_returns_404() {
+        let app = build_app(build_state());
+        let req = Request::builder()
+            .method("DELETE")
+            .uri("/admin/routes/nonexistent")
+            .header("x-admin-key", ADMIN_KEY)
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    // ── GET /admin/health ─────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn health_returns_summary() {
+        let app = build_app(build_state());
+        let req = Request::builder()
+            .method("GET")
+            .uri("/admin/health")
+            .header("x-admin-key", ADMIN_KEY)
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = json_body(resp.into_body()).await;
+        assert!(body.get("uptime_secs").is_some());
+        assert!(body.get("total_requests").is_some());
+        assert!(body.get("routes_count").is_some());
+        assert!(body.get("hot_reload_active").is_some());
+        assert!(body.get("version").is_some());
+    }
+
+    // ── Full lifecycle ────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn route_lifecycle_register_inspect_toggle_deregister() {
+        let state = build_state();
+
+        // 1. Register.
+        let req = Request::builder()
+            .method("POST")
+            .uri("/admin/routes")
+            .header("x-admin-key", ADMIN_KEY)
+            .header("content-type", "application/json")
+            .body(Body::from(
+                json!({
+                    "id": "lifecycle",
+                    "path_pattern": "/v1/lifecycle",
+                    "agent_id": "agent-lc",
+                    "method": "GET"
+                })
+                .to_string(),
+            ))
+            .unwrap();
+        let app = build_app(Arc::clone(&state));
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        // 2. Inspect — route appears in list, enabled by default.
+        let req = Request::builder()
+            .method("GET")
+            .uri("/admin/routes")
+            .header("x-admin-key", ADMIN_KEY)
+            .body(Body::empty())
+            .unwrap();
+        let app = build_app(Arc::clone(&state));
+        let resp = app.oneshot(req).await.unwrap();
+        let body = json_body(resp.into_body()).await;
+        let routes = body.as_array().unwrap();
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0]["id"], "lifecycle");
+        assert_eq!(routes[0]["enabled"], true);
+
+        // 3. Record a request (simulate serving).
+        state.record_request("lifecycle");
+        assert_eq!(state.total_requests(), 1);
+
+        // 4. Disable route.
+        let req = Request::builder()
+            .method("PATCH")
+            .uri("/admin/routes/lifecycle")
+            .header("x-admin-key", ADMIN_KEY)
+            .header("content-type", "application/json")
+            .body(Body::from(json!({ "enabled": false }).to_string()))
+            .unwrap();
+        let app = build_app(Arc::clone(&state));
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // 5. Deregister.
+        let req = Request::builder()
+            .method("DELETE")
+            .uri("/admin/routes/lifecycle")
+            .header("x-admin-key", ADMIN_KEY)
+            .body(Body::empty())
+            .unwrap();
+        let app = build_app(Arc::clone(&state));
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // 6. Confirm gone — list is empty again.
+        let req = Request::builder()
+            .method("GET")
+            .uri("/admin/routes")
+            .header("x-admin-key", ADMIN_KEY)
+            .body(Body::empty())
+            .unwrap();
+        let app = build_app(Arc::clone(&state));
+        let resp = app.oneshot(req).await.unwrap();
+        let body = json_body(resp.into_body()).await;
+        assert_eq!(body, json!([]));
+    }
+}

--- a/crates/mofa-gateway/src/admin/types.rs
+++ b/crates/mofa-gateway/src/admin/types.rs
@@ -1,0 +1,60 @@
+//! Serialisable response types for the admin API.
+
+use serde::{Deserialize, Serialize};
+
+/// A single route entry returned by `GET /admin/routes`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdminRouteEntry {
+    /// Stable route identifier.
+    pub id: String,
+    /// URL path pattern.
+    pub path_pattern: String,
+    /// Target agent ID.
+    pub agent_id: String,
+    /// HTTP method string (e.g. `"POST"`).
+    pub method: String,
+    /// Numeric priority — higher values are evaluated first.
+    pub priority: i32,
+    /// Whether the route is currently enabled.
+    pub enabled: bool,
+    /// Requests served by this route since gateway startup.
+    pub requests_served: u64,
+}
+
+/// Request body for `POST /admin/routes`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegisterRouteRequest {
+    /// Unique route identifier.
+    pub id: String,
+    /// URL path pattern (must start with `/`).
+    pub path_pattern: String,
+    /// Target agent ID (must exist in the agent registry).
+    pub agent_id: String,
+    /// HTTP method string, e.g. `"POST"`.
+    pub method: String,
+    /// Numeric priority. Defaults to `0`.
+    #[serde(default)]
+    pub priority: i32,
+    /// Whether the route starts enabled. Defaults to `true`.
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+}
+
+fn default_enabled() -> bool {
+    true
+}
+
+/// Response body for `GET /admin/health`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayHealthSummary {
+    /// Total uptime in seconds since the admin server started.
+    pub uptime_secs: u64,
+    /// Total requests served across all routes since startup.
+    pub total_requests: u64,
+    /// Number of currently registered routes.
+    pub routes_count: usize,
+    /// Whether the hot-reload file watcher is active.
+    pub hot_reload_active: bool,
+    /// Gateway version string.
+    pub version: String,
+}

--- a/crates/mofa-gateway/src/lib.rs
+++ b/crates/mofa-gateway/src/lib.rs
@@ -72,6 +72,7 @@
 #![warn(missing_docs)]
 #![warn(clippy::all)]
 
+pub mod admin;
 pub mod consensus;
 pub mod control_plane;
 pub mod error;

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2142,6 +2142,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2356,6 +2362,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "gateway_admin_demo"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "http-body-util",
+ "mofa-gateway",
+ "serde_json",
+ "tokio",
+ "tower 0.5.3",
+ "tracing",
+ "tracing-subscriber 0.3.22",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2387,20 +2407,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
@@ -2772,7 +2792,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3112,9 +3132,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
@@ -3848,6 +3868,7 @@ dependencies = [
  "futures",
  "hyper",
  "hyper-util",
+ "mofa-foundation",
  "mofa-kernel",
  "mofa-runtime",
  "parking_lot",
@@ -4575,10 +4596,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pastey"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 name = "parse-zoneinfo"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4586,6 +4603,12 @@ checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
 dependencies = [
  "regex",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "pathdiff"
@@ -4667,7 +4690,17 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.4.2",
+ "indexmap 2.13.0",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset 0.5.7",
  "indexmap 2.13.0",
 ]
 
@@ -4908,11 +4941,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit 0.25.4+spec-1.1.0",
 ]
 
 [[package]]
@@ -4960,6 +4993,9 @@ dependencies = [
  "tokio",
  "tracing",
  "windows 0.62.2",
+]
+
+[[package]]
 name = "prometheus"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4994,7 +5030,7 @@ dependencies = [
  "log",
  "multimap",
  "once_cell",
- "petgraph",
+ "petgraph 0.7.1",
  "prettyplease",
  "prost",
  "prost-types",
@@ -5083,7 +5119,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5120,16 +5156,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -5139,6 +5175,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "ractor"
@@ -5222,7 +5264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
  "chacha20",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "rand_core 0.10.0",
 ]
 
@@ -6316,12 +6358,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6884,7 +6926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -6964,7 +7006,7 @@ dependencies = [
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
- "fixedbitset",
+ "fixedbitset 0.4.2",
  "hex",
  "lazy_static",
  "libc",
@@ -7120,9 +7162,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -7130,7 +7172,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -7138,9 +7180,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7273,6 +7315,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.0.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7288,12 +7339,12 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
@@ -7771,12 +7822,12 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "atomic",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -7946,7 +7997,7 @@ dependencies = [
  "im-rc",
  "indexmap 2.13.0",
  "log",
- "petgraph",
+ "petgraph 0.6.5",
  "serde",
  "serde_derive",
  "serde_yaml",
@@ -9039,9 +9090,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -51,6 +51,7 @@ members = [
     "memory_scheduler_demo",
     "rag_retrieval_demo",
     "rag_indexing_demo",
+    "gateway_admin_demo",
 ]
 
 [workspace.package]

--- a/examples/gateway_admin_demo/Cargo.toml
+++ b/examples/gateway_admin_demo/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "gateway_admin_demo"
+version.workspace = true
+edition.workspace = true
+
+[[bin]]
+name = "gateway_admin_demo"
+path = "src/main.rs"
+
+[dependencies]
+mofa-gateway = { path = "../../crates/mofa-gateway" }
+
+tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+serde_json.workspace = true
+axum = { workspace = true }
+tower = { version = "0.5", features = ["util"] }
+http-body-util = "0.1"
+
+[lints]
+workspace = true

--- a/examples/gateway_admin_demo/src/main.rs
+++ b/examples/gateway_admin_demo/src/main.rs
@@ -1,0 +1,240 @@
+//! Gateway Admin API — end-to-end demo
+//!
+//! Demonstrates the full route lifecycle against the MoFA admin REST API:
+//!
+//! 1. Start the admin server in-process on a random port
+//! 2. `GET  /admin/health`              — confirm gateway is up
+//! 3. `POST /admin/routes`              — register two routes at runtime
+//! 4. `GET  /admin/routes`              — inspect the live route table
+//! 5. `PATCH /admin/routes/:id`         — disable one route without deregistering
+//! 6. `GET  /admin/routes`              — confirm enabled flag changed
+//! 7. `DELETE /admin/routes/:id`        — deregister the disabled route
+//! 8. `GET  /admin/routes`              — confirm only one route remains
+//!
+//! Run with:
+//! ```sh
+//! cargo run -p gateway_admin_demo
+//! ```
+
+use std::sync::Arc;
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::response::Response;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+use tracing::info;
+
+use mofa_gateway::admin::{AdminServer, AdminServerConfig, AdminState};
+
+const ADMIN_KEY: &str = "demo-secret-key";
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_target(false)
+        .with_level(true)
+        .init();
+
+    info!("MoFA Gateway Admin API Demo");
+    info!("============================");
+
+    // Build the admin server and get a handle to the shared state.
+    let config = AdminServerConfig::new(ADMIN_KEY);
+    let server = AdminServer::new(config);
+    let state: Arc<AdminState> = Arc::clone(&server.state);
+    let app: Router = server.build_router();
+
+    // ── Step 1: Health check ──────────────────────────────────────────────────
+    info!("\n[1] GET /admin/health");
+    let resp: Response = app
+        .clone()
+        .oneshot(auth_get("/admin/health"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = read_json(resp).await;
+    info!("    uptime_secs     = {}", body["uptime_secs"]);
+    info!("    routes_count    = {}", body["routes_count"]);
+    info!("    hot_reload      = {}", body["hot_reload_active"]);
+    info!("    version         = {}", body["version"]);
+
+    // ── Step 2: Register route — chat ─────────────────────────────────────────
+    info!("\n[2] POST /admin/routes  (chat agent)");
+    let resp: Response = app
+        .clone()
+        .oneshot(auth_post(
+            "/admin/routes",
+            json!({
+                "id": "chat",
+                "path_pattern": "/v1/chat",
+                "agent_id": "agent-chat",
+                "method": "POST",
+                "strategy": "weighted_round_robin"
+            }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    info!("    → {}", read_json(resp).await);
+
+    // ── Step 3: Register route — summariser ───────────────────────────────────
+    info!("\n[3] POST /admin/routes  (summariser agent)");
+    let resp: Response = app
+        .clone()
+        .oneshot(auth_post(
+            "/admin/routes",
+            json!({
+                "id": "summarise",
+                "path_pattern": "/v1/summarise",
+                "agent_id": "agent-summariser",
+                "method": "POST",
+                "strategy": "capability_match"
+            }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    info!("    → {}", read_json(resp).await);
+
+    // ── Step 4: List routes ───────────────────────────────────────────────────
+    info!("\n[4] GET /admin/routes");
+    let resp: Response = app
+        .clone()
+        .oneshot(auth_get("/admin/routes"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let routes = read_json(resp).await;
+    info!("    {} routes registered:", routes.as_array().unwrap().len());
+    for r in routes.as_array().unwrap() {
+        info!(
+            "      • {} → {}  [enabled={}  strategy={}]",
+            r["path_pattern"], r["agent_id"], r["enabled"], r["strategy"]
+        );
+    }
+
+    // ── Step 5: Simulate some traffic ─────────────────────────────────────────
+    info!("\n[5] Simulating 5 requests on 'chat' route...");
+    for _ in 0..5 {
+        state.record_request("chat");
+    }
+    info!("    total_requests = {}", state.total_requests());
+
+    // ── Step 6: Disable the summariser route ──────────────────────────────────
+    info!("\n[6] PATCH /admin/routes/summarise  (disable)");
+    let resp: Response = app
+        .clone()
+        .oneshot(auth_patch(
+            "/admin/routes/summarise",
+            json!({ "enabled": false }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    info!("    → {}", read_json(resp).await);
+
+    // ── Step 7: Confirm disabled ──────────────────────────────────────────────
+    info!("\n[7] GET /admin/routes  (check enabled flags)");
+    let resp: Response = app
+        .clone()
+        .oneshot(auth_get("/admin/routes"))
+        .await
+        .unwrap();
+    let routes = read_json(resp).await;
+    for r in routes.as_array().unwrap() {
+        info!(
+            "      • {}  enabled={}  requests={}",
+            r["id"], r["enabled"], r["requests_served"]
+        );
+    }
+
+    // ── Step 8: Deregister disabled route ────────────────────────────────────
+    info!("\n[8] DELETE /admin/routes/summarise");
+    let resp: Response = app
+        .clone()
+        .oneshot(auth_delete("/admin/routes/summarise"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    info!("    → {}", read_json(resp).await);
+
+    // ── Step 9: Confirm one route remains ────────────────────────────────────
+    info!("\n[9] GET /admin/routes  (final state)");
+    let resp: Response = app
+        .clone()
+        .oneshot(auth_get("/admin/routes"))
+        .await
+        .unwrap();
+    let routes = read_json(resp).await;
+    let arr = routes.as_array().unwrap();
+    assert_eq!(arr.len(), 1, "expected exactly one route remaining");
+    info!(
+        "    {} route remaining: {}  requests={}",
+        arr.len(),
+        arr[0]["id"],
+        arr[0]["requests_served"]
+    );
+
+    // ── Step 10: Auth guard ───────────────────────────────────────────────────
+    info!("\n[10] Auth guard — wrong key should return 401");
+    let req = Request::builder()
+        .method("GET")
+        .uri("/admin/routes")
+        .header("x-admin-key", "wrong-key")
+        .body(Body::empty())
+        .unwrap();
+    let resp: Response = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    info!("     → 401 UNAUTHORIZED (correct)");
+
+    info!("\nDemo complete. All assertions passed.");
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn auth_get(uri: &str) -> Request<Body> {
+    Request::builder()
+        .method("GET")
+        .uri(uri)
+        .header("x-admin-key", ADMIN_KEY)
+        .body(Body::empty())
+        .unwrap()
+}
+
+fn auth_post(uri: &str, body: Value) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("x-admin-key", ADMIN_KEY)
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+fn auth_patch(uri: &str, body: Value) -> Request<Body> {
+    Request::builder()
+        .method("PATCH")
+        .uri(uri)
+        .header("x-admin-key", ADMIN_KEY)
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+fn auth_delete(uri: &str) -> Request<Body> {
+    Request::builder()
+        .method("DELETE")
+        .uri(uri)
+        .header("x-admin-key", ADMIN_KEY)
+        .body(Body::empty())
+        .unwrap()
+}
+
+async fn read_json(resp: Response) -> Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+}


### PR DESCRIPTION
closes #706

implement admin REST API for mofa-gateway — Phase 8/10 of the Cognitive Gateway

The admin module in mofa-gateway existed as scaffolding but was completely broken after upstream merged the kernel types in Phase 1 (#699). All references pointed to `mofa_foundation::gateway::config::RouteConfig` which no longer exists, and the module was never exported from `lib.rs` so it was unreachable externally.

This PR fixes all of that and delivers a fully working admin REST API.

what changed:

the module is now grounded on the merged kernel types — `mofa_kernel::gateway::route::{GatewayRoute, HttpMethod}` — so it stays in sync with the rest of the gateway stack.

`lib.rs` now exports `pub mod admin` so external code can actually reach it.

handlers.rs got a new `PATCH /admin/routes/:id` endpoint (`toggle_route`) that flips a route's `enabled` flag at runtime without deregistering it. useful for temporarily taking a route offline while keeping its config intact.

state.rs got `set_route_enabled()` and `parse_method()` helpers wired up to the new handler.

types.rs had a phantom `strategy` field removed — `GatewayRoute` has no such field. replaced with `priority: i32` which matches the actual struct.

tests.rs was fully rewritten: auth guard tests, list empty, register success, duplicate 409, invalid path 422, toggle disable/enable, toggle missing 404, deregister success, deregister missing 404, health summary, and a full lifecycle test (register → inspect → simulate traffic → disable → deregister → confirm gone).

a new `gateway_admin_demo` example drives the entire API in-process using `tower::ServiceExt::oneshot` — no port binding needed — and exercises all 10 steps end to end.

routes exposed:

`GET    /admin/routes`        list all routes with per-route request counts
`POST   /admin/routes`        register a route at runtime
`PATCH  /admin/routes/:id`    toggle enabled/disabled without deregistering
`DELETE /admin/routes/:id`    permanently deregister a route
`GET    /admin/health`        uptime, total requests, route count, hot-reload status, version

all endpoints require the `X-Admin-Key` header. missing or wrong key returns 401.