### PR TITLE
test: add 54 unit tests for kernel agent component types

### DIFF
--- a/crates/mofa-kernel/src/agent/components/context_compressor.rs
+++ b/crates/mofa-kernel/src/agent/components/context_compressor.rs
@@ -220,3 +220,140 @@ pub trait ContextCompressor: Send + Sync {
     /// A short human-readable name for this compressor (used in logs).
     fn name(&self) -> &str;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── CompressionMetrics::new ──────────────────────────────────────────
+
+    #[test]
+    fn metrics_full_compression() {
+        let m = CompressionMetrics::new(1000, 0, 20, 1);
+        assert_eq!(m.compression_ratio, 0.0);
+        assert!((m.token_reduction_percent - 100.0).abs() < f64::EPSILON);
+        assert!((m.message_reduction_percent - 95.0).abs() < f64::EPSILON);
+        assert!(m.was_compressed());
+        assert_eq!(m.tokens_saved(), 1000);
+    }
+
+    #[test]
+    fn metrics_no_compression() {
+        let m = CompressionMetrics::new(500, 500, 10, 10);
+        assert!((m.compression_ratio - 1.0).abs() < f64::EPSILON);
+        assert!((m.token_reduction_percent - 0.0).abs() < f64::EPSILON);
+        assert!((m.message_reduction_percent - 0.0).abs() < f64::EPSILON);
+        assert!(!m.was_compressed());
+        assert_eq!(m.tokens_saved(), 0);
+    }
+
+    #[test]
+    fn metrics_partial_compression() {
+        let m = CompressionMetrics::new(1000, 400, 10, 6);
+        assert!((m.compression_ratio - 0.4).abs() < f64::EPSILON);
+        assert!((m.token_reduction_percent - 60.0).abs() < f64::EPSILON);
+        assert!((m.message_reduction_percent - 40.0).abs() < f64::EPSILON);
+        assert!(m.was_compressed());
+        assert_eq!(m.tokens_saved(), 600);
+    }
+
+    #[test]
+    fn metrics_zero_tokens_before() {
+        let m = CompressionMetrics::new(0, 0, 0, 0);
+        // When tokens_before is 0, ratio defaults to 1.0 and reduction to 0.0
+        assert!((m.compression_ratio - 1.0).abs() < f64::EPSILON);
+        assert!((m.token_reduction_percent - 0.0).abs() < f64::EPSILON);
+        assert!((m.message_reduction_percent - 0.0).abs() < f64::EPSILON);
+        assert!(!m.was_compressed());
+        assert_eq!(m.tokens_saved(), 0);
+    }
+
+    #[test]
+    fn metrics_tokens_after_exceeds_before() {
+        // Edge case: tokens_after > tokens_before (shouldn't happen in practice
+        // but tests the saturating_sub in tokens_saved)
+        let m = CompressionMetrics::new(100, 200, 5, 10);
+        assert!(m.compression_ratio > 1.0);
+        assert!(!m.was_compressed());
+        assert_eq!(m.tokens_saved(), 0); // saturating_sub prevents underflow
+    }
+
+    // ── CompressionStrategy construction ─────────────────────────────────
+
+    #[test]
+    fn strategy_sliding_window() {
+        let s = CompressionStrategy::SlidingWindow { window_size: 10 };
+        let json = serde_json::to_string(&s).unwrap();
+        let recovered: CompressionStrategy = serde_json::from_str(&json).unwrap();
+        assert_eq!(recovered, s);
+    }
+
+    #[test]
+    fn strategy_summarize_roundtrip() {
+        let s = CompressionStrategy::Summarize;
+        let json = serde_json::to_string(&s).unwrap();
+        let recovered: CompressionStrategy = serde_json::from_str(&json).unwrap();
+        assert_eq!(recovered, s);
+    }
+
+    #[test]
+    fn strategy_semantic() {
+        let s = CompressionStrategy::Semantic {
+            similarity_threshold: 0.85,
+            keep_recent: 5,
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        let recovered: CompressionStrategy = serde_json::from_str(&json).unwrap();
+        assert_eq!(recovered, s);
+    }
+
+    #[test]
+    fn strategy_hierarchical() {
+        let s = CompressionStrategy::Hierarchical { keep_recent: 3 };
+        let json = serde_json::to_string(&s).unwrap();
+        let recovered: CompressionStrategy = serde_json::from_str(&json).unwrap();
+        assert_eq!(recovered, s);
+    }
+
+    #[test]
+    fn strategy_hybrid() {
+        let s = CompressionStrategy::Hybrid {
+            strategies: vec!["sliding_window".into(), "summarize".into()],
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        let recovered: CompressionStrategy = serde_json::from_str(&json).unwrap();
+        assert_eq!(recovered, s);
+    }
+
+    // ── CompressionResult ────────────────────────────────────────────────
+
+    #[test]
+    fn compression_result_into_messages() {
+        let msgs = vec![ChatMessage {
+            role: "assistant".into(),
+            content: Some("summary".into()),
+            tool_call_id: None,
+            tool_calls: None,
+        }];
+        let metrics = CompressionMetrics::new(500, 100, 10, 1);
+        let result = CompressionResult::new(msgs.clone(), metrics, "test".into());
+        assert_eq!(result.strategy_name, "test");
+        let extracted = result.into_messages();
+        assert_eq!(extracted.len(), 1);
+        assert_eq!(extracted[0].content.as_deref(), Some("summary"));
+    }
+
+    // ── CompressionMetrics serde ─────────────────────────────────────────
+
+    #[test]
+    fn compression_metrics_serde_roundtrip() {
+        let m = CompressionMetrics::new(800, 200, 15, 4);
+        let json = serde_json::to_string(&m).unwrap();
+        let recovered: CompressionMetrics = serde_json::from_str(&json).unwrap();
+        assert_eq!(recovered.tokens_before, 800);
+        assert_eq!(recovered.tokens_after, 200);
+        assert_eq!(recovered.messages_before, 15);
+        assert_eq!(recovered.messages_after, 4);
+        assert_eq!(recovered, m);
+    }
+}

--- a/crates/mofa-kernel/src/agent/components/memory.rs
+++ b/crates/mofa-kernel/src/agent/components/memory.rs
@@ -361,3 +361,217 @@ pub struct MemoryStats {
     /// Memory usage (bytes)
     pub memory_bytes: usize,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── MemoryValue factory methods ──────────────────────────────────────
+
+    #[test]
+    fn memory_value_text_factory() {
+        let val = MemoryValue::text("hello");
+        assert_eq!(val.as_text(), Some("hello"));
+        assert!(val.as_embedding().is_none());
+        assert!(val.as_structured().is_none());
+    }
+
+    #[test]
+    fn memory_value_embedding_factory() {
+        let vec = vec![0.1, 0.2, 0.3];
+        let val = MemoryValue::embedding(vec.clone());
+        assert_eq!(val.as_embedding(), Some(vec.as_slice()));
+        assert!(val.as_text().is_none());
+    }
+
+    #[test]
+    fn memory_value_structured_factory() {
+        let json = serde_json::json!({"key": "value"});
+        let val = MemoryValue::structured(json.clone());
+        assert_eq!(val.as_structured(), Some(&json));
+        assert!(val.as_text().is_none());
+    }
+
+    #[test]
+    fn memory_value_text_with_embedding_factory() {
+        let emb = vec![1.0, 2.0];
+        let val = MemoryValue::text_with_embedding("combined", emb.clone());
+        // as_text returns the text portion
+        assert_eq!(val.as_text(), Some("combined"));
+        // as_embedding returns the embedding portion
+        assert_eq!(val.as_embedding(), Some(emb.as_slice()));
+        // as_structured returns None
+        assert!(val.as_structured().is_none());
+    }
+
+    #[test]
+    fn memory_value_binary_has_no_text_or_embedding() {
+        let val = MemoryValue::Binary(vec![0xDE, 0xAD]);
+        assert!(val.as_text().is_none());
+        assert!(val.as_embedding().is_none());
+        assert!(val.as_structured().is_none());
+    }
+
+    // ── From conversions ─────────────────────────────────────────────────
+
+    #[test]
+    fn memory_value_from_string() {
+        let val: MemoryValue = String::from("owned").into();
+        assert_eq!(val.as_text(), Some("owned"));
+    }
+
+    #[test]
+    fn memory_value_from_str_ref() {
+        let val: MemoryValue = "borrowed".into();
+        assert_eq!(val.as_text(), Some("borrowed"));
+    }
+
+    #[test]
+    fn memory_value_from_json() {
+        let json = serde_json::json!(42);
+        let val: MemoryValue = json.clone().into();
+        assert_eq!(val.as_structured(), Some(&json));
+    }
+
+    // ── MemoryItem ───────────────────────────────────────────────────────
+
+    #[test]
+    fn memory_item_new_defaults() {
+        let item = MemoryItem::new("k1", MemoryValue::text("v1"));
+        assert_eq!(item.key, "k1");
+        assert_eq!(item.score, 1.0);
+        assert!(item.metadata.is_empty());
+        assert!(item.created_at > 0);
+        assert_eq!(item.created_at, item.last_accessed);
+    }
+
+    #[test]
+    fn memory_item_with_score_clamps_high() {
+        let item = MemoryItem::new("k", MemoryValue::text("v")).with_score(2.5);
+        assert_eq!(item.score, 1.0);
+    }
+
+    #[test]
+    fn memory_item_with_score_clamps_low() {
+        let item = MemoryItem::new("k", MemoryValue::text("v")).with_score(-0.5);
+        assert_eq!(item.score, 0.0);
+    }
+
+    #[test]
+    fn memory_item_with_score_normal() {
+        let item = MemoryItem::new("k", MemoryValue::text("v")).with_score(0.75);
+        assert!((item.score - 0.75).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn memory_item_with_metadata() {
+        let item = MemoryItem::new("k", MemoryValue::text("v"))
+            .with_metadata("source", "test")
+            .with_metadata("priority", "high");
+        assert_eq!(item.metadata.get("source").unwrap(), "test");
+        assert_eq!(item.metadata.get("priority").unwrap(), "high");
+    }
+
+    // ── Message factory methods ──────────────────────────────────────────
+
+    #[test]
+    fn message_system() {
+        let msg = Message::system("you are helpful");
+        assert_eq!(msg.role, MessageRole::System);
+        assert_eq!(msg.content, "you are helpful");
+        assert!(msg.timestamp > 0);
+        assert!(msg.metadata.is_empty());
+    }
+
+    #[test]
+    fn message_user() {
+        let msg = Message::user("hello");
+        assert_eq!(msg.role, MessageRole::User);
+        assert_eq!(msg.content, "hello");
+    }
+
+    #[test]
+    fn message_assistant() {
+        let msg = Message::assistant("hi there");
+        assert_eq!(msg.role, MessageRole::Assistant);
+        assert_eq!(msg.content, "hi there");
+    }
+
+    #[test]
+    fn message_tool_inserts_metadata() {
+        let msg = Message::tool("calculator", "42");
+        assert_eq!(msg.role, MessageRole::Tool);
+        assert_eq!(msg.content, "42");
+        let tool_name = msg.metadata.get("tool_name").unwrap();
+        assert_eq!(tool_name, &serde_json::Value::String("calculator".into()));
+    }
+
+    #[test]
+    fn message_with_metadata_builder() {
+        let msg = Message::user("q")
+            .with_metadata("session", serde_json::json!("abc"))
+            .with_metadata("turn", serde_json::json!(3));
+        assert_eq!(msg.metadata.len(), 2);
+        assert_eq!(msg.metadata["session"], serde_json::json!("abc"));
+    }
+
+    // ── MessageRole ──────────────────────────────────────────────────────
+
+    #[test]
+    fn message_role_display() {
+        assert_eq!(MessageRole::System.to_string(), "system");
+        assert_eq!(MessageRole::User.to_string(), "user");
+        assert_eq!(MessageRole::Assistant.to_string(), "assistant");
+        assert_eq!(MessageRole::Tool.to_string(), "tool");
+    }
+
+    #[test]
+    fn message_role_equality() {
+        assert_eq!(MessageRole::System, MessageRole::System);
+        assert_ne!(MessageRole::User, MessageRole::Assistant);
+    }
+
+    // ── MemoryStats ──────────────────────────────────────────────────────
+
+    #[test]
+    fn memory_stats_default_is_zero() {
+        let stats = MemoryStats::default();
+        assert_eq!(stats.total_items, 0);
+        assert_eq!(stats.total_sessions, 0);
+        assert_eq!(stats.total_messages, 0);
+        assert_eq!(stats.memory_bytes, 0);
+    }
+
+    // ── Serialization round-trips ────────────────────────────────────────
+
+    #[test]
+    fn memory_value_serde_roundtrip_text() {
+        let original = MemoryValue::text("round-trip");
+        let json = serde_json::to_string(&original).unwrap();
+        let recovered: MemoryValue = serde_json::from_str(&json).unwrap();
+        assert_eq!(recovered.as_text(), Some("round-trip"));
+    }
+
+    #[test]
+    fn memory_value_serde_roundtrip_structured() {
+        let data = serde_json::json!({"nested": [1, 2, 3]});
+        let original = MemoryValue::structured(data.clone());
+        let json = serde_json::to_string(&original).unwrap();
+        let recovered: MemoryValue = serde_json::from_str(&json).unwrap();
+        assert_eq!(recovered.as_structured(), Some(&data));
+    }
+
+    #[test]
+    fn message_role_serde_roundtrip() {
+        for role in [
+            MessageRole::System,
+            MessageRole::User,
+            MessageRole::Assistant,
+            MessageRole::Tool,
+        ] {
+            let json = serde_json::to_string(&role).unwrap();
+            let recovered: MessageRole = serde_json::from_str(&json).unwrap();
+            assert_eq!(recovered, role);
+        }
+    }
+}

--- a/crates/mofa-kernel/src/agent/components/reasoner.rs
+++ b/crates/mofa-kernel/src/agent/components/reasoner.rs
@@ -298,3 +298,208 @@ impl ToolCall {
 
 // Note: Concrete Reasoner implementations (like DirectReasoner) are provided
 // in the foundation layer (mofa-foundation::agent::components::reasoner)
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── ReasoningResult::respond ──────────────────────────────────────────
+
+    #[test]
+    fn reasoning_result_respond() {
+        let r = ReasoningResult::respond("hello world");
+        assert!(r.thoughts.is_empty());
+        assert!((r.confidence - 1.0).abs() < f32::EPSILON);
+        match &r.decision {
+            Decision::Respond { content } => assert_eq!(content, "hello world"),
+            _ => panic!("expected Decision::Respond"),
+        }
+    }
+
+    // ── ReasoningResult::call_tool ────────────────────────────────────────
+
+    #[test]
+    fn reasoning_result_call_tool() {
+        let args = serde_json::json!({"query": "weather"});
+        let r = ReasoningResult::call_tool("search", args.clone());
+        assert!(r.thoughts.is_empty());
+        assert!((r.confidence - 1.0).abs() < f32::EPSILON);
+        match &r.decision {
+            Decision::CallTool {
+                tool_name,
+                arguments,
+            } => {
+                assert_eq!(tool_name, "search");
+                assert_eq!(arguments, &args);
+            }
+            _ => panic!("expected Decision::CallTool"),
+        }
+    }
+
+    // ── ReasoningResult::with_confidence clamping ─────────────────────────
+
+    #[test]
+    fn confidence_clamps_above_one() {
+        let r = ReasoningResult::respond("x").with_confidence(5.0);
+        assert!((r.confidence - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn confidence_clamps_below_zero() {
+        let r = ReasoningResult::respond("x").with_confidence(-2.0);
+        assert!((r.confidence - 0.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn confidence_normal_value() {
+        let r = ReasoningResult::respond("x").with_confidence(0.42);
+        assert!((r.confidence - 0.42).abs() < f32::EPSILON);
+    }
+
+    // ── ReasoningResult::with_thought ─────────────────────────────────────
+
+    #[test]
+    fn with_thought_appends() {
+        let r = ReasoningResult::respond("answer")
+            .with_thought(ThoughtStep::thought("first idea", 1))
+            .with_thought(ThoughtStep::analysis("deeper look", 2));
+        assert_eq!(r.thoughts.len(), 2);
+        assert_eq!(r.thoughts[0].step_number, 1);
+        assert_eq!(r.thoughts[0].step_type, ThoughtStepType::Thought);
+        assert_eq!(r.thoughts[1].step_type, ThoughtStepType::Analysis);
+    }
+
+    // ── ThoughtStep factory methods ───────────────────────────────────────
+
+    #[test]
+    fn thought_step_thought() {
+        let s = ThoughtStep::thought("thinking...", 1);
+        assert_eq!(s.step_type, ThoughtStepType::Thought);
+        assert_eq!(s.content, "thinking...");
+        assert_eq!(s.step_number, 1);
+        assert!(s.timestamp_ms > 0);
+    }
+
+    #[test]
+    fn thought_step_analysis() {
+        let s = ThoughtStep::analysis("analyzing...", 2);
+        assert_eq!(s.step_type, ThoughtStepType::Analysis);
+        assert_eq!(s.step_number, 2);
+    }
+
+    #[test]
+    fn thought_step_planning() {
+        let s = ThoughtStep::planning("planning...", 3);
+        assert_eq!(s.step_type, ThoughtStepType::Planning);
+        assert_eq!(s.step_number, 3);
+    }
+
+    #[test]
+    fn thought_step_reflection() {
+        let s = ThoughtStep::reflection("reflecting...", 4);
+        assert_eq!(s.step_type, ThoughtStepType::Reflection);
+        assert_eq!(s.step_number, 4);
+    }
+
+    #[test]
+    fn thought_step_custom_type() {
+        let s = ThoughtStep::new(ThoughtStepType::Custom("brainstorm".into()), "ideas", 5);
+        assert_eq!(s.step_type, ThoughtStepType::Custom("brainstorm".into()));
+        assert_eq!(s.content, "ideas");
+    }
+
+    // ── ToolCall ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn tool_call_new() {
+        let tc = ToolCall::new("calculator", serde_json::json!({"expr": "2+2"}));
+        assert_eq!(tc.tool_name, "calculator");
+        assert_eq!(tc.arguments["expr"], "2+2");
+    }
+
+    // ── Decision variants ─────────────────────────────────────────────────
+
+    #[test]
+    fn decision_delegate() {
+        let d = Decision::Delegate {
+            agent_id: "agent-2".into(),
+            task: "summarize".into(),
+        };
+        match d {
+            Decision::Delegate { agent_id, task } => {
+                assert_eq!(agent_id, "agent-2");
+                assert_eq!(task, "summarize");
+            }
+            _ => panic!("expected Delegate"),
+        }
+    }
+
+    #[test]
+    fn decision_need_more_info() {
+        let d = Decision::NeedMoreInfo {
+            questions: vec!["what format?".into(), "how long?".into()],
+        };
+        match d {
+            Decision::NeedMoreInfo { questions } => assert_eq!(questions.len(), 2),
+            _ => panic!("expected NeedMoreInfo"),
+        }
+    }
+
+    #[test]
+    fn decision_cannot_handle() {
+        let d = Decision::CannotHandle {
+            reason: "out of scope".into(),
+        };
+        match d {
+            Decision::CannotHandle { reason } => assert_eq!(reason, "out of scope"),
+            _ => panic!("expected CannotHandle"),
+        }
+    }
+
+    #[test]
+    fn decision_call_multiple_tools() {
+        let d = Decision::CallMultipleTools {
+            tool_calls: vec![
+                ToolCall::new("tool_a", serde_json::json!({})),
+                ToolCall::new("tool_b", serde_json::json!({"k": "v"})),
+            ],
+        };
+        match d {
+            Decision::CallMultipleTools { tool_calls } => {
+                assert_eq!(tool_calls.len(), 2);
+                assert_eq!(tool_calls[0].tool_name, "tool_a");
+                assert_eq!(tool_calls[1].tool_name, "tool_b");
+            }
+            _ => panic!("expected CallMultipleTools"),
+        }
+    }
+
+    // ── Serialization ─────────────────────────────────────────────────────
+
+    #[test]
+    fn reasoning_result_serde_roundtrip() {
+        let r = ReasoningResult::respond("test answer")
+            .with_confidence(0.9)
+            .with_thought(ThoughtStep::thought("step 1", 1));
+        let json = serde_json::to_string(&r).unwrap();
+        let recovered: ReasoningResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(recovered.thoughts.len(), 1);
+        assert!((recovered.confidence - 0.9).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn thought_step_type_serde_roundtrip() {
+        for step_type in [
+            ThoughtStepType::Thought,
+            ThoughtStepType::Analysis,
+            ThoughtStepType::Planning,
+            ThoughtStepType::Reflection,
+            ThoughtStepType::Evaluation,
+            ThoughtStepType::Custom("test".into()),
+        ] {
+            let json = serde_json::to_string(&step_type).unwrap();
+            let recovered: ThoughtStepType = serde_json::from_str(&json).unwrap();
+            assert_eq!(recovered, step_type);
+        }
+    }
+}


### PR DESCRIPTION
Closes #983

## Summary

Adds inline `#[cfg(test)]` modules to three core kernel files that previously had zero test coverage:

- **memory.rs** (25 tests): `MemoryValue` factory methods, accessor round-trips, `From` conversions, `MemoryItem::with_score` clamping to `[0.0, 1.0]`, `Message` factory methods including `Message::tool()` metadata insertion, `MessageRole` Display, serde round-trips
- **context_compressor.rs** (12 tests): `CompressionMetrics::new()` edge cases (division-by-zero when `tokens_before == 0`, `tokens_after > tokens_before` saturating subtraction), `was_compressed()` / `tokens_saved()` correctness, all 5 `CompressionStrategy` variants serde round-trips
- **reasoner.rs** (17 tests): `ReasoningResult` builders, `with_confidence` clamping to `[0.0, 1.0]`, `with_thought` append ordering, `ThoughtStep` factory methods with auto-timestamps, all `Decision` variants, `ToolCall::new`, serde round-trips

54 tests total, all passing. No behavioral changes — test-only PR.

## Test plan

- [x] `cargo test -p mofa-kernel -- components::memory::tests components::context_compressor::tests components::reasoner::tests` → 54 passed
- [x] `cargo clippy -p mofa-kernel --tests` → no new warnings