### PR TITLE
fix(monitoring): route periodic updates through topic-filtered broadcast

### DIFF
--- a/crates/mofa-monitoring/src/dashboard/websocket.rs
+++ b/crates/mofa-monitoring/src/dashboard/websocket.rs
@@ -243,15 +243,12 @@ impl WebSocketHandler {
         self: Arc<Self>,
         mut rx: mpsc::Receiver<DebugEvent>,
     ) -> tokio::task::JoinHandle<()> {
-        let broadcast_tx = self.broadcast_tx.clone();
         info!("Starting debug event forwarder");
 
         tokio::spawn(async move {
             while let Some(event) = rx.recv().await {
                 let msg = WebSocketMessage::Debug(event);
-                if let Err(e) = broadcast_tx.send(msg) {
-                    debug!("Failed to broadcast debug event: {}", e);
-                }
+                self.broadcast("debug", msg).await;
             }
             info!("Debug event forwarder stopped");
         })
@@ -267,11 +264,11 @@ impl WebSocketHandler {
             loop {
                 ticker.tick().await;
 
-                // Collect and broadcast metrics
+                // Collect and broadcast metrics to subscribed clients only
                 let snapshot = self.collector.current().await;
                 let msg = WebSocketMessage::Metrics(snapshot);
 
-                let _ = self.broadcast_tx.send(msg);
+                self.broadcast("metrics", msg).await;
             }
         })
     }


### PR DESCRIPTION
## Summary

Closes #948

`start_updates()` and `start_debug_event_forwarder()` were sending messages directly through the `broadcast_tx` channel, which delivers to ALL connected WebSocket clients regardless of their topic subscriptions. A client subscribed only to `"alerts"` would still receive metrics snapshots every second and all debug events — the Subscribe/Unsubscribe protocol had no effect on these streams.

**Fix:** Route both through `self.broadcast(topic, msg)` which checks `is_subscribed()` per client, so topic filtering is actually enforced.

## Changes

- `crates/mofa-monitoring/src/dashboard/websocket.rs`:
  - `start_updates()`: replaced `self.broadcast_tx.send(msg)` with `self.broadcast("metrics", msg).await`
  - `start_debug_event_forwarder()`: replaced `broadcast_tx.send(msg)` with `self.broadcast("debug", msg).await`

## Test plan

- [x] `cargo check -p mofa-monitoring` passes
- [ ] Existing WebSocket tests pass
- [ ] Clients only receive messages for topics they are subscribed to
- [ ] Default subscription (metrics) still works — new clients get metrics on connect