### PR TITLE
test: add 12 unit tests for runtime interrupt and fallback modules

### DIFF
--- a/crates/mofa-runtime/src/fallback.rs
+++ b/crates/mofa-runtime/src/fallback.rs
@@ -36,3 +36,49 @@ impl FallbackStrategy for NoFallback {
         None
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_error() -> AgentError {
+        AgentError::NotFound("test-agent".into())
+    }
+
+    #[tokio::test]
+    async fn static_fallback_returns_output() {
+        let fallback = StaticFallback {
+            output: AgentOutput::text("service unavailable"),
+        };
+        let result = fallback.on_failure("agent-1", &test_error(), 3).await;
+        assert!(result.is_some());
+    }
+
+    #[tokio::test]
+    async fn static_fallback_ignores_agent_id_and_attempts() {
+        let fallback = StaticFallback {
+            output: AgentOutput::text("down"),
+        };
+        // Different agent_id and attempt_count should still return the same output
+        let r1 = fallback.on_failure("a", &test_error(), 1).await;
+        let r2 = fallback.on_failure("b", &test_error(), 100).await;
+        assert!(r1.is_some());
+        assert!(r2.is_some());
+    }
+
+    #[tokio::test]
+    async fn no_fallback_returns_none() {
+        let fallback = NoFallback;
+        let result = fallback.on_failure("agent-1", &test_error(), 5).await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn no_fallback_always_none_regardless_of_inputs() {
+        let fallback = NoFallback;
+        for attempts in [0, 1, 10, 100] {
+            let result = fallback.on_failure("any", &test_error(), attempts).await;
+            assert!(result.is_none());
+        }
+    }
+}

--- a/crates/mofa-runtime/src/interrupt.rs
+++ b/crates/mofa-runtime/src/interrupt.rs
@@ -45,3 +45,81 @@ impl AgentInterrupt {
             .store(false, std::sync::atomic::Ordering::SeqCst);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_is_not_interrupted() {
+        let interrupt = AgentInterrupt::new();
+        assert!(!interrupt.check());
+    }
+
+    #[test]
+    fn default_is_not_interrupted() {
+        let interrupt = AgentInterrupt::default();
+        assert!(!interrupt.check());
+    }
+
+    #[test]
+    fn trigger_sets_interrupted() {
+        let interrupt = AgentInterrupt::new();
+        interrupt.trigger();
+        assert!(interrupt.check());
+    }
+
+    #[test]
+    fn reset_clears_interrupted() {
+        let interrupt = AgentInterrupt::new();
+        interrupt.trigger();
+        assert!(interrupt.check());
+        interrupt.reset();
+        assert!(!interrupt.check());
+    }
+
+    #[test]
+    fn trigger_reset_trigger_cycle() {
+        let interrupt = AgentInterrupt::new();
+        interrupt.trigger();
+        interrupt.reset();
+        interrupt.trigger();
+        assert!(interrupt.check());
+    }
+
+    #[test]
+    fn clone_shares_state() {
+        let a = AgentInterrupt::new();
+        let b = a.clone();
+        a.trigger();
+        // Both clones see the same atomic — this is the whole point of Arc
+        assert!(b.check());
+    }
+
+    #[test]
+    fn clone_reset_affects_both() {
+        let a = AgentInterrupt::new();
+        let b = a.clone();
+        a.trigger();
+        b.reset();
+        assert!(!a.check());
+    }
+
+    #[tokio::test]
+    async fn notify_wakes_waiter() {
+        let interrupt = AgentInterrupt::new();
+        let interrupt2 = interrupt.clone();
+
+        let handle = tokio::spawn(async move {
+            interrupt2.notify.notified().await;
+            interrupt2.check()
+        });
+
+        // Small yield to let the spawned task reach the notified().await
+        tokio::task::yield_now().await;
+        interrupt.trigger();
+
+        let was_interrupted = handle.await.unwrap();
+        assert!(was_interrupted);
+    }
+}


### PR DESCRIPTION
Closes #986

## Summary

Adds inline `#[cfg(test)]` modules to two runtime files with zero prior coverage:

- **interrupt.rs** (8 tests): Verifies the full `AgentInterrupt` lifecycle — `new()`/`Default` start uninterrupted, `trigger()` sets the atomic flag, `reset()` clears it, trigger/reset/trigger cycle, and critically that `Clone` shares `Arc` state (a trigger on one clone is visible on the other, and a reset from either side clears it for both). Includes an async test confirming `Notify::notified()` wakes when `trigger()` fires.

- **fallback.rs** (4 tests): Verifies `StaticFallback` always returns `Some` regardless of agent_id/attempt_count, and `NoFallback` always returns `None`.

12 tests total, all passing. No behavioral changes — test-only PR.

## Test plan

- [x] `cargo test -p mofa-runtime -- interrupt::tests fallback::tests` → 12 passed
- [x] `cargo clippy -p mofa-runtime --tests` → no new warnings