### PR TITLE
fix(coordination): track all workers in master-slave task_tracker

### DIFF
--- a/crates/mofa-foundation/src/coordination/mod.rs
+++ b/crates/mofa-foundation/src/coordination/mod.rs
@@ -26,9 +26,9 @@ pub struct AgentCoordinator {
     // 维护协同拓扑：角色→智能体ID列表
     // Maintain coordination topology: Role -> Agent ID list
     role_mapping: Arc<RwLock<HashMap<String, Vec<String>>>>,
-    // 维护任务状态：任务ID→执行智能体ID+状态
-    // Maintain task status: Task ID -> Executor Agent ID + Status
-    task_tracker: Arc<RwLock<HashMap<String, (String, TaskStatus)>>>,
+    // 维护任务状态：任务ID→执行智能体ID+状态（列表）
+    // Maintain task status: Task ID -> list of (Executor Agent ID, Status)
+    task_tracker: Arc<RwLock<HashMap<String, Vec<(String, TaskStatus)>>>>,
     // 优先级调度器
     // Priority scheduler
     scheduler: scheduler::PriorityScheduler,
@@ -98,12 +98,13 @@ impl AgentCoordinator {
             .await
             .map_err(|e| GlobalError::Other(e.to_string()))?;
 
-        // 4. 跟踪任务状态（简化示例）
-        // 4. Track task status (Simplified example)
+        // 4. 跟踪任务状态
+        // 4. Track task status for all workers
         if let AgentMessage::TaskRequest { task_id, .. } = task_msg {
             let mut tracker = self.task_tracker.write().await;
+            let entries = tracker.entry(task_id.clone()).or_default();
             for worker_id in workers {
-                tracker.insert(task_id.clone(), (worker_id.clone(), TaskStatus::Pending));
+                entries.push((worker_id.clone(), TaskStatus::Pending));
             }
         }
         Ok(())


### PR DESCRIPTION
## Summary

Closes #1019

`master_slave_coordinate` tracks worker assignments in a `HashMap<String, (String, TaskStatus)>` keyed by `task_id`. The loop inserts the same `task_id` for each worker, so `HashMap::insert` overwrites on every iteration — only the last worker survives.

**Before:** `tracker.insert(task_id, (worker_id, Pending))` in a loop → last worker wins
**After:** `tracker.entry(task_id).or_default().push((worker_id, Pending))` → all workers tracked

Changed the value type to `Vec<(String, TaskStatus)>` so each task maps to a list of `(worker_id, status)` pairs.

## Test plan

- [x] `cargo check -p mofa-foundation` passes
- [x] All 7 existing coordination/scheduler tests pass
- [x] No other code reads from `task_tracker`, so the type change has zero downstream impact