### PR TITLE
fix: update outdated SecretaryAgent / SecretaryConfig references in docs

### DIFF
--- a/docs/mofa-doc/src/api-reference/foundation/README.md
+++ b/docs/mofa-doc/src/api-reference/foundation/README.md
@@ -21,8 +21,9 @@ ReAct agent pattern implementation.
 ### secretary
 Secretary agent pattern for human-in-the-loop workflows.
 
-- `SecretaryAgent` — Secretary agent
-- `SecretaryConfig` — Configuration
+- `DefaultSecretaryBuilder` — Build secretary behavior
+- `SecretaryCore` — Event-loop runtime
+- `DefaultInput` / `DefaultOutput` — Message contracts
 
 ### persistence
 Persistence layer for state and session management.

--- a/docs/mofa-doc/src/api-reference/foundation/patterns.md
+++ b/docs/mofa-doc/src/api-reference/foundation/patterns.md
@@ -47,13 +47,27 @@ pub struct ReActConfig {
 Human-in-the-loop coordination agent.
 
 ```rust
-use mofa_sdk::secretary::SecretaryAgent;
+use mofa_sdk::secretary::{
+    ChannelConnection,
+    DefaultInput,
+    DefaultSecretaryBuilder,
+    SecretaryCore,
+};
 
-let agent = SecretaryAgent::builder()
-    .with_llm(client)
-    .with_human_feedback(true)
-    .with_delegation_targets(vec!["researcher", "writer"])
+let behavior = DefaultSecretaryBuilder::new()
+    .with_name("Project Secretary")
+    .with_auto_clarify(true)
+    .with_auto_dispatch(true)
     .build();
+
+let (conn, input_tx, mut output_rx) = ChannelConnection::new_pair(32);
+let (_handle, _join) = SecretaryCore::new(behavior).start(conn).await;
+
+input_tx.send(DefaultInput::Idea {
+    content: "Refactor notification system".to_string(),
+    priority: None,
+    metadata: None,
+}).await?;
 ```
 
 ### Phases

--- a/docs/mofa-doc/src/concepts/agents.md
+++ b/docs/mofa-doc/src/concepts/agents.md
@@ -231,18 +231,32 @@ let agent = ReActAgent::builder()
     .build();
 ```
 
-### SecretaryAgent
+### Secretary Pattern
 
-Human-in-the-loop workflow management:
+Human-in-the-loop workflow management (event-loop based):
 
 ```rust
-use mofa_sdk::secretary::SecretaryAgent;
+use mofa_sdk::secretary::{
+    ChannelConnection,
+    DefaultInput,
+    DefaultSecretaryBuilder,
+    SecretaryCore,
+};
 
-let agent = SecretaryAgent::builder()
-    .with_llm(client)
-    .with_human_feedback(true)
-    .with_delegation_targets(vec!["researcher", "writer"])
+let behavior = DefaultSecretaryBuilder::new()
+    .with_name("Project Secretary")
+    .with_auto_clarify(true)
+    .with_auto_dispatch(true)
     .build();
+
+let (conn, input_tx, mut output_rx) = ChannelConnection::new_pair(32);
+let (_handle, _join) = SecretaryCore::new(behavior).start(conn).await;
+
+input_tx.send(DefaultInput::Idea {
+    content: "Build release dashboard".to_string(),
+    priority: None,
+    metadata: None,
+}).await?;
 ```
 
 ## Using AgentRunner

--- a/docs/mofa-doc/src/guides/secretary-agent.md
+++ b/docs/mofa-doc/src/guides/secretary-agent.md
@@ -4,13 +4,19 @@ The Secretary Agent pattern enables human-in-the-loop workflows where AI manages
 
 ## Overview
 
-The Secretary Agent acts as an intelligent coordinator that:
+The current Secretary API is event-loop based:
 
-1. **Receives Ideas** — Records tasks and todos
-2. **Clarifies Requirements** — Generates project documents
-3. **Schedules Dispatch** — Calls execution agents
-4. **Monitors Feedback** — Pushes key decisions to humans
-5. **Acceptance Report** — Updates todos and status
+1. Build behavior with `DefaultSecretaryBuilder`
+2. Start runtime with `SecretaryCore`
+3. Exchange messages through `DefaultInput` and `DefaultOutput`
+
+This pattern maps to the five work phases:
+
+1. Receive ideas
+2. Clarify requirements
+3. Schedule dispatch
+4. Monitor feedback and decisions
+5. Generate acceptance reports
 
 ```mermaid
 graph LR
@@ -30,214 +36,184 @@ graph LR
 
 ## Basic Usage
 
-### Creating a Secretary Agent
-
 ```rust
-use mofa_sdk::secretary::{SecretaryAgent, SecretaryConfig};
-use mofa_sdk::llm::openai_from_env;
-
-let config = SecretaryConfig {
-    human_feedback_enabled: true,
-    max_delegations: 5,
-    check_interval: Duration::from_secs(30),
+use mofa_sdk::secretary::{
+    AgentInfo,
+    ChannelConnection,
+    DefaultInput,
+    DefaultOutput,
+    DefaultSecretaryBuilder,
+    SecretaryCommand,
+    SecretaryCore,
+    TodoPriority,
 };
 
-let secretary = SecretaryAgent::builder()
-    .with_llm(openai_from_env()?)
-    .with_config(config)
-    .with_delegation_target("researcher", researcher_agent)
-    .with_delegation_target("writer", writer_agent)
-    .build();
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 1) Register executors
+    let mut backend = AgentInfo::new("backend_agent", "Backend Agent");
+    backend.capabilities = vec!["backend".to_string(), "api".to_string()];
+    backend.available = true;
+    backend.performance_score = 0.9;
+
+    // 2) Build secretary behavior
+    let behavior = DefaultSecretaryBuilder::new()
+        .with_name("Project Secretary")
+        .with_auto_clarify(true)
+        .with_auto_dispatch(true)
+        .with_executor(backend)
+        .build();
+
+    // 3) Start core loop
+    let (conn, input_tx, mut output_rx) = ChannelConnection::new_pair(32);
+    let (handle, join_handle) = SecretaryCore::new(behavior).start(conn).await;
+
+    // Phase 1: Receive idea
+    input_tx
+        .send(DefaultInput::Idea {
+            content: "Build a GitHub issue summarizer CLI".to_string(),
+            priority: Some(TodoPriority::High),
+            metadata: None,
+        })
+        .await?;
+
+    // Phase 2 and 3: Trigger clarify and dispatch for a specific todo
+    input_tx
+        .send(DefaultInput::Command(SecretaryCommand::Clarify {
+            todo_id: "todo_1".to_string(),
+        }))
+        .await?;
+    input_tx
+        .send(DefaultInput::Command(SecretaryCommand::Dispatch {
+            todo_id: "todo_1".to_string(),
+        }))
+        .await?;
+
+    // Phase 4 and 5: Handle feedback, decisions, and reports
+    while let Some(output) = output_rx.recv().await {
+        match output {
+            DefaultOutput::Acknowledgment { message } => {
+                println!("ack: {}", message);
+            }
+            DefaultOutput::DecisionRequired { decision } => {
+                println!("decision required: {}", decision.description);
+
+                // Human responds by sending a Decision input
+                input_tx
+                    .send(DefaultInput::Decision {
+                        decision_id: decision.id,
+                        selected_option: 0,
+                        comment: Some("approved".to_string()),
+                    })
+                    .await?;
+            }
+            DefaultOutput::StatusUpdate { todo_id, status } => {
+                println!("{} => {:?}", todo_id, status);
+            }
+            DefaultOutput::TaskCompleted { todo_id, result } => {
+                println!("completed {}: {}", todo_id, result.summary);
+            }
+            DefaultOutput::Report { report } => {
+                println!("report: {}", report.content);
+                break;
+            }
+            DefaultOutput::Error { message } => {
+                eprintln!("error: {}", message);
+            }
+            DefaultOutput::Message { content } => {
+                println!("message: {}", content);
+            }
+        }
+    }
+
+    handle.stop().await;
+    join_handle.abort();
+    Ok(())
+}
 ```
 
-### Processing Tasks
-
-```rust
-use mofa_sdk::kernel::{AgentInput, AgentContext};
-
-let ctx = AgentContext::new("exec-001");
-let mut secretary = secretary.await?;
-
-// Initialize
-secretary.initialize(&ctx).await?;
-
-// Process a task
-let input = AgentInput::text("I want to build a web scraper for news articles");
-let output = secretary.execute(input, &ctx).await?;
-
-println!("{}", output.as_text().unwrap());
-
-// Shutdown
-secretary.shutdown().await?;
-```
-
-## The Five Phases
+## The Five Phases in API Terms
 
 ### Phase 1: Receive Ideas
 
-The secretary records incoming ideas and creates a todo list:
-
-```rust
-// User input
-let idea = "Build a CLI tool that summarizes GitHub issues";
-
-// Secretary creates todos
-// - [ ] Research existing solutions
-// - [ ] Design CLI interface
-// - [ ] Implement core functionality
-// - [ ] Add tests
-// - [ ] Document usage
-```
+Use `DefaultInput::Idea` to submit user tasks.
 
 ### Phase 2: Clarify Requirements
 
-The secretary generates clarifying questions:
-
-```rust
-let questions = secretary.clarify_requirements(&idea).await?;
-
-// Questions might include:
-// - What programming language?
-// - Which LLM provider for summarization?
-// - Should it handle private repos?
-```
+Use `DefaultInput::Command(SecretaryCommand::Clarify { .. })`.
 
 ### Phase 3: Schedule Dispatch
 
-Tasks are delegated to specialized agents:
-
-```rust
-// Secretary decides which agent to use
-let dispatch = secretary.schedule_dispatch(&todos).await?;
-
-// {
-//   "research": ["Research existing solutions"],
-//   "developer": ["Implement core functionality"],
-//   "writer": ["Document usage"]
-// }
-```
+Use `DefaultInput::Command(SecretaryCommand::Dispatch { .. })`.
 
 ### Phase 4: Monitor Feedback
 
-The secretary monitors progress and flags important decisions:
-
-```rust
-// Set up feedback handler
-secretary.on_decision(|decision| {
-    println!("Decision needed: {}", decision.question);
-    // Present to human
-    let choice = prompt_human(&decision.options);
-    async move { choice }
-}).await;
-
-// Secretary will pause and wait for human input on key decisions
-```
+Handle `DefaultOutput::DecisionRequired` and send back `DefaultInput::Decision`.
 
 ### Phase 5: Acceptance Report
 
-Final status and todo updates:
-
-```rust
-let report = secretary.generate_report().await?;
-
-// {
-//   "completed": ["Research", "Core implementation"],
-//   "in_progress": ["Documentation"],
-//   "blocked": [],
-//   "next_steps": ["Add error handling"]
-// }
-```
+Use `DefaultInput::Command(SecretaryCommand::GenerateReport { .. })` and consume `DefaultOutput::Report`.
 
 ## Human Feedback Integration
 
-### Sync Mode (Blocking)
+Human feedback is handled through message exchange:
+
+1. Receive `DefaultOutput::DecisionRequired`
+2. Ask a human for choice
+3. Send `DefaultInput::Decision`
 
 ```rust
-use mofa_sdk::secretary::HumanFeedback;
+if let DefaultOutput::DecisionRequired { decision } = output {
+    let selected_option = 0; // Replace with real human input
 
-let feedback = HumanFeedback::sync(|decision| {
-    print!("{} [y/n]: ", decision.question);
-    let mut input = String::new();
-    std::io::stdin().read_line(&mut input).unwrap();
-    input.trim() == "y"
-});
-
-secretary.with_human_feedback(feedback);
-```
-
-### Async Mode (Non-blocking)
-
-```rust
-use mofa_sdk::secretary::AsyncFeedback;
-
-let feedback = AsyncFeedback::new()
-    .with_webhook("https://your-app.com/approve")
-    .with_timeout(Duration::from_minutes(30));
-
-secretary.with_async_feedback(feedback);
-```
-
-### File-based Feedback
-
-```rust
-use mofa_sdk::secretary::FileFeedback;
-
-let feedback = FileFeedback::new("./feedback_queue/")
-    .with_poll_interval(Duration::from_secs(5));
-
-// Secretary writes decisions to ./feedback_queue/pending/
-// Human writes responses to ./feedback_queue/resolved/
+    input_tx
+        .send(DefaultInput::Decision {
+            decision_id: decision.id,
+            selected_option,
+            comment: Some("approved by operator".to_string()),
+        })
+        .await?;
+}
 ```
 
 ## Delegation
 
-### Registering Agents
+Register executors through the builder and let dispatch commands route tasks:
 
 ```rust
-secretary
-    .with_delegation_target("researcher", ResearcherAgent::new())
-    .with_delegation_target("coder", CoderAgent::new())
-    .with_delegation_target("reviewer", ReviewerAgent::new());
-```
+use mofa_sdk::secretary::{AgentInfo, DefaultSecretaryBuilder, DispatchStrategy};
 
-### Delegation Rules
+let mut researcher = AgentInfo::new("researcher", "Research Agent");
+researcher.capabilities = vec!["research".to_string()];
+researcher.available = true;
+researcher.performance_score = 0.85;
 
-```rust
-use mofa_sdk::secretary::DelegationRule;
+let mut writer = AgentInfo::new("writer", "Writer Agent");
+writer.capabilities = vec!["writing".to_string()];
+writer.available = true;
+writer.performance_score = 0.9;
 
-let rule = DelegationRule::new()
-    .when_tag("code", delegate_to("coder"))
-    .when_tag("research", delegate_to("researcher"))
-    .when_complexity_gt(0.8, require_human_approval())
-    .default(delegate_to("general"));
-
-secretary.with_delegation_rules(rule);
+let behavior = DefaultSecretaryBuilder::new()
+    .with_dispatch_strategy(DispatchStrategy::CapabilityFirst)
+    .with_executor(researcher)
+    .with_executor(writer)
+    .build();
 ```
 
 ## Configuration
 
-```rust
-pub struct SecretaryConfig {
-    /// Enable human feedback loop
-    pub human_feedback_enabled: bool,
+Use builder methods instead of a standalone config struct:
 
-    /// Maximum delegations before requiring approval
-    pub max_delegations: usize,
-
-    /// How often to check for feedback
-    pub check_interval: Duration,
-
-    /// Auto-approve low-risk decisions
-    pub auto_approve_threshold: f32,
-
-    /// Keep context size manageable
-    pub context_window: usize,
-}
-```
+- `.with_name(...)`
+- `.with_llm(...)`
+- `.with_auto_clarify(...)`
+- `.with_auto_dispatch(...)`
+- `.with_dispatch_strategy(...)`
+- `.with_executor(...)`
 
 ## Examples
 
-See the complete example in `examples/secretary_agent/`:
+See the complete runtime example in `examples/secretary_agent/`:
 
 ```bash
 cargo run -p secretary_agent
@@ -245,6 +221,6 @@ cargo run -p secretary_agent
 
 ## See Also
 
-- [Workflows](../concepts/workflows.md) — Workflow orchestration
-- [Multi-Agent Systems](multi-agent.md) — Coordination patterns
-- [Tutorial Chapter 6](../tutorial/06-multi-agent.md) — Multi-agent tutorial
+- [Workflows](../concepts/workflows.md) - Workflow orchestration
+- [Multi-Agent Systems](multi-agent.md) - Coordination patterns
+- [Tutorial Chapter 6](../tutorial/06-multi-agent.md) - Multi-agent tutorial

--- a/docs/mofa-doc/src/zh/api-reference/foundation/README.md
+++ b/docs/mofa-doc/src/zh/api-reference/foundation/README.md
@@ -21,8 +21,9 @@ ReAct 智能体模式实现。
 ### secretary
 用于人在回路工作流的秘书智能体模式。
 
-- `SecretaryAgent` — 秘书智能体
-- `SecretaryConfig` — 配置
+- `DefaultSecretaryBuilder` — 构建秘书行为
+- `SecretaryCore` — 事件循环运行时
+- `DefaultInput` / `DefaultOutput` — 消息契约
 
 ### persistence
 用于状态和会话管理的持久化层。

--- a/docs/mofa-doc/src/zh/api-reference/foundation/patterns.md
+++ b/docs/mofa-doc/src/zh/api-reference/foundation/patterns.md
@@ -47,13 +47,27 @@ pub struct ReActConfig {
 人在回路协调智能体。
 
 ```rust
-use mofa_sdk::secretary::SecretaryAgent;
+use mofa_sdk::secretary::{
+    ChannelConnection,
+    DefaultInput,
+    DefaultSecretaryBuilder,
+    SecretaryCore,
+};
 
-let agent = SecretaryAgent::builder()
-    .with_llm(client)
-    .with_human_feedback(true)
-    .with_delegation_targets(vec!["researcher", "writer"])
+let behavior = DefaultSecretaryBuilder::new()
+    .with_name("项目秘书")
+    .with_auto_clarify(true)
+    .with_auto_dispatch(true)
     .build();
+
+let (conn, input_tx, mut output_rx) = ChannelConnection::new_pair(32);
+let (_handle, _join) = SecretaryCore::new(behavior).start(conn).await;
+
+input_tx.send(DefaultInput::Idea {
+    content: "重构通知系统".to_string(),
+    priority: None,
+    metadata: None,
+}).await?;
 ```
 
 ### 阶段

--- a/docs/mofa-doc/src/zh/concepts/agents.md
+++ b/docs/mofa-doc/src/zh/concepts/agents.md
@@ -231,18 +231,32 @@ let agent = ReActAgent::builder()
     .build();
 ```
 
-### SecretaryAgent
+### Secretary 模式
 
-人在回路的工作流管理:
+人在回路工作流管理（事件循环模式）:
 
 ```rust
-use mofa_sdk::secretary::SecretaryAgent;
+use mofa_sdk::secretary::{
+    ChannelConnection,
+    DefaultInput,
+    DefaultSecretaryBuilder,
+    SecretaryCore,
+};
 
-let agent = SecretaryAgent::builder()
-    .with_llm(client)
-    .with_human_feedback(true)
-    .with_delegation_targets(vec!["researcher", "writer"])
+let behavior = DefaultSecretaryBuilder::new()
+    .with_name("项目秘书")
+    .with_auto_clarify(true)
+    .with_auto_dispatch(true)
     .build();
+
+let (conn, input_tx, mut output_rx) = ChannelConnection::new_pair(32);
+let (_handle, _join) = SecretaryCore::new(behavior).start(conn).await;
+
+input_tx.send(DefaultInput::Idea {
+    content: "开发发布看板".to_string(),
+    priority: None,
+    metadata: None,
+}).await?;
 ```
 
 ## 使用 AgentRunner

--- a/docs/mofa-doc/src/zh/guides/secretary-agent.md
+++ b/docs/mofa-doc/src/zh/guides/secretary-agent.md
@@ -4,13 +4,19 @@
 
 ## 概述
 
-秘书智能体作为一个智能协调者：
+当前秘书 API 采用事件循环模式：
 
-1. **接收想法** — 记录任务和待办事项
-2. **澄清需求** — 生成项目文档
-3. **调度分发** — 调用执行智能体
-4. **监控反馈** — 将关键决策推送给人类
-5. **验收报告** — 更新待办和状态
+1. 使用 `DefaultSecretaryBuilder` 构建行为
+2. 使用 `SecretaryCore` 启动运行时
+3. 通过 `DefaultInput` 和 `DefaultOutput` 交换消息
+
+这对应 5 个阶段：
+
+1. 接收想法
+2. 澄清需求
+3. 调度分发
+4. 监控反馈与决策
+5. 生成验收汇报
 
 ```mermaid
 graph LR
@@ -30,214 +36,184 @@ graph LR
 
 ## 基本使用
 
-### 创建秘书智能体
-
 ```rust
-use mofa_sdk::secretary::{SecretaryAgent, SecretaryConfig};
-use mofa_sdk::llm::openai_from_env;
-
-let config = SecretaryConfig {
-    human_feedback_enabled: true,
-    max_delegations: 5,
-    check_interval: Duration::from_secs(30),
+use mofa_sdk::secretary::{
+    AgentInfo,
+    ChannelConnection,
+    DefaultInput,
+    DefaultOutput,
+    DefaultSecretaryBuilder,
+    SecretaryCommand,
+    SecretaryCore,
+    TodoPriority,
 };
 
-let secretary = SecretaryAgent::builder()
-    .with_llm(openai_from_env()?)
-    .with_config(config)
-    .with_delegation_target("researcher", researcher_agent)
-    .with_delegation_target("writer", writer_agent)
-    .build();
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 1) 注册执行智能体
+    let mut backend = AgentInfo::new("backend_agent", "后端智能体");
+    backend.capabilities = vec!["backend".to_string(), "api".to_string()];
+    backend.available = true;
+    backend.performance_score = 0.9;
+
+    // 2) 构建秘书行为
+    let behavior = DefaultSecretaryBuilder::new()
+        .with_name("项目秘书")
+        .with_auto_clarify(true)
+        .with_auto_dispatch(true)
+        .with_executor(backend)
+        .build();
+
+    // 3) 启动核心事件循环
+    let (conn, input_tx, mut output_rx) = ChannelConnection::new_pair(32);
+    let (handle, join_handle) = SecretaryCore::new(behavior).start(conn).await;
+
+    // 阶段1：接收想法
+    input_tx
+        .send(DefaultInput::Idea {
+            content: "开发一个 GitHub issue 摘要 CLI".to_string(),
+            priority: Some(TodoPriority::High),
+            metadata: None,
+        })
+        .await?;
+
+    // 阶段2/3：针对具体 todo 触发澄清和分发
+    input_tx
+        .send(DefaultInput::Command(SecretaryCommand::Clarify {
+            todo_id: "todo_1".to_string(),
+        }))
+        .await?;
+    input_tx
+        .send(DefaultInput::Command(SecretaryCommand::Dispatch {
+            todo_id: "todo_1".to_string(),
+        }))
+        .await?;
+
+    // 阶段4/5：处理反馈、决策与汇报
+    while let Some(output) = output_rx.recv().await {
+        match output {
+            DefaultOutput::Acknowledgment { message } => {
+                println!("ack: {}", message);
+            }
+            DefaultOutput::DecisionRequired { decision } => {
+                println!("需要决策: {}", decision.description);
+
+                // 人类决策通过 DefaultInput::Decision 回传
+                input_tx
+                    .send(DefaultInput::Decision {
+                        decision_id: decision.id,
+                        selected_option: 0,
+                        comment: Some("批准".to_string()),
+                    })
+                    .await?;
+            }
+            DefaultOutput::StatusUpdate { todo_id, status } => {
+                println!("{} => {:?}", todo_id, status);
+            }
+            DefaultOutput::TaskCompleted { todo_id, result } => {
+                println!("完成 {}: {}", todo_id, result.summary);
+            }
+            DefaultOutput::Report { report } => {
+                println!("report: {}", report.content);
+                break;
+            }
+            DefaultOutput::Error { message } => {
+                eprintln!("error: {}", message);
+            }
+            DefaultOutput::Message { content } => {
+                println!("message: {}", content);
+            }
+        }
+    }
+
+    handle.stop().await;
+    join_handle.abort();
+    Ok(())
+}
 ```
 
-### 处理任务
-
-```rust
-use mofa_sdk::kernel::{AgentInput, AgentContext};
-
-let ctx = AgentContext::new("exec-001");
-let mut secretary = secretary.await?;
-
-// 初始化
-secretary.initialize(&ctx).await?;
-
-// 处理任务
-let input = AgentInput::text("我想构建一个新闻文章的网络爬虫");
-let output = secretary.execute(input, &ctx).await?;
-
-println!("{}", output.as_text().unwrap());
-
-// 关闭
-secretary.shutdown().await?;
-```
-
-## 五个阶段
+## 五个阶段与 API 对应
 
 ### 阶段一：接收想法
 
-秘书记录传入的想法并创建待办列表：
-
-```rust
-// 用户输入
-let idea = "构建一个总结 GitHub issues 的 CLI 工具";
-
-// 秘书创建待办
-// - [ ] 研究现有解决方案
-// - [ ] 设计 CLI 接口
-// - [ ] 实现核心功能
-// - [ ] 添加测试
-// - [ ] 编写文档
-```
+通过 `DefaultInput::Idea` 提交任务。
 
 ### 阶段二：澄清需求
 
-秘书生成澄清问题：
-
-```rust
-let questions = secretary.clarify_requirements(&idea).await?;
-
-// 问题可能包括：
-// - 使用什么编程语言？
-// - 使用哪个 LLM 提供商进行总结？
-// - 是否需要处理私有仓库？
-```
+使用 `DefaultInput::Command(SecretaryCommand::Clarify { .. })`。
 
 ### 阶段三：调度分发
 
-任务被委派给专门的智能体：
-
-```rust
-// 秘书决定使用哪个智能体
-let dispatch = secretary.schedule_dispatch(&todos).await?;
-
-// {
-//   "research": ["研究现有解决方案"],
-//   "developer": ["实现核心功能"],
-//   "writer": ["编写文档"]
-// }
-```
+使用 `DefaultInput::Command(SecretaryCommand::Dispatch { .. })`。
 
 ### 阶段四：监控反馈
 
-秘书监控进度并标记重要决策：
-
-```rust
-// 设置反馈处理器
-secretary.on_decision(|decision| {
-    println!("需要决策: {}", decision.question);
-    // 展示给人类
-    let choice = prompt_human(&decision.options);
-    async move { choice }
-}).await;
-
-// 秘书会在关键决策时暂停等待人工输入
-```
+消费 `DefaultOutput::DecisionRequired`，然后发送 `DefaultInput::Decision`。
 
 ### 阶段五：验收报告
 
-最终状态和待办更新：
-
-```rust
-let report = secretary.generate_report().await?;
-
-// {
-//   "completed": ["研究", "核心实现"],
-//   "in_progress": ["文档编写"],
-//   "blocked": [],
-//   "next_steps": ["添加错误处理"]
-// }
-```
+发送 `DefaultInput::Command(SecretaryCommand::GenerateReport { .. })`，并处理 `DefaultOutput::Report`。
 
 ## 人工反馈集成
 
-### 同步模式（阻塞）
+人工反馈通过消息交互完成：
+
+1. 接收 `DefaultOutput::DecisionRequired`
+2. 获取人工选择
+3. 发送 `DefaultInput::Decision`
 
 ```rust
