### PR TITLE
fix(plugins): emit Removed event for orphaned rename-from in file watcher

### DIFF
--- a/crates/mofa-plugins/src/hot_reload/watcher.rs
+++ b/crates/mofa-plugins/src/hot_reload/watcher.rs
@@ -318,6 +318,16 @@ impl PluginWatcher {
                                     Some(WatchEvent::new(WatchEventKind::Removed, path.clone()))
                                 }
                                 EventKind::Modify(ModifyKind::Name(RenameMode::From)) => {
+                                    // If a previous From was never paired with a To,
+                                    // the source file effectively disappeared.
+                                    if let Some(orphaned) = rename_from.take() {
+                                        warn!("Orphaned rename-from path, treating as removal: {:?}", orphaned);
+                                        let evt = WatchEvent::new(WatchEventKind::Removed, orphaned);
+                                        if event_tx.send(evt).await.is_err() {
+                                            error!("Failed to send watch event");
+                                            return;
+                                        }
+                                    }
                                     rename_from = Some(path.clone());
                                     None
                                 }

--- a/crates/mofa-plugins/src/hot_reload/watcher.rs
+++ b/crates/mofa-plugins/src/hot_reload/watcher.rs
@@ -55,6 +55,23 @@ impl WatchEvent {
     }
 }
 
+/// Handle a `RenameMode::From` event, checking for an orphaned previous path.
+///
+/// If `rename_from` already holds a path (meaning a prior From was never
+/// paired with a To), that path is treated as a removal and returned as a
+/// `WatchEvent`. The new path then replaces it.
+fn handle_rename_from(rename_from: &mut Option<PathBuf>, new_path: PathBuf) -> Option<WatchEvent> {
+    let orphan_event = rename_from.take().map(|orphaned| {
+        warn!(
+            "Orphaned rename-from path, treating as removal: {:?}",
+            orphaned
+        );
+        WatchEvent::new(WatchEventKind::Removed, orphaned)
+    });
+    *rename_from = Some(new_path);
+    orphan_event
+}
+
 /// Watch configuration
 #[derive(Debug, Clone)]
 pub struct WatchConfig {
@@ -318,17 +335,12 @@ impl PluginWatcher {
                                     Some(WatchEvent::new(WatchEventKind::Removed, path.clone()))
                                 }
                                 EventKind::Modify(ModifyKind::Name(RenameMode::From)) => {
-                                    // If a previous From was never paired with a To,
-                                    // the source file effectively disappeared.
-                                    if let Some(orphaned) = rename_from.take() {
-                                        warn!("Orphaned rename-from path, treating as removal: {:?}", orphaned);
-                                        let evt = WatchEvent::new(WatchEventKind::Removed, orphaned);
+                                    if let Some(evt) = handle_rename_from(&mut rename_from, path.clone()) {
                                         if event_tx.send(evt).await.is_err() {
                                             error!("Failed to send watch event");
                                             return;
                                         }
                                     }
-                                    rename_from = Some(path.clone());
                                     None
                                 }
                                 EventKind::Modify(ModifyKind::Name(RenameMode::To)) => {
@@ -469,5 +481,48 @@ mod tests {
 
         assert!(watcher.take_event_receiver().is_some());
         assert!(watcher.take_event_receiver().is_none()); // Can only take once
+    }
+
+    #[test]
+    fn test_handle_rename_from_no_previous() {
+        let mut state: Option<PathBuf> = None;
+        let result = handle_rename_from(&mut state, PathBuf::from("/tmp/a.so"));
+        assert!(result.is_none(), "no orphan event when rename_from is empty");
+        assert_eq!(state, Some(PathBuf::from("/tmp/a.so")));
+    }
+
+    #[test]
+    fn test_handle_rename_from_orphaned_previous() {
+        let mut state = Some(PathBuf::from("/tmp/old.so"));
+        let result = handle_rename_from(&mut state, PathBuf::from("/tmp/new.so"));
+
+        // The orphaned path must produce a Removed event
+        let evt = result.expect("orphaned rename_from should emit Removed event");
+        assert!(matches!(evt.kind, WatchEventKind::Removed));
+        assert_eq!(evt.path, PathBuf::from("/tmp/old.so"));
+
+        // State must now track the new path
+        assert_eq!(state, Some(PathBuf::from("/tmp/new.so")));
+    }
+
+    #[test]
+    fn test_handle_rename_from_chained_orphans() {
+        let mut state: Option<PathBuf> = None;
+
+        // First From — no orphan
+        let r1 = handle_rename_from(&mut state, PathBuf::from("/a"));
+        assert!(r1.is_none());
+
+        // Second From without To — first path is orphaned
+        let r2 = handle_rename_from(&mut state, PathBuf::from("/b"));
+        let evt = r2.expect("should emit Removed for /a");
+        assert_eq!(evt.path, PathBuf::from("/a"));
+
+        // Third From without To — second path is orphaned
+        let r3 = handle_rename_from(&mut state, PathBuf::from("/c"));
+        let evt = r3.expect("should emit Removed for /b");
+        assert_eq!(evt.path, PathBuf::from("/b"));
+
+        assert_eq!(state, Some(PathBuf::from("/c")));
     }
 }


### PR DESCRIPTION
Closes #962

## Problem

The rename tracking in the file watcher (`watcher.rs:320-335`) unconditionally overwrites `rename_from` on each `RenameMode::From` event. During rapid rename sequences (e.g., `mv a b && mv c d`), the first source path is silently lost:

1. `From(A)` → `rename_from = Some(A)`
2. `From(C)` → `rename_from = Some(C)` — **A is silently dropped**
3. `To(B)` → incorrectly pairs with C
4. `To(D)` → no `rename_from`, falls through to the `else` branch and emits `Created(D)` instead of `Renamed(C→D)`

The downstream hot-reload consumer never learns that path A disappeared.

## Fix

Before overwriting `rename_from`, check if it already holds a value. If so, emit a `Removed` event for the orphaned path — the file at that location no longer exists under its original name. Then record the new `from` path as before.

## Testing

All 4 watcher tests pass. The fix is defensive (only triggers during rapid rename sequences) and has no impact on normal single-rename flows.