### PR TITLE
chore: update cargo lock weekly

### DIFF
--- a/.github/workflows/update-cargo-lock.yml
+++ b/.github/workflows/update-cargo-lock.yml
@@ -1,0 +1,78 @@
+name: Update Cargo.lock
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: update-cargo-lock
+  cancel-in-progress: true
+
+jobs:
+  update-lock:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run cargo update and capture summary
+        id: update
+        run: |
+          # Capture dry-run output for the PR body (cargo update prints to stderr)
+          SUMMARY=$(cargo update --dry-run 2>&1)
+          
+          # Write summary to GITHUB_OUTPUT safely
+          EOF=$(date +%s%N)
+          echo "summary<<$EOF" >> "$GITHUB_OUTPUT"
+          echo "$SUMMARY" >> "$GITHUB_OUTPUT"
+          echo "$EOF" >> "$GITHUB_OUTPUT"
+          
+          # Run actual cargo update
+          cargo update
+
+      - name: Check if Cargo.lock was modified
+        id: check
+        run: |
+          if git diff --exit-code Cargo.lock > /dev/null; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Cargo.lock is already up to date"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Cargo.lock has been modified"
+          fi
+
+      - name: Get current date
+        if: steps.check.outputs.changed == 'true'
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+
+      - name: Create Pull Request
+        if: steps.check.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/update-cargo-lock-${{ steps.date.outputs.date }}
+          commit-message: 'chore(deps): update Cargo.lock'
+          title: 'chore(deps): weekly Cargo.lock update'
+          body: |
+            Automated weekly `Cargo.lock` update.
+            
+            <details>
+            <summary>Update Summary (from `cargo update --dry-run`)</summary>
+            
+            ```text
+            ${{ steps.update.outputs.summary }}
+            ```
+            </details>
+          labels: dependencies


### PR DESCRIPTION
## Summary
Adds a weekly scheduled workflow that runs `cargo update` and opens a PR
with the refreshed Cargo.lock whenever dependencies have changed.

## Motivation
Dependabot updates individual `Cargo.toml` version constraints, but does
not run `cargo update` to pull in compatible patch-level updates within
existing constraints. This job fills that gap.

## Changes
- Added `.github/workflows/update-cargo-lock.yml`
  - Triggers every Monday at 06:00 UTC + `workflow_dispatch`
  - Runs `cargo update`, checks for diff, opens a PR if changed
  - Uses `peter-evans/create-pull-request@v6` for PR creation
  - Labels PR with `dependencies`, branches as `chore/update-cargo-lock-<date>`

## Related Issues
closes #1044 
## Testing
Triggered manually via `workflow_dispatch` and verified PR creation on a
branch with a stale Cargo.lock.

## Checklist
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-features -- -D errors` passes
- [x] `cargo test --workspace --all-features` passes
- [x] `cargo build --examples` succeeds
- [x] `cargo doc --workspace --no-deps --all-features` succeeds
