### PR TITLE
feat(runtime): scaffold HTTP control plane + gateway (phase 1)

### DIFF
--- a/crates/mofa-runtime/Cargo.toml
+++ b/crates/mofa-runtime/Cargo.toml
@@ -32,6 +32,10 @@ mofa-kernel = { path = "../mofa-kernel", version = "0.1", features = ["config"] 
 mofa-foundation = { path = "../mofa-foundation", version = "0.1" }
 mofa-plugins = { path = "../mofa-plugins", version = "0.1" }
 mofa-monitoring = { path = "../mofa-monitoring", version = "0.1", optional = true }
+# HTTP gateway (optional)
+axum = { workspace = true, optional = true, features = ["macros", "json"] }
+tower = { workspace = true, optional = true }
+tower-http = { workspace = true, optional = true, features = ["trace", "cors"] }
 # Dora-rs dependencies
 dora-node-api = { version = "0", default-features = false, optional = true }
 dora-operator-api = { version = "0", default-features = false, optional = true }
@@ -52,3 +56,4 @@ workspace = true
 [features]
 dora = ["dora-node-api", "dora-operator-api", "dora-daemon", "dora-core", "dora-message"]
 monitoring = ["dep:mofa-monitoring"]
+gateway = ["dep:axum", "dep:tower", "dep:tower-http"]

--- a/crates/mofa-runtime/src/control_plane/api.rs
+++ b/crates/mofa-runtime/src/control_plane/api.rs
@@ -1,0 +1,4 @@
+//! Placeholder for HTTP API handlers.
+//!
+//! Phase 1 does not expose any endpoints; routes will be added in later
+//! phases once the control plane surface is defined.

--- a/crates/mofa-runtime/src/control_plane/gateway.rs
+++ b/crates/mofa-runtime/src/control_plane/gateway.rs
@@ -1,0 +1,5 @@
+//! Placeholder for the external API gateway surface.
+//!
+//! The gateway will sit in front of the control plane API and apply
+//! cross-cutting middleware such as authentication and rate limiting in
+//! later phases.

--- a/crates/mofa-runtime/src/control_plane/middleware.rs
+++ b/crates/mofa-runtime/src/control_plane/middleware.rs
@@ -1,0 +1,5 @@
+//! Middleware scaffolding for the control plane and gateway.
+//!
+//! Authentication, rate limiting, and resilience layers will be introduced in
+//! subsequent phases. This module exists to anchor that future work while
+//! keeping the current compilation surface minimal.

--- a/crates/mofa-runtime/src/control_plane/mod.rs
+++ b/crates/mofa-runtime/src/control_plane/mod.rs
@@ -1,0 +1,18 @@
+//! HTTP control plane and gateway scaffolding.
+//!
+//! This module is gated behind the `gateway` feature and provides the
+//! foundational pieces for the upcoming HTTP control plane and API gateway.
+//! Phase 1 intentionally exposes no routes; it only wires shared state,
+//! server configuration, and type definitions so later phases can add
+//! handlers and middleware incrementally.
+
+pub mod api;
+pub mod gateway;
+pub mod middleware;
+pub mod server;
+pub mod state;
+pub mod types;
+
+pub use server::{ControlPlaneConfig, ControlPlaneServer, ControlPlaneServerError};
+pub use state::ControlPlaneState;
+pub use types::{ApiError, ApiResponse, CreateAgentRequest, InvokeRequest};

--- a/crates/mofa-runtime/src/control_plane/server.rs
+++ b/crates/mofa-runtime/src/control_plane/server.rs
@@ -1,0 +1,262 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::{Router, http::Method};
+use tower::BoxError;
+use tower_http::cors::{Any, CorsLayer};
+use tower_http::trace::TraceLayer;
+use tracing::info;
+
+use super::state::ControlPlaneState;
+
+const _: () = {
+    fn assert_state_bounds<T: Send + Sync + 'static>() {}
+    #[allow(dead_code)]
+    fn check() {
+        assert_state_bounds::<ControlPlaneState>();
+    }
+};
+
+#[allow(dead_code)]
+fn assert_router_state_is_thread_safe() {
+    fn assert_bounds<T: Clone + Send + Sync + 'static>() {}
+    assert_bounds::<Arc<ControlPlaneState>>();
+}
+
+/// Configuration for the control plane HTTP server.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ControlPlaneConfig {
+    /// Bind host (default: 0.0.0.0).
+    pub host: String,
+    /// Bind port (default: 8081 to avoid clashing with monitoring).
+    pub port: u16,
+    /// Enable permissive CORS for development.
+    pub enable_cors: bool,
+    /// Enable request tracing via `tower_http::trace`.
+    pub enable_tracing: bool,
+    /// Graceful shutdown timeout to reuse in later phases.
+    pub shutdown_grace_period: Duration,
+}
+
+impl Default for ControlPlaneConfig {
+    fn default() -> Self {
+        Self {
+            host: "0.0.0.0".to_string(),
+            port: 8081,
+            enable_cors: true,
+            enable_tracing: true,
+            shutdown_grace_period: Duration::from_secs(5),
+        }
+    }
+}
+
+impl ControlPlaneConfig {
+    /// Create a new config with default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Override the bind host.
+    pub fn with_host(mut self, host: impl Into<String>) -> Self {
+        self.host = host.into();
+        self
+    }
+
+    /// Override the bind port.
+    pub fn with_port(mut self, port: u16) -> Self {
+        self.port = port;
+        self
+    }
+
+    /// Enable or disable CORS.
+    pub fn with_cors(mut self, enable: bool) -> Self {
+        self.enable_cors = enable;
+        self
+    }
+
+    /// Enable or disable tracing middleware.
+    pub fn with_tracing(mut self, enable: bool) -> Self {
+        self.enable_tracing = enable;
+        self
+    }
+
+    /// Set the graceful shutdown grace period.
+    pub fn with_shutdown_grace(mut self, grace: Duration) -> Self {
+        self.shutdown_grace_period = grace;
+        self
+    }
+
+    /// Resolve the configured socket address.
+    pub fn socket_addr(&self) -> SocketAddr {
+        format!("{}:{}", self.host, self.port)
+            .parse()
+            .unwrap_or_else(|_| SocketAddr::from(([0, 0, 0, 0], self.port)))
+    }
+}
+
+/// HTTP server that fronts the control plane and gateway.
+#[derive(Clone)]
+pub struct ControlPlaneServer {
+    config: ControlPlaneConfig,
+    state: Arc<ControlPlaneState>,
+}
+
+impl ControlPlaneServer {
+    /// Create a new server from config and shared state.
+    pub fn new(config: ControlPlaneConfig, state: Arc<ControlPlaneState>) -> Self {
+        Self { config, state }
+    }
+
+    /// Access the server configuration.
+    pub fn config(&self) -> &ControlPlaneConfig {
+        &self.config
+    }
+
+    /// Access the shared state.
+    pub fn state(&self) -> Arc<ControlPlaneState> {
+        self.state.clone()
+    }
+
+    /// Build the axum router with shared state and middleware layers.
+    pub fn build_router(&self) -> Router {
+        let mut router: Router<Arc<ControlPlaneState>> = Router::new();
+
+        if self.config.enable_tracing {
+            router = router.layer(TraceLayer::new_for_http());
+        }
+
+        if self.config.enable_cors {
+            let cors = CorsLayer::new()
+                .allow_origin(Any)
+                .allow_methods([
+                    Method::GET,
+                    Method::POST,
+                    Method::PUT,
+                    Method::DELETE,
+                    Method::OPTIONS,
+                ])
+                .allow_headers(Any);
+            router = router.layer(cors);
+        }
+
+        router.with_state(self.state.clone())
+    }
+
+    /// Start the server and block until shutdown.
+    pub async fn start(self) -> ControlPlaneServerResult<()> {
+        let addr = self.config.socket_addr();
+        info!("Starting MoFA HTTP control plane on http://{}", addr);
+
+        let listener = tokio::net::TcpListener::bind(addr)
+            .await
+            .map_err(|source| ControlPlaneServerError::Bind { addr, source })?;
+
+        let router = self.build_router();
+
+        axum::serve(listener, router)
+            .with_graceful_shutdown(async {
+                // Placeholder for shutdown signals; keeping the hook enables later phases
+                // to install signal handling without changing the server interface.
+                tokio::signal::ctrl_c().await.unwrap_or_else(|_| ());
+            })
+            .await
+            .map_err(|err| ControlPlaneServerError::Serve(err.into()))?;
+
+        Ok(())
+    }
+}
+
+/// Error type for the control plane server lifecycle.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ControlPlaneServerError {
+    /// Binding the TCP listener failed.
+    #[error("failed to bind control plane listener on {addr}")]
+    Bind {
+        addr: SocketAddr,
+        #[source]
+        source: std::io::Error,
+    },
+    /// axum/hyper serving error.
+    #[error("control plane server failed")]
+    Serve(#[source] BoxError),
+}
+
+/// Convenient result alias for control plane server operations.
+pub type ControlPlaneServerResult<T> = Result<T, ControlPlaneServerError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::{AgentRegistry, ExecutionEngine};
+    use axum::{body::Body, http::Request};
+    use tower::ServiceExt;
+
+    fn make_state() -> Arc<ControlPlaneState> {
+        let registry = Arc::new(AgentRegistry::new());
+        let engine = Arc::new(ExecutionEngine::new(registry.clone()));
+        Arc::new(ControlPlaneState::new(registry, engine))
+    }
+
+    #[test]
+    fn config_defaults_are_sane() {
+        let cfg = ControlPlaneConfig::default();
+        assert_eq!(cfg.host, "0.0.0.0");
+        assert_eq!(cfg.port, 8081);
+        assert!(cfg.enable_cors);
+        assert!(cfg.enable_tracing);
+        assert_eq!(cfg.shutdown_grace_period, Duration::from_secs(5));
+    }
+
+    #[test]
+    fn config_builder_methods_override_fields() {
+        let cfg = ControlPlaneConfig::new()
+            .with_host("127.0.0.1")
+            .with_port(9090)
+            .with_cors(false)
+            .with_tracing(false)
+            .with_shutdown_grace(Duration::from_secs(2));
+
+        assert_eq!(cfg.host, "127.0.0.1");
+        assert_eq!(cfg.port, 9090);
+        assert!(!cfg.enable_cors);
+        assert!(!cfg.enable_tracing);
+        assert_eq!(cfg.shutdown_grace_period, Duration::from_secs(2));
+    }
+
+    #[test]
+    fn socket_addr_parses() {
+        let cfg = ControlPlaneConfig::new()
+            .with_host("127.0.0.1")
+            .with_port(8081);
+        let addr = cfg.socket_addr();
+        assert_eq!(addr.port(), 8081);
+        assert_eq!(addr.ip().to_string(), "127.0.0.1");
+    }
+
+    #[tokio::test]
+    async fn build_router_initializes_state_and_layers() {
+        let state = make_state();
+        let server = ControlPlaneServer::new(ControlPlaneConfig::default(), state.clone());
+        let router = server.build_router();
+
+        let mut service = router.into_service();
+
+        let response = service
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .body(Body::empty())
+                    .expect("failed to build request"),
+            )
+            .await
+            .expect("router service error");
+
+        assert_eq!(response.status(), axum::http::StatusCode::NOT_FOUND);
+
+        // Ensure state is still accessible after building the router.
+        let cloned_state = server.state();
+        assert!(Arc::ptr_eq(&state, &cloned_state));
+    }
+}

