### PR TITLE
fix(cli): colorize TRACE log lines consistently

### DIFF
--- a/crates/mofa-cli/src/commands/agent/logs.rs
+++ b/crates/mofa-cli/src/commands/agent/logs.rs
@@ -171,7 +171,7 @@ fn colorize_log_line(line: &str) -> String {
         line.yellow().to_string()
     } else if upper.contains("INFO") {
         line.green().to_string()
-    } else if upper.contains("DEBUG") || upper.contains(" TRACE ") {
+    } else if upper.contains("DEBUG") || matches_log_level(line, "TRACE") {
         line.bright_black().to_string()
     } else {
         line.to_string()
@@ -392,5 +392,17 @@ mod tests {
         let result = run(&ctx, "new-agent", false, None, None, None, false).await;
         // Should succeed but show message about no logs
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_colorize_log_line_dims_trace_prefix_without_spaces() {
+        let line = "TRACE module::op starting";
+        assert_eq!(colorize_log_line(line), line.bright_black().to_string());
+    }
+
+    #[test]
+    fn test_colorize_log_line_dims_bracketed_trace_prefix() {
+        let line = "[TRACE] module::op starting";
+        assert_eq!(colorize_log_line(line), line.bright_black().to_string());
     }
 }

--- a/crates/mofa-cli/src/commands/agent/logs.rs
+++ b/crates/mofa-cli/src/commands/agent/logs.rs
@@ -171,7 +171,7 @@ fn colorize_log_line(line: &str) -> String {
         line.yellow().to_string()
     } else if upper.contains("INFO") {
         line.green().to_string()
-    } else if upper.contains("DEBUG") || matches_log_level(line, "TRACE") {
+    } else if upper.contains("DEBUG") || upper.contains("TRACE") {
         line.bright_black().to_string()
     } else {
         line.to_string()


### PR DESCRIPTION
## Summary

Fixes inconsistent TRACE log colorization in `mofa-cli` so TRACE lines are dimmed using the same detection rule already used for log-level filtering.

Before:
- `matches_log_level(..., "TRACE")` matched any line containing `TRACE`
- `colorize_log_line()` only dimmed TRACE when the line contained the exact substring `" TRACE "`
- common formats like `TRACE module::op starting` and `[TRACE] module::op starting` were not colorized consistently

After:
- both filtering and colorization treat TRACE lines consistently
- common TRACE prefixes are dimmed correctly

## Related Issues

Closes #936

---

##  Context

The CLI log command already recognized TRACE as a valid filter level, but its colorization logic used a narrower string check. That made TRACE handling inconsistent depending on log formatting and made CLI output harder to scan.

This change aligns colorization with the existing TRACE matching behavior while keeping the scope limited to the log rendering path.

---

## Changes

- Updated `colorize_log_line()` to reuse TRACE level matching instead of checking only for `" TRACE "`
- Added regression test:
  - `test_colorize_log_line_dims_trace_prefix_without_spaces`
- Added regression test:
  - `test_colorize_log_line_dims_bracketed_trace_prefix`

---

## How you Tested

1. Added regression tests for plain and bracketed TRACE prefixes.
2. Ran verification tools:
   - `cargo test -p mofa-cli logs -- --nocapture` (passed)

```bash
cargo test -p mofa-cli logs -- --nocapture
running 7 tests
...
test result: ok. 7 passed; 0 failed
```

---

## Screenshots / Logs (if applicable)

```bash
running 7 tests
test commands::agent::logs::tests::test_colorize_log_line_dims_bracketed_trace_prefix ... ok
test commands::agent::logs::tests::test_colorize_log_line_dims_trace_prefix_without_spaces ... ok
test commands::agent::logs::tests::test_get_agent_log_path ... ok
test commands::agent::logs::tests::test_display_log_file ... ok
test commands::agent::logs::tests::test_logs_command_missing_agent ... ok
test commands::agent::logs::tests::test_logs_command_no_logs_yet ... ok
test commands::agent::logs::tests::test_logs_command_with_existing_file ... ok
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 97 filtered out; finished in 0.04s
```

---

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (describe below)

If breaking:

---

## Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [x] Public APIs documented
- [ ] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---

## Deployment Notes (if applicable)

No migration or configuration changes required.

---

## Additional Notes for Reviewers

- File touched: `crates/mofa-cli/src/commands/agent/logs.rs`
- Scope is intentionally minimal: TRACE colorization consistency + regression coverage


