### PR TITLE
fix(monitoring): abort orphaned WebSocket task on client disconnect

### DIFF
--- a/crates/mofa-monitoring/src/dashboard/websocket.rs
+++ b/crates/mofa-monitoring/src/dashboard/websocket.rs
@@ -328,7 +328,7 @@ impl WebSocketHandler {
         let mut broadcast_rx = self.broadcast_tx.subscribe();
 
         // Task to send messages to client
-        let send_task = tokio::spawn(async move {
+        let mut send_task = tokio::spawn(async move {
             loop {
                 tokio::select! {
                     // Messages from direct send
@@ -352,7 +352,7 @@ impl WebSocketHandler {
         // Task to receive messages from client
         let clients = self.clients.clone();
         let client_id_clone = client_id.clone();
-        let receive_task = tokio::spawn(async move {
+        let mut receive_task = tokio::spawn(async move {
             while let Some(result) = receiver.next().await {
                 match result {
                     Ok(Message::Text(text)) => {
@@ -400,10 +400,18 @@ impl WebSocketHandler {
             }
         });
 
-        // Wait for either task to complete
+        // Wait for either task to complete, then abort the other.
+        // Dropping a JoinHandle only detaches the task — it does NOT
+        // cancel it, so the "losing" task would keep running as an
+        // orphan (sending to a closed socket or processing messages
+        // for a disconnected client).
         tokio::select! {
-            _ = send_task => {}
-            _ = receive_task => {}
+            _ = &mut send_task => {
+                receive_task.abort();
+            }
+            _ = &mut receive_task => {
+                send_task.abort();
+            }
         }
 
         // Cleanup


### PR DESCRIPTION
Closes #964

## Problem

Two tasks are spawned per WebSocket client — one for sending, one for receiving. When either finishes, `tokio::select!` drops the other's `JoinHandle`. But dropping a `JoinHandle` only **detaches** the task; it does not cancel it. The "losing" task runs indefinitely as an orphan:

- **Orphaned send task**: keeps attempting to push messages to a closed socket
- **Orphaned receive task**: keeps processing messages for a client already removed from the client map, holding references to the shared `clients` `RwLock`

Both cases leak CPU and memory proportional to client churn.

## Fix

Use `&mut` references in `tokio::select!` so both `JoinHandle`s remain accessible after one completes. The winning arm explicitly calls `.abort()` on the losing task, ensuring clean teardown on every disconnect path.

```rust
tokio::select! {
    _ = &mut send_task => {
        receive_task.abort();
    }
    _ = &mut receive_task => {
        send_task.abort();
    }
}
```

## Testing

All 68 monitoring tests pass. The fix is a behavioral change (tasks are now properly cancelled), but no API surface changes.