### PR TITLE
fix(gateway): replace SystemTime-based random load balancing with proper RNG

### DIFF
--- a/crates/mofa-gateway/src/gateway/load_balancer.rs
+++ b/crates/mofa-gateway/src/gateway/load_balancer.rs
@@ -9,6 +9,7 @@
 
 use crate::error::GatewayResult;
 use crate::types::{LoadBalancingAlgorithm, NodeId};
+use rand::Rng;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -147,13 +148,7 @@ impl LoadBalancer {
                 Ok(selected)
             }
             LoadBalancingAlgorithm::Random => {
-                // Use a simple time-based pseudo-random selection for deterministic testing.
-                // In production, prefer a real RNG instead of SystemTime-based selection.
-                let duration = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default();
-                let nanos = duration.as_nanos();
-                let index = (nanos % nodes.len() as u128) as usize;
+                let index = rand::thread_rng().gen_range(0..nodes.len());
                 Ok(Some(nodes[index].clone()))
             }
         }
@@ -264,5 +259,59 @@ mod tests {
         assert!(node1_count >= node2_count);
         assert!(node2_count >= node3_count);
         assert!(node3_count > 0);
+    }
+
+    #[tokio::test]
+    async fn test_wrr_large_weight_no_truncation() {
+        let lb = LoadBalancer::new(LoadBalancingAlgorithm::WeightedRoundRobin);
+        lb.add_node(NodeId::new("heavy")).await;
+        lb.add_node(NodeId::new("light")).await;
+
+        // Weight that exceeds i32::MAX — would silently become negative
+        // with the old `as i32` cast, inverting this node's priority.
+        lb.set_node_weight(&NodeId::new("heavy"), u32::MAX).await;
+        lb.set_node_weight(&NodeId::new("light"), 1).await;
+
+        let mut heavy_count = 0u32;
+        for _ in 0..20 {
+            if let Ok(Some(node)) = lb.select_node().await {
+                if node == NodeId::new("heavy") {
+                    heavy_count += 1;
+                }
+            }
+        }
+
+        // With i64 arithmetic, the u32::MAX weight is preserved correctly
+        // and the heavy node is selected proportionally.
+        // Before this fix, `u32::MAX as i32` silently became -1, causing
+        // the high-weight node to NEVER be selected (0/20).
+        assert!(
+            heavy_count >= 10,
+            "high-weight node must not be starved by truncation, got {heavy_count}/20"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_random_distribution() {
+        let lb = LoadBalancer::new(LoadBalancingAlgorithm::Random);
+        lb.add_node(NodeId::new("node-1")).await;
+        lb.add_node(NodeId::new("node-2")).await;
+        lb.add_node(NodeId::new("node-3")).await;
+
+        let mut counts = HashMap::new();
+        for _ in 0..300 {
+            let node = lb.select_node().await.unwrap().unwrap();
+            *counts.entry(node).or_insert(0u32) += 1;
+        }
+
+        // Every node should be selected at least once over 300 trials
+        assert!(counts.contains_key(&NodeId::new("node-1")));
+        assert!(counts.contains_key(&NodeId::new("node-2")));
+        assert!(counts.contains_key(&NodeId::new("node-3")));
+
+        // No single node should dominate (> 60% would indicate bias)
+        for count in counts.values() {
+            assert!(*count < 180, "Node selected {} times out of 300 — distribution is biased", count);
+        }
     }
 }


### PR DESCRIPTION
Closes #959

## Problem

The `Random` load balancing algorithm selects nodes using `SystemTime::now().as_nanos() % nodes.len()`. This has two issues:

1. **Temporal clustering** — multiple calls within the same nanosecond always pick the same node. Under burst traffic, an entire wave of requests hits one node while others idle.
2. **Modulo bias** — when `nodes.len()` doesn't evenly divide the nanosecond range, some nodes have a marginally higher selection probability.

The code itself flags this: `"In production, prefer a real RNG instead of SystemTime-based selection."`

## Fix

Replace with `rand::thread_rng().gen_range(0..nodes.len())`. The `rand` crate is already a dependency of `mofa-gateway`, so no new dependencies are introduced.

Added a distribution test that runs 300 selections across 3 nodes and verifies:
- Every node is selected at least once
- No single node captures more than 60% of selections

## Testing

All 6 gateway tests pass (4 unit + 2 integration), including the new `test_random_distribution`.