-use mofa_sdk::secretary::HumanFeedback;
+if let DefaultOutput::DecisionRequired { decision } = output {
+    let selected_option = 0; // 这里替换为真实人工输入
 
-let feedback = HumanFeedback::sync(|decision| {
-    print!("{} [y/n]: ", decision.question);
-    let mut input = String::new();
-    std::io::stdin().read_line(&mut input).unwrap();
-    input.trim() == "y"
-});
-
-secretary.with_human_feedback(feedback);
-```
-
-### 异步模式（非阻塞）
-
-```rust
-use mofa_sdk::secretary::AsyncFeedback;
-
-let feedback = AsyncFeedback::new()
-    .with_webhook("https://your-app.com/approve")
-    .with_timeout(Duration::from_minutes(30));
-
-secretary.with_async_feedback(feedback);
-```
-
-### 基于文件的反馈
-
-```rust
-use mofa_sdk::secretary::FileFeedback;
-
-let feedback = FileFeedback::new("./feedback_queue/")
-    .with_poll_interval(Duration::from_secs(5));
-
-// 秘书将决策写入 ./feedback_queue/pending/
-// 人类将响应写入 ./feedback_queue/resolved/
+    input_tx
+        .send(DefaultInput::Decision {
+            decision_id: decision.id,
+            selected_option,
+            comment: Some("人工审批通过".to_string()),
+        })
+        .await?;
+}
 ```
 
 ## 委派
 
-### 注册智能体
+通过构建器注册执行智能体，并使用分发命令进行任务路由：
 
 ```rust
