### PR TITLE
feat(testing): add assertion macros for mock verification

### DIFF
--- a/tests/src/assertions.rs
+++ b/tests/src/assertions.rs
@@ -1,0 +1,86 @@
+//! Convenience assertion macros for mock verification.
+//!
+//! Reduces boilerplate when checking that mocks were called as expected.
+
+/// Assert the named tool was called at least once.
+///
+/// # Example
+/// ```ignore
+/// assert_tool_called!(tool, "search");
+/// ```
+#[macro_export]
+macro_rules! assert_tool_called {
+    ($tool:expr, $name:expr) => {{
+        use mofa_foundation::agent::components::tool::SimpleTool as _;
+        assert_eq!(
+            $tool.name(),
+            $name,
+            "Tool name mismatch: expected '{}', got '{}'",
+            $name,
+            $tool.name()
+        );
+        let count = $tool.call_count().await;
+        assert!(
+            count > 0,
+            "Expected tool '{}' to be called at least once, but it was never called",
+            $name
+        );
+    }};
+}
+
+/// Assert the tool received a call with the given JSON arguments.
+///
+/// # Example
+/// ```ignore
+/// assert_tool_called_with!(tool, json!({"query": "rust"}));
+/// ```
+#[macro_export]
+macro_rules! assert_tool_called_with {
+    ($tool:expr, $args:expr) => {{
+        let history = $tool.history().await;
+        let expected = $args;
+        assert!(
+            history.iter().any(|h| h.arguments == expected),
+            "Expected tool to be called with arguments {:?}, but no matching call found in history: {:?}",
+            expected,
+            history.iter().map(|h| &h.arguments).collect::<Vec<_>>()
+        );
+    }};
+}
+
+/// Assert the LLM backend's `infer()` was called at least once.
+///
+/// # Example
+/// ```ignore
+/// assert_infer_called!(backend);
+/// ```
+#[macro_export]
+macro_rules! assert_infer_called {
+    ($backend:expr) => {{
+        let count = $backend.call_count();
+        assert!(
+            count > 0,
+            "Expected LLM backend infer() to be called at least once, but call_count is 0"
+        );
+    }};
+}
+
+/// Assert a bus message was sent by the given sender.
+///
+/// # Example
+/// ```ignore
+/// assert_bus_message_sent!(bus, "agent-1");
+/// ```
+#[macro_export]
+macro_rules! assert_bus_message_sent {
+    ($bus:expr, $sender_id:expr) => {{
+        let messages = $bus.captured_messages.read().await;
+        let found = messages.iter().any(|(sid, _, _)| sid == $sender_id);
+        assert!(
+            found,
+            "Expected a message from sender '{}', but none found among {} captured message(s)",
+            $sender_id,
+            messages.len()
+        );
+    }};
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -3,6 +3,7 @@
 //! Provides mock implementations, failure injection, and deterministic time
 //! control for testing MoFA agents.
 
+pub mod assertions;
 pub mod backend;
 pub mod bus;
 pub mod clock;

--- a/tests/src/tools.rs
+++ b/tests/src/tools.rs
@@ -137,7 +137,7 @@ impl SimpleTool for MockTool {
 
 /// Assert that a [`MockTool`] was called exactly `$expected` times.
 #[macro_export]
-macro_rules! assert_tool_called {
+macro_rules! assert_tool_call_count {
     ($tool:expr, $expected_count:expr) => {{
         use mofa_foundation::agent::components::tool::SimpleTool as _;
         let count = $tool.call_count().await;

--- a/tests/tests/assertion_macro_tests.rs
+++ b/tests/tests/assertion_macro_tests.rs
@@ -1,0 +1,120 @@
+//! Tests for assertion macros: assert_tool_called!, assert_tool_called_with!,
+//! assert_infer_called!, assert_bus_message_sent!.
+
+use mofa_foundation::agent::components::tool::SimpleTool;
+use mofa_foundation::orchestrator::{ModelOrchestrator, ModelProviderConfig, ModelType};
+use mofa_kernel::agent::components::tool::ToolInput;
+use mofa_kernel::bus::CommunicationMode;
+use mofa_kernel::message::AgentMessage;
+use mofa_testing::backend::MockLLMBackend;
+use mofa_testing::bus::MockAgentBus;
+use mofa_testing::tools::MockTool;
+use serde_json::json;
+use std::collections::HashMap;
+
+fn make_config(name: &str) -> ModelProviderConfig {
+    ModelProviderConfig {
+        model_name: name.into(),
+        model_path: "/mock".into(),
+        device: "cpu".into(),
+        model_type: ModelType::Llm,
+        max_context_length: None,
+        quantization: None,
+        extra_config: HashMap::new(),
+    }
+}
+
+// ===================================================================
+// assert_tool_called!
+// ===================================================================
+
+#[tokio::test]
+async fn assert_tool_called_passes_when_tool_was_called() {
+    let tool = MockTool::new("search", "Search tool", json!({"type": "object"}));
+    tool.execute(ToolInput::from_json(json!({"q": "rust"}))).await;
+
+    mofa_testing::assert_tool_called!(tool, "search");
+}
+
+#[tokio::test]
+#[should_panic(expected = "to be called at least once")]
+async fn assert_tool_called_panics_when_tool_never_called() {
+    let tool = MockTool::new("search", "Search tool", json!({"type": "object"}));
+    mofa_testing::assert_tool_called!(tool, "search");
+}
+
+// ===================================================================
+// assert_tool_called_with!
+// ===================================================================
+
+#[tokio::test]
+async fn assert_tool_called_with_passes_on_matching_arguments() {
+    let tool = MockTool::new("search", "Search tool", json!({"type": "object"}));
+    tool.execute(ToolInput::from_json(json!({"query": "rust"}))).await;
+
+    mofa_testing::assert_tool_called_with!(tool, json!({"query": "rust"}));
+}
+
+#[tokio::test]
+#[should_panic(expected = "no matching call found")]
+async fn assert_tool_called_with_panics_on_mismatched_arguments() {
+    let tool = MockTool::new("search", "Search tool", json!({"type": "object"}));
+    tool.execute(ToolInput::from_json(json!({"query": "python"}))).await;
+
+    mofa_testing::assert_tool_called_with!(tool, json!({"query": "rust"}));
+}
+
+// ===================================================================
+// assert_infer_called!
+// ===================================================================
+
+#[tokio::test]
+async fn assert_infer_called_passes_after_infer_call() {
+    let backend = MockLLMBackend::new();
+    backend.add_response("hi", "hello");
+    backend.register_model(make_config("m")).await.unwrap();
+    backend.load_model("m").await.unwrap();
+    backend.infer("m", "hi").await.unwrap();
+
+    mofa_testing::assert_infer_called!(backend);
+}
+
+#[tokio::test]
+#[should_panic(expected = "call_count is 0")]
+async fn assert_infer_called_panics_when_call_count_is_zero() {
+    let backend = MockLLMBackend::new();
+    mofa_testing::assert_infer_called!(backend);
+}
+
+// ===================================================================
+// assert_bus_message_sent!
+// ===================================================================
+
+#[tokio::test]
+async fn assert_bus_message_sent_passes_when_sender_matches() {
+    let bus = MockAgentBus::new();
+    let msg = AgentMessage::TaskRequest {
+        task_id: "t-1".into(),
+        content: "ping".into(),
+    };
+    let _ = bus
+        .send_and_capture("agent-1", CommunicationMode::Broadcast, msg)
+        .await;
+
+    mofa_testing::assert_bus_message_sent!(bus, "agent-1");
+}
+
+#[tokio::test]
+#[should_panic(expected = "Expected a message from sender")]
+async fn assert_bus_message_sent_panics_when_no_message_from_sender() {
+    let bus = MockAgentBus::new();
+    let msg = AgentMessage::TaskRequest {
+        task_id: "t-1".into(),
+        content: "ping".into(),
+    };
+    let _ = bus
+        .send_and_capture("agent-1", CommunicationMode::Broadcast, msg)
+        .await;
+
+    mofa_testing::assert_bus_message_sent!(bus, "agent-2");
+}

--- a/tests/tests/integration.rs
+++ b/tests/tests/integration.rs
@@ -239,5 +239,5 @@ async fn tool_assert_macro_passes() {
     tool.execute(ToolInput::from_json(json!({}))).await;
     tool.execute(ToolInput::from_json(json!({}))).await;
 
-    mofa_testing::assert_tool_called!(tool, 2);
+    mofa_testing::assert_tool_call_count!(tool, 2);
 }


### PR DESCRIPTION
##  Summary

Add convenience macros (`assert_tool_called!`, `assert_tool_called_with!`, `assert_infer_called!`, `assert_bus_message_sent!`) that wrap existing mock history checks into one-line assertions. Reduces boilerplate in test code.

##  Related Issues

Closes #1017

---

##  Changes

- **New file:** `tests/src/assertions.rs` — 4 assertion macros
- **Renamed:** existing `assert_tool_called!` to `assert_tool_call_count!` to avoid name collisions
- **Updated:** `tests/src/lib.rs` to export `pub mod assertions`
- **New tests:** `tests/tests/assertion_macro_tests.rs` (8 tests)

---
##   Tested

1. `cargo test -p mofa-testing --test assertion_macro_tests` — **8 tests pass**
2. Verified pass/fail paths for all 4 macros using `#[should_panic]`


##  Checklist

- [x] Code follows Rust idioms and project conventions
- [x] `cargo clippy` passes without warnings
- [x] Tests added/updated
- [x] `cargo test` passes locally
```
