### PR TITLE
feat(testing): add MockTool last_call() and nth_call() helpers

### DIFF
--- a/tests/src/tools.rs
+++ b/tests/src/tools.rs
@@ -74,6 +74,16 @@ impl MockTool {
             .push((input_pattern, error_msg.to_string()));
     }
 
+    /// Returns the most recent call's input, or `None` if never called.
+    pub async fn last_call(&self) -> Option<ToolInput> {
+        self.call_history.read().await.last().cloned()
+    }
+
+    /// Returns the Nth call (0-indexed), or `None` if out of bounds.
+    pub async fn nth_call(&self, n: usize) -> Option<ToolInput> {
+        self.call_history.read().await.get(n).cloned()
+    }
+
     /// Add a sequence of results. Each call consumes the next entry;
     /// when exhausted, falls back to `stubbed_result`.
     pub async fn add_result_sequence(&self, results: Vec<ToolResult>) {

--- a/tests/tests/accessor_helpers_tests.rs
+++ b/tests/tests/accessor_helpers_tests.rs
@@ -1,0 +1,59 @@
+//! Tests for MockTool accessor helpers: last_call(), nth_call()
+
+use mofa_foundation::agent::components::tool::SimpleTool;
+use mofa_kernel::agent::components::tool::ToolInput;
+use mofa_testing::tools::MockTool;
+use serde_json::json;
+
+#[tokio::test]
+async fn last_call_returns_none_when_never_called() {
+    let tool = MockTool::new("test", "test", json!({}));
+    assert!(tool.last_call().await.is_none());
+}
+
+#[tokio::test]
+async fn last_call_returns_most_recent_call() {
+    let tool = MockTool::new("test", "test", json!({}));
+    tool.execute(ToolInput::from_json(json!({"id": 1}))).await;
+    tool.execute(ToolInput::from_json(json!({"id": 2}))).await;
+
+    let last = tool.last_call().await.unwrap();
+    assert_eq!(last.arguments, json!({"id": 2}));
+}
+
+#[tokio::test]
+async fn nth_call_returns_first_call() {
+    let tool = MockTool::new("test", "test", json!({}));
+    tool.execute(ToolInput::from_json(json!({"id": 1}))).await;
+    tool.execute(ToolInput::from_json(json!({"id": 2}))).await;
+
+    let first = tool.nth_call(0).await.unwrap();
+    assert_eq!(first.arguments, json!({"id": 1}));
+}
+
+#[tokio::test]
+async fn nth_call_returns_none_for_out_of_bounds() {
+    let tool = MockTool::new("test", "test", json!({}));
+    tool.execute(ToolInput::from_json(json!({"id": 1}))).await;
+    assert!(tool.nth_call(1).await.is_none());
+}
+
+#[tokio::test]
+async fn nth_call_works_after_interleaved_failures() {
+    let tool = MockTool::new("test", "test", json!({}));
+    tool.fail_next(1, "error").await;
+
+    // Call 0 (fails)
+    let res1 = tool.execute(ToolInput::from_json(json!({"id": 1}))).await;
+    assert!(!res1.success);
+
+    // Call 1 (succeeds)
+    let res2 = tool.execute(ToolInput::from_json(json!({"id": 2}))).await;
+    assert!(res2.success);
+
+    let first = tool.nth_call(0).await.unwrap();
+    let second = tool.nth_call(1).await.unwrap();
+
+    assert_eq!(first.arguments, json!({"id": 1}));
+    assert_eq!(second.arguments, json!({"id": 2}));
+}


### PR DESCRIPTION
## Summary

Add `last_call()` and `nth_call(n)` convenience methods to `MockTool` so tests don't have to manually index into the `history()` vector.

##  Related Issues

Closes #1018

---

##  Changes

- **`tests/src/tools.rs`** — Added `last_call()` and `nth_call(n)` methods to `MockTool` returning `Option<ToolInput>`
- **`tests/tests/accessor_helpers_tests.rs`** — **New** 5 integration tests

---

##  How you Tested

1. `cargo test -p mofa-testing --test accessor_helpers_tests` — **5 tests pass**
2. Tested out-of-bounds indexing, correct return values, and behavior following interleaved tool failures.

##  Checklist

- [x] Code follows Rust idioms and project conventions
- [x] `cargo clippy` passes without warnings
- [x] Tests added/updated
- [x] `cargo test` passes locally
```