### PR TITLE
fix(prompt): unify GlobalPromptRegistry error handling — replace pani…

### DIFF
--- a/crates/mofa-foundation/src/prompt/registry.rs
+++ b/crates/mofa-foundation/src/prompt/registry.rs
@@ -8,7 +8,7 @@ use super::template::{PromptComposition, PromptError, PromptResult, PromptTempla
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 /// Prompt 注册中心
 /// Prompt Registry
@@ -316,131 +316,113 @@ impl GlobalPromptRegistry {
         Self::default()
     }
 
-    /// 注册模板
-    /// Register a template
-    pub fn register(&self, template: PromptTemplate) {
+    /// Acquire a read lock on the inner registry.
+    fn read_registry(&self) -> PromptResult<RwLockReadGuard<'_, PromptRegistry>> {
+        self.inner
+            .read()
+            .map_err(|e| PromptError::LockPoisoned(e.to_string()))
+    }
+
+    /// Acquire a write lock on the inner registry.
+    fn write_registry(&self) -> PromptResult<RwLockWriteGuard<'_, PromptRegistry>> {
         self.inner
             .write()
-            .expect("Failed to acquire write lock on prompt registry")
-            .register(template);
+            .map_err(|e| PromptError::LockPoisoned(e.to_string()))
+    }
+
+    /// 注册模板
+    /// Register a template
+    pub fn register(&self, template: PromptTemplate) -> PromptResult<()> {
+        self.write_registry()?.register(template);
+        Ok(())
     }
 
     /// 获取模板（克隆）
     /// Get a template (cloned)
     pub fn get(&self, id: &str) -> PromptResult<PromptTemplate> {
-        self.inner
-            .read()
-            .map_err(|e| PromptError::LockPoisoned(e.to_string()))?
-            .get(id)
-            .cloned()
+        self.read_registry()?.get(id).cloned()
     }
 
     /// 渲染模板
     /// Render a template
     pub fn render(&self, id: &str, vars: &[(&str, &str)]) -> PromptResult<String> {
-        self.inner
-            .read()
-            .map_err(|e| PromptError::LockPoisoned(e.to_string()))?
-            .render(id, vars)
+        self.read_registry()?.render(id, vars)
     }
 
     /// 检查是否包含
     /// Check if it contains
