### PR TITLE
fix(monitoring): close TOCTOU race in TracerProvider::tracer()

### DIFF
--- a/crates/mofa-monitoring/src/tracing/tracer.rs
+++ b/crates/mofa-monitoring/src/tracing/tracer.rs
@@ -428,11 +428,19 @@ impl TracerProvider {
     /// 获取或创建 Tracer
     /// Get or create a Tracer
     pub async fn tracer(&self, name: &str) -> Arc<Tracer> {
+        // Fast path: read lock only
         {
             let tracers = self.tracers.read().await;
             if let Some(tracer) = tracers.get(name) {
                 return tracer.clone();
             }
+        }
+
+        // Slow path: acquire write lock and re-check to avoid creating
+        // duplicate tracers under concurrent access
+        let mut tracers = self.tracers.write().await;
+        if let Some(tracer) = tracers.get(name) {
+            return tracer.clone();
         }
 
         let tracer = Arc::new(Tracer::new(
@@ -443,11 +451,7 @@ impl TracerProvider {
             self.processor.clone(),
         ));
 
-        {
-            let mut tracers = self.tracers.write().await;
-            tracers.insert(name.to_string(), tracer.clone());
-        }
-
+        tracers.insert(name.to_string(), tracer.clone());
         tracer
     }
 


### PR DESCRIPTION
## Summary

Closes #947

`TracerProvider::tracer()` had a race condition between releasing the read lock (after finding no tracer) and acquiring the write lock (to insert a new one). Under concurrent access, two callers could both create separate `Tracer` instances for the same name — the second insert overwrites the first, leaving one caller with an orphaned instance.

**Fix:** Re-check the map after acquiring the write lock before inserting (double-checked locking). Only one Tracer is ever created per name.

## Changes

- `crates/mofa-monitoring/src/tracing/tracer.rs`: Added a second lookup after acquiring the write lock in `tracer()`. If another task inserted a tracer between the read and write lock acquisitions, we return the existing one instead of creating a duplicate.

## Test plan

- [x] `cargo check -p mofa-monitoring` passes
- [ ] Existing tracing tests pass (no behavior change for non-concurrent callers)
- [ ] Concurrent access now correctly returns the same `Arc<Tracer>` instance