### PR TITLE
feat(patterns): add classic agentic Chain-of-Thought and Router showcase

### DIFF
--- a/crates/mofa-foundation/src/adapter/config.rs
+++ b/crates/mofa-foundation/src/adapter/config.rs
@@ -103,6 +103,12 @@ impl ModelConfigBuilder {
     }
 }
 
+impl Default for ModelConfigBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Hardware profile describing available hardware resources
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HardwareProfile {
@@ -238,6 +244,12 @@ impl HardwareProfileBuilder {
     }
 }
 
+impl Default for HardwareProfileBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Preferred hardware characteristics
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HardwarePreferences {
@@ -304,6 +316,12 @@ impl HardwarePreferencesBuilder {
 
     pub fn build(self) -> HardwarePreferences {
         self.preferences
+    }
+}
+
+impl Default for HardwarePreferencesBuilder {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/mofa-foundation/src/adapter/descriptor.rs
+++ b/crates/mofa-foundation/src/adapter/descriptor.rs
@@ -135,7 +135,7 @@ impl std::fmt::Display for QuantizationProfile {
 }
 
 /// Hardware constraints for adapter execution
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HardwareConstraint {
     /// Minimum RAM required in MB
     pub min_ram_mb: Option<u64>,
@@ -151,19 +151,6 @@ pub struct HardwareConstraint {
     pub gpu_required: bool,
 }
 
-impl Default for HardwareConstraint {
-    fn default() -> Self {
-        Self {
-            min_ram_mb: None,
-            min_vram_mb: None,
-            required_os: None,
-            required_cpu_features: None,
-            required_gpu_type: None,
-            gpu_required: false,
-        }
-    }
-}
-
 impl HardwareConstraint {
     /// Create a new hardware constraint builder
     pub fn builder() -> HardwareConstraintBuilder {
@@ -173,17 +160,17 @@ impl HardwareConstraint {
     /// Check if this hardware constraint is satisfied by the given requirements
     pub fn is_satisfied_by(&self, profile: &super::HardwareProfile) -> bool {
         // Check RAM requirement
-        if let Some(min_ram) = self.min_ram_mb {
-            if profile.available_ram_mb < min_ram {
-                return false;
-            }
+        if let Some(min_ram) = self.min_ram_mb
+            && profile.available_ram_mb < min_ram
+        {
+            return false;
         }
 
         // Check VRAM requirement
-        if let Some(min_vram) = self.min_vram_mb {
-            if profile.available_vram_mb.unwrap_or(0) < min_vram {
-                return false;
-            }
+        if let Some(min_vram) = self.min_vram_mb
+            && profile.available_vram_mb.unwrap_or(0) < min_vram
+        {
+            return false;
         }
 
         // Check GPU requirement
@@ -203,10 +190,11 @@ impl HardwareConstraint {
         }
 
         // Check OS requirement
-        if let Some(ref required_os) = self.required_os {
-            if !required_os.is_empty() && !required_os.contains(&profile.os) {
-                return false;
-            }
+        if let Some(ref required_os) = self.required_os
+            && !required_os.is_empty()
+            && !required_os.contains(&profile.os)
+        {
+            return false;
         }
 
         true
@@ -253,6 +241,12 @@ impl HardwareConstraintBuilder {
 
     pub fn build(self) -> HardwareConstraint {
         self.constraint
+    }
+}
+
+impl Default for HardwareConstraintBuilder {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -420,6 +414,12 @@ impl AdapterDescriptorBuilder {
             panic!("AdapterDescriptor must have at least one supported format");
         }
         self.descriptor
+    }
+}
+
+impl Default for AdapterDescriptorBuilder {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/mofa-foundation/src/adapter/registry.rs
+++ b/crates/mofa-foundation/src/adapter/registry.rs
@@ -149,17 +149,17 @@ impl AdapterRegistry {
             }
 
             // Step 3: Check quantization support (hard constraint, if specified)
-            if let Some(ref required_quant) = config.required_quantization {
-                if !adapter.supports_quantization(required_quant) {
-                    rejections.push(RejectionReason::QuantizationMismatch {
-                        required: required_quant.clone(),
-                        supported: adapter
-                            .supported_quantizations
-                            .iter()
-                            .map(|q| q.name.clone())
-                            .collect(),
-                    });
-                }
+            if let Some(ref required_quant) = config.required_quantization
+                && !adapter.supports_quantization(required_quant)
+            {
+                rejections.push(RejectionReason::QuantizationMismatch {
+                    required: required_quant.clone(),
+                    supported: adapter
+                        .supported_quantizations
+                        .iter()
+                        .map(|q| q.name.clone())
+                        .collect(),
+                });
             }
 
             // Step 4: Check hardware compatibility (hard constraint)
@@ -171,13 +171,13 @@ impl AdapterRegistry {
             }
 
             // Step 5: Check priority threshold (soft constraint)
-            if let Some(min_priority) = config.min_priority {
-                if adapter.priority < min_priority {
-                    rejections.push(RejectionReason::PriorityTooLow {
-                        required_min_priority: min_priority,
-                        adapter_priority: adapter.priority,
-                    });
-                }
+            if let Some(min_priority) = config.min_priority
+                && adapter.priority < min_priority
+            {
+                rejections.push(RejectionReason::PriorityTooLow {
+                    required_min_priority: min_priority,
+                    adapter_priority: adapter.priority,
+                });
             }
 
             // Step 6: Check experimental flag

--- a/crates/mofa-foundation/src/agent/components/context_compressor.rs
+++ b/crates/mofa-foundation/src/agent/components/context_compressor.rs
@@ -61,18 +61,17 @@ mod cache {
         /// get cached embedding
         pub async fn get_embedding(&self, key: &str) -> Option<Vec<f32>> {
             let cache = self.embedding_cache.read().await;
-            cache.get(key).map(|entry| {
-                entry.embedding.clone()
-            })
+            cache.get(key).map(|entry| entry.embedding.clone())
         }
 
         /// store embedding in cache
         pub async fn store_embedding(&self, key: String, embedding: Vec<f32>) {
             let mut cache = self.embedding_cache.write().await;
-            
+
             // evict oldest if at capacity
             if cache.len() >= self.max_embedding_entries && !cache.is_empty() {
-                let oldest_key = cache.iter()
+                let oldest_key = cache
+                    .iter()
                     .min_by_key(|(_, entry)| entry.accessed_at)
                     .map(|(k, _)| k.clone());
                 if let Some(key) = oldest_key {
@@ -80,27 +79,29 @@ mod cache {
                 }
             }
 
-            cache.insert(key, EmbeddingCacheEntry {
-                embedding,
-                accessed_at: Instant::now(),
-            });
+            cache.insert(
+                key,
+                EmbeddingCacheEntry {
+                    embedding,
+                    accessed_at: Instant::now(),
+                },
+            );
         }
 
         /// get cached summary
         pub async fn get_summary(&self, key: &str) -> Option<String> {
             let cache = self.summary_cache.read().await;
-            cache.get(key).map(|entry| {
-                entry.summary.clone()
-            })
+            cache.get(key).map(|entry| entry.summary.clone())
         }
 
         /// store summary in cache
         pub async fn store_summary(&self, key: String, summary: String) {
             let mut cache = self.summary_cache.write().await;
-            
+
             // evict oldest if at capacity
             if cache.len() >= self.max_summary_entries && !cache.is_empty() {
-                let oldest_key = cache.iter()
+                let oldest_key = cache
+                    .iter()
                     .min_by_key(|(_, entry)| entry.accessed_at)
                     .map(|(k, _)| k.clone());
                 if let Some(key) = oldest_key {
@@ -108,10 +109,13 @@ mod cache {
                 }
             }
 
-            cache.insert(key, SummaryCacheEntry {
-                summary,
-                accessed_at: Instant::now(),
-            });
+            cache.insert(
+                key,
+                SummaryCacheEntry {
+                    summary,
+                    accessed_at: Instant::now(),
+                },
+            );
         }
 
         /// clear all caches
@@ -144,7 +148,7 @@ mod cache {
 }
 
 #[cfg(feature = "compression-cache")]
-pub use cache::{CompressionCache, CacheStats};
+pub use cache::{CacheStats, CompressionCache};
 
 // token counter utility
 
@@ -311,7 +315,11 @@ impl ContextCompressor for SlidingWindowCompressor {
                 messages_before,
                 messages_before,
             );
-            return Ok(CompressionResult::new(messages, metrics, self.name().to_string()));
+            return Ok(CompressionResult::new(
+                messages,
+                metrics,
+                self.name().to_string(),
+            ));
         }
 
         let (system_msgs, mut conversation): (Vec<_>, Vec<_>) =
@@ -327,12 +335,8 @@ impl ContextCompressor for SlidingWindowCompressor {
         let tokens_after = self.count_tokens(&result);
         let messages_after = result.len();
 
-        let metrics = CompressionMetrics::new(
-            tokens_before,
-            tokens_after,
-            messages_before,
-            messages_after,
-        );
+        let metrics =
+            CompressionMetrics::new(tokens_before, tokens_after, messages_before, messages_after);
 
         // log compression event
         if metrics.was_compressed() {
@@ -356,7 +360,11 @@ impl ContextCompressor for SlidingWindowCompressor {
             );
         }
 
-        Ok(CompressionResult::new(result, metrics, self.name().to_string()))
+        Ok(CompressionResult::new(
+            result,
+            metrics,
+            self.name().to_string(),
+        ))
     }
 
     fn strategy(&self) -> CompressionStrategy {
@@ -436,7 +444,11 @@ impl ContextCompressor for SummarizingCompressor {
                 messages_before,
                 messages_before,
             );
-            return Ok(CompressionResult::new(messages, metrics, self.name().to_string()));
+            return Ok(CompressionResult::new(
+                messages,
+                metrics,
+                self.name().to_string(),
+            ));
         }
 
         let (system_msgs, conversation): (Vec<_>, Vec<_>) =
@@ -446,20 +458,20 @@ impl ContextCompressor for SummarizingCompressor {
             let mut result = system_msgs;
             result.extend(conversation);
             let tokens_after = self.count_tokens(&result);
-            let metrics = CompressionMetrics::new(
-                tokens_before,
-                tokens_after,
-                messages_before,
-                result.len(),
-            );
-            return Ok(CompressionResult::new(result, metrics, self.name().to_string()));
+            let metrics =
+                CompressionMetrics::new(tokens_before, tokens_after, messages_before, result.len());
+            return Ok(CompressionResult::new(
+                result,
+                metrics,
+                self.name().to_string(),
+            ));
         }
 
         let split_at = conversation.len() - self.keep_recent;
         let (to_summarise, recent) = conversation.split_at(split_at);
 
         let prompt = Self::build_summary_prompt(to_summarise);
-        
+
         // check cache if enabled
         #[cfg(feature = "compression-cache")]
         let cache_key = if let Some(ref cache) = self.cache {
@@ -469,44 +481,47 @@ impl ContextCompressor for SummarizingCompressor {
         };
 
         #[cfg(feature = "compression-cache")]
-        let summary_text = if let (Some(ref cache), Some(ref key)) = (self.cache.as_ref(), cache_key.as_ref()) {
-            if let Some(cached) = cache.get_summary(key).await {
-                cached
-            } else {
-                let summary_response = self
-                    .llm
-                    .chat(crate::llm::types::ChatCompletionRequest::new("gpt-4o-mini")
-                        .user(prompt.clone())
-                        .temperature(0.3)
-                        .max_tokens(512))
-                    .await
-                    .map_err(|e| AgentError::ExecutionFailed(format!("summarisation failed: {e}")))?;
+        let summary_text =
+            if let (Some(ref cache), Some(ref key)) = (self.cache.as_ref(), cache_key.as_ref()) {
+                if let Some(cached) = cache.get_summary(key).await {
+                    cached
+                } else {
+                    let summary_response = self
+                        .llm
+                        .chat(
+                            crate::llm::types::ChatCompletionRequest::new("gpt-4o-mini")
+                                .user(prompt.clone())
+                                .temperature(0.3)
+                                .max_tokens(512),
+                        )
+                        .await
+                        .map_err(|e| {
+                            AgentError::ExecutionFailed(format!("summarisation failed: {e}"))
+                        })?;
 
-                let text = summary_response
+                    let text = summary_response
+                        .content()
+                        .map(str::to_string)
+                        .unwrap_or_else(|| "[summary unavailable]".to_string());
+
+                    cache.store_summary(key.to_string(), text.clone()).await;
+                    text
+                }
+            } else {
+                let summary_request = crate::llm::types::ChatCompletionRequest::new("gpt-4o-mini")
+                    .user(prompt)
+                    .temperature(0.3)
+                    .max_tokens(512);
+
+                let summary_response = self.llm.chat(summary_request).await.map_err(|e| {
+                    AgentError::ExecutionFailed(format!("summarisation failed: {e}"))
+                })?;
+
+                summary_response
                     .content()
                     .map(str::to_string)
-                    .unwrap_or_else(|| "[summary unavailable]".to_string());
-                
-                cache.store_summary(key.to_string(), text.clone()).await;
-                text
-            }
-        } else {
-        let summary_request = crate::llm::types::ChatCompletionRequest::new("gpt-4o-mini")
-            .user(prompt)
-            .temperature(0.3)
-            .max_tokens(512);
-
-        let summary_response = self
-            .llm
-            .chat(summary_request)
-            .await
-            .map_err(|e| AgentError::ExecutionFailed(format!("summarisation failed: {e}")))?;
-
-            summary_response
-            .content()
-            .map(str::to_string)
-                .unwrap_or_else(|| "[summary unavailable]".to_string())
-        };
+                    .unwrap_or_else(|| "[summary unavailable]".to_string())
+            };
 
         #[cfg(not(feature = "compression-cache"))]
         let summary_text = {
@@ -515,11 +530,10 @@ impl ContextCompressor for SummarizingCompressor {
                 .temperature(0.3)
                 .max_tokens(512);
 
-            let summary_response = self
-                .llm
-                .chat(summary_request)
-                .await
-                .map_err(|e| AgentError::ExecutionFailed(format!("summarisation failed: {e}")))?;
+            let summary_response =
+                self.llm.chat(summary_request).await.map_err(|e| {
+                    AgentError::ExecutionFailed(format!("summarisation failed: {e}"))
+                })?;
 
             summary_response
                 .content()
@@ -540,12 +554,8 @@ impl ContextCompressor for SummarizingCompressor {
         let tokens_after = self.count_tokens(&result);
         let messages_after = result.len();
 
-        let metrics = CompressionMetrics::new(
-            tokens_before,
-            tokens_after,
-            messages_before,
-            messages_after,
-        );
+        let metrics =
+            CompressionMetrics::new(tokens_before, tokens_after, messages_before, messages_after);
 
         // log compression event
         if metrics.was_compressed() {
@@ -569,7 +579,11 @@ impl ContextCompressor for SummarizingCompressor {
             );
         }
 
-        Ok(CompressionResult::new(result, metrics, self.name().to_string()))
+        Ok(CompressionResult::new(
+            result,
+            metrics,
+            self.name().to_string(),
+        ))
     }
 
     fn strategy(&self) -> CompressionStrategy {
@@ -689,9 +703,11 @@ impl SemanticCompressor {
                         .data
                         .into_iter()
                         .next()
-                        .ok_or_else(|| AgentError::ExecutionFailed("no embedding data".to_string()))?
+                        .ok_or_else(|| {
+                            AgentError::ExecutionFailed("no embedding data".to_string())
+                        })?
                         .embedding;
-                    
+
                     cache.store_embedding(cache_key, emb.clone()).await;
                     emb
                 }
@@ -827,7 +843,11 @@ impl ContextCompressor for SemanticCompressor {
                 messages_before,
                 messages_before,
             );
-            return Ok(CompressionResult::new(messages, metrics, self.name().to_string()));
+            return Ok(CompressionResult::new(
+                messages,
+                metrics,
+                self.name().to_string(),
+            ));
         }
 
         let (system_msgs, conversation): (Vec<_>, Vec<_>) =
@@ -837,13 +857,13 @@ impl ContextCompressor for SemanticCompressor {
             let mut result = system_msgs;
             result.extend(conversation);
             let tokens_after = self.count_tokens(&result);
-            let metrics = CompressionMetrics::new(
-                tokens_before,
-                tokens_after,
-                messages_before,
-                result.len(),
-            );
-            return Ok(CompressionResult::new(result, metrics, self.name().to_string()));
+            let metrics =
+                CompressionMetrics::new(tokens_before, tokens_after, messages_before, result.len());
+            return Ok(CompressionResult::new(
+                result,
+                metrics,
+                self.name().to_string(),
+            ));
         }
 
         let split_at = conversation.len().saturating_sub(self.keep_recent);
@@ -869,8 +889,13 @@ impl ContextCompressor for SemanticCompressor {
             assigned[i] = true;
 
             if let Some(Some(emb_i)) = embeddings.get(i) {
-                for j in (i + 1)..to_compress.len() {
-                    if assigned[j] {
+                for (j, is_assigned) in assigned
+                    .iter_mut()
+                    .enumerate()
+                    .take(to_compress.len())
+                    .skip(i + 1)
+                {
+                    if *is_assigned {
                         continue;
                     }
 
@@ -878,7 +903,7 @@ impl ContextCompressor for SemanticCompressor {
                         let similarity = Self::cosine_similarity(emb_i, emb_j);
                         if similarity >= self.similarity_threshold {
                             cluster.push(j);
-                            assigned[j] = true;
+                            *is_assigned = true;
                         }
                     }
                 }
@@ -905,12 +930,8 @@ impl ContextCompressor for SemanticCompressor {
         let tokens_after = self.count_tokens(&result);
         let messages_after = result.len();
 
-        let metrics = CompressionMetrics::new(
-            tokens_before,
-            tokens_after,
-            messages_before,
-            messages_after,
-        );
+        let metrics =
+            CompressionMetrics::new(tokens_before, tokens_after, messages_before, messages_after);
 
         // log compression event
         if metrics.was_compressed() {
@@ -934,7 +955,11 @@ impl ContextCompressor for SemanticCompressor {
             );
         }
 
-        Ok(CompressionResult::new(result, metrics, self.name().to_string()))
+        Ok(CompressionResult::new(
+            result,
+            metrics,
+            self.name().to_string(),
+        ))
     }
 
     fn strategy(&self) -> CompressionStrategy {
@@ -1007,7 +1032,11 @@ impl ContextCompressor for HierarchicalCompressor {
                 messages_before,
                 messages_before,
             );
-            return Ok(CompressionResult::new(messages, metrics, self.name().to_string()));
+            return Ok(CompressionResult::new(
+                messages,
+                metrics,
+                self.name().to_string(),
+            ));
         }
 
         let (system_msgs, conversation): (Vec<_>, Vec<_>) =
@@ -1017,13 +1046,13 @@ impl ContextCompressor for HierarchicalCompressor {
             let mut result = system_msgs;
             result.extend(conversation);
             let tokens_after = self.count_tokens(&result);
-            let metrics = CompressionMetrics::new(
-                tokens_before,
-                tokens_after,
-                messages_before,
-                result.len(),
-            );
-            return Ok(CompressionResult::new(result, metrics, self.name().to_string()));
+            let metrics =
+                CompressionMetrics::new(tokens_before, tokens_after, messages_before, result.len());
+            return Ok(CompressionResult::new(
+                result,
+                metrics,
+                self.name().to_string(),
+            ));
         }
 
         let split_at = conversation.len().saturating_sub(self.keep_recent);
@@ -1043,16 +1072,16 @@ impl ContextCompressor for HierarchicalCompressor {
         let mut compressed = Vec::new();
         let mut current_tokens = system_msgs
             .iter()
-            .map(|m| self.count_tokens(&[m.clone()]))
+            .map(|m| self.count_tokens(std::slice::from_ref(m)))
             .sum::<usize>();
 
         for (score, msg) in scored {
-            let msg_tokens = self.count_tokens(&[msg.clone()]);
+            let msg_tokens = self.count_tokens(std::slice::from_ref(&msg));
             let estimated_total = current_tokens
                 + msg_tokens
                 + recent
                     .iter()
-                    .map(|m| self.count_tokens(&[m.clone()]))
+                    .map(|m| self.count_tokens(std::slice::from_ref(m)))
                     .sum::<usize>();
 
             if estimated_total <= max_tokens {
@@ -1072,23 +1101,20 @@ impl ContextCompressor for HierarchicalCompressor {
                             .temperature(0.3)
                             .max_tokens(256);
 
-                    match self.llm.chat(summary_request).await {
-                        Ok(response) => {
-                            if let Some(summary) = response.content() {
-                                let summary_msg = ChatMessage {
-                                    role: msg.role.clone(),
-                                    content: Some(format!("[Compressed] {}", summary)),
-                                    tool_call_id: None,
-                                    tool_calls: None,
-                                };
-                                let summary_tokens = self.count_tokens(&[summary_msg.clone()]);
-                                if current_tokens + summary_tokens <= max_tokens {
-                                    compressed.push(summary_msg);
-                                    current_tokens += summary_tokens;
-                                }
-                            }
+                    if let Ok(response) = self.llm.chat(summary_request).await
+                        && let Some(summary) = response.content()
+                    {
+                        let summary_msg = ChatMessage {
+                            role: msg.role.clone(),
+                            content: Some(format!("[Compressed] {}", summary)),
+                            tool_call_id: None,
+                            tool_calls: None,
+                        };
+                        let summary_tokens = self.count_tokens(std::slice::from_ref(&summary_msg));
+                        if current_tokens + summary_tokens <= max_tokens {
+                            compressed.push(summary_msg);
+                            current_tokens += summary_tokens;
                         }
-                        Err(_) => {}
                     }
                 }
             }
@@ -1101,12 +1127,8 @@ impl ContextCompressor for HierarchicalCompressor {
         let tokens_after = self.count_tokens(&result);
         let messages_after = result.len();
 
-        let metrics = CompressionMetrics::new(
-            tokens_before,
-            tokens_after,
-            messages_before,
-            messages_after,
-        );
+        let metrics =
+            CompressionMetrics::new(tokens_before, tokens_after, messages_before, messages_after);
 
         // log compression event
         if metrics.was_compressed() {
@@ -1130,7 +1152,11 @@ impl ContextCompressor for HierarchicalCompressor {
             );
         }
 
-        Ok(CompressionResult::new(result, metrics, self.name().to_string()))
+        Ok(CompressionResult::new(
+            result,
+            metrics,
+            self.name().to_string(),
+        ))
     }
 
     fn strategy(&self) -> CompressionStrategy {
@@ -1189,12 +1215,18 @@ impl ContextCompressor for HybridCompressor {
                 messages_before,
                 messages_before,
             );
-            return Ok(CompressionResult::new(messages, metrics, self.name().to_string()));
+            return Ok(CompressionResult::new(
+                messages,
+                metrics,
+                self.name().to_string(),
+            ));
         }
 
         let mut current = messages;
         for strategy in &self.strategies {
-            let result = strategy.compress_with_metrics(current.clone(), max_tokens).await?;
+            let result = strategy
+                .compress_with_metrics(current.clone(), max_tokens)
+                .await?;
             if result.metrics.tokens_after <= max_tokens {
                 return Ok(result);
             }
@@ -1203,14 +1235,14 @@ impl ContextCompressor for HybridCompressor {
 
         let tokens_after = self.count_tokens(&current);
         let messages_after = current.len();
-        let metrics = CompressionMetrics::new(
-            tokens_before,
-            tokens_after,
-            messages_before,
-            messages_after,
-        );
+        let metrics =
+            CompressionMetrics::new(tokens_before, tokens_after, messages_before, messages_after);
 
-        Ok(CompressionResult::new(current, metrics, self.name().to_string()))
+        Ok(CompressionResult::new(
+            current,
+            metrics,
+            self.name().to_string(),
+        ))
     }
 
     fn strategy(&self) -> CompressionStrategy {

--- a/crates/mofa-foundation/src/coordination/scheduler.rs
+++ b/crates/mofa-foundation/src/coordination/scheduler.rs
@@ -127,71 +127,64 @@ impl PriorityScheduler {
 
             // 检查是否需要抢占 — 内联以避免死锁
             // Check for preemption — inlined to avoid deadlock
-            if let Some(&load) = agent_load.get(&target_agent) {
-                if load > 0 {
-                    if let Some(tasks_on_agent) = agent_tasks.get(&target_agent) {
-                        let preemptable_task = tasks_on_agent
-                            .iter()
-                            .filter(|tid| task_status.get(*tid) == Some(&SchedulingStatus::Running))
-                            .filter(|tid| {
-                                if let Some(task_priority) = task_priorities.get(*tid) {
-                                    task.priority > *task_priority
-                                } else {
-                                    false
-                                }
-                            })
-                            .min_by_key(|tid| task_priorities.get(*tid).cloned())
-                            .cloned();
-
-                        if let Some(low_priority_task_id) = preemptable_task {
-                            let preempt_msg = AgentMessage::Event(AgentEvent::TaskPreempted(
-                                low_priority_task_id.clone(),
-                            ));
-                            self.bus
-                                .send_message(
-                                    "scheduler",
-                                    CommunicationMode::PointToPoint(target_agent.clone()),
-                                    &preempt_msg,
-                                )
-                                .await
-                                .map_err(|e| GlobalError::Other(e.to_string()))?;
-
-                            // Clean up preempted task state to prevent ghost entries:
-                            // Without this, preempted tasks leak in all 4 HashMaps,
-                            // causing agent_load drift, OOM, and scheduling starvation.
-                            task_status
-                                .insert(low_priority_task_id.clone(), SchedulingStatus::Preempted);
-                            if let Some(count) = agent_load.get_mut(&target_agent) {
-                                *count = count.saturating_sub(1);
-                            }
-                            if let Some(tasks) = agent_tasks.get_mut(&target_agent) {
-                                tasks.retain(|t| t != &low_priority_task_id);
-                            }
-
-                            // Re-enqueue the preempted task so it can be rescheduled
-                            // to a different (or the same) agent in a future cycle.
-                            if let Some(orig_priority) =
-                                task_priorities.remove(&low_priority_task_id)
-                            {
-                                let requeued = PriorityTask {
-                                    priority: orig_priority.clone(),
-                                    task: TaskRequest {
-                                        task_id: low_priority_task_id.clone(),
-                                        content: task.content.clone(),
-                                        priority: orig_priority.clone(),
-                                        deadline: None,
-                                        metadata: std::collections::HashMap::new(),
-                                    },
-                                    submit_time: std::time::Instant::now(),
-                                };
-                                task_queue.push(requeued);
-                                task_status.insert(
-                                    low_priority_task_id.clone(),
-                                    SchedulingStatus::Pending,
-                                );
-                                task_priorities.insert(low_priority_task_id, orig_priority);
-                            }
+            if let Some(&load) = agent_load.get(&target_agent)
+                && load > 0
+                && let Some(tasks_on_agent) = agent_tasks.get(&target_agent)
+            {
+                let preemptable_task = tasks_on_agent
+                    .iter()
+                    .filter(|tid| task_status.get(*tid) == Some(&SchedulingStatus::Running))
+                    .filter(|tid| {
+                        if let Some(task_priority) = task_priorities.get(*tid) {
+                            task.priority > *task_priority
+                        } else {
+                            false
                         }
+                    })
+                    .min_by_key(|tid| task_priorities.get(*tid).cloned())
+                    .cloned();
+
+                if let Some(low_priority_task_id) = preemptable_task {
+                    let preempt_msg = AgentMessage::Event(AgentEvent::TaskPreempted(
+                        low_priority_task_id.clone(),
+                    ));
+                    self.bus
+                        .send_message(
+                            "scheduler",
+                            CommunicationMode::PointToPoint(target_agent.clone()),
+                            &preempt_msg,
+                        )
+                        .await
+                        .map_err(|e| GlobalError::Other(e.to_string()))?;
+
+                    // Clean up preempted task state to prevent ghost entries:
+                    // Without this, preempted tasks leak in all 4 HashMaps,
+                    // causing agent_load drift, OOM, and scheduling starvation.
+                    task_status.insert(low_priority_task_id.clone(), SchedulingStatus::Preempted);
+                    if let Some(count) = agent_load.get_mut(&target_agent) {
+                        *count = count.saturating_sub(1);
+                    }
+                    if let Some(tasks) = agent_tasks.get_mut(&target_agent) {
+                        tasks.retain(|t| t != &low_priority_task_id);
+                    }
+
+                    // Re-enqueue the preempted task so it can be rescheduled
+                    // to a different (or the same) agent in a future cycle.
+                    if let Some(orig_priority) = task_priorities.remove(&low_priority_task_id) {
+                        let requeued = PriorityTask {
+                            priority: orig_priority.clone(),
+                            task: TaskRequest {
+                                task_id: low_priority_task_id.clone(),
+                                content: task.content.clone(),
+                                priority: orig_priority.clone(),
+                                deadline: None,
+                                metadata: std::collections::HashMap::new(),
+                            },
+                            submit_time: std::time::Instant::now(),
+                        };
+                        task_queue.push(requeued);
+                        task_status.insert(low_priority_task_id.clone(), SchedulingStatus::Pending);
+                        task_priorities.insert(low_priority_task_id, orig_priority);
                     }
                 }
             }
@@ -424,9 +417,15 @@ mod tests {
         assert_eq!(*load.get("agent-1").unwrap(), 0);
         // Completed task metadata is evicted — entry must not linger in the map.
         let status = scheduler.task_status.read().await;
-        assert!(status.get("t1").is_none(), "task_status entry should be removed on completion");
+        assert!(
+            status.get("t1").is_none(),
+            "task_status entry should be removed on completion"
+        );
         let priorities = scheduler.task_priorities.read().await;
-        assert!(priorities.get("t1").is_none(), "task_priorities entry should be removed on completion");
+        assert!(
+            priorities.get("t1").is_none(),
+            "task_priorities entry should be removed on completion"
+        );
     }
 
     /// Verifies the priority queue orders tasks correctly (higher priority first).

--- a/crates/mofa-foundation/src/llm/anthropic.rs
+++ b/crates/mofa-foundation/src/llm/anthropic.rs
@@ -178,7 +178,7 @@ impl AnthropicProvider {
                                         let data = image_url
                                             .url
                                             .split(',')
-                                            .last()
+                                            .next_back()
                                             .unwrap_or(&image_url.url);
                                         contents.push(serde_json::json!({
                                             "type": "image",
@@ -192,8 +192,11 @@ impl AnthropicProvider {
                                     ContentPart::Audio { audio } => {
                                         let media_type =
                                             format!("audio/{}", audio.format.to_lowercase());
-                                        let data =
-                                            audio.data.split(',').last().unwrap_or(&audio.data);
+                                        let data = audio
+                                            .data
+                                            .split(',')
+                                            .next_back()
+                                            .unwrap_or(&audio.data);
                                         // Some providers/models may not support this block, but this is the standard Anthropics structure if/when supported.
                                         contents.push(serde_json::json!({
                                             "type": "audio",
@@ -207,8 +210,11 @@ impl AnthropicProvider {
                                     ContentPart::Video { video } => {
                                         let media_type =
                                             format!("video/{}", video.format.to_lowercase());
-                                        let data =
-                                            video.data.split(',').last().unwrap_or(&video.data);
+                                        let data = video
+                                            .data
+                                            .split(',')
+                                            .next_back()
+                                            .unwrap_or(&video.data);
                                         contents.push(serde_json::json!({
                                             "type": "video",
                                             "source": {
@@ -869,9 +875,9 @@ data: {\"type\":\"message_stop\"}";
     /// Integration: SSE text to parse_sse_event to adapter to bridge
     #[tokio::test]
     async fn sse_through_adapter_and_bridge() {
-        use crate::llm::stream_adapter::{adapter_for_provider, StreamAdapter};
-        use crate::llm::stream_bridge::{token_stream_to_events, token_stream_to_text};
         use crate::llm::agent::StreamEvent;
+        use crate::llm::stream_adapter::{StreamAdapter, adapter_for_provider};
+        use crate::llm::stream_bridge::{token_stream_to_events, token_stream_to_text};
         use futures::StreamExt;
 
         let raw = "\
@@ -898,7 +904,11 @@ data: {\"type\":\"message_stop\"}\n";
             Box::pin(futures::stream::iter(chunks.clone().into_iter().map(Ok)));
         let token_stream = adapter_for_provider("anthropic").adapt(chat_stream);
         let texts: Vec<String> = token_stream_to_text(token_stream)
-            .collect::<Vec<_>>().await.into_iter().map(|r| r.unwrap()).collect();
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .map(|r| r.unwrap())
+            .collect();
         assert_eq!(texts, vec!["Hello", " world"]);
 
         // events path
@@ -906,7 +916,11 @@ data: {\"type\":\"message_stop\"}\n";
             Box::pin(futures::stream::iter(chunks.into_iter().map(Ok)));
         let token_stream2 = adapter_for_provider("anthropic").adapt(chat_stream2);
         let events: Vec<StreamEvent> = token_stream_to_events(token_stream2)
-            .collect::<Vec<_>>().await.into_iter().map(|r| r.unwrap()).collect();
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .map(|r| r.unwrap())
+            .collect();
         assert!(matches!(events[0], StreamEvent::Text(ref s) if s == "Hello"));
         assert!(matches!(events[1], StreamEvent::Text(ref s) if s == " world"));
         assert!(matches!(events[2], StreamEvent::Done(_)));
@@ -916,13 +930,13 @@ data: {\"type\":\"message_stop\"}\n";
     /// Negative path: Anthropic errors + timeout through adapter to bridge
     #[tokio::test]
     async fn sse_error_and_timeout_through_pipeline() {
-        use crate::llm::stream_adapter::{adapter_for_provider, StreamAdapter};
+        use crate::llm::stream_adapter::{StreamAdapter, adapter_for_provider};
         use crate::llm::stream_bridge::token_stream_to_text;
         use futures::StreamExt;
 
         let good_chunk = process_sse_text(
             "event: content_block_delta\n\
-             data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"ok\"}}\n"
+             data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"ok\"}}\n",
         );
 
         // Network error mid stream
@@ -930,28 +944,23 @@ data: {\"type\":\"message_stop\"}\n";
             Ok(good_chunk[0].clone()),
             Err(LLMError::NetworkError("connection reset".into())),
         ];
-        let ts = adapter_for_provider("anthropic")
-            .adapt(Box::pin(futures::stream::iter(items)));
+        let ts = adapter_for_provider("anthropic").adapt(Box::pin(futures::stream::iter(items)));
         let results: Vec<_> = token_stream_to_text(ts).collect().await;
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].as_ref().unwrap(), "ok");
         let err = results[1].as_ref().unwrap_err();
         assert!(matches!(err, LLMError::NetworkError(msg) if msg == "connection reset"));
 
-        let items2: Vec<LLMResult<ChatCompletionChunk>> = vec![
-            Err(LLMError::Timeout("30s exceeded".into())),
-        ];
-        let ts2 = adapter_for_provider("anthropic")
-            .adapt(Box::pin(futures::stream::iter(items2)));
+        let items2: Vec<LLMResult<ChatCompletionChunk>> =
+            vec![Err(LLMError::Timeout("30s exceeded".into()))];
+        let ts2 = adapter_for_provider("anthropic").adapt(Box::pin(futures::stream::iter(items2)));
         let results2: Vec<_> = token_stream_to_text(ts2).collect().await;
         assert_eq!(results2.len(), 1);
         assert!(matches!(results2[0], Err(LLMError::NetworkError(_))));
 
-        let items3: Vec<LLMResult<ChatCompletionChunk>> = vec![
-            Err(LLMError::SerializationError("bad json".into())),
-        ];
-        let ts3 = adapter_for_provider("anthropic")
-            .adapt(Box::pin(futures::stream::iter(items3)));
+        let items3: Vec<LLMResult<ChatCompletionChunk>> =
+            vec![Err(LLMError::SerializationError("bad json".into()))];
+        let ts3 = adapter_for_provider("anthropic").adapt(Box::pin(futures::stream::iter(items3)));
         let results3: Vec<_> = token_stream_to_text(ts3).collect().await;
         assert_eq!(results3.len(), 1);
         assert!(matches!(results3[0], Err(LLMError::SerializationError(_))));
@@ -986,12 +995,21 @@ data: {\"type\":\"message_stop\"}\n";
         assert_eq!(contents.len(), 3);
 
         assert_eq!(contents[0]["type"], "image");
-        assert_eq!(contents[0]["source"]["data"], "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==");
-        
+        assert_eq!(
+            contents[0]["source"]["data"],
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+        );
+
         assert_eq!(contents[1]["type"], "audio");
-        assert_eq!(contents[1]["source"]["data"], "UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA=");
+        assert_eq!(
+            contents[1]["source"]["data"],
+            "UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA="
+        );
 
         assert_eq!(contents[2]["type"], "video");
-        assert_eq!(contents[2]["source"]["data"], "AAAAIGZ0eXBtcDQyAAAAAG1wNDJpc29tYXZjMQAAADhmoW9v...");
+        assert_eq!(
+            contents[2]["source"]["data"],
+            "AAAAIGZ0eXBtcDQyAAAAAG1wNDJpc29tYXZjMQAAADhmoW9v..."
+        );
     }
 }

--- a/crates/mofa-foundation/src/llm/google.rs
+++ b/crates/mofa-foundation/src/llm/google.rs
@@ -168,7 +168,7 @@ impl GeminiProvider {
                                         let data = image_url
                                             .url
                                             .split(',')
-                                            .last()
+                                            .next_back()
                                             .unwrap_or(&image_url.url);
                                         gemini_parts.push(serde_json::json!({
                                             "inlineData": {
@@ -180,8 +180,11 @@ impl GeminiProvider {
                                     ContentPart::Audio { audio } => {
                                         let mime_type =
                                             format!("audio/{}", audio.format.to_lowercase());
-                                        let data =
-                                            audio.data.split(',').last().unwrap_or(&audio.data);
+                                        let data = audio
+                                            .data
+                                            .split(',')
+                                            .next_back()
+                                            .unwrap_or(&audio.data);
                                         gemini_parts.push(serde_json::json!({
                                             "inlineData": {
                                                 "mimeType": mime_type,
@@ -192,8 +195,11 @@ impl GeminiProvider {
                                     ContentPart::Video { video } => {
                                         let mime_type =
                                             format!("video/{}", video.format.to_lowercase());
-                                        let data =
-                                            video.data.split(',').last().unwrap_or(&video.data);
+                                        let data = video
+                                            .data
+                                            .split(',')
+                                            .next_back()
+                                            .unwrap_or(&video.data);
                                         gemini_parts.push(serde_json::json!({
                                             "inlineData": {
                                                 "mimeType": mime_type,
@@ -460,12 +466,21 @@ mod tests {
         assert_eq!(parts.len(), 3);
 
         assert_eq!(parts[0]["inlineData"]["mimeType"], "image/png");
-        assert_eq!(parts[0]["inlineData"]["data"], "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==");
-        
+        assert_eq!(
+            parts[0]["inlineData"]["data"],
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+        );
+
         assert_eq!(parts[1]["inlineData"]["mimeType"], "audio/wav");
-        assert_eq!(parts[1]["inlineData"]["data"], "UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA=");
+        assert_eq!(
+            parts[1]["inlineData"]["data"],
+            "UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA="
+        );
 
         assert_eq!(parts[2]["inlineData"]["mimeType"], "video/mp4");
-        assert_eq!(parts[2]["inlineData"]["data"], "AAAAIGZ0eXBtcDQyAAAAAG1wNDJpc29tYXZjMQAAADhmoW9v...");
+        assert_eq!(
+            parts[2]["inlineData"]["data"],
+            "AAAAIGZ0eXBtcDQyAAAAAG1wNDJpc29tYXZjMQAAADhmoW9v..."
+        );
     }
 }

--- a/crates/mofa-foundation/src/rag/loaders.rs
+++ b/crates/mofa-foundation/src/rag/loaders.rs
@@ -73,9 +73,7 @@ impl DocumentLoader for TextLoader {
         })?;
 
         if content.trim().is_empty() {
-            return Err(LoaderError::EmptyDocument(
-                path.display().to_string(),
-            ));
+            return Err(LoaderError::EmptyDocument(path.display().to_string()));
         }
 
         // Use full path for unique IDs across directories
@@ -152,9 +150,7 @@ impl DocumentLoader for MarkdownLoader {
         })?;
 
         if content.trim().is_empty() {
-            return Err(LoaderError::EmptyDocument(
-                path.display().to_string(),
-            ));
+            return Err(LoaderError::EmptyDocument(path.display().to_string()));
         }
 
         let source = path.display().to_string();
@@ -167,30 +163,30 @@ impl DocumentLoader for MarkdownLoader {
         let mut section_index = 0usize;
 
         for line in content.lines() {
-            if let Some(level) = Self::heading_level(line) {
-                if level <= self.split_level {
-                    // Save previous section
-                    if !current_content.trim().is_empty() {
-                        let mut metadata = HashMap::new();
-                        metadata.insert("source".into(), source.clone());
-                        metadata.insert("format".into(), "markdown".into());
-                        metadata.insert("section_index".into(), section_index.to_string());
-                        if !current_heading.is_empty() {
-                            metadata.insert("heading".into(), current_heading.clone());
-                        }
-
-                        documents.push(Document {
-                            id: format!("{base_id}:s{section_index}"),
-                            text: current_content.trim().to_string(),
-                            metadata,
-                        });
-                        section_index += 1;
+            if let Some(level) = Self::heading_level(line)
+                && level <= self.split_level
+            {
+                // Save previous section
+                if !current_content.trim().is_empty() {
+                    let mut metadata = HashMap::new();
+                    metadata.insert("source".into(), source.clone());
+                    metadata.insert("format".into(), "markdown".into());
+                    metadata.insert("section_index".into(), section_index.to_string());
+                    if !current_heading.is_empty() {
+                        metadata.insert("heading".into(), current_heading.clone());
                     }
 
-                    current_heading = Self::heading_text(line);
-                    current_content = format!("{line}\n");
-                    continue;
+                    documents.push(Document {
+                        id: format!("{base_id}:s{section_index}"),
+                        text: current_content.trim().to_string(),
+                        metadata,
+                    });
+                    section_index += 1;
                 }
+
+                current_heading = Self::heading_text(line);
+                current_content = format!("{line}\n");
+                continue;
             }
 
             current_content.push_str(line);
@@ -215,9 +211,7 @@ impl DocumentLoader for MarkdownLoader {
         }
 
         if documents.is_empty() {
-            return Err(LoaderError::EmptyDocument(
-                path.display().to_string(),
-            ));
+            return Err(LoaderError::EmptyDocument(path.display().to_string()));
         }
 
         Ok(documents)

--- a/crates/mofa-foundation/src/rag/pipeline_adapters.rs
+++ b/crates/mofa-foundation/src/rag/pipeline_adapters.rs
@@ -58,7 +58,7 @@ impl Retriever for InMemoryRetriever {
                 };
 
                 let mut ranked = item.clone();
-                ranked.score = ranked.score + lexical;
+                ranked.score += lexical;
                 ranked
             })
             .collect::<Vec<_>>();

--- a/crates/mofa-foundation/src/rag/recursive_chunker.rs
+++ b/crates/mofa-foundation/src/rag/recursive_chunker.rs
@@ -25,11 +25,11 @@ impl Default for RecursiveChunkConfig {
             chunk_size: 1000,
             chunk_overlap: 200,
             separators: vec![
-                "\n\n".into(),  // Paragraph
-                "\n".into(),    // Line
-                ". ".into(),    // Sentence
-                ", ".into(),    // Clause
-                " ".into(),     // Word
+                "\n\n".into(), // Paragraph
+                "\n".into(),   // Line
+                ". ".into(),   // Sentence
+                ", ".into(),   // Clause
+                " ".into(),    // Word
             ],
         }
     }
@@ -63,17 +63,9 @@ impl RecursiveChunkConfig {
 ///
 /// This produces higher-quality chunks than fixed-size splitting because
 /// it preserves semantic boundaries where possible.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct RecursiveChunker {
     config: RecursiveChunkConfig,
-}
-
-impl Default for RecursiveChunker {
-    fn default() -> Self {
-        Self {
-            config: RecursiveChunkConfig::default(),
-        }
-    }
 }
 
 impl RecursiveChunker {
@@ -217,7 +209,8 @@ mod tests {
     fn splits_at_paragraph_boundary() {
         let config = RecursiveChunkConfig::new(50, 0);
         let chunker = RecursiveChunker::new(config);
-        let text = "First paragraph content.\n\nSecond paragraph content.\n\nThird paragraph content.";
+        let text =
+            "First paragraph content.\n\nSecond paragraph content.\n\nThird paragraph content.";
         let chunks = chunker.chunk(text);
         assert!(chunks.len() >= 2);
         // Each chunk should be under the size limit
@@ -253,8 +246,7 @@ mod tests {
 
     #[test]
     fn custom_separators() {
-        let config = RecursiveChunkConfig::new(20, 0)
-            .with_separators(vec!["|".into(), " ".into()]);
+        let config = RecursiveChunkConfig::new(20, 0).with_separators(vec!["|".into(), " ".into()]);
         let chunker = RecursiveChunker::new(config);
         let text = "part one content|part two content|part three content here";
         let chunks = chunker.chunk(text);
@@ -263,8 +255,7 @@ mod tests {
 
     #[test]
     fn hard_split_fallback() {
-        let config = RecursiveChunkConfig::new(5, 0)
-            .with_separators(vec![]); // No separators → immediate hard split
+        let config = RecursiveChunkConfig::new(5, 0).with_separators(vec![]); // No separators → immediate hard split
         let chunker = RecursiveChunker::new(config);
         let text = "abcdefghijklmnopqrst"; // 20 chars, no separators
         let chunks = chunker.chunk(text);

--- a/crates/mofa-foundation/src/rag/retrieval.rs
+++ b/crates/mofa-foundation/src/rag/retrieval.rs
@@ -189,9 +189,10 @@ pub async fn query_documents<S: VectorStore>(
         .into_iter()
         .map(RetrievedChunk::from)
         .filter(|chunk| {
-            config.metadata_filter.iter().all(|(key, value)| {
-                chunk.metadata.get(key).map(|v| v == value).unwrap_or(false)
-            })
+            config
+                .metadata_filter
+                .iter()
+                .all(|(key, value)| chunk.metadata.get(key).map(|v| v == value).unwrap_or(false))
         })
         .collect();
 
@@ -231,10 +232,11 @@ fn pack_context(
         let separator_cost = if parts.is_empty() { 0 } else { SEPARATOR.len() };
         let cost = chunk.text.len() + separator_cost;
 
-        if let Some(budget) = max_chars {
-            if total_chars + cost > budget && !packed.is_empty() {
-                break;
-            }
+        if let Some(budget) = max_chars
+            && total_chars + cost > budget
+            && !packed.is_empty()
+        {
+            break;
         }
 
         packed.push(chunk.clone());
@@ -260,47 +262,76 @@ mod tests {
 
     // -- Mock embedder --
 
-    struct MockProvider { dimensions: usize }
+    struct MockProvider {
+        dimensions: usize,
+    }
 
     #[async_trait]
     impl crate::llm::provider::LLMProvider for MockProvider {
-        fn name(&self) -> &str { "mock" }
-        fn default_model(&self) -> &str { "mock-embed" }
-        fn supports_streaming(&self) -> bool { false }
-        fn supports_tools(&self) -> bool { false }
-        fn supports_vision(&self) -> bool { false }
+        fn name(&self) -> &str {
+            "mock"
+        }
+        fn default_model(&self) -> &str {
+            "mock-embed"
+        }
+        fn supports_streaming(&self) -> bool {
+            false
+        }
+        fn supports_tools(&self) -> bool {
+            false
+        }
+        fn supports_vision(&self) -> bool {
+            false
+        }
 
         async fn chat(
-            &self, _r: crate::llm::types::ChatCompletionRequest,
+            &self,
+            _r: crate::llm::types::ChatCompletionRequest,
         ) -> crate::llm::types::LLMResult<crate::llm::types::ChatCompletionResponse> {
             Err(crate::llm::types::LLMError::Other("not supported".into()))
         }
         async fn chat_stream(
-            &self, _r: crate::llm::types::ChatCompletionRequest,
+            &self,
+            _r: crate::llm::types::ChatCompletionRequest,
         ) -> crate::llm::types::LLMResult<crate::llm::provider::ChatStream> {
             Err(crate::llm::types::LLMError::Other("not supported".into()))
         }
         async fn embedding(
-            &self, request: crate::llm::types::EmbeddingRequest,
+            &self,
+            request: crate::llm::types::EmbeddingRequest,
         ) -> crate::llm::types::LLMResult<crate::llm::types::EmbeddingResponse> {
             let inputs = match request.input {
                 crate::llm::types::EmbeddingInput::Single(s) => vec![s],
                 crate::llm::types::EmbeddingInput::Multiple(v) => v,
             };
-            let data = inputs.iter().map(|text| {
-                let mut vec = vec![0.0f32; self.dimensions];
-                for (i, b) in text.bytes().enumerate() {
-                    vec[i % self.dimensions] += b as f32 / 255.0;
-                }
-                let norm = vec.iter().map(|x| x * x).sum::<f32>().sqrt();
-                if norm > 0.0 { for v in &mut vec { *v /= norm; } }
-                crate::llm::types::EmbeddingData {
-                    object: "embedding".into(), embedding: vec, index: 0,
-                }
-            }).collect();
+            let data = inputs
+                .iter()
+                .map(|text| {
+                    let mut vec = vec![0.0f32; self.dimensions];
+                    for (i, b) in text.bytes().enumerate() {
+                        vec[i % self.dimensions] += b as f32 / 255.0;
+                    }
+                    let norm = vec.iter().map(|x| x * x).sum::<f32>().sqrt();
+                    if norm > 0.0 {
+                        for v in &mut vec {
+                            *v /= norm;
+                        }
+                    }
+                    crate::llm::types::EmbeddingData {
+                        object: "embedding".into(),
+                        embedding: vec,
+                        index: 0,
+                    }
+                })
+                .collect();
             Ok(crate::llm::types::EmbeddingResponse {
-                object: "list".into(), data, model: request.model,
-                usage: crate::llm::types::EmbeddingUsage { prompt_tokens: 0, total_tokens: 0 },
+                object: "list".into(),
+                data,
+                model: request.model,
+                usage: crate::llm::types::EmbeddingUsage {
+                    prompt_tokens: 0,
+                    total_tokens: 0,
+                },
             })
         }
     }
@@ -317,7 +348,14 @@ mod tests {
         chunks: HashMap<String, DocumentChunk>,
         dimensions: Option<usize>,
     }
-    impl TestStore { fn new() -> Self { Self { chunks: HashMap::new(), dimensions: None } } }
+    impl TestStore {
+        fn new() -> Self {
+            Self {
+                chunks: HashMap::new(),
+                dimensions: None,
+            }
+        }
+    }
 
     #[async_trait]
     impl VectorStore for TestStore {
@@ -325,29 +363,67 @@ mod tests {
             if let Some(d) = self.dimensions {
                 if chunk.embedding.len() != d {
                     return Err(AgentError::InvalidInput(format!(
-                        "dim mismatch: {} vs {}", d, chunk.embedding.len())));
+                        "dim mismatch: {} vs {}",
+                        d,
+                        chunk.embedding.len()
+                    )));
                 }
-            } else { self.dimensions = Some(chunk.embedding.len()); }
+            } else {
+                self.dimensions = Some(chunk.embedding.len());
+            }
             self.chunks.insert(chunk.id.clone(), chunk);
             Ok(())
         }
-        async fn search(&self, qe: &[f32], top_k: usize, threshold: Option<f32>) -> AgentResult<Vec<SearchResult>> {
-            let mut results: Vec<SearchResult> = self.chunks.values().map(|c| {
-                let score: f32 = c.embedding.iter().zip(qe.iter()).map(|(a, b)| a * b).sum();
-                SearchResult { id: c.id.clone(), text: c.text.clone(), score, metadata: c.metadata.clone() }
-            }).filter(|r| threshold.map(|t| r.score >= t).unwrap_or(true)).collect();
-            results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+        async fn search(
+            &self,
+            qe: &[f32],
+            top_k: usize,
+            threshold: Option<f32>,
+        ) -> AgentResult<Vec<SearchResult>> {
+            let mut results: Vec<SearchResult> = self
+                .chunks
+                .values()
+                .map(|c| {
+                    let score: f32 = c.embedding.iter().zip(qe.iter()).map(|(a, b)| a * b).sum();
+                    SearchResult {
+                        id: c.id.clone(),
+                        text: c.text.clone(),
+                        score,
+                        metadata: c.metadata.clone(),
+                    }
+                })
+                .filter(|r| threshold.map(|t| r.score >= t).unwrap_or(true))
+                .collect();
+            results.sort_by(|a, b| {
+                b.score
+                    .partial_cmp(&a.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
             results.truncate(top_k);
             Ok(results)
         }
-        async fn delete(&mut self, id: &str) -> AgentResult<bool> { Ok(self.chunks.remove(id).is_some()) }
-        async fn clear(&mut self) -> AgentResult<()> { self.chunks.clear(); self.dimensions = None; Ok(()) }
-        async fn count(&self) -> AgentResult<usize> { Ok(self.chunks.len()) }
-        fn similarity_metric(&self) -> SimilarityMetric { SimilarityMetric::DotProduct }
+        async fn delete(&mut self, id: &str) -> AgentResult<bool> {
+            Ok(self.chunks.remove(id).is_some())
+        }
+        async fn clear(&mut self) -> AgentResult<()> {
+            self.chunks.clear();
+            self.dimensions = None;
+            Ok(())
+        }
+        async fn count(&self) -> AgentResult<usize> {
+            Ok(self.chunks.len())
+        }
+        fn similarity_metric(&self) -> SimilarityMetric {
+            SimilarityMetric::DotProduct
+        }
     }
 
     /// Helper: embed text and insert into a TestStore
-    async fn seed_store(store: &mut TestStore, adapter: &LlmEmbeddingAdapter, entries: &[(&str, &str, &[(&str, &str)])]) {
+    async fn seed_store(
+        store: &mut TestStore,
+        adapter: &LlmEmbeddingAdapter,
+        entries: &[(&str, &str, &[(&str, &str)])],
+    ) {
         for (id, text, meta) in entries {
             let emb = adapter.embed_one(text).await.unwrap();
             let mut chunk = DocumentChunk::new(*id, *text, emb);
@@ -364,7 +440,9 @@ mod tests {
     async fn query_empty_store() {
         let store = TestStore::new();
         let adapter = make_adapter(16);
-        let result = query_documents(&store, &adapter, "hello", &RagQueryConfig::default()).await.unwrap();
+        let result = query_documents(&store, &adapter, "hello", &RagQueryConfig::default())
+            .await
+            .unwrap();
         assert!(result.chunks.is_empty());
         assert!(result.context.is_empty());
     }
@@ -373,12 +451,24 @@ mod tests {
     async fn query_returns_relevant_results() {
         let mut store = TestStore::new();
         let adapter = make_adapter(16);
-        seed_store(&mut store, &adapter, &[
-            ("rust-0", "Rust programming language systems", &[]),
-            ("python-0", "Python scripting language", &[]),
-        ]).await;
+        seed_store(
+            &mut store,
+            &adapter,
+            &[
+                ("rust-0", "Rust programming language systems", &[]),
+                ("python-0", "Python scripting language", &[]),
+            ],
+        )
+        .await;
 
-        let result = query_documents(&store, &adapter, "Rust systems", &RagQueryConfig::default().with_top_k(2)).await.unwrap();
+        let result = query_documents(
+            &store,
+            &adapter,
+            "Rust systems",
+            &RagQueryConfig::default().with_top_k(2),
+        )
+        .await
+        .unwrap();
         assert!(!result.chunks.is_empty());
         assert!(!result.context.is_empty());
         assert_eq!(result.query, "Rust systems");
@@ -388,7 +478,9 @@ mod tests {
     async fn query_rejects_empty_query() {
         let store = TestStore::new();
         let adapter = make_adapter(16);
-        let err = query_documents(&store, &adapter, "  ", &RagQueryConfig::default()).await.unwrap_err();
+        let err = query_documents(&store, &adapter, "  ", &RagQueryConfig::default())
+            .await
+            .unwrap_err();
         assert!(matches!(err, RagOrchestrationError::InvalidInput(_)));
     }
 
@@ -396,15 +488,27 @@ mod tests {
     async fn query_with_metadata_filter() {
         let mut store = TestStore::new();
         let adapter = make_adapter(16);
-        seed_store(&mut store, &adapter, &[
-            ("a", "Rust lang", &[("category", "systems")]),
-            ("b", "Python lang", &[("category", "scripting")]),
-        ]).await;
+        seed_store(
+            &mut store,
+            &adapter,
+            &[
+                ("a", "Rust lang", &[("category", "systems")]),
+                ("b", "Python lang", &[("category", "scripting")]),
+            ],
+        )
+        .await;
 
-        let config = RagQueryConfig::default().with_top_k(10).with_filter("category", "systems");
-        let result = query_documents(&store, &adapter, "language", &config).await.unwrap();
+        let config = RagQueryConfig::default()
+            .with_top_k(10)
+            .with_filter("category", "systems");
+        let result = query_documents(&store, &adapter, "language", &config)
+            .await
+            .unwrap();
         for chunk in &result.chunks {
-            assert_eq!(chunk.metadata.get("category").map(String::as_str), Some("systems"));
+            assert_eq!(
+                chunk.metadata.get("category").map(String::as_str),
+                Some("systems")
+            );
         }
     }
 
@@ -413,14 +517,23 @@ mod tests {
         let mut store = TestStore::new();
         let adapter = make_adapter(16);
         // Seed multiple chunks so budget can trim
-        seed_store(&mut store, &adapter, &[
-            ("c1", "AAAAAAAAAA", &[]),
-            ("c2", "BBBBBBBBBB", &[]),
-            ("c3", "CCCCCCCCCC", &[]),
-        ]).await;
+        seed_store(
+            &mut store,
+            &adapter,
+            &[
+                ("c1", "AAAAAAAAAA", &[]),
+                ("c2", "BBBBBBBBBB", &[]),
+                ("c3", "CCCCCCCCCC", &[]),
+            ],
+        )
+        .await;
 
-        let config = RagQueryConfig::default().with_top_k(10).with_max_context_chars(15);
-        let result = query_documents(&store, &adapter, "AAAA", &config).await.unwrap();
+        let config = RagQueryConfig::default()
+            .with_top_k(10)
+            .with_max_context_chars(15);
+        let result = query_documents(&store, &adapter, "AAAA", &config)
+            .await
+            .unwrap();
         assert!(result.context_bytes <= 15 || result.chunks.len() == 1);
     }
 
@@ -435,7 +548,12 @@ mod tests {
 
     #[test]
     fn pack_context_single_chunk() {
-        let chunks = vec![RetrievedChunk { id: "1".into(), text: "Hello".into(), score: 1.0, metadata: HashMap::new() }];
+        let chunks = vec![RetrievedChunk {
+            id: "1".into(),
+            text: "Hello".into(),
+            score: 1.0,
+            metadata: HashMap::new(),
+        }];
         let (packed, ctx) = pack_context(&chunks, None);
         assert_eq!(packed.len(), 1);
         assert_eq!(ctx, "Hello");
@@ -444,8 +562,18 @@ mod tests {
     #[test]
     fn pack_context_multiple_with_separator() {
         let chunks = vec![
-            RetrievedChunk { id: "1".into(), text: "First".into(), score: 1.0, metadata: HashMap::new() },
-            RetrievedChunk { id: "2".into(), text: "Second".into(), score: 0.9, metadata: HashMap::new() },
+            RetrievedChunk {
+                id: "1".into(),
+                text: "First".into(),
+                score: 1.0,
+                metadata: HashMap::new(),
+            },
+            RetrievedChunk {
+                id: "2".into(),
+                text: "Second".into(),
+                score: 0.9,
+                metadata: HashMap::new(),
+            },
         ];
         let (packed, ctx) = pack_context(&chunks, None);
         assert_eq!(packed.len(), 2);
@@ -457,8 +585,18 @@ mod tests {
     #[test]
     fn pack_context_budget_truncates() {
         let chunks = vec![
-            RetrievedChunk { id: "1".into(), text: "Short".into(), score: 1.0, metadata: HashMap::new() },
-            RetrievedChunk { id: "2".into(), text: "Much longer text here".into(), score: 0.9, metadata: HashMap::new() },
+            RetrievedChunk {
+                id: "1".into(),
+                text: "Short".into(),
+                score: 1.0,
+                metadata: HashMap::new(),
+            },
+            RetrievedChunk {
+                id: "2".into(),
+                text: "Much longer text here".into(),
+                score: 0.9,
+                metadata: HashMap::new(),
+            },
         ];
         let (packed, _) = pack_context(&chunks, Some(8));
         assert_eq!(packed.len(), 1);

--- a/crates/mofa-foundation/src/react/chain_of_thought.rs
+++ b/crates/mofa-foundation/src/react/chain_of_thought.rs
@@ -1,0 +1,323 @@
+//! Chain-of-Thought pattern.
+//!
+//! Provides a structured step-by-step reasoning loop for tasks that benefit
+//! from deliberate decomposition before producing a final answer.
+
+use crate::llm::{LLMAgent, LLMError, LLMResult};
+use mofa_kernel::agent::{ReasoningStep, ReasoningStepType};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+/// Runtime configuration for [`ChainOfThought`].
+#[derive(Debug, Clone)]
+pub struct ChainOfThoughtConfig {
+    /// Number of reasoning steps to generate before synthesis.
+    pub steps: usize,
+    /// Emit tracing logs during execution.
+    pub verbose: bool,
+    /// Prompt template used for each reasoning step.
+    pub step_prompt_template: String,
+    /// Prompt template used to synthesize the final answer.
+    pub final_prompt_template: String,
+}
+
+impl Default for ChainOfThoughtConfig {
+    fn default() -> Self {
+        Self {
+            steps: 4,
+            verbose: true,
+            step_prompt_template: concat!(
+                "You are solving a task with deliberate chain-of-thought reasoning.\n\n",
+                "Task:\n{task}\n\n",
+                "Reasoning so far:\n{previous_steps}\n\n",
+                "Produce reasoning step {step_number}/{total_steps}. ",
+                "Advance the solution, but do not give the final answer yet."
+            )
+            .to_string(),
+            final_prompt_template: concat!(
+                "You have produced a chain-of-thought trace for the task below.\n\n",
+                "Task:\n{task}\n\n",
+                "Reasoning trace:\n{reasoning_trace}\n\n",
+                "Now provide the best final answer."
+            )
+            .to_string(),
+        }
+    }
+}
+
+impl ChainOfThoughtConfig {
+    /// Set the number of reasoning steps.
+    pub fn with_steps(mut self, steps: usize) -> Self {
+        self.steps = steps.max(1);
+        self
+    }
+
+    /// Set verbose tracing mode.
+    pub fn with_verbose(mut self, verbose: bool) -> Self {
+        self.verbose = verbose;
+        self
+    }
+
+    /// Override the per-step prompt template.
+    pub fn with_step_prompt_template(mut self, template: impl Into<String>) -> Self {
+        self.step_prompt_template = template.into();
+        self
+    }
+
+    /// Override the final synthesis prompt template.
+    pub fn with_final_prompt_template(mut self, template: impl Into<String>) -> Self {
+        self.final_prompt_template = template.into();
+        self
+    }
+}
+
+/// Result of a chain-of-thought run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChainOfThoughtResult {
+    /// Original task.
+    pub task: String,
+    /// Generated reasoning steps.
+    pub reasoning_steps: Vec<ReasoningStep>,
+    /// Final answer synthesized from the reasoning trace.
+    pub final_answer: String,
+    /// Total runtime in milliseconds.
+    pub total_duration_ms: u64,
+}
+
+impl ChainOfThoughtResult {
+    /// Render the reasoning trace as markdown.
+    pub fn to_markdown_trace(&self) -> String {
+        let mut lines = vec![
+            "# Chain-of-Thought Trace".to_string(),
+            String::new(),
+            format!("**Task:** {}", self.task),
+            format!("**Duration:** {} ms", self.total_duration_ms),
+            String::new(),
+            "## Reasoning Steps".to_string(),
+        ];
+
+        for step in &self.reasoning_steps {
+            lines.push(format!("{}. {}", step.step_number, step.content));
+        }
+
+        lines.push(String::new());
+        lines.push("## Final Answer".to_string());
+        lines.push("```text".to_string());
+        lines.push(self.final_answer.clone());
+        lines.push("```".to_string());
+
+        lines.join("\n")
+    }
+}
+
+/// Classic chain-of-thought reasoning pattern.
+pub struct ChainOfThought {
+    thinker: Arc<LLMAgent>,
+    synthesizer: Option<Arc<LLMAgent>>,
+    config: ChainOfThoughtConfig,
+}
+
+impl ChainOfThought {
+    /// Create a builder for [`ChainOfThought`].
+    pub fn builder() -> ChainOfThoughtBuilder {
+        ChainOfThoughtBuilder::new()
+    }
+
+    /// Execute the reasoning loop.
+    pub async fn run(&self, task: impl Into<String>) -> LLMResult<ChainOfThoughtResult> {
+        let task = task.into();
+        let start = std::time::Instant::now();
+        let mut reasoning_steps = Vec::with_capacity(self.config.steps);
+
+        for step_number in 1..=self.config.steps {
+            if self.config.verbose {
+                tracing::info!(
+                    "[ChainOfThought] Generating reasoning step {}/{}",
+                    step_number,
+                    self.config.steps
+                );
+            }
+
+            let previous_steps = render_reasoning_trace(&reasoning_steps);
+            let step_number_text = step_number.to_string();
+            let total_steps_text = self.config.steps.to_string();
+            let prompt = fill_template(
+                &self.config.step_prompt_template,
+                &[
+                    ("task", task.as_str()),
+                    ("previous_steps", previous_steps.as_str()),
+                    ("step_number", step_number_text.as_str()),
+                    ("total_steps", total_steps_text.as_str()),
+                ],
+            );
+
+            let thought = self.thinker.ask(&prompt).await?;
+            reasoning_steps.push(ReasoningStep::new(
+                ReasoningStepType::Thought,
+                thought,
+                step_number,
+            ));
+        }
+
+        let reasoning_trace = render_reasoning_trace(&reasoning_steps);
+        let final_prompt = fill_template(
+            &self.config.final_prompt_template,
+            &[
+                ("task", task.as_str()),
+                ("reasoning_trace", reasoning_trace.as_str()),
+            ],
+        );
+        let final_answer = self
+            .synthesizer
+            .as_ref()
+            .unwrap_or(&self.thinker)
+            .ask(&final_prompt)
+            .await?;
+
+        Ok(ChainOfThoughtResult {
+            task,
+            reasoning_steps,
+            final_answer,
+            total_duration_ms: start.elapsed().as_millis() as u64,
+        })
+    }
+
+    /// Alias for [`Self::run`].
+    pub async fn execute(&self, task: impl Into<String>) -> LLMResult<ChainOfThoughtResult> {
+        self.run(task).await
+    }
+}
+
+/// Builder for [`ChainOfThought`].
+pub struct ChainOfThoughtBuilder {
+    thinker: Option<Arc<LLMAgent>>,
+    synthesizer: Option<Arc<LLMAgent>>,
+    config: ChainOfThoughtConfig,
+}
+
+impl ChainOfThoughtBuilder {
+    /// Create a new builder.
+    pub fn new() -> Self {
+        Self {
+            thinker: None,
+            synthesizer: None,
+            config: ChainOfThoughtConfig::default(),
+        }
+    }
+
+    /// Set the reasoning agent.
+    pub fn with_llm(mut self, thinker: Arc<LLMAgent>) -> Self {
+        self.thinker = Some(thinker);
+        self
+    }
+
+    /// Set an optional dedicated synthesizer agent.
+    pub fn with_synthesizer(mut self, synthesizer: Arc<LLMAgent>) -> Self {
+        self.synthesizer = Some(synthesizer);
+        self
+    }
+
+    /// Set the number of reasoning steps.
+    pub fn with_steps(mut self, steps: usize) -> Self {
+        self.config = self.config.with_steps(steps);
+        self
+    }
+
+    /// Set verbose tracing mode.
+    pub fn with_verbose(mut self, verbose: bool) -> Self {
+        self.config = self.config.with_verbose(verbose);
+        self
+    }
+
+    /// Set the runtime config.
+    pub fn with_config(mut self, config: ChainOfThoughtConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    /// Build the pattern.
+    pub fn build(self) -> Result<ChainOfThought, LLMError> {
+        let thinker = self
+            .thinker
+            .ok_or_else(|| LLMError::ConfigError("ChainOfThought requires an LLM".to_string()))?;
+
+        Ok(ChainOfThought {
+            thinker,
+            synthesizer: self.synthesizer,
+            config: self.config,
+        })
+    }
+}
+
+impl Default for ChainOfThoughtBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn render_reasoning_trace(steps: &[ReasoningStep]) -> String {
+    if steps.is_empty() {
+        return "No reasoning steps yet.".to_string();
+    }
+
+    steps
+        .iter()
+        .map(|step| format!("{}. {}", step.step_number, step.content))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn fill_template(template: &str, replacements: &[(&str, &str)]) -> String {
+    let mut rendered = template.to_string();
+    for (key, value) in replacements {
+        rendered = rendered.replace(&format!("{{{}}}", key), value);
+    }
+    rendered
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm::{MockLLMProvider, simple_llm_agent};
+
+    #[test]
+    fn config_defaults() {
+        let config = ChainOfThoughtConfig::default();
+        assert_eq!(config.steps, 4);
+        assert!(config.verbose);
+    }
+
+    #[tokio::test]
+    async fn chain_of_thought_runs_reasoning_and_synthesis() {
+        let provider = Arc::new(MockLLMProvider::new("thoughts"));
+        provider
+            .add_response("Break the problem into sub-parts.")
+            .await;
+        provider
+            .add_response("Check constraints and likely edge cases.")
+            .await;
+        provider
+            .add_response("Combine the strongest observations into an answer.")
+            .await;
+        provider
+            .add_response("Final answer generated from the trace.")
+            .await;
+
+        let llm = Arc::new(simple_llm_agent("cot", provider, "Reason carefully."));
+        let chain = ChainOfThought::builder()
+            .with_llm(llm)
+            .with_steps(3)
+            .with_verbose(false)
+            .build()
+            .unwrap();
+
+        let result = chain.run("Explain why retries need backoff").await.unwrap();
+
+        assert_eq!(result.reasoning_steps.len(), 3);
+        assert_eq!(
+            result.final_answer,
+            "Final answer generated from the trace."
+        );
+        assert!(result.to_markdown_trace().contains("## Final Answer"));
+    }
+}

--- a/crates/mofa-foundation/src/react/mod.rs
+++ b/crates/mofa-foundation/src/react/mod.rs
@@ -101,20 +101,27 @@
 //! ```
 
 mod actor;
+pub mod chain_of_thought;
 mod core;
 pub mod patterns;
 pub mod reflection;
+pub mod router;
 pub mod tools;
 
 pub use actor::*;
+pub use chain_of_thought::*;
 pub use core::*;
 pub use patterns::*;
 pub use reflection::*;
+pub use router::*;
 pub use tools::*;
 
 /// 便捷 prelude 模块
 /// Convenient prelude module
 pub mod prelude {
+    pub use super::chain_of_thought::{
+        ChainOfThought, ChainOfThoughtBuilder, ChainOfThoughtConfig, ChainOfThoughtResult,
+    };
     pub use super::patterns::{
         AgentOutput, AgentUnit, AggregationStrategy, ChainAgent, ChainResult, ChainStepResult,
         MapReduceAgent, MapReduceResult, ParallelAgent, ParallelResult, ParallelStepResult,
@@ -123,5 +130,6 @@ pub mod prelude {
     pub use super::reflection::{
         ReflectionAgent, ReflectionAgentBuilder, ReflectionConfig, ReflectionResult, ReflectionStep,
     };
+    pub use super::router::{Router, RouterBuilder, RouterConfig, RouterDecision, RouterResult};
     pub use super::tools::prelude::*;
 }

--- a/crates/mofa-foundation/src/react/router.rs
+++ b/crates/mofa-foundation/src/react/router.rs
@@ -1,0 +1,481 @@
+//! Router pattern for dispatching tasks to specialized agents.
+
+use super::patterns::{AgentOutput, AgentUnit};
+use crate::llm::{LLMAgent, LLMError, LLMResult};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+/// Routing configuration for [`Router`].
+#[derive(Debug, Clone)]
+pub struct RouterConfig {
+    /// Emit tracing logs during routing and execution.
+    pub verbose: bool,
+    /// Prompt template used to classify the task.
+    pub classifier_prompt_template: String,
+}
+
+impl Default for RouterConfig {
+    fn default() -> Self {
+        Self {
+            verbose: true,
+            classifier_prompt_template: concat!(
+                "You are an expert task router.\n",
+                "Choose the best route for the task below.\n",
+                "Return only JSON: {\"route\":\"<route>\",\"reason\":\"<short why>\",\"confidence\":0.0}\n\n",
+                "Available routes:\n{routes}\n\n",
+                "Task:\n{task}"
+            )
+            .to_string(),
+        }
+    }
+}
+
+impl RouterConfig {
+    /// Set verbose tracing mode.
+    pub fn with_verbose(mut self, verbose: bool) -> Self {
+        self.verbose = verbose;
+        self
+    }
+
+    /// Override the classifier prompt template.
+    pub fn with_classifier_prompt_template(mut self, template: impl Into<String>) -> Self {
+        self.classifier_prompt_template = template.into();
+        self
+    }
+}
+
+#[derive(Clone)]
+struct RouteEntry {
+    description: Option<String>,
+    unit: AgentUnit,
+}
+
+/// Structured routing decision.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RouterDecision {
+    /// Route requested by the classifier.
+    pub requested_route: String,
+    /// Route actually executed.
+    pub resolved_route: String,
+    /// Short rationale from the classifier.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Optional confidence score from the classifier.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<f32>,
+    /// Whether the router had to fall back to the default route.
+    pub used_default: bool,
+}
+
+/// Result of a router dispatch.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RouterResult {
+    /// Original task.
+    pub task: String,
+    /// Routing metadata.
+    pub decision: RouterDecision,
+    /// Output from the selected expert.
+    pub output: AgentOutput,
+    /// Total runtime in milliseconds.
+    pub total_duration_ms: u64,
+}
+
+impl RouterResult {
+    /// Render the routing trace as markdown.
+    pub fn to_markdown_trace(&self) -> String {
+        let mut lines = vec![
+            "# Router Trace".to_string(),
+            String::new(),
+            format!("**Task:** {}", self.task),
+            format!("**Requested Route:** {}", self.decision.requested_route),
+            format!("**Resolved Route:** {}", self.decision.resolved_route),
+            format!("**Used Default:** {}", self.decision.used_default),
+        ];
+
+        if let Some(reason) = &self.decision.reason {
+            lines.push(format!("**Reason:** {}", reason));
+        }
+        if let Some(confidence) = self.decision.confidence {
+            lines.push(format!("**Confidence:** {:.2}", confidence));
+        }
+
+        lines.push(String::new());
+        lines.push("## Expert Output".to_string());
+        lines.push("```text".to_string());
+        lines.push(self.output.content.clone());
+        lines.push("```".to_string());
+
+        lines.join("\n")
+    }
+}
+
+/// Classic router pattern.
+pub struct Router {
+    classifier: Arc<LLMAgent>,
+    routes: Vec<(String, RouteEntry)>,
+    default_route: Option<RouteEntry>,
+    config: RouterConfig,
+}
+
+impl Router {
+    /// Create a builder for [`Router`].
+    pub fn builder() -> RouterBuilder {
+        RouterBuilder::new()
+    }
+
+    /// Route and execute a task.
+    pub async fn run(&self, task: impl Into<String>) -> LLMResult<RouterResult> {
+        let task = task.into();
+        let start = std::time::Instant::now();
+        let route_catalog = self.render_routes();
+        let prompt = fill_template(
+            &self.config.classifier_prompt_template,
+            &[("routes", route_catalog.as_str()), ("task", task.as_str())],
+        );
+
+        let classifier_raw = self.classifier.ask(&prompt).await?;
+        let mut decision = self.parse_decision(&classifier_raw);
+
+        let selected_entry = if let Some((name, entry)) = self.find_route(&decision.requested_route)
+        {
+            decision.resolved_route = name.to_string();
+            decision.used_default = false;
+            entry
+        } else if let Some(default_route) = &self.default_route {
+            decision.resolved_route = "default".to_string();
+            decision.used_default = true;
+            default_route
+        } else {
+            return Err(LLMError::Other(format!(
+                "Router selected unknown route '{}'",
+                decision.requested_route
+            )));
+        };
+
+        if self.config.verbose {
+            tracing::info!(
+                "[Router] requested='{}' resolved='{}'",
+                decision.requested_route,
+                decision.resolved_route
+            );
+        }
+
+        let output = selected_entry.unit.run(task.clone()).await?;
+
+        Ok(RouterResult {
+            task,
+            decision,
+            output,
+            total_duration_ms: start.elapsed().as_millis() as u64,
+        })
+    }
+
+    /// Alias for [`Self::run`].
+    pub async fn execute(&self, task: impl Into<String>) -> LLMResult<RouterResult> {
+        self.run(task).await
+    }
+
+    fn render_routes(&self) -> String {
+        self.routes
+            .iter()
+            .map(|(name, entry)| match &entry.description {
+                Some(description) => format!("- {}: {}", name, description),
+                None => format!("- {}", name),
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn parse_decision(&self, raw: &str) -> RouterDecision {
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(raw) {
+            if let Some(route) = value.get("route").and_then(|route| route.as_str()) {
+                return RouterDecision {
+                    requested_route: route.to_string(),
+                    resolved_route: route.to_string(),
+                    reason: value
+                        .get("reason")
+                        .and_then(|reason| reason.as_str())
+                        .map(ToOwned::to_owned),
+                    confidence: value
+                        .get("confidence")
+                        .and_then(|confidence| confidence.as_f64())
+                        .map(|confidence| confidence as f32),
+                    used_default: false,
+                };
+            }
+        }
+
+        let trimmed = raw.trim();
+        if !trimmed.is_empty() {
+            if let Some((name, _)) = self.find_route(trimmed) {
+                return RouterDecision {
+                    requested_route: name.to_string(),
+                    resolved_route: name.to_string(),
+                    reason: None,
+                    confidence: None,
+                    used_default: false,
+                };
+            }
+
+            let lowered = trimmed.to_lowercase();
+            if let Some((name, _)) = self
+                .routes
+                .iter()
+                .find(|(name, _)| lowered.contains(&name.to_lowercase()))
+            {
+                return RouterDecision {
+                    requested_route: name.to_string(),
+                    resolved_route: name.to_string(),
+                    reason: None,
+                    confidence: None,
+                    used_default: false,
+                };
+            }
+        }
+
+        RouterDecision {
+            requested_route: trimmed.to_string(),
+            resolved_route: trimmed.to_string(),
+            reason: None,
+            confidence: None,
+            used_default: false,
+        }
+    }
+
+    fn find_route(&self, requested_route: &str) -> Option<(&str, &RouteEntry)> {
+        self.routes
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case(requested_route))
+            .map(|(name, entry)| (name.as_str(), entry))
+    }
+}
+
+/// Builder for [`Router`].
+pub struct RouterBuilder {
+    classifier: Option<Arc<LLMAgent>>,
+    routes: Vec<(String, RouteEntry)>,
+    default_route: Option<RouteEntry>,
+    config: RouterConfig,
+}
+
+impl RouterBuilder {
+    /// Create a new builder.
+    pub fn new() -> Self {
+        Self {
+            classifier: None,
+            routes: Vec::new(),
+            default_route: None,
+            config: RouterConfig::default(),
+        }
+    }
+
+    /// Set the classifier agent.
+    pub fn with_classifier(mut self, classifier: Arc<LLMAgent>) -> Self {
+        self.classifier = Some(classifier);
+        self
+    }
+
+    /// Add a named route backed by a ReAct agent.
+    pub fn with_route(mut self, name: impl Into<String>, agent: Arc<super::ReActAgent>) -> Self {
+        self.routes.push((
+            name.into(),
+            RouteEntry {
+                description: None,
+                unit: AgentUnit::react(agent),
+            },
+        ));
+        self
+    }
+
+    /// Add a named route backed by an LLM agent.
+    pub fn with_route_llm(mut self, name: impl Into<String>, agent: Arc<LLMAgent>) -> Self {
+        self.routes.push((
+            name.into(),
+            RouteEntry {
+                description: None,
+                unit: AgentUnit::llm(agent),
+            },
+        ));
+        self
+    }
+
+    /// Attach a human-readable description to a route.
+    pub fn describe_route(
+        mut self,
+        route_name: impl AsRef<str>,
+        description: impl Into<String>,
+    ) -> Self {
+        if let Some((_, entry)) = self
+            .routes
+            .iter_mut()
+            .find(|(name, _)| name == route_name.as_ref())
+        {
+            entry.description = Some(description.into());
+        }
+        self
+    }
+
+    /// Set the default ReAct route.
+    pub fn with_default(mut self, agent: Arc<super::ReActAgent>) -> Self {
+        self.default_route = Some(RouteEntry {
+            description: Some("Fallback route".to_string()),
+            unit: AgentUnit::react(agent),
+        });
+        self
+    }
+
+    /// Set the default LLM route.
+    pub fn with_default_llm(mut self, agent: Arc<LLMAgent>) -> Self {
+        self.default_route = Some(RouteEntry {
+            description: Some("Fallback route".to_string()),
+            unit: AgentUnit::llm(agent),
+        });
+        self
+    }
+
+    /// Set the runtime config.
+    pub fn with_config(mut self, config: RouterConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    /// Build the router.
+    pub fn build(self) -> Result<Router, LLMError> {
+        let classifier = self
+            .classifier
+            .ok_or_else(|| LLMError::ConfigError("Router requires a classifier".to_string()))?;
+        if self.routes.is_empty() {
+            return Err(LLMError::ConfigError(
+                "Router requires at least one route".to_string(),
+            ));
+        }
+
+        Ok(Router {
+            classifier,
+            routes: self.routes,
+            default_route: self.default_route,
+            config: self.config,
+        })
+    }
+}
+
+impl Default for RouterBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn fill_template(template: &str, replacements: &[(&str, &str)]) -> String {
+    let mut rendered = template.to_string();
+    for (key, value) in replacements {
+        rendered = rendered.replace(&format!("{{{}}}", key), value);
+    }
+    rendered
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm::{MockLLMProvider, simple_llm_agent};
+
+    #[test]
+    fn builder_requires_classifier_and_routes() {
+        let err = Router::builder().build().err().unwrap();
+        assert!(matches!(err, LLMError::ConfigError(_)));
+    }
+
+    #[tokio::test]
+    async fn router_selects_named_route() {
+        let classifier_provider = Arc::new(MockLLMProvider::new("classifier"));
+        classifier_provider
+            .add_response(r#"{"route":"billing","reason":"invoice question","confidence":0.93}"#)
+            .await;
+        let billing_provider = Arc::new(MockLLMProvider::new("billing"));
+        billing_provider
+            .add_response("Billing specialist response")
+            .await;
+        let technical_provider = Arc::new(MockLLMProvider::new("technical"));
+        technical_provider
+            .add_response("Technical specialist response")
+            .await;
+
+        let router = Router::builder()
+            .with_classifier(Arc::new(simple_llm_agent(
+                "classifier",
+                classifier_provider,
+                "You classify tasks by specialty.",
+            )))
+            .with_route_llm(
+                "technical",
+                Arc::new(simple_llm_agent(
+                    "technical",
+                    technical_provider,
+                    "You answer technical questions.",
+                )),
+            )
+            .with_route_llm(
+                "billing",
+                Arc::new(simple_llm_agent(
+                    "billing",
+                    billing_provider,
+                    "You answer billing questions.",
+                )),
+            )
+            .with_config(RouterConfig::default().with_verbose(false))
+            .build()
+            .unwrap();
+
+        let result = router.run("Why was I charged twice?").await.unwrap();
+
+        assert_eq!(result.decision.resolved_route, "billing");
+        assert_eq!(result.output.content, "Billing specialist response");
+    }
+
+    #[tokio::test]
+    async fn router_falls_back_to_default() {
+        let classifier_provider = Arc::new(MockLLMProvider::new("classifier"));
+        classifier_provider
+            .add_response(r#"{"route":"legal","reason":"not a supported expert"}"#)
+            .await;
+        let technical_provider = Arc::new(MockLLMProvider::new("technical"));
+        technical_provider
+            .add_response("Technical specialist response")
+            .await;
+        let default_provider = Arc::new(MockLLMProvider::new("default"));
+        default_provider
+            .add_response("General fallback response")
+            .await;
+
+        let router = Router::builder()
+            .with_classifier(Arc::new(simple_llm_agent(
+                "classifier",
+                classifier_provider,
+                "You classify tasks by specialty.",
+            )))
+            .with_route_llm(
+                "technical",
+                Arc::new(simple_llm_agent(
+                    "technical",
+                    technical_provider,
+                    "You answer technical questions.",
+                )),
+            )
+            .with_default_llm(Arc::new(simple_llm_agent(
+                "default",
+                default_provider,
+                "You handle fallback questions.",
+            )))
+            .with_config(RouterConfig::default().with_verbose(false))
+            .build()
+            .unwrap();
+
+        let result = router
+            .run("Please review my contract language")
+            .await
+            .unwrap();
+
+        assert!(result.decision.used_default);
+        assert_eq!(result.decision.resolved_route, "default");
+        assert_eq!(result.output.content, "General fallback response");
+    }
+}

--- a/crates/mofa-foundation/src/react/router.rs
+++ b/crates/mofa-foundation/src/react/router.rs
@@ -187,22 +187,22 @@ impl Router {
     }
 
     fn parse_decision(&self, raw: &str) -> RouterDecision {
-        if let Ok(value) = serde_json::from_str::<serde_json::Value>(raw) {
-            if let Some(route) = value.get("route").and_then(|route| route.as_str()) {
-                return RouterDecision {
-                    requested_route: route.to_string(),
-                    resolved_route: route.to_string(),
-                    reason: value
-                        .get("reason")
-                        .and_then(|reason| reason.as_str())
-                        .map(ToOwned::to_owned),
-                    confidence: value
-                        .get("confidence")
-                        .and_then(|confidence| confidence.as_f64())
-                        .map(|confidence| confidence as f32),
-                    used_default: false,
-                };
-            }
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(raw)
+            && let Some(route) = value.get("route").and_then(|route| route.as_str())
+        {
+            return RouterDecision {
+                requested_route: route.to_string(),
+                resolved_route: route.to_string(),
+                reason: value
+                    .get("reason")
+                    .and_then(|reason| reason.as_str())
+                    .map(ToOwned::to_owned),
+                confidence: value
+                    .get("confidence")
+                    .and_then(|confidence| confidence.as_f64())
+                    .map(|confidence| confidence as f32),
+                used_default: false,
+            };
         }
 
         let trimmed = raw.trim();

--- a/crates/mofa-foundation/src/recovery.rs
+++ b/crates/mofa-foundation/src/recovery.rs
@@ -258,6 +258,9 @@ where
 // FallbackChain - Execute a chain of fallback operations
 // ============================================================================
 
+type BoxedFallbackFuture<T> = std::pin::Pin<Box<dyn Future<Output = GlobalResult<T>> + Send>>;
+type FallbackOperation<T> = Box<dyn FnOnce() -> BoxedFallbackFuture<T> + Send>;
+
 /// Execute a series of fallback operations, returning the first success.
 ///
 /// Each operation in the chain is tried in order. If one fails, the next
@@ -272,9 +275,7 @@ where
 ///     Box::new(|| Box::pin(cached_fallback())),
 /// ]).await;
 /// ```
-pub async fn fallback_chain<T>(
-    operations: Vec<Box<dyn FnOnce() -> std::pin::Pin<Box<dyn Future<Output = GlobalResult<T>> + Send>> + Send>>,
-) -> GlobalResult<T> {
+pub async fn fallback_chain<T>(operations: Vec<FallbackOperation<T>>) -> GlobalResult<T> {
     let mut last_error = GlobalError::Other("no fallback operations provided".to_string());
 
     for operation in operations {

--- a/crates/mofa-foundation/src/security/regex_pii.rs
+++ b/crates/mofa-foundation/src/security/regex_pii.rs
@@ -14,7 +14,6 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use tracing::warn;
 
-
 // =============================================================================
 // Compiled Regex Patterns
 // =============================================================================
@@ -24,17 +23,15 @@ static EMAIL_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}").unwrap());
 
 // Phone: US formats (xxx-xxx-xxxx, (xxx) xxx-xxxx, +1xxxxxxxxxx, etc.)
-static PHONE_RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"(?:\+?1[-.\s]?)?\(?[2-9]\d{2}\)?[-.\s]?\d{3}[-.\s]?\d{4}").unwrap()
-});
+static PHONE_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?:\+?1[-.\s]?)?\(?[2-9]\d{2}\)?[-.\s]?\d{3}[-.\s]?\d{4}").unwrap());
 
 // Credit card: 13-19 digit sequences (with optional separators)
 static CREDIT_CARD_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"\b\d{4}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{1,7}\b").unwrap());
 
 // SSN: xxx-xx-xxxx
-static SSN_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"\b\d{3}-\d{2}-\d{4}\b").unwrap());
+static SSN_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\b\d{3}-\d{2}-\d{4}\b").unwrap());
 
 // IPv4
 static IPV4_RE: Lazy<Regex> = Lazy::new(|| {
@@ -50,8 +47,10 @@ static IPV6_RE: Lazy<Regex> = Lazy::new(|| {
 
 // API keys: common formats (sk-..., ghp_..., AKIA..., xoxb-...)
 static API_KEY_RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"\b(?:sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36,}|AKIA[A-Z0-9]{16}|xoxb-[a-zA-Z0-9-]+)\b")
-        .unwrap()
+    Regex::new(
+        r"\b(?:sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36,}|AKIA[A-Z0-9]{16}|xoxb-[a-zA-Z0-9-]+)\b",
+    )
+    .unwrap()
 });
 
 // =============================================================================
@@ -85,7 +84,7 @@ fn luhn_check(number: &str) -> bool {
         double = !double;
     }
 
-    sum % 10 == 0
+    sum.is_multiple_of(10)
 }
 
 // =============================================================================
@@ -153,7 +152,8 @@ impl PiiDetector for RegexPiiDetector {
                 for re in regexes {
                     for m in re.find_iter(text) {
                         // Extra validation for credit cards (Luhn check)
-                        if *category == SensitiveDataCategory::CreditCard && !luhn_check(m.as_str()) {
+                        if *category == SensitiveDataCategory::CreditCard && !luhn_check(m.as_str())
+                        {
                             continue;
                         }
 
@@ -197,7 +197,11 @@ impl RegexPiiRedactor {
         }
     }
 
-    fn apply_strategy(original: &str, category: &SensitiveDataCategory, strategy: &RedactionStrategy) -> String {
+    fn apply_strategy(
+        original: &str,
+        category: &SensitiveDataCategory,
+        strategy: &RedactionStrategy,
+    ) -> String {
         match strategy {
             RedactionStrategy::Mask => Self::mask_value(original, category),
             RedactionStrategy::Hash => {
@@ -312,7 +316,10 @@ mod tests {
     #[tokio::test]
     async fn detect_email() {
         let detector = RegexPiiDetector::with_categories(vec![SensitiveDataCategory::Email]);
-        let matches = detector.detect("Contact: john@example.com or support@test.org").await.unwrap();
+        let matches = detector
+            .detect("Contact: john@example.com or support@test.org")
+            .await
+            .unwrap();
         assert_eq!(matches.len(), 2);
         assert_eq!(matches[0].original, "john@example.com");
         assert_eq!(matches[1].original, "support@test.org");
@@ -321,14 +328,16 @@ mod tests {
     #[tokio::test]
     async fn detect_phone() {
         let detector = RegexPiiDetector::with_categories(vec![SensitiveDataCategory::Phone]);
-        let matches = detector.detect("Call 555-123-4567 or (555) 987-6543").await.unwrap();
+        let matches = detector
+            .detect("Call 555-123-4567 or (555) 987-6543")
+            .await
+            .unwrap();
         assert_eq!(matches.len(), 2);
     }
 
     #[tokio::test]
     async fn detect_credit_card_with_luhn() {
-        let detector =
-            RegexPiiDetector::with_categories(vec![SensitiveDataCategory::CreditCard]);
+        let detector = RegexPiiDetector::with_categories(vec![SensitiveDataCategory::CreditCard]);
         // Valid Visa test number
         let matches = detector.detect("Card: 4111 1111 1111 1111").await.unwrap();
         assert_eq!(matches.len(), 1);
@@ -349,7 +358,10 @@ mod tests {
     #[tokio::test]
     async fn detect_ip_address() {
         let detector = RegexPiiDetector::with_categories(vec![SensitiveDataCategory::IpAddress]);
-        let matches = detector.detect("Server at 192.168.1.1 and 10.0.0.1").await.unwrap();
+        let matches = detector
+            .detect("Server at 192.168.1.1 and 10.0.0.1")
+            .await
+            .unwrap();
         assert_eq!(matches.len(), 2);
     }
 
@@ -454,8 +466,7 @@ mod tests {
 
     #[tokio::test]
     async fn redact_credit_card_mask() {
-        let redactor =
-            RegexPiiRedactor::with_categories(vec![SensitiveDataCategory::CreditCard]);
+        let redactor = RegexPiiRedactor::with_categories(vec![SensitiveDataCategory::CreditCard]);
         let result = redactor
             .redact("Card: 4111111111111111", &RedactionStrategy::Mask)
             .await

--- a/crates/mofa-foundation/src/workflow/profiler.rs
+++ b/crates/mofa-foundation/src/workflow/profiler.rs
@@ -107,12 +107,12 @@ impl ExecutionTimeline {
 
     /// End the current node span
     pub fn end_node(&mut self) {
-        if let Some(idx) = self.current_node_span {
-            if let Some(span) = self.node_spans.get_mut(idx) {
-                let now = DebugEvent::now_ms();
-                span.ended_at_ms = Some(now);
-                span.duration_ms = Some(now.saturating_sub(span.started_at_ms));
-            }
+        if let Some(idx) = self.current_node_span
+            && let Some(span) = self.node_spans.get_mut(idx)
+        {
+            let now = DebugEvent::now_ms();
+            span.ended_at_ms = Some(now);
+            span.duration_ms = Some(now.saturating_sub(span.started_at_ms));
         }
         self.current_node_span = None;
         self.current_tool_span = None;
@@ -120,33 +120,31 @@ impl ExecutionTimeline {
 
     /// Start recording a tool span within current node
     pub fn start_tool(&mut self, tool_id: String, tool_name: String) {
-        if let Some(idx) = self.current_node_span {
-            if let Some(span) = self.node_spans.get_mut(idx) {
-                let tool_span = ToolSpan {
-                    tool_id,
-                    tool_name,
-                    started_at_ms: DebugEvent::now_ms(),
-                    ended_at_ms: None,
-                    duration_ms: None,
-                };
-                self.current_tool_span = Some(span.tool_spans.len());
-                span.tool_spans.push(tool_span);
-            }
+        if let Some(idx) = self.current_node_span
+            && let Some(span) = self.node_spans.get_mut(idx)
+        {
+            let tool_span = ToolSpan {
+                tool_id,
+                tool_name,
+                started_at_ms: DebugEvent::now_ms(),
+                ended_at_ms: None,
+                duration_ms: None,
+            };
+            self.current_tool_span = Some(span.tool_spans.len());
+            span.tool_spans.push(tool_span);
         }
     }
 
     /// End the current tool span
     pub fn end_tool(&mut self) {
-        if let Some(node_idx) = self.current_node_span {
-            if let Some(span) = self.node_spans.get_mut(node_idx) {
-                if let Some(tool_idx) = self.current_tool_span {
-                    if let Some(tool_span) = span.tool_spans.get_mut(tool_idx) {
-                        let now = DebugEvent::now_ms();
-                        tool_span.ended_at_ms = Some(now);
-                        tool_span.duration_ms = Some(now.saturating_sub(tool_span.started_at_ms));
-                    }
-                }
-            }
+        if let Some(node_idx) = self.current_node_span
+            && let Some(span) = self.node_spans.get_mut(node_idx)
+            && let Some(tool_idx) = self.current_tool_span
+            && let Some(tool_span) = span.tool_spans.get_mut(tool_idx)
+        {
+            let now = DebugEvent::now_ms();
+            tool_span.ended_at_ms = Some(now);
+            tool_span.duration_ms = Some(now.saturating_sub(tool_span.started_at_ms));
         }
         self.current_tool_span = None;
     }

--- a/crates/mofa-foundation/src/workflow/state_graph.rs
+++ b/crates/mofa-foundation/src/workflow/state_graph.rs
@@ -450,9 +450,7 @@ impl<S: GraphState> CompiledGraphImpl<S> {
     /// Get the next node(s) based on the current node and command
     fn get_next_nodes(&self, current_node: &str, command: &Command) -> AgentResult<Vec<String>> {
         match &command.control {
-            ControlFlow::Goto(target) => {
-                Ok(vec![target.clone()])
-            }
+            ControlFlow::Goto(target) => Ok(vec![target.clone()]),
             ControlFlow::Return => {
                 Ok(vec![]) // End execution
             }
@@ -467,10 +465,10 @@ impl<S: GraphState> CompiledGraphImpl<S> {
                     Some(EdgeTarget::Parallel(targets)) => Ok(targets.clone()),
                     Some(EdgeTarget::Conditional(routes)) => {
                         // Priority 1: explicit route decision
-                        if let Some(decision) = command.route_value() {
-                            if let Some(target) = routes.get(decision) {
-                                return Ok(vec![target.clone()]);
-                            }
+                        if let Some(decision) = command.route_value()
+                            && let Some(target) = routes.get(decision)
+                        {
+                            return Ok(vec![target.clone()]);
                         }
                         // Priority 2: legacy key-name matching (backward compatible)
                         for update in &command.updates {
@@ -479,7 +477,8 @@ impl<S: GraphState> CompiledGraphImpl<S> {
                             }
                         }
                         // No route matched — report error instead of silent fallback
-                        let update_keys: Vec<&str> = command.updates.iter().map(|u| u.key.as_str()).collect();
+                        let update_keys: Vec<&str> =
+                            command.updates.iter().map(|u| u.key.as_str()).collect();
                         let route_keys: Vec<&String> = routes.keys().collect();
                         warn!(
                             node_id = current_node,
@@ -688,10 +687,10 @@ impl<S: GraphState + 'static> CompiledGraph<S, serde_json::Value> for CompiledGr
                             Some(EdgeTarget::Parallel(targets)) => Ok(targets.clone()),
                             Some(EdgeTarget::Conditional(routes)) => {
                                 // Priority 1: explicit route decision
-                                if let Some(decision) = command.route_value() {
-                                    if let Some(target) = routes.get(decision) {
-                                        return Ok(vec![target.clone()]);
-                                    }
+                                if let Some(decision) = command.route_value()
+                                    && let Some(target) = routes.get(decision)
+                                {
+                                    return Ok(vec![target.clone()]);
                                 }
                                 // Priority 2: legacy key-name matching (backward compatible)
                                 for update in &command.updates {
@@ -1020,8 +1019,8 @@ impl<S: GraphState + 'static> CompiledGraph<S, serde_json::Value> for CompiledGr
 mod tests {
     use super::*;
     use futures::StreamExt;
-    use mofa_kernel::workflow::telemetry::TelemetryEmitter;
     use mofa_kernel::workflow::GraphConfig;
+    use mofa_kernel::workflow::telemetry::TelemetryEmitter;
     use mofa_kernel::workflow::{JsonState, StateGraph};
     use serde_json::json;
     use std::collections::HashMap;
@@ -1524,7 +1523,10 @@ mod tests {
         let compiled = graph.compile().unwrap();
         let result = compiled.invoke(JsonState::new(), None).await;
 
-        assert!(result.is_err(), "invoke should return Err when no conditional route matches");
+        assert!(
+            result.is_err(),
+            "invoke should return Err when no conditional route matches"
+        );
         let err_msg = result.unwrap_err().to_string();
         assert!(
             err_msg.contains("No conditional route matched"),
@@ -1583,6 +1585,9 @@ mod tests {
             }
         }
 
-        assert!(got_error, "stream should emit an error event when no conditional route matches");
+        assert!(
+            got_error,
+            "stream should emit an error event when no conditional route matches"
+        );
     }
 }

--- a/crates/mofa-sdk/src/lib.rs
+++ b/crates/mofa-sdk/src/lib.rs
@@ -740,7 +740,6 @@ pub mod react {
     pub use mofa_foundation::react::*;
 }
 
-/// Classic agentic patterns re-exported from the foundation layer.
 pub mod patterns {
     //! High-level agentic patterns with ergonomic builders.
     //!

--- a/crates/mofa-sdk/src/lib.rs
+++ b/crates/mofa-sdk/src/lib.rs
@@ -122,18 +122,17 @@ pub mod kernel {
     pub use mofa_kernel::agent::{
         AgentCapabilities, AgentCapabilitiesBuilder, AgentContext, AgentError, AgentFactory,
         AgentInput, AgentLifecycle, AgentMessage as CoreAgentMessage, AgentMessaging,
-        AgentMetadata, AgentOutput, AgentPluginSupport, AgentRequirements,
-        AgentRequirementsBuilder, AgentReport, AgentResult, AgentState, AgentStats,
-        ChatCompletionRequest, ChatCompletionResponse, ChatMessage, ContextConfig,
-        CoordinationPattern, Coordinator, DynAgent, ErrorCategory, ErrorContext, EventBuilder,
-        EventBus, GlobalError, GlobalEvent, GlobalMessage, GlobalReport, GlobalResult,
-        HealthStatus, InputType, IntoAgentReport, IntoGlobalReport, InterruptResult, LLMProvider,
-        Memory,
-        MemoryItem, MemoryStats, MemoryValue, Message, MessageContent, MessageMetadata,
-        MessageRole, MoFAAgent, OutputContent, OutputType, Reasoner, ReasoningResult,
-        ReasoningStep, ReasoningStepType, ReasoningStrategy, TokenUsage, Tool, ToolCall,
-        ToolDefinition, ToolDescriptor, ToolInput, ToolMetadata, ToolResult, ToolUsage,
-        execution_events, lifecycle, message_events, plugin_events, state_events,
+        AgentMetadata, AgentOutput, AgentPluginSupport, AgentReport, AgentRequirements,
+        AgentRequirementsBuilder, AgentResult, AgentState, AgentStats, ChatCompletionRequest,
+        ChatCompletionResponse, ChatMessage, ContextConfig, CoordinationPattern, Coordinator,
+        DynAgent, ErrorCategory, ErrorContext, EventBuilder, EventBus, GlobalError, GlobalEvent,
+        GlobalMessage, GlobalReport, GlobalResult, HealthStatus, InputType, InterruptResult,
+        IntoAgentReport, IntoGlobalReport, LLMProvider, Memory, MemoryItem, MemoryStats,
+        MemoryValue, Message, MessageContent, MessageMetadata, MessageRole, MoFAAgent,
+        OutputContent, OutputType, Reasoner, ReasoningResult, ReasoningStep, ReasoningStepType,
+        ReasoningStrategy, TokenUsage, Tool, ToolCall, ToolDefinition, ToolDescriptor, ToolInput,
+        ToolMetadata, ToolResult, ToolUsage, execution_events, lifecycle, message_events,
+        plugin_events, state_events,
     };
 
     // Core AgentConfig (runtime-level, lightweight)
@@ -739,6 +738,19 @@ pub mod react {
     //! Agents solve problems through a "Think-Act-Observe" cycle.
 
     pub use mofa_foundation::react::*;
+}
+
+/// Classic agentic patterns re-exported from the foundation layer.
+pub mod patterns {
+    //! High-level agentic patterns with ergonomic builders.
+    //!
+    //! These patterns target common MoFA use cases such as deliberate reasoning
+    //! and expert routing, while keeping the runtime surface small.
+
+    pub use mofa_foundation::react::{
+        ChainOfThought, ChainOfThoughtBuilder, ChainOfThoughtConfig, ChainOfThoughtResult, Router,
+        RouterBuilder, RouterConfig, RouterDecision, RouterResult,
+    };
 }
 
 // Re-export collaboration module from mofa-foundation (always available)

--- a/docs/mofa-doc/src/api-reference/foundation/patterns.md
+++ b/docs/mofa-doc/src/api-reference/foundation/patterns.md
@@ -74,7 +74,10 @@ use mofa_sdk::patterns::ChainOfThought;
 let agent = ChainOfThought::builder()
     .with_llm(client)
     .with_steps(5)
-    .build();
+    .build()?;
+
+let result = agent.run("Explain how retries interact with backpressure").await?;
+println!("{}", result.to_markdown_trace());
 ```
 
 ## Router Pattern
@@ -86,13 +89,20 @@ use mofa_sdk::patterns::Router;
 
 let router = Router::builder()
     .with_classifier(classifier_agent)
-    .with_route("technical", tech_agent)
-    .with_route("billing", billing_agent)
-    .with_default(general_agent)
-    .build();
+    .with_route_llm("technical", tech_agent)
+    .describe_route("technical", "Engineering strategy and implementation tradeoffs")
+    .with_route_llm("billing", billing_agent)
+    .describe_route("billing", "Invoices, payments, and account adjustments")
+    .with_default_llm(general_agent)
+    .build()?;
 
-let output = router.execute(input, &ctx).await?;
+let output = router.run("Why was I charged twice?").await?;
+println!("{}", output.to_markdown_trace());
 ```
+
+### Showcase Example
+
+See `examples/classic_agentic_patterns/` for a runnable demo of both patterns.
 
 ## Custom Patterns
 

--- a/docs/mofa-doc/src/examples/README.md
+++ b/docs/mofa-doc/src/examples/README.md
@@ -38,7 +38,7 @@ Web dashboards and metrics collection.
 LLM streaming with text-to-speech integration.
 
 ### Advanced Patterns
-Reflection agents and human-in-the-loop workflows.
+Reflection agents, chain-of-thought reasoning, router dispatch, and human-in-the-loop workflows.
 
 ## Running Examples
 

--- a/docs/mofa-doc/src/examples/advanced-patterns.md
+++ b/docs/mofa-doc/src/examples/advanced-patterns.md
@@ -57,6 +57,36 @@ let config = ReflectionConfig::default()
     .with_verbose(true);              // Log each step
 ```
 
+## Classic Pattern Showcase
+
+Combined demonstration of the newly implemented Chain-of-Thought and Router patterns.
+
+**Location:** `examples/classic_agentic_patterns/`
+
+```rust
+use mofa_sdk::patterns::{ChainOfThought, Router};
+
+// Build a deliberate reasoner
+let chain = ChainOfThought::builder()
+    .with_llm(reasoning_agent)
+    .with_steps(3)
+    .build()?;
+
+// Build an expert router
+let router = Router::builder()
+    .with_classifier(classifier_agent)
+    .with_route_llm("technical", technical_agent)
+    .with_route_llm("billing", billing_agent)
+    .with_default_llm(general_agent)
+    .build()?;
+```
+
+### What It Demonstrates
+
+1. **Chain-of-Thought**: Produces an inspectable multi-step reasoning trace before synthesis.
+2. **Router**: Classifies a task and dispatches it to the best expert with a structured route decision.
+3. **Reviewer-friendly output**: Both patterns render markdown traces that can be pasted directly into docs or PRs.
+
 ## Human-in-the-Loop Secretary
 
 Secretary agent with human decision points.
@@ -242,6 +272,9 @@ let agent = LLMAgentBuilder::from_config(&config).build_async().await?;
 export OPENAI_API_KEY=sk-xxx
 cargo run -p reflection_agent
 
+# Classic pattern showcase
+cargo run -p classic_agentic_patterns
+
 # HITL Secretary
 cargo run -p hitl_secretary
 
@@ -259,6 +292,7 @@ cargo run -p config
 
 | Example | Description |
 |---------|-------------|
+| `classic_agentic_patterns` | Chain-of-thought + router showcase |
 | `reflection_agent` | Self-improving agent pattern |
 | `hitl_secretary` | Human-in-the-loop secretary |
 | `agent_with_plugins_and_rhai` | Combined plugins + Rhai |

--- a/docs/mofa-doc/src/zh/api-reference/foundation/patterns.md
+++ b/docs/mofa-doc/src/zh/api-reference/foundation/patterns.md
@@ -74,7 +74,10 @@ use mofa_sdk::patterns::ChainOfThought;
 let agent = ChainOfThought::builder()
     .with_llm(client)
     .with_steps(5)
-    .build();
+    .build()?;
+
+let result = agent.run("解释退避重试为什么更稳定").await?;
+println!("{}", result.to_markdown_trace());
 ```
 
 ## Router 模式
@@ -86,12 +89,15 @@ use mofa_sdk::patterns::Router;
 
 let router = Router::builder()
     .with_classifier(classifier_agent)
-    .with_route("technical", tech_agent)
-    .with_route("billing", billing_agent)
-    .with_default(general_agent)
-    .build();
+    .with_route_llm("technical", tech_agent)
+    .describe_route("technical", "工程策略、实现设计与权衡")
+    .with_route_llm("billing", billing_agent)
+    .describe_route("billing", "发票、付款与账户调整")
+    .with_default_llm(general_agent)
+    .build()?;
 
-let output = router.execute(input, &ctx).await?;
+let output = router.run("为什么我被重复扣费了？").await?;
+println!("{}", output.to_markdown_trace());
 ```
 
 ## 自定义模式

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -878,6 +878,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "classic_agentic_patterns"
+version = "0.1.0"
+dependencies = [
+ "mofa-sdk",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.22",
+]
+
+[[package]]
 name = "claxon"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "llm_tts_streaming",
     "agent_from_database_streaming",
     "workflow_dsl",
+    "classic_agentic_patterns",
     "reflection_agent",
     "tool_routing",
     "runtime_message_bus_backpressure",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -110,7 +110,7 @@ type_complexity = "allow"
 
 await_holding_lock = "warn"
 dbg_macro = "warn"
-empty_enum = "warn"
+empty_enums = "warn"
 enum_glob_use = "warn"
 exit = "warn"
 filter_map_next = "warn"

--- a/examples/classic_agentic_patterns/Cargo.toml
+++ b/examples/classic_agentic_patterns/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "classic_agentic_patterns"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+mofa-sdk = { path = "../../crates/mofa-sdk" }
+
+tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+[lints]
+workspace = true

--- a/examples/classic_agentic_patterns/src/main.rs
+++ b/examples/classic_agentic_patterns/src/main.rs
@@ -1,0 +1,133 @@
+//! Showcase for classic agentic patterns in MoFA.
+
+use mofa_sdk::llm::{MockLLMProvider, simple_llm_agent};
+use mofa_sdk::patterns::{ChainOfThought, Router, RouterConfig};
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    println!("==================================================");
+    println!("MoFA Classic Agentic Patterns Showcase");
+    println!("==================================================");
+    println!();
+
+    run_chain_of_thought_demo().await?;
+    println!();
+    run_router_demo().await?;
+
+    Ok(())
+}
+
+async fn run_chain_of_thought_demo() -> Result<(), Box<dyn std::error::Error>> {
+    println!("--- Chain-of-Thought Demo ---");
+
+    let provider = Arc::new(MockLLMProvider::new("cot"));
+    provider
+        .add_response("First, identify the operational constraints and what can fail under load.")
+        .await;
+    provider
+        .add_response("Next, compare the cost of immediate retries versus staggered retries.")
+        .await;
+    provider
+        .add_response("Finally, connect retry timing to service recovery and queue stability.")
+        .await;
+    provider
+        .add_response(
+            "Backoff matters because it reduces synchronized retry storms, gives dependencies time to recover, and improves success probability under contention.",
+        )
+        .await;
+
+    let chain = ChainOfThought::builder()
+        .with_llm(Arc::new(simple_llm_agent(
+            "cot-thinker",
+            provider,
+            "You reason in crisp operational steps.",
+        )))
+        .with_steps(3)
+        .with_verbose(false)
+        .build()?;
+
+    let result = chain
+        .run("Explain why retry backoff improves resilience in distributed systems.")
+        .await?;
+
+    println!("{}", result.to_markdown_trace());
+    Ok(())
+}
+
+async fn run_router_demo() -> Result<(), Box<dyn std::error::Error>> {
+    println!("--- Router Demo ---");
+
+    let classifier_provider = Arc::new(MockLLMProvider::new("classifier"));
+    classifier_provider
+        .add_response(
+            r#"{"route":"technical","reason":"the task asks about implementation strategy","confidence":0.94}"#,
+        )
+        .await;
+    let technical_provider = Arc::new(MockLLMProvider::new("technical"));
+    technical_provider
+        .add_response(
+            "Technical expert: build the prototype around the smallest stable API, then add typed traces and tests before expanding scope.",
+        )
+        .await;
+    let billing_provider = Arc::new(MockLLMProvider::new("billing"));
+    billing_provider
+        .add_response("Billing expert: check invoice history and duplicate payment events.")
+        .await;
+    let general_provider = Arc::new(MockLLMProvider::new("general"));
+    general_provider
+        .add_response("General expert: clarify the request and route it manually.")
+        .await;
+
+    let router = Router::builder()
+        .with_classifier(Arc::new(simple_llm_agent(
+            "classifier",
+            classifier_provider,
+            "You classify tasks to the best expert.",
+        )))
+        .with_route_llm(
+            "technical",
+            Arc::new(simple_llm_agent(
+                "technical",
+                technical_provider,
+                "You answer technical design questions.",
+            )),
+        )
+        .describe_route(
+            "technical",
+            "Engineering strategy, implementation design, and tradeoffs",
+        )
+        .with_route_llm(
+            "billing",
+            Arc::new(simple_llm_agent(
+                "billing",
+                billing_provider,
+                "You answer invoice and payment questions.",
+            )),
+        )
+        .describe_route(
+            "billing",
+            "Invoices, billing corrections, and payment questions",
+        )
+        .with_default_llm(Arc::new(simple_llm_agent(
+            "general",
+            general_provider,
+            "You provide fallback help when no expert matches.",
+        )))
+        .with_config(RouterConfig::default().with_verbose(false))
+        .build()?;
+
+    let result = router
+        .run("How should we scope a new idea-8 pattern contribution so it is distinct and reviewable?")
+        .await?;
+
+    println!("{}", result.to_markdown_trace());
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Implements two classic agentic patterns for Idea 8 and turns an existing docs/code gap into a runnable SDK surface.

Before:
- `mofa_sdk::patterns::ChainOfThought` and `mofa_sdk::patterns::Router` were referenced in docs but not actually available as first-class SDK APIs.
- There was no focused example showing these classic patterns working end-to-end.

After:
- both patterns are implemented in `mofa-foundation`
- both are re-exported through `mofa_sdk::patterns`
- both have tests and markdown trace output for reviewability
- a new `classic_agentic_patterns` example showcases deliberate reasoning + expert routing together
- the stated clippy checks now pass without warnings

## Related Issues

Closes #938

Related to Idea 8 in `mofa-org/gsoc`: Implement classic agentic design patterns using MoFA, and iterate on the framework.

---

## Context

Idea 8 is a good fit for contributions that improve both framework capability and contributor ergonomics.

MoFA's docs already advertised Chain-of-Thought and Router patterns, but contributors could not actually import those APIs from `mofa_sdk::patterns`. That made the docs aspirational instead of executable.

This PR closes that gap with a concrete, reviewable implementation that is small enough to land independently and visible enough to help future GSoC contributors build on top of it.

A small follow-up lint cleanup was also included so the advertised no-warning clippy commands for the touched crates actually hold.

---

## Changes

- Added `ChainOfThought` with:
  - configurable multi-step reasoning
  - optional dedicated synthesizer
  - structured `ChainOfThoughtResult`
  - `to_markdown_trace()` for reviewer-friendly output
- Added `Router` with:
  - classifier-driven route selection
  - named expert routes
  - route descriptions for better prompting
  - default fallback route
  - structured `RouterResult` and `RouterDecision`
  - `to_markdown_trace()` for inspection
- Added SDK re-exports under `mofa_sdk::patterns`
- Added regression/unit tests for both patterns
- Added `examples/classic_agentic_patterns/` showcase
- Updated English and Chinese docs so the documented API matches the real implementation
- Fixed low-risk clippy findings in adjacent `mofa-foundation` support code and updated the examples workspace lint name from `empty_enum` to `empty_enums`

---

## How you Tested

1. Added targeted tests for the new pattern implementations.
2. Formatted the touched code paths:
   - `rustfmt --edition 2024 --config skip_children=true crates/mofa-foundation/src/adapter/config.rs crates/mofa-foundation/src/adapter/descriptor.rs crates/mofa-foundation/src/adapter/registry.rs crates/mofa-foundation/src/agent/components/context_compressor.rs crates/mofa-foundation/src/coordination/scheduler.rs crates/mofa-foundation/src/llm/anthropic.rs crates/mofa-foundation/src/llm/google.rs crates/mofa-foundation/src/rag/loaders.rs crates/mofa-foundation/src/rag/pipeline_adapters.rs crates/mofa-foundation/src/rag/recursive_chunker.rs crates/mofa-foundation/src/rag/retrieval.rs crates/mofa-foundation/src/react/router.rs crates/mofa-foundation/src/recovery.rs crates/mofa-foundation/src/security/regex_pii.rs crates/mofa-foundation/src/workflow/profiler.rs crates/mofa-foundation/src/workflow/state_graph.rs crates/mofa-sdk/src/lib.rs`
   - `cargo fmt --manifest-path examples/Cargo.toml -p classic_agentic_patterns`
3. Ran verification commands:
   - `cargo clippy -p mofa-foundation -p mofa-sdk --no-deps -- -D warnings`
   - `cargo clippy --manifest-path examples/Cargo.toml -p classic_agentic_patterns --no-deps -- -D warnings`
   - `cargo test -p mofa-foundation chain_of_thought -- --nocapture`
   - `cargo test -p mofa-foundation router -- --nocapture`
   - `cargo run --manifest-path examples/classic_agentic_patterns/Cargo.toml`

```bash
cargo clippy -p mofa-foundation -p mofa-sdk --no-deps -- -D warnings
cargo clippy --manifest-path examples/Cargo.toml -p classic_agentic_patterns --no-deps -- -D warnings
cargo test -p mofa-foundation chain_of_thought -- --nocapture
cargo test -p mofa-foundation router -- --nocapture
cargo run --manifest-path examples/classic_agentic_patterns/Cargo.toml
```

---

## Screenshots / Logs (if applicable)

```bash
==================================================
MoFA Classic Agentic Patterns Showcase
==================================================

--- Chain-of-Thought Demo ---
# Chain-of-Thought Trace
...

--- Router Demo ---
# Router Trace
**Requested Route:** technical
**Resolved Route:** technical
```

---

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (describe below)

If breaking:

---

## Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [x] Public APIs documented
- [x] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [ ] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---

## Deployment Notes (if applicable)

No migration or configuration changes required.

---

## Additional Notes for Reviewers

- Main implementation files:
  - `crates/mofa-foundation/src/react/chain_of_thought.rs`
  - `crates/mofa-foundation/src/react/router.rs`
  - `crates/mofa-sdk/src/lib.rs`
- Showcase example:
  - `examples/classic_agentic_patterns/`
- Follow-up commit `79044402` is intentionally limited to lint and formatting cleanup needed to make the stated quality checks pass.
- This PR intentionally does **not** overlap with gateway/provider routing work such as SmartRouter policy changes. It targets classic agent dispatch patterns at the SDK/foundation layer.