-secretary
-    .with_delegation_target("researcher", ResearcherAgent::new())
-    .with_delegation_target("coder", CoderAgent::new())
-    .with_delegation_target("reviewer", ReviewerAgent::new());
-```
+use mofa_sdk::secretary::{AgentInfo, DefaultSecretaryBuilder, DispatchStrategy};
 
-### 委派规则
+let mut researcher = AgentInfo::new("researcher", "研究智能体");
+researcher.capabilities = vec!["research".to_string()];
+researcher.available = true;
+researcher.performance_score = 0.85;
 
-```rust
-use mofa_sdk::secretary::DelegationRule;
+let mut writer = AgentInfo::new("writer", "写作智能体");
+writer.capabilities = vec!["writing".to_string()];
+writer.available = true;
+writer.performance_score = 0.9;
 
-let rule = DelegationRule::new()
-    .when_tag("code", delegate_to("coder"))
-    .when_tag("research", delegate_to("researcher"))
-    .when_complexity_gt(0.8, require_human_approval())
-    .default(delegate_to("general"));
-
-secretary.with_delegation_rules(rule);
+let behavior = DefaultSecretaryBuilder::new()
+    .with_dispatch_strategy(DispatchStrategy::CapabilityFirst)
+    .with_executor(researcher)
+    .with_executor(writer)
+    .build();
 ```
 
 ## 配置
 
-```rust
-pub struct SecretaryConfig {
-    /// 启用人工反馈循环
-    pub human_feedback_enabled: bool,
+通过构建器方法配置，而不是单独的旧配置结构体：
 
-    /// 需要审批前的最大委派次数
-    pub max_delegations: usize,
-
-    /// 检查反馈的频率
-    pub check_interval: Duration,
-
-    /// 自动批准低风险决策的阈值
-    pub auto_approve_threshold: f32,
-
-    /// 保持上下文大小可控
-    pub context_window: usize,
-}
-```
+- `.with_name(...)`
+- `.with_llm(...)`
+- `.with_auto_clarify(...)`
+- `.with_auto_dispatch(...)`
+- `.with_dispatch_strategy(...)`
+- `.with_executor(...)`
 
 ## 示例
 
-查看完整示例 `examples/secretary_agent/`：
+完整运行示例位于 `examples/secretary_agent/`：
 
 ```bash
 cargo run -p secretary_agent
