### PR TITLE
feat(gateway): add per-route deadline propagation and structured 504 enforcement (Phase 9/10)

### DIFF
--- a/crates/mofa-gateway/examples/gateway_server.rs
+++ b/crates/mofa-gateway/examples/gateway_server.rs
@@ -43,6 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         load_balancing: LoadBalancingAlgorithm::RoundRobin,
         enable_rate_limiting: true,
         enable_circuit_breakers: true,
+        default_request_timeout_ms: Some(30_000),
     };
 
     // Create gateway instance (without control plane for this example)

--- a/crates/mofa-gateway/src/deadline.rs
+++ b/crates/mofa-gateway/src/deadline.rs
@@ -1,0 +1,230 @@
+//! Per-route deadline propagation and 504 enforcement.
+//!
+//! [`enforce_deadline`] wraps any async agent-call future with
+//! `tokio::time::timeout`.  On expiry it cancels the agent future and returns
+//! a [`GatewayResponse`] with status 504 and a structured JSON error body.
+//!
+//! # Effective timeout resolution
+//!
+//! The effective timeout for a request is resolved in this order:
+//!
+//! 1. `route.deadline.request_timeout_ms` — per-route override (if `Some`)
+//! 2. `gateway_default_ms` — gateway-level default from `GatewayConfig`
+//! 3. No timeout — the future is awaited without any time bound
+//!
+//! The resolved timeout (if any) is then used both to:
+//! * stamp `RequestEnvelope::deadline` so downstream layers can inspect
+//!   remaining time, and
+//! * wrap the agent future with `tokio::time::timeout`.
+
+use std::future::Future;
+use std::time::Duration;
+
+use mofa_kernel::gateway::envelope::{GatewayResponse, RequestEnvelope};
+use mofa_kernel::gateway::route::GatewayRoute;
+
+/// Resolve the effective `request_timeout_ms` for a route.
+///
+/// Returns `None` when neither the route nor the gateway default carries a
+/// timeout (i.e. the request is unbounded).
+pub fn resolve_timeout_ms(route: &GatewayRoute, gateway_default_ms: Option<u64>) -> Option<u64> {
+    route
+        .deadline
+        .as_ref()
+        .and_then(|d| d.request_timeout_ms)
+        .or(gateway_default_ms)
+}
+
+/// Stamp `envelope.deadline` using the effective timeout for `route`.
+///
+/// If the resolved timeout is `None` the envelope is returned unchanged.
+pub fn stamp_deadline(
+    mut envelope: RequestEnvelope,
+    route: &GatewayRoute,
+    gateway_default_ms: Option<u64>,
+) -> RequestEnvelope {
+    if let Some(ms) = resolve_timeout_ms(route, gateway_default_ms) {
+        envelope = envelope.with_timeout_ms(ms);
+    }
+    envelope
+}
+
+/// Enforce the deadline for a single agent dispatch.
+///
+/// Wraps `agent_fut` with `tokio::time::timeout` using the effective timeout
+/// resolved from `route` and `gateway_default_ms`.  On expiry the agent
+/// future is cancelled and a 504 [`GatewayResponse`] is returned.
+///
+/// If no timeout is configured the future is awaited without any time bound
+/// and its result is returned directly.
+///
+/// # Type parameters
+///
+/// * `F` — an async future that returns a [`GatewayResponse`]
+pub async fn enforce_deadline<F>(
+    route: &GatewayRoute,
+    gateway_default_ms: Option<u64>,
+    agent_fut: F,
+) -> GatewayResponse
+where
+    F: Future<Output = GatewayResponse>,
+{
+    match resolve_timeout_ms(route, gateway_default_ms) {
+        Some(timeout_ms) => {
+            match tokio::time::timeout(Duration::from_millis(timeout_ms), agent_fut).await {
+                Ok(response) => response,
+                Err(_elapsed) => GatewayResponse::deadline_exceeded(&route.id, timeout_ms),
+            }
+        }
+        None => agent_fut.await,
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use mofa_kernel::gateway::envelope::RequestEnvelope;
+    use mofa_kernel::gateway::route::{GatewayRoute, HttpMethod, RouteDeadline};
+
+    use super::*;
+
+    fn route_with_timeout(ms: u64) -> GatewayRoute {
+        GatewayRoute::new("test", "agent-test", "/v1/test", HttpMethod::Post)
+            .with_deadline(RouteDeadline {
+                request_timeout_ms: Some(ms),
+                connect_timeout_ms: None,
+                idle_timeout_ms: None,
+            })
+    }
+
+    fn route_no_deadline() -> GatewayRoute {
+        GatewayRoute::new("test", "agent-test", "/v1/test", HttpMethod::Post)
+    }
+
+    // ── resolve_timeout_ms ────────────────────────────────────────────────────
+
+    #[test]
+    fn per_route_timeout_takes_precedence_over_default() {
+        let route = route_with_timeout(100);
+        assert_eq!(resolve_timeout_ms(&route, Some(5_000)), Some(100));
+    }
+
+    #[test]
+    fn falls_back_to_gateway_default_when_no_per_route_deadline() {
+        let route = route_no_deadline();
+        assert_eq!(resolve_timeout_ms(&route, Some(5_000)), Some(5_000));
+    }
+
+    #[test]
+    fn returns_none_when_neither_route_nor_default_has_timeout() {
+        let route = route_no_deadline();
+        assert_eq!(resolve_timeout_ms(&route, None), None);
+    }
+
+    // ── stamp_deadline ────────────────────────────────────────────────────────
+
+    #[test]
+    fn stamp_deadline_sets_instant_within_tolerance() {
+        let route = route_with_timeout(500);
+        let env = RequestEnvelope::new("cid", "test", "/v1/test", "POST");
+        let env = stamp_deadline(env, &route, None);
+
+        let deadline = env.deadline.expect("deadline must be set");
+        let expected = Instant::now() + Duration::from_millis(500);
+        // Allow 50 ms of scheduling jitter.
+        assert!(deadline <= expected + Duration::from_millis(50));
+        assert!(!env.is_expired());
+    }
+
+    #[test]
+    fn stamp_deadline_leaves_envelope_unchanged_when_no_timeout() {
+        let route = route_no_deadline();
+        let env = RequestEnvelope::new("cid", "test", "/v1/test", "POST");
+        let env = stamp_deadline(env, &route, None);
+        assert!(env.deadline.is_none());
+    }
+
+    // ── enforce_deadline ─────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn agent_responding_within_deadline_returns_200() {
+        let route = route_with_timeout(500);
+
+        // Agent responds immediately — well within the 500 ms window.
+        let response = enforce_deadline(&route, None, async {
+            GatewayResponse::ok(serde_json::json!({ "reply": "hello" }))
+        })
+        .await;
+
+        assert_eq!(response.status, 200);
+        assert!(response.is_success());
+    }
+
+    #[tokio::test]
+    async fn agent_exceeding_deadline_returns_504() {
+        let route = route_with_timeout(50); // 50 ms
+
+        // Agent sleeps longer than the deadline.
+        let response = enforce_deadline(&route, None, async {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            GatewayResponse::ok(serde_json::json!({ "reply": "too late" }))
+        })
+        .await;
+
+        assert_eq!(response.status, 504);
+        assert_eq!(response.body["error"], "deadline_exceeded");
+        assert_eq!(response.body["route_id"], "test");
+        assert_eq!(response.body["timeout_ms"], 50);
+    }
+
+    #[tokio::test]
+    async fn gateway_default_enforced_when_route_has_no_deadline() {
+        let route = route_no_deadline();
+
+        let response = enforce_deadline(&route, Some(50), async {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            GatewayResponse::ok(serde_json::json!({}))
+        })
+        .await;
+
+        assert_eq!(response.status, 504);
+        assert_eq!(response.body["timeout_ms"], 50);
+    }
+
+    #[tokio::test]
+    async fn no_timeout_configured_awaits_future_normally() {
+        let route = route_no_deadline();
+
+        let response = enforce_deadline(&route, None, async {
+            // A small sleep is fine here since there is no timeout to trigger.
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            GatewayResponse::ok(serde_json::json!({ "ok": true }))
+        })
+        .await;
+
+        assert_eq!(response.status, 200);
+    }
+
+    // ── RequestEnvelope helpers ───────────────────────────────────────────────
+
+    #[test]
+    fn envelope_remaining_returns_positive_duration_before_expiry() {
+        let env = RequestEnvelope::new("c", "r", "/", "GET")
+            .with_timeout_ms(1_000);
+        let rem = env.remaining().expect("remaining must be Some");
+        assert!(rem > Duration::ZERO);
+        assert!(rem <= Duration::from_millis(1_000));
+    }
+
+    #[test]
+    fn envelope_is_expired_false_for_future_deadline() {
+        let env = RequestEnvelope::new("c", "r", "/", "GET")
+            .with_timeout_ms(10_000);
+        assert!(!env.is_expired());
+    }
+}

