### PR TITLE
feat(tracing): add top-level spans to AgentRunner and CompiledGraphImpl

### DIFF
--- a/crates/mofa-foundation/src/workflow/state_graph.rs
+++ b/crates/mofa-foundation/src/workflow/state_graph.rs
@@ -418,6 +418,10 @@ impl<S: GraphState> CompiledGraphImpl<S> {
             let node_id = node_id.clone();
             let sem = semaphore.clone();
 
+            let node_span = tracing::info_span!(
+                "workflow.node",
+                node_id = %node_id,
+            );
             join_set.spawn(async move {
                 // Acquire semaphore permit to enforce max_parallelism
                 let _permit = sem.acquire().await.map_err(|_| {
@@ -425,7 +429,7 @@ impl<S: GraphState> CompiledGraphImpl<S> {
                 })?;
                 let command = node.call(&mut isolated_state, &node_ctx).await?;
                 Ok::<(usize, String, Command), AgentError>((index, node_id, command))
-            });
+            }.instrument(node_span));
         }
 
         let mut ordered_results: Vec<Option<(String, Command)>> = vec![None; node_ids.len()];
@@ -525,9 +529,22 @@ impl<S: GraphState + 'static> CompiledGraph<S, serde_json::Value> for CompiledGr
         &self.id
     }
 
+    #[tracing::instrument(
+        name = "workflow.invoke",
+        skip_all,
+        fields(
+            graph_id = %self.id,
+            execution_id = tracing::field::Empty,
+        )
+    )]
     async fn invoke(&self, input: S, config: Option<RuntimeContext>) -> AgentResult<S> {
         let ctx =
             config.unwrap_or_else(|| RuntimeContext::with_config(&self.id, self.config.clone()));
+
+        tracing::Span::current().record(
+            "execution_id",
+            tracing::field::display(&ctx.execution_id),
+        );
 
         info!(
             "Starting graph execution '{}' with execution_id={}",
@@ -666,7 +683,13 @@ impl<S: GraphState + 'static> CompiledGraph<S, serde_json::Value> for CompiledGr
         let (tx, rx) = tokio::sync::mpsc::channel(100);
 
         // Spawn execution task
-        let stream_span = tracing::info_span!("state_graph.stream");
+        let graph_id_owned = self.id.clone();
+        let exec_id_owned = ctx.execution_id.clone();
+        let stream_span = tracing::info_span!(
+            "state_graph.stream",
+            graph_id = %graph_id_owned,
+            execution_id = %exec_id_owned,
+        );
         tokio::spawn(async move {
             let mut state = input;
             let mut current_nodes = vec![entry_point];

--- a/crates/mofa-runtime/src/runner.rs
+++ b/crates/mofa-runtime/src/runner.rs
@@ -94,6 +94,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio::time::{Duration, MissedTickBehavior};
+use tracing::instrument;
 
 /// 运行器状态
 /// Runner state
@@ -384,6 +385,14 @@ impl<T: MoFAAgent> AgentRunner<T> {
     ///
     /// 返回 Agent 的输出。
     /// Returns the Agent's output.
+    #[instrument(
+        name = "agent.execute",
+        skip(self, input),
+        fields(
+            agent_id = %self.agent.id(),
+            execution_id = %self.context.execution_id,
+        )
+    )]
     pub async fn execute(&mut self, input: AgentInput) -> AgentResult<AgentOutput> {
         // 检查状态
         // Check state


### PR DESCRIPTION
## Summary

Adds structured tracing spans to the two main execution entry points (`AgentRunner::execute` and `CompiledGraphImpl::invoke`) so that every agent run and workflow invocation produces a root span carrying `agent_id`/`graph_id` and `execution_id`.

### What changed

- **`AgentRunner::execute()`** — `#[instrument]` with span name `agent.execute`, recording `agent_id` and `execution_id` as structured fields. Downstream retry spans and node-level spans now have a common parent.

- **`CompiledGraphImpl::invoke()`** — `#[instrument]` with span name `workflow.invoke`, recording `graph_id` upfront and `execution_id` via deferred field recording (since `execution_id` comes from the `RuntimeContext` which is resolved inside the method body).

- **Parallel node tasks** in `execute_parallel_nodes()` — each spawned task is now wrapped with `.instrument(node_span)` carrying the `node_id`, so parallel failures can be correlated back to the parent workflow invocation.

- **`stream()` span** — enriched with `graph_id` and `execution_id` fields (previously had no identifying attributes).

### Scope

- No behavior changes
- No API changes
- No config changes
- No new dependencies (`tracing` is already a workspace dep)
- All existing tests pass

Closes #673