@@ -245,6 +221,6 @@ cargo run -p secretary_agent
 
 ## 相关链接
 
-- [工作流](../concepts/workflows.md) — 工作流编排
-- [多智能体系统](multi-agent.md) — 协调模式
-- [教程第六章](../tutorial/06-multi-agent.md) — 多智能体教程
+- [工作流](../concepts/workflows.md) - 工作流编排
+- [多智能体系统](multi-agent.md) - 协调模式
+- [教程第六章](../tutorial/06-multi-agent.md) - 多智能体教程


### PR DESCRIPTION
## 📋 Summary

Updated Secretary documentation to reflect the current event-loop, message-driven API.
The docs previously referenced an outdated `SecretaryAgent` / `SecretaryConfig` interface that no longer exists in the codebase.

This PR migrates all Secretary-related documentation to the current architecture using:

* `DefaultSecretaryBuilder`
* `SecretaryCore`
* `ChannelConnection`
* `DefaultInput` / `DefaultOutput`
* `SecretaryCommand`

The conceptual five-phase Secretary workflow (Receive -> Clarify -> Dispatch -> Monitor -> Report) is preserved while mapping each phase to the current message-driven API.

English and Chinese documentation are updated together to keep them synchronized.

---


## 🔗 Related Issues

Closes #961 