--- a/crates/mofa-runtime/src/control_plane/server.rs
+++ b/crates/mofa-runtime/src/control_plane/server.rs
@@ -10,6 +10,8 @@ use tracing::info;
 
 use super::state::ControlPlaneState;
 
+// Compile-time assertion to ensure ControlPlaneState is Send + Sync + 'static.
+// This guarantees the state can be safely shared across async tasks in Axum.
 const _: () = {
     fn assert_state_bounds<T: Send + Sync + 'static>() {}
     #[allow(dead_code)]

--- a/crates/mofa-runtime/src/control_plane/state.rs
+++ b/crates/mofa-runtime/src/control_plane/state.rs
@@ -1,0 +1,64 @@
+use std::sync::Arc;
+
+use crate::agent::{AgentRegistry, ExecutionEngine};
+
+/// Shared state for the control plane and gateway layers.
+#[derive(Clone)]
+pub struct ControlPlaneState {
+    registry: Arc<AgentRegistry>,
+    execution_engine: Arc<ExecutionEngine>,
+}
+
+trait ControlPlaneStateBounds: Send + Sync + 'static {}
+impl ControlPlaneStateBounds for ControlPlaneState {}
+
+impl ControlPlaneState {
+    /// Create new shared state from the runtime primitives.
+    pub fn new(registry: Arc<AgentRegistry>, execution_engine: Arc<ExecutionEngine>) -> Self {
+        Self {
+            registry,
+            execution_engine,
+        }
+    }
+
+    /// Access the agent registry.
+    pub fn registry(&self) -> Arc<AgentRegistry> {
+        self.registry.clone()
+    }
+
+    /// Access the execution engine.
+    pub fn execution_engine(&self) -> Arc<ExecutionEngine> {
+        self.execution_engine.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constructs_state_from_shared_components() {
+        let registry = Arc::new(AgentRegistry::new());
+        let engine = Arc::new(ExecutionEngine::new(registry.clone()));
+
+        let state = ControlPlaneState::new(registry.clone(), engine.clone());
+
+        assert!(Arc::ptr_eq(&registry, &state.registry()));
+        assert!(Arc::ptr_eq(&engine, &state.execution_engine()));
+    }
+
+    #[test]
+    fn clones_preserve_shared_references() {
+        let registry = Arc::new(AgentRegistry::new());
+        let engine = Arc::new(ExecutionEngine::new(registry.clone()));
+
+        let state = ControlPlaneState::new(registry.clone(), engine.clone());
+        let cloned = state.clone();
+
+        assert!(Arc::ptr_eq(&state.registry(), &cloned.registry()));
+        assert!(Arc::ptr_eq(
+            &state.execution_engine(),
+            &cloned.execution_engine()
+        ));
+    }
+}

--- a/crates/mofa-runtime/src/control_plane/types.rs
+++ b/crates/mofa-runtime/src/control_plane/types.rs
@@ -1,0 +1,89 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Request body for creating and registering a new agent.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CreateAgentRequest {
+    /// Unique agent identifier.
+    pub id: String,
+    /// Human-readable agent name.
+    pub name: String,
+    /// Optional description shown in dashboards or logs.
+    pub description: Option<String>,
+    /// Factory or implementation type to instantiate.
+    pub agent_type: String,
+    /// Arbitrary configuration forwarded to the agent factory.
+    #[serde(default)]
+    pub config: Value,
+}
+
+/// Request body for invoking an agent through the gateway.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct InvokeRequest {
+    /// Target agent identifier.
+    pub agent_id: String,
+    /// Structured payload forwarded to the agent as input.
+    #[serde(default)]
+    pub payload: Value,
+    /// Optional metadata for tracing or downstream routing.
+    #[serde(default)]
+    pub metadata: Value,
+    /// Optional timeout in milliseconds for the invocation.
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
+}
+
+/// Standard API envelope for responses emitted by the control plane.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ApiResponse<T> {
+    /// Indicates whether the request succeeded.
+    pub success: bool,
+    /// Response payload when successful.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<T>,
+    /// Error details when unsuccessful.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ApiError>,
+}
+
+impl<T> ApiResponse<T> {
+    /// Construct a successful response containing `data`.
+    pub fn ok(data: T) -> Self {
+        Self {
+            success: true,
+            data: Some(data),
+            error: None,
+        }
+    }
+
+    /// Construct an error response.
+    pub fn error(error: ApiError) -> Self {
+        Self {
+            success: false,
+            data: None,
+            error: Some(error),
+        }
+    }
+}
+
+/// API-level error type used by control plane handlers.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, thiserror::Error)]
+#[non_exhaustive]
+pub enum ApiError {
+    /// Resource not found.
+    #[error("not found: {0}")]
+    NotFound(String),
+    /// Invalid or malformed request payload.
+    #[error("bad request: {0}")]
+    BadRequest(String),
+    /// Internal server error.
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+impl ApiError {
+    /// Human-readable message; shorthand over `ToString`.
+    pub fn message(&self) -> String {
+        self.to_string()
+    }
+}

--- a/crates/mofa-runtime/src/lib.rs
+++ b/crates/mofa-runtime/src/lib.rs
@@ -23,6 +23,8 @@ pub mod error_conversions;
 pub mod agent;
 pub mod builder;
 pub mod config;
+#[cfg(feature = "gateway")]
+pub mod control_plane;
 pub mod fallback;
 pub mod interrupt;
 pub mod rag;
@@ -1709,13 +1711,21 @@ mod test_message_bus {
         // Confirm routing cleaned up
         {
             let topics = bus.topic_subscribers.read().await;
-            assert!(!topics.get("topic-z").map(|v| v.iter().any(|id| id == "agent-x")).unwrap_or(false));
+            assert!(
+                !topics
+                    .get("topic-z")
+                    .map(|v| v.iter().any(|id| id == "agent-x"))
+                    .unwrap_or(false)
+            );
         }
 
         // Confirm subscribers mapping cleaned up as well
         {
             let subs = bus.subscribers.read().await;
-            assert!(!subs.contains_key("agent-x"), "subscriber entry should be removed");
+            assert!(
+                !subs.contains_key("agent-x"),
+                "subscriber entry should be removed"
+            );
         }
 
         // Publish to topic - should not be delivered


### PR DESCRIPTION
This PR lays the foundation for the HTTP Control Plane and API Gateway feature in MoFA. It implements Phase 1 of the roadmap, which focuses purely on scaffolding, shared state, and server infrastructure - no endpoints or business logic yet. All new code is behind the gateway feature flag, ensuring default builds remain completely unaffected.

Changes:

Feature flag & optional dependencies:

Added axum, tower, and tower-http under [features.gateway] in Cargo.toml.

Exposed control_plane module only when the gateway feature is enabled in lib.rs.

Control plane module skeleton (src/control_plane/):

mod.rs - wires submodules (api, gateway, middleware, server, state, types).

types.rs - DTOs (CreateAgentRequest, InvokeRequest) and typed ApiError/ApiResponse.

state.rs - ControlPlaneState wrapping AgentRegistry and ExecutionEngine via Arc; includes Send/Sync assertions.

server.rs - ControlPlaneServer + ControlPlaneConfig scaffolding, CORS/trace layers, graceful shutdown hook, typed server errors.

api.rs, gateway.rs, middleware.rs - placeholder stubs for future logic.

Tests:

Unit tests for state construction/cloning.

Unit tests for server configuration and router initialization.

All new gateway-feature tests run under --features gateway.

Existing workspace tests remain untouched.