### PR TITLE
feat: add Display impl for DebugEvent telemetry type

### DIFF
--- a/crates/mofa-kernel/src/workflow/telemetry.rs
+++ b/crates/mofa-kernel/src/workflow/telemetry.rs
@@ -127,6 +127,68 @@ pub enum DebugEvent {
     },
 }
 
+impl std::fmt::Display for DebugEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::WorkflowStart {
+                workflow_id,
+                execution_id,
+                timestamp_ms,
+            } => write!(
+                f,
+                "[{timestamp_ms}] workflow_start: workflow={workflow_id} execution={execution_id}"
+            ),
+            Self::NodeStart {
+                node_id,
+                timestamp_ms,
+                ..
+            } => write!(f, "[{timestamp_ms}] node_start: node={node_id}"),
+            Self::StateChange {
+                node_id,
+                timestamp_ms,
+                key,
+                old_value,
+                new_value,
+            } => {
+                let old = match old_value {
+                    Some(v) => v.to_string(),
+                    None => "<new>".to_string(),
+                };
+                write!(
+                    f,
+                    "[{timestamp_ms}] state_change: node={node_id} key={key} {old} -> {new_value}"
+                )
+            }
+            Self::NodeEnd {
+                node_id,
+                timestamp_ms,
+                duration_ms,
+                ..
+            } => write!(
+                f,
+                "[{timestamp_ms}] node_end: node={node_id} duration={duration_ms}ms"
+            ),
+            Self::WorkflowEnd {
+                workflow_id,
+                execution_id,
+                timestamp_ms,
+                status,
+            } => write!(
+                f,
+                "[{timestamp_ms}] workflow_end: workflow={workflow_id} execution={execution_id} status={status}"
+            ),
+            Self::Error {
+                node_id,
+                timestamp_ms,
+                error,
+            } => {
+                let node = node_id.as_deref().unwrap_or("<global>");
+                write!(f, "[{timestamp_ms}] error: node={node} {error}")
+            }
+        }
+    }
+}
+
 impl DebugEvent {
     /// Get the timestamp of this event in milliseconds since epoch
     pub fn timestamp_ms(&self) -> u64 {
@@ -655,5 +717,114 @@ mod tests {
         let query = SessionQuery::default();
         let s = make_session("s1", "wf", "completed", 1000, Some(2000));
         assert!(query.matches(&s));
+    }
+
+    // --- Display impl ---
+
+    #[test]
+    fn test_display_workflow_start() {
+        let event = DebugEvent::WorkflowStart {
+            workflow_id: "wf-1".into(),
+            execution_id: "exec-1".into(),
+            timestamp_ms: 1000,
+        };
+        let s = event.to_string();
+        assert!(s.contains("[1000]"));
+        assert!(s.contains("workflow_start"));
+        assert!(s.contains("workflow=wf-1"));
+        assert!(s.contains("execution=exec-1"));
+    }
+
+    #[test]
+    fn test_display_node_start() {
+        let event = DebugEvent::NodeStart {
+            node_id: "process".into(),
+            timestamp_ms: 2000,
+            state_snapshot: json!({}),
+        };
+        let s = event.to_string();
+        assert!(s.contains("[2000]"));
+        assert!(s.contains("node_start"));
+        assert!(s.contains("node=process"));
+    }
+
+    #[test]
+    fn test_display_state_change_with_old_value() {
+        let event = DebugEvent::StateChange {
+            node_id: "n1".into(),
+            timestamp_ms: 3000,
+            key: "count".into(),
+            old_value: Some(json!(0)),
+            new_value: json!(1),
+        };
+        let s = event.to_string();
+        assert!(s.contains("[3000]"));
+        assert!(s.contains("state_change"));
+        assert!(s.contains("key=count"));
+        assert!(s.contains("0 -> 1"));
+    }
+
+    #[test]
+    fn test_display_state_change_new_key() {
+        let event = DebugEvent::StateChange {
+            node_id: "n1".into(),
+            timestamp_ms: 3500,
+            key: "name".into(),
+            old_value: None,
+            new_value: json!("alice"),
+        };
+        let s = event.to_string();
+        assert!(s.contains("<new> -> "));
+    }
+
+    #[test]
+    fn test_display_node_end() {
+        let event = DebugEvent::NodeEnd {
+            node_id: "n1".into(),
+            timestamp_ms: 4000,
+            state_snapshot: json!({}),
+            duration_ms: 150,
+        };
+        let s = event.to_string();
+        assert!(s.contains("node_end"));
+        assert!(s.contains("duration=150ms"));
+    }
+
+    #[test]
+    fn test_display_workflow_end() {
+        let event = DebugEvent::WorkflowEnd {
+            workflow_id: "wf-1".into(),
+            execution_id: "exec-1".into(),
+            timestamp_ms: 5000,
+            status: "completed".into(),
+        };
+        let s = event.to_string();
+        assert!(s.contains("workflow_end"));
+        assert!(s.contains("status=completed"));
+    }
+
+    #[test]
+    fn test_display_error_with_node() {
+        let event = DebugEvent::Error {
+            node_id: Some("n2".into()),
+            timestamp_ms: 6000,
+            error: "timeout exceeded".into(),
+        };
+        let s = event.to_string();
+        assert!(s.contains("error"));
+        assert!(s.contains("node=n2"));
+        assert!(s.contains("timeout exceeded"));
+    }
+
+    #[test]
+    fn test_display_error_without_node() {
+        let event = DebugEvent::Error {
+            node_id: None,
+            timestamp_ms: 7000,
+            error: "global failure".into(),
+        };
+        let s = event.to_string();
+        assert!(s.contains("node=<global>"));
+        assert!(s.contains("global failure"));
     }
 }


### PR DESCRIPTION
Closes #988

## Summary

- Adds a `Display` impl for `DebugEvent` that produces structured, human-readable log lines following `[timestamp] event_type: key=value` conventions
- Each variant renders the most relevant fields inline — `StateChange` shows the before→after diff, `NodeEnd` includes duration, `Error` shows `<global>` when no node_id is set
- Useful for CLI logging, monitoring dashboards, and the Cognitive Observatory event timeline where the full `Debug` output is too noisy to scan at a glance
- Includes 8 unit tests covering all 6 variants plus edge cases (`None` old_value, `None` node_id)

Example output:
```
[1700000003000] node_end: node=process duration=150ms
[1700000002000] state_change: node=n1 key=count 0 -> 1
[1700000006000] error: node=<global> timeout exceeded
```

## Test plan

- [x] `cargo test -p mofa-kernel -- workflow::telemetry::tests` → 14 passed (6 existing + 8 new)
- [x] `cargo clippy -p mofa-kernel --tests` → no new warnings