-    pub fn contains(&self, id: &str) -> bool {
-        self.inner
-            .read()
-            .expect("Failed to acquire read lock on prompt registry")
-            .contains(id)
+    pub fn contains(&self, id: &str) -> PromptResult<bool> {
+        Ok(self.read_registry()?.contains(id))
     }
 
     /// 删除模板
     /// Remove a template
-    pub fn remove(&self, id: &str) -> Option<PromptTemplate> {
-        self.inner
-            .write()
-            .expect("Failed to acquire write lock on prompt registry")
-            .remove(id)
+    pub fn remove(&self, id: &str) -> PromptResult<Option<PromptTemplate>> {
+        Ok(self.write_registry()?.remove(id))
     }
 
     /// 从文件加载
     /// Load from a file
     pub fn load_from_file(&self, path: impl AsRef<Path>) -> PromptResult<()> {
-        self.inner
-            .write()
-            .map_err(|e| PromptError::LockPoisoned(e.to_string()))?
-            .load_from_file(path)
+        self.write_registry()?.load_from_file(path)
     }
 
     /// 从 YAML 加载
     /// Load from YAML
     pub fn load_from_yaml(&self, yaml: &str) -> PromptResult<()> {
-        self.inner
-            .write()
-            .expect("Failed to acquire write lock on prompt registry")
-            .load_from_yaml(yaml)
+        self.write_registry()?.load_from_yaml(yaml)
     }
 
     /// 获取所有模板 ID
     /// Get all template IDs
-    pub fn list_ids(&self) -> Vec<String> {
-        self.inner
-            .read()
-            .unwrap()
+    pub fn list_ids(&self) -> PromptResult<Vec<String>> {
+        Ok(self
+            .read_registry()?
             .list_ids()
             .iter()
             .map(|s| s.to_string())
-            .collect()
+            .collect())
     }
 
     /// 按标签查找
     /// Find by tag
-    pub fn find_by_tag(&self, tag: &str) -> Vec<PromptTemplate> {
-        self.inner
-            .read()
-            .unwrap()
+    pub fn find_by_tag(&self, tag: &str) -> PromptResult<Vec<PromptTemplate>> {
+        Ok(self
+            .read_registry()?
             .find_by_tag(tag)
             .iter()
             .map(|t| (*t).clone())
-            .collect()
+            .collect())
     }
 
     /// 搜索模板
     /// Search templates
-    pub fn search(&self, query: &str) -> Vec<PromptTemplate> {
-        self.inner
-            .read()
-            .unwrap()
+    pub fn search(&self, query: &str) -> PromptResult<Vec<PromptTemplate>> {
+        Ok(self
+            .read_registry()?
             .search(query)
             .iter()
             .map(|t| (*t).clone())
-            .collect()
+            .collect())
     }
 
     /// 模板数量
     /// Number of templates
-    pub fn len(&self) -> usize {
-        self.inner
-            .read()
-            .expect("Failed to acquire read lock on prompt registry")
-            .len()
+    pub fn len(&self) -> PromptResult<usize> {
+        Ok(self.read_registry()?.len())
     }
 
     /// 是否为空
     /// Whether it is empty
-    pub fn is_empty(&self) -> bool {
-        self.inner
-            .read()
-            .expect("Failed to acquire read lock on prompt registry")
-            .is_empty()
+    pub fn is_empty(&self) -> PromptResult<bool> {
+        Ok(self.read_registry()?.is_empty())
     }
 
     /// 清空
     /// Clear
-    pub fn clear(&self) {
-        self.inner
-            .write()
-            .expect("Failed to acquire write lock on prompt registry")
-            .clear();
+    pub fn clear(&self) -> PromptResult<()> {
+        self.write_registry()?.clear();
+        Ok(())
     }
 }
 
@@ -602,11 +584,222 @@ compositions:
     fn test_global_registry() {
         let registry = GlobalPromptRegistry::new();
 
-        registry.register(PromptTemplate::new("test").with_content("Hello, {name}!"));
+        registry
+            .register(PromptTemplate::new("test").with_content("Hello, {name}!"))
+            .unwrap();
 
-        assert!(registry.contains("test"));
+        assert!(registry.contains("test").unwrap());
 
         let result = registry.render("test", &[("name", "World")]).unwrap();
         assert_eq!(result, "Hello, World!");
+    }
+
+    #[test]
+    fn test_global_registry_register_and_get() {
+        let registry = GlobalPromptRegistry::new();
+
+        let template = PromptTemplate::new("greet")
+            .with_content("Hi, {user}!")
+            .with_tag("greeting");
+
+        registry.register(template).unwrap();
+
+        let retrieved = registry.get("greet").unwrap();
+        assert_eq!(retrieved.id, "greet");
+    }
+
+    #[test]
+    fn test_global_registry_get_nonexistent_returns_error() {
+        let registry = GlobalPromptRegistry::new();
+        assert!(registry.get("does-not-exist").is_err());
+    }
+
+    #[test]
+    fn test_global_registry_contains() {
+        let registry = GlobalPromptRegistry::new();
+
+        assert!(!registry.contains("missing").unwrap());
+
+        registry
+            .register(PromptTemplate::new("present").with_content("here"))
+            .unwrap();
+
+        assert!(registry.contains("present").unwrap());
+    }
+
+    #[test]
+    fn test_global_registry_remove() {
+        let registry = GlobalPromptRegistry::new();
+
+        registry
+            .register(
+                PromptTemplate::new("removable")
+                    .with_content("bye")
+                    .with_tag("temp"),
+            )
+            .unwrap();
+
+        assert!(registry.contains("removable").unwrap());
+
+        let removed = registry.remove("removable").unwrap();
+        assert!(removed.is_some());
+        assert!(!registry.contains("removable").unwrap());
+
+        // Removing again returns None
+        let removed_again = registry.remove("removable").unwrap();
+        assert!(removed_again.is_none());
+    }
+
+    #[test]
+    fn test_global_registry_len_and_is_empty() {
+        let registry = GlobalPromptRegistry::new();
+
+        assert!(registry.is_empty().unwrap());
+        assert_eq!(registry.len().unwrap(), 0);
+
+        registry
+            .register(PromptTemplate::new("a").with_content("A"))
+            .unwrap();
+        registry
+            .register(PromptTemplate::new("b").with_content("B"))
+            .unwrap();
+
+        assert!(!registry.is_empty().unwrap());
+        assert_eq!(registry.len().unwrap(), 2);
+    }
+
+    #[test]
+    fn test_global_registry_list_ids() {
+        let registry = GlobalPromptRegistry::new();
+
+        registry
+            .register(PromptTemplate::new("alpha").with_content("A"))
+            .unwrap();
+        registry
+            .register(PromptTemplate::new("beta").with_content("B"))
+            .unwrap();
+
+        let mut ids = registry.list_ids().unwrap();
+        ids.sort();
+        assert_eq!(ids, vec!["alpha", "beta"]);
+    }
+
+    #[test]
+    fn test_global_registry_find_by_tag() {
+        let registry = GlobalPromptRegistry::new();
+
+        registry
+            .register(
+                PromptTemplate::new("t1")
+                    .with_content("T1")
+                    .with_tag("shared")
+                    .with_tag("unique-a"),
+            )
+            .unwrap();
+        registry
+            .register(
+                PromptTemplate::new("t2")
+                    .with_content("T2")
+                    .with_tag("shared"),
+            )
+            .unwrap();
+
+        let shared = registry.find_by_tag("shared").unwrap();
+        assert_eq!(shared.len(), 2);
+
+        let unique = registry.find_by_tag("unique-a").unwrap();
+        assert_eq!(unique.len(), 1);
+
+        let none = registry.find_by_tag("nonexistent").unwrap();
+        assert!(none.is_empty());
+    }
+
+    #[test]
+    fn test_global_registry_search() {
+        let registry = GlobalPromptRegistry::new();
+
+        registry
+            .register(
+                PromptTemplate::new("code-review")
+                    .with_name("Code Review")
+                    .with_description("Review code"),
+            )
+            .unwrap();
+        registry
+            .register(
+                PromptTemplate::new("chat")
+                    .with_name("Chat Bot")
+                    .with_description("General chat"),
+            )
+            .unwrap();
+
+        let results = registry.search("code").unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, "code-review");
+    }
+
+    #[test]
+    fn test_global_registry_render() {
+        let registry = GlobalPromptRegistry::new();
+
+        registry
+            .register(PromptTemplate::new("tmpl").with_content("Hello, {who}!"))
+            .unwrap();
+
+        let rendered = registry.render("tmpl", &[("who", "Rust")]).unwrap();
+        assert_eq!(rendered, "Hello, Rust!");
+
+        // Rendering a non-existent template returns an error
+        assert!(registry.render("missing", &[]).is_err());
+    }
+
+    #[test]
+    fn test_global_registry_clear() {
+        let registry = GlobalPromptRegistry::new();
+
+        registry
+            .register(PromptTemplate::new("x").with_content("X"))
+            .unwrap();
+        registry
+            .register(PromptTemplate::new("y").with_content("Y"))
+            .unwrap();
+
+        assert_eq!(registry.len().unwrap(), 2);
+
+        registry.clear().unwrap();
+
+        assert_eq!(registry.len().unwrap(), 0);
+        assert!(registry.is_empty().unwrap());
+    }
+
+    #[test]
+    fn test_global_registry_load_from_yaml() {
+        let registry = GlobalPromptRegistry::new();
+
+        let yaml = r#"
+templates:
+  - id: hello
+    content: "Hello, {name}!"
+    variables:
+      - name: name
+        required: true
+  - id: bye
+    content: "Bye, {name}!"
+    variables:
+      - name: name
+        default: friend
+"#;
+
+        registry.load_from_yaml(yaml).unwrap();
+
+        assert_eq!(registry.len().unwrap(), 2);
+        assert!(registry.contains("hello").unwrap());
+        assert!(registry.contains("bye").unwrap());
+
+        let rendered = registry.render("hello", &[("name", "MoFA")]).unwrap();
+        assert_eq!(rendered, "Hello, MoFA!");
+
+        let rendered_default = registry.render("bye", &[]).unwrap();
+        assert_eq!(rendered_default, "Bye, friend!");
     }
 }


### PR DESCRIPTION
## 📋 Summary

Unify error handling in [GlobalPromptRegistry](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#308-311) by replacing 9 panicking `.unwrap()` / `.expect()` calls with proper `PromptResult<T>` return types. Introduces [read_registry()](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#319-325) / [write_registry()](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#326-332) private helper functions to centralize lock acquisition and eliminate code repetition, as suggested in issue review.

## 🔗 Related Issues

Closes #971 

---

## 🧠 Context

[GlobalPromptRegistry](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#308-311) wraps a [PromptRegistry](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#19-30) behind `Arc<RwLock<...>>`. Out of 13 public methods, **9 used `.unwrap()` or `.expect()`** to acquire the lock — which panics and crashes the entire process if the `RwLock` becomes poisoned. The remaining 4 methods ([get](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#340-345), [render](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#346-351), [load_from_file](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#172-209), [load_from_yaml](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#210-234)) already correctly returned `PromptResult` via `.map_err()`.

This inconsistency meant a single panic in any thread holding the lock would cascade into panics across **all** subsequent callers. The sibling module [memory_store.rs](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/memory_store.rs) already uses `PromptError::LockPoisoned` with `.map_err()` throughout (19 occurrences), so this fix aligns with the established pattern in the codebase.

---

## 🛠️ Changes

- **Added [read_registry()](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#319-325) / [write_registry()](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#326-332) private helpers** to centralize lock acquisition and error conversion, avoiding repeated `.map_err(|e| PromptError::LockPoisoned(e.to_string()))` in every method
- **Updated 10 method signatures** to return `PromptResult<T>` instead of panicking:
  - [register()](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#333-339): [()](file:///Users/mustafahussain/mofa/crates/mofa-monitoring/src/tracing/tracer.rs#116-122) → `PromptResult<()>`
  - [contains()](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#352-357): `bool` → `PromptResult<bool>`
  - [remove()](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#358-363): `Option<PromptTemplate>` → `PromptResult<Option<PromptTemplate>>`
  - [load_from_yaml()](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#210-234): already `PromptResult<()>` but used `.expect()` internally → now uses helper
  - [list_ids()](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#376-386): `Vec<String>` → `PromptResult<Vec<String>>`
  - [find_by_tag()](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#387-397): `Vec<PromptTemplate>` → `PromptResult<Vec<PromptTemplate>>`
  - [search()](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#398-408): `Vec<PromptTemplate>` → `PromptResult<Vec<PromptTemplate>>`
  - [len()](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#409-414): `usize` → `PromptResult<usize>`
  - [is_empty()](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#415-420): `bool` → `PromptResult<bool>`
  - [clear()](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#421-427): [()](file:///Users/mustafahussain/mofa/crates/mofa-monitoring/src/tracing/tracer.rs#116-122) → `PromptResult<()>`
- **Added `RwLockReadGuard` and `RwLockWriteGuard` imports** for helper return types
- **Added 11 new tests** covering all [GlobalPromptRegistry](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#308-311) public methods

---

## 🧪 How you Tested

1. `rustfmt --check crates/mofa-foundation/src/prompt/registry.rs` — passes ✅
2. `cargo check -p mofa-foundation` — compiles with zero warnings ✅
3. `cargo test -p mofa-foundation prompt::registry::tests` — all **17 tests pass** (6 original + 11 new) ✅

New tests added:
- [test_global_registry_register_and_get](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#597-610)
- [test_global_registry_get_nonexistent_returns_error](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#611-616)
- [test_global_registry_contains](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#617-629)
- [test_global_registry_remove](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#630-652)
- [test_global_registry_len_and_is_empty](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#653-670)
- [test_global_registry_list_ids](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#671-686)
- [test_global_registry_find_by_tag](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#687-716)
- [test_global_registry_search](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#717-740)
- [test_global_registry_render](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#741-755)
- [test_global_registry_clear](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#756-774)
- [test_global_registry_load_from_yaml](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#775-805)

---

## ⚠️ Breaking Changes

- [x] Breaking change (describe below)

This is a breaking API change: 10 methods now return `PromptResult<T>` instead of plain values. However, **no downstream callers exist** outside the crate's own test module — verified by searching the entire workspace for [GlobalPromptRegistry](file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/prompt/registry.rs#308-311) usages.

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [x] Public APIs documented
- [x] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---

## 🧩 Additional Notes for Reviewers

The helper function approach was suggested by the maintainer in the issue discussion. Before this change:

```rust
// Repeated 13 times across all methods:
self.inner
    .read()  // or .write()
    .map_err(|e| PromptError::LockPoisoned(e.to_string()))?
```

After this change:

```rust
// Centralized in two helpers, each method is now a one-liner:
fn read_registry(&self) -> PromptResult<RwLockReadGuard<'_, PromptRegistry>> { ... }
fn write_registry(&self) -> PromptResult<RwLockWriteGuard<'_, PromptRegistry>> { ... }

// Usage:
pub fn contains(&self, id: &str) -> PromptResult<bool> {
    Ok(self.read_registry()?.contains(id))
}
```
