### PR TITLE
fix(monitoring): handle broadcast channel lag in WebSocket send task

### DIFF
--- a/crates/mofa-monitoring/src/dashboard/websocket.rs
+++ b/crates/mofa-monitoring/src/dashboard/websocket.rs
@@ -339,10 +339,20 @@ impl WebSocketHandler {
                         }
                     }
                     // Messages from broadcast
-                    Ok(msg) = broadcast_rx.recv() => {
-                        let json = serde_json::to_string(&msg).unwrap_or_default();
-                        if sender.send(Message::Text(json.into())).await.is_err() {
-                            break;
+                    result = broadcast_rx.recv() => {
+                        match result {
+                            Ok(msg) => {
+                                let json = serde_json::to_string(&msg).unwrap_or_default();
+                                if sender.send(Message::Text(json.into())).await.is_err() {
+                                    break;
+                                }
+                            }
+                            Err(broadcast::error::RecvError::Lagged(n)) => {
+                                warn!("WebSocket broadcast lagged by {} messages", n);
+                            }
+                            Err(broadcast::error::RecvError::Closed) => {
+                                break;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Closes #957

## Problem

The WebSocket send task in `websocket.rs` only pattern-matches `Ok(msg)` from `broadcast_rx.recv()`. When the broadcast buffer fills (slow client), `recv()` returns `Err(RecvError::Lagged(n))` — but `tokio::select!` silently discards it since the `Ok(msg)` pattern doesn't match. Slow dashboard clients miss monitoring events with zero indication that data was dropped.

The `Closed` variant has the same issue: it returns `Closed` on every loop iteration, and `select!` keeps discarding it, effectively spinning until the other branch completes.

## Fix

Match the full `Result` instead of just `Ok(msg)`:

- **`Lagged(n)`**: log a warning with the count of skipped messages — gives operators visibility into slow consumers and helps tune buffer sizes.
- **`Closed`**: break the send loop cleanly.

This is consistent with 3 other call-sites in the codebase that already handle `Lagged`:

| File | Line | Handling |
|------|------|----------|
| `hot_reload.rs` | 166 | `warn!` + continue |
| `socketio/mod.rs` | 118 | `warn!` + break on `Closed` |
| `workflow_viz/main.rs` | 317 | `debug!` + break on `Closed` |

## Testing

All 68 existing tests in `mofa-monitoring` pass. `cargo clippy` clean (pre-existing warnings only).