--- a/crates/mofa-gateway/src/gateway/mod.rs
+++ b/crates/mofa-gateway/src/gateway/mod.rs
@@ -40,6 +40,12 @@ pub struct GatewayConfig {
     pub enable_rate_limiting: bool,
     /// Enable circuit breakers.
     pub enable_circuit_breakers: bool,
+    /// Gateway-level default request timeout in milliseconds.
+    ///
+    /// Applied to every route that does not carry its own
+    /// `RouteDeadline::request_timeout_ms`.  `None` means no default timeout
+    /// is enforced (requests may wait indefinitely).
+    pub default_request_timeout_ms: Option<u64>,
 }
 
 impl Default for GatewayConfig {
@@ -49,6 +55,7 @@ impl Default for GatewayConfig {
             load_balancing: LoadBalancingAlgorithm::RoundRobin,
             enable_rate_limiting: true,
             enable_circuit_breakers: true,
+            default_request_timeout_ms: Some(30_000),
         }
     }
 }

--- a/crates/mofa-gateway/src/lib.rs
+++ b/crates/mofa-gateway/src/lib.rs
@@ -74,6 +74,7 @@
 
 pub mod consensus;
 pub mod control_plane;
+pub mod deadline;
 pub mod error;
 pub mod gateway;
 pub mod handlers;

--- a/crates/mofa-gateway/tests/gateway_integration.rs
+++ b/crates/mofa-gateway/tests/gateway_integration.rs
@@ -14,6 +14,7 @@ async fn test_gateway_startup() {
         load_balancing: LoadBalancingAlgorithm::RoundRobin,
         enable_rate_limiting: true,
         enable_circuit_breakers: true,
+        default_request_timeout_ms: Some(30_000),
     };
 
     let mut gateway = Gateway::new(config).await.unwrap();
@@ -33,6 +34,7 @@ async fn test_gateway_metrics_endpoint() {
         load_balancing: LoadBalancingAlgorithm::RoundRobin,
         enable_rate_limiting: true,
         enable_circuit_breakers: true,
+        default_request_timeout_ms: Some(30_000),
     };
 
     let mut gateway = Gateway::new(config).await.unwrap();
@@ -64,6 +66,7 @@ async fn test_gateway_with_control_plane() {
         load_balancing: LoadBalancingAlgorithm::RoundRobin,
         enable_rate_limiting: true,
         enable_circuit_breakers: true,
+        default_request_timeout_ms: Some(30_000),
     };
 
     let mut gateway = Gateway::with_control_plane(config, None).await.unwrap();

--- a/crates/mofa-kernel/src/gateway/envelope.rs
+++ b/crates/mofa-kernel/src/gateway/envelope.rs
@@ -1,0 +1,136 @@
+//! Request envelope and gateway response types.
+//!
+//! [`RequestEnvelope`] is the canonical wrapper around an admitted request.
+//! It carries the per-request deadline `Instant` so every layer downstream
+//! (middleware, routing strategy, agent handler) can check how much time
+//! remains without recomputing it from the original timeout.
+//!
+//! [`GatewayResponse`] is the typed response returned by the dispatch layer.
+//! Using this struct (rather than ad-hoc strings) ensures that structured
+//! error bodies like the 504 deadline-exceeded payload are machine-readable.
+
+use std::collections::HashMap;
+use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RequestEnvelope
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A request after it has been admitted at the gateway boundary.
+///
+/// The `deadline` field holds the absolute `Instant` by which the response
+/// must be sent.  It is computed once at admission time by adding the
+/// effective `request_timeout_ms` (per-route if set, gateway default
+/// otherwise) to `Instant::now()`.  A `None` value means no deadline is
+/// configured for this request.
+#[derive(Debug, Clone)]
+pub struct RequestEnvelope {
+    /// Per-request correlation ID for distributed tracing and log correlation.
+    pub correlation_id: String,
+    /// ID of the route that matched this request.
+    pub route_id: String,
+    /// Request path (e.g. `/v1/chat`).
+    pub path: String,
+    /// HTTP method string (e.g. `"POST"`).
+    pub method: String,
+    /// Lowercased request headers.
+    pub headers: HashMap<String, String>,
+    /// Raw request body bytes.
+    pub body: Vec<u8>,
+    /// Absolute deadline for the full request-response cycle.
+    ///
+    /// `None` means no timeout is enforced for this request.
+    pub deadline: Option<Instant>,
+}
+
+impl RequestEnvelope {
+    /// Create a new envelope without a deadline.
+    pub fn new(
+        correlation_id: impl Into<String>,
+        route_id: impl Into<String>,
+        path: impl Into<String>,
+        method: impl Into<String>,
+    ) -> Self {
+        Self {
+            correlation_id: correlation_id.into(),
+            route_id: route_id.into(),
+            path: path.into(),
+            method: method.into(),
+            headers: HashMap::new(),
+            body: Vec::new(),
+            deadline: None,
+        }
+    }
+
+    /// Attach a deadline computed from a timeout duration in milliseconds.
+    ///
+    /// Calling this sets `deadline = Some(Instant::now() + timeout_ms)`.
+    pub fn with_timeout_ms(mut self, timeout_ms: u64) -> Self {
+        self.deadline = Some(
+            Instant::now() + std::time::Duration::from_millis(timeout_ms),
+        );
+        self
+    }
+
+    /// Returns the remaining time before the deadline, or `None` if no
+    /// deadline is set.  Returns `Some(Duration::ZERO)` if the deadline has
+    /// already passed.
+    pub fn remaining(&self) -> Option<std::time::Duration> {
+        self.deadline.map(|d| {
+            let now = Instant::now();
+            if d > now { d - now } else { std::time::Duration::ZERO }
+        })
+    }
+
+    /// Returns `true` if a deadline is set and it has already passed.
+    pub fn is_expired(&self) -> bool {
+        self.deadline.map(|d| Instant::now() >= d).unwrap_or(false)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GatewayResponse
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A typed response produced by the gateway dispatch layer.
+///
+/// Using this struct ensures that error bodies (e.g. 504 deadline exceeded)
+/// are machine-readable JSON rather than hand-rolled strings.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayResponse {
+    /// HTTP status code.
+    pub status: u16,
+    /// Response body serialised as a JSON value.
+    pub body: serde_json::Value,
+}
+
+impl GatewayResponse {
+    /// Create a successful (200) response with an arbitrary JSON body.
+    pub fn ok(body: serde_json::Value) -> Self {
+        Self { status: 200, body }
+    }
+
+    /// Create a 504 Gateway Timeout response for a deadline-exceeded event.
+    ///
+    /// The body format is:
+    /// ```json
+    /// { "error": "deadline_exceeded", "route_id": "...", "timeout_ms": ... }
+    /// ```
+    pub fn deadline_exceeded(route_id: &str, timeout_ms: u64) -> Self {
+        Self {
+            status: 504,
+            body: serde_json::json!({
+                "error": "deadline_exceeded",
+                "route_id": route_id,
+                "timeout_ms": timeout_ms,
+            }),
+        }
+    }
+
+    /// Returns `true` if the status code indicates success (2xx).
+    pub fn is_success(&self) -> bool {
+        self.status >= 200 && self.status < 300
+    }
+}

--- a/crates/mofa-kernel/src/gateway/mod.rs
+++ b/crates/mofa-kernel/src/gateway/mod.rs
@@ -10,11 +10,15 @@
 //! | Type | Description |
 //! |------|-------------|
 //! | [`GatewayRoute`] | A routing rule mapping a path + method to an agent |
+//! | [`RouteDeadline`] | Per-route deadline policy (request, connect, idle timeouts) |
 //! | [`RouteRegistry`] | Trait for registering, looking up, and listing routes |
 //! | [`RoutingContext`] | Per-request dispatch context (path, method, headers, correlation ID) |
 //! | [`HttpMethod`] | HTTP method enum |
 //! | [`RegistryError`] | Error type for registry operations |
+//! | [`RequestEnvelope`] | Admitted request with computed deadline `Instant` |
+//! | [`GatewayResponse`] | Typed gateway response (status + JSON body) |
 
+pub mod envelope;
 pub mod error;
 pub mod route;
 
@@ -22,4 +26,5 @@ pub mod route;
 mod tests;
 
 pub use error::RegistryError;
-pub use route::{GatewayRoute, HttpMethod, RouteRegistry, RoutingContext};
+pub use route::{GatewayRoute, HttpMethod, RouteDeadline, RouteRegistry, RoutingContext};
+pub use envelope::{GatewayResponse, RequestEnvelope};

--- a/crates/mofa-kernel/src/gateway/route.rs
+++ b/crates/mofa-kernel/src/gateway/route.rs
@@ -12,6 +12,26 @@ use std::collections::HashMap;
 use super::error::RegistryError;
 
 // ─────────────────────────────────────────────────────────────────────────────
+// RouteDeadline
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Per-route deadline policy.
+///
+/// All fields are `Option<u64>` (milliseconds).  A `None` value means "inherit
+/// the gateway-level default".  Setting a field to `Some(0)` disables that
+/// particular check for the route.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct RouteDeadline {
+    /// Maximum wall-clock time (ms) from envelope admission to final response.
+    /// Enforced at the dispatch layer; exceeding it yields HTTP 504.
+    pub request_timeout_ms: Option<u64>,
+    /// Time (ms) allowed to establish a connection to the agent backend.
+    pub connect_timeout_ms: Option<u64>,
+    /// Time (ms) allowed between successive response chunks for streaming routes.
+    pub idle_timeout_ms: Option<u64>,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // HTTP method
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -100,6 +120,9 @@ pub struct GatewayRoute {
     /// returned by [`RouteRegistry::list_active`] and never matched at
     /// dispatch time.
     pub enabled: bool,
+    /// Optional per-route deadline policy.  `None` means use the
+    /// gateway-level default configured in `GatewayConfig`.
+    pub deadline: Option<RouteDeadline>,
 }
 
 impl GatewayRoute {
@@ -117,12 +140,19 @@ impl GatewayRoute {
             method,
             priority: 0,
             enabled: true,
+            deadline: None,
         }
     }
 
     /// Set the routing priority.
     pub fn with_priority(mut self, priority: i32) -> Self {
         self.priority = priority;
+        self
+    }
+
+    /// Attach a per-route deadline policy.
+    pub fn with_deadline(mut self, deadline: RouteDeadline) -> Self {
+        self.deadline = Some(deadline);
         self
     }
 


### PR DESCRIPTION
 closes #707

A single slow LLM call or hung agent process could hold a gateway connection open indefinitely, exhausting the connection pool and degrading all other routes. There was no way for an operator to declare that a particular route must complete within a given window, and no mechanism to enforce that declaration at the gateway boundary. This PR fixes that.

This is distinct from the executor-level timeout (#648) and node-level circuit breaker (#504) — those operate inside the agent execution graph. This operates at the admission boundary, before the request is handed off.

```mermaid
sequenceDiagram
    participant C as Client
    participant G as Gateway Dispatch
    participant E as RequestEnvelope
    participant A as Agent Future
    participant T as tokio::time::timeout

    C->>G: HTTP request
    G->>E: admit request, stamp deadline Instant
    note over E: deadline = now + effective_timeout_ms
    G->>T: enforce_deadline(route, gateway_default, agent_fut)

    alt agent responds in time
        T->>A: poll future
        A-->>T: GatewayResponse { status: 200, body }
        T-->>G: Ok(response)
        G-->>C: 200 OK
    else agent exceeds deadline
        T->>A: cancel future
        T-->>G: Err(Elapsed)
        G-->>C: 504 { "error": "deadline_exceeded", "route_id": "...", "timeout_ms": ... }
    end
```

**Timeout resolution order**

```
route.deadline.request_timeout_ms        ← per-route override (highest precedence)
        ↓ None
GatewayConfig::default_request_timeout_ms   ← gateway-level default (30 000 ms)
        ↓ None
(no timeout — request is unbounded)
```

**mofa-kernel changes**

`RouteDeadline` struct added to `GatewayRoute` with three `Option<u64>` fields: `request_timeout_ms` (total wall-clock time from admission to response), `connect_timeout_ms` (time to establish backend connection), `idle_timeout_ms` (time between streaming chunks). All `None` by default — routes inherit the gateway-level default. Builder method `GatewayRoute::with_deadline` wires it in fluently.

`RequestEnvelope` type introduced in a new `envelope` module. Carries `deadline: Option<Instant>` stamped at admission so every downstream layer (middleware, routing strategy, agent handler) can call `.remaining()` or `.is_expired()` without recomputing from the original timeout value.

`GatewayResponse` struct introduced as the typed response produced by the dispatch layer. Using a struct instead of hand-rolled strings ensures the 504 body is machine-readable JSON with a stable schema: `{ "error": "deadline_exceeded", "route_id": "...", "timeout_ms": ... }`.

**mofa-gateway changes**

`GatewayConfig` gains `default_request_timeout_ms: Option<u64>` (default `Some(30_000)`). Operators set this once and all routes without a per-route override inherit it.

New `deadline` module exposes three public functions:

`resolve_timeout_ms(route, gateway_default)` — pure function that returns the effective timeout for a route or `None` if unbounded.

`stamp_deadline(envelope, route, gateway_default)` — mutates the envelope's deadline field using the resolved timeout.

`enforce_deadline(route, gateway_default, agent_fut)` — wraps any `Future<Output = GatewayResponse>` with `tokio::time::timeout`. On `Elapsed` it cancels the agent future and returns a 504 `GatewayResponse`. When no timeout is configured it simply awaits the future.

**Tests (11)**

`per_route_timeout_takes_precedence_over_default` — route override wins over gateway default

`falls_back_to_gateway_default_when_no_per_route_deadline` — gateway default applied when route has none

`returns_none_when_neither_route_nor_default_has_timeout` — unbounded path returns `None`

`stamp_deadline_sets_instant_within_tolerance` — deadline `Instant` is within 50 ms scheduling jitter

`stamp_deadline_leaves_envelope_unchanged_when_no_timeout` — no-op when timeout is absent

`agent_responding_within_deadline_returns_200` — happy path returns response unchanged

`agent_exceeding_deadline_returns_504` — slow agent is cancelled, 504 body matches schema

`gateway_default_enforced_when_route_has_no_deadline` — gateway default triggers 504 correctly

`no_timeout_configured_awaits_future_normally` — unbounded path does not interfere with response

`envelope_remaining_returns_positive_duration_before_expiry` — remaining time is positive and bounded

`envelope_is_expired_false_for_future_deadline` — not expired immediately after stamping