---

## 🧠 Context

Several documentation pages referenced APIs that are no longer part of the current implementation, including:

```
SecretaryAgent
SecretaryConfig
clarify_requirements(...)
schedule_dispatch(...)
on_decision(...)
```

The current implementation uses an event-loop architecture built around message passing (`DefaultInput` / `DefaultOutput`) and the runtime managed by `SecretaryCore`.

As a result, existing examples could not be followed directly and might lead to compile errors or confusion when implementing the Secretary pattern.


---

## 🛠️ Changes

### Secretary guides

**`secretary-agent.md` (EN)**

* Migrated from `SecretaryAgent` / `SecretaryConfig` to the current API:

  * `DefaultSecretaryBuilder`
  * `SecretaryCore`
  * `ChannelConnection`
  * `DefaultInput` / `DefaultOutput`
  * `SecretaryCommand`
* Reworked phase descriptions to map to message-driven operations.


**`secretary-agent.md` (ZH)**

* Same migration as the English guide.


### Agent overview docs

**`agents.md` (EN)**

* Updated Secretary example to the event-loop pattern.
* Renamed section to **Secretary Pattern**.
* Removed outdated builder-style example.

**`agents.md` (ZH)**

* Same update applied to the Chinese documentation.

### Root documentation

**`README.md` (EN)**

* Updated Secretary module references:

  * removed `SecretaryAgent`, `SecretaryConfig`
  * added `DefaultSecretaryBuilder`, `SecretaryCore`, `DefaultInput`, `DefaultOutput`.

**`README.md` (ZH)**

* Same updates applied to Chinese documentation.

### Pattern documentation

**`patterns.md` (EN)**

* Replaced old Secretary snippet with event-loop usage.

**`patterns.md` (ZH)**

* Same update applied to Chinese documentation.
---

## 🧪 How you Tested

```
cargo check --workspace
```

```
cargo test --workspace -q
```

```
cargo fmt --all -- --check
```


```
cargo clippy --workspace --all-targets -q
```
---

## 📸 Screenshots / Logs (if applicable)

<img width="1268" height="481" alt="image" src="https://github.com/user-attachments/assets/8bd8fddd-5378-40a4-8f7c-4dc2bf2467a2" />

---

## ⚠️ Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (describe below)

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [ ] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [x] Public APIs documented
- [x] README / docs updated (if needed)

### PR Hygiene
- [ ] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---