### PR TITLE
fix(monitoring): add missing TracingExporter impl for JaegerExporter

### DIFF
--- a/crates/mofa-monitoring/src/tracing/exporter.rs
+++ b/crates/mofa-monitoring/src/tracing/exporter.rs
@@ -317,6 +317,28 @@ impl JaegerExporter {
             Err("No collector endpoint configured".to_string())
         }
     }
+}
+
+#[async_trait]
+impl TracingExporter for JaegerExporter {
+    async fn export(&self, spans: Vec<SpanData>) -> Result<(), String> {
+        if spans.is_empty() {
+            return Ok(());
+        }
+
+        {
+            let mut buffer = self.buffer.write().await;
+            buffer.extend(spans);
+
+            if buffer.len() >= self.config.batch_size {
+                let to_export: Vec<_> = buffer.drain(..).collect();
+                drop(buffer);
+                return self.send_to_collector(&to_export).await;
+            }
+        }
+
+        Ok(())
+    }
 
     async fn shutdown(&self) -> Result<(), String> {
         self.force_flush().await?;
@@ -708,6 +730,27 @@ mod tests {
 
         let spans = vec![create_test_span()];
         let result = composite.export(spans).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_jaeger_exporter_buffers_spans() {
+        let config = ExporterConfig::new("test-service").with_batch_size(100);
+        let jaeger_config = JaegerConfig::default();
+        let exporter = JaegerExporter::new(config, jaeger_config);
+
+        // Export fewer spans than batch_size — they should be buffered, not sent.
+        let spans = vec![create_test_span(), create_test_span()];
+        let result = exporter.export(spans).await;
+        assert!(result.is_ok());
+
+        // Verify the exporter can be used as a dyn TracingExporter.
+        let dyn_exporter: Arc<dyn TracingExporter> = Arc::new({
+            let config = ExporterConfig::new("test-service").with_batch_size(100);
+            let jaeger_config = JaegerConfig::default();
+            JaegerExporter::new(config, jaeger_config)
+        });
+        let result = dyn_exporter.export(vec![create_test_span()]).await;
         assert!(result.is_ok());
     }
 }


### PR DESCRIPTION


JaegerExporter had shutdown() and force_flush() defined as inherent methods instead of trait implementations, and was entirely missing the required export() method. This made it impossible to use JaegerExporter as a dyn TracingExporter (e.g. with CompositeExporter or BatchExporter).

- Move shutdown() and force_flush() from inherent impl to TracingExporter trait impl
- Add export() method with buffered batch export (matching OtlpExporter)
- Add unit test verifying buffering and dyn TracingExporter usage



## 📋 Summary

This PR adds the missing [TracingExporter](cci:2://file:///c:/Users/aftab/mofa/crates/mofa-monitoring/src/tracing/exporter.rs:69:0-81:1) trait implementation for [JaegerExporter](cci:2://file:///c:/Users/aftab/mofa/crates/mofa-monitoring/src/tracing/exporter.rs:221:0-225:1). It resolves an issue where the Jaeger exporter was publicly exported as a tracing exporter but couldn't actually be used dynamically (e.g., as `dyn TracingExporter`), and couldn't actually export span data due to a missing [export()](cci:1://file:///c:/Users/aftab/mofa/crates/mofa-monitoring/src/tracing/exporter.rs:582:4-596:5) method.

## 🔗 Related Issues

Closes #920



---

## 🧠 Context

[JaegerExporter](cci:2://file:///c:/Users/aftab/mofa/crates/mofa-monitoring/src/tracing/exporter.rs:221:0-225:1) included [shutdown()](cci:1://file:///c:/Users/aftab/mofa/crates/mofa-runtime/src/agent/execution.rs:831:8-834:9) and [force_flush()](cci:1://file:///c:/Users/aftab/mofa/crates/mofa-monitoring/src/tracing/exporter.rs:348:4-359:5) as inherent methods instead of trait implementations. It also lacked the [export()](cci:1://file:///c:/Users/aftab/mofa/crates/mofa-monitoring/src/tracing/exporter.rs:582:4-596:5) method entirely. This completely broke compatibility with [CompositeExporter](cci:2://file:///c:/Users/aftab/mofa/crates/mofa-monitoring/src/tracing/exporter.rs:566:0-568:1) and [BatchExporter](cci:2://file:///c:/Users/aftab/mofa/crates/mofa-monitoring/src/tracing/exporter.rs:633:0-636:1), and meant there was no way to actually batch-export spans to a Jaeger collector using this struct.

---

## 🛠️ Changes

- Moved [shutdown()](cci:1://file:///c:/Users/aftab/mofa/crates/mofa-runtime/src/agent/execution.rs:831:8-834:9) and [force_flush()](cci:1://file:///c:/Users/aftab/mofa/crates/mofa-monitoring/src/tracing/exporter.rs:348:4-359:5) out of the inherent `impl JaegerExporter` block into a proper `#[async_trait] impl TracingExporter for JaegerExporter` block.
- Implemented the missing [export()](cci:1://file:///c:/Users/aftab/mofa/crates/mofa-monitoring/src/tracing/exporter.rs:582:4-596:5) method using the same array buffering logic found in [OtlpExporter](cci:2://file:///c:/Users/aftab/mofa/crates/mofa-monitoring/src/tracing/exporter.rs:400:0-404:1).
- Added a unit test ([test_jaeger_exporter_buffers_spans](cci:1://file:///c:/Users/aftab/mofa/crates/mofa-monitoring/src/tracing/exporter.rs:735:4-754:5)) to verify buffering behavior and ensure the struct compiles as a `dyn TracingExporter`.

---

## 🧪 How you Tested

1. Verified the code compiles successfully without warnings via `cargo check -p mofa-monitoring`.
2. Ran `cargo test -p mofa-monitoring` to verify the newly added [test_jaeger_exporter_buffers_spans](cci:1://file:///c:/Users/aftab/mofa/crates/mofa-monitoring/src/tracing/exporter.rs:735:4-754:5) test passes, along with the rest of the existing monitoring tests.
3. Verified the exporter can now be instantiated as an `Arc<dyn TracingExporter>` correctly.

---

## 📸 Screenshots / Logs (if applicable)

N/A

---

## ⚠️ Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (describe below)

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [x] Public APIs documented
- [ ] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---

## 🚀 Deployment Notes (if applicable)

N/A

---

## 🧩 Additional Notes for Reviewers

The implementation of [export()](cci:1://file:///c:/Users/aftab/mofa/crates/mofa-monitoring/src/tracing/exporter.rs:582:4-596:5) exactly mirrors the implementation used for [OtlpExporter](cci:2://file:///c:/Users/aftab/mofa/crates/mofa-monitoring/src/tracing/exporter.rs:400:0-404:1), buffering the spans using a `RwLock` and flushing when the configured `batch_size` is reached.
