### PR TITLE
refactor(workflow): deduplicate routing logic between invoke() and stream()

### DIFF
--- a/crates/mofa-foundation/src/workflow/state_graph.rs
+++ b/crates/mofa-foundation/src/workflow/state_graph.rs
@@ -447,8 +447,16 @@ impl<S: GraphState> CompiledGraphImpl<S> {
             .collect()
     }
 
-    /// Get the next node(s) based on the current node and command
-    fn get_next_nodes(&self, current_node: &str, command: &Command) -> AgentResult<Vec<String>> {
+    /// Determine the next node(s) based on the current node, its command, and the
+    /// graph edge map.
+    ///
+    /// This is a **static** helper so that both `invoke()` and `stream()` share
+    /// a single routing implementation (see issue #1053).
+    fn resolve_next_nodes(
+        edges: &HashMap<NodeId, EdgeTarget>,
+        current_node: &str,
+        command: &Command,
+    ) -> AgentResult<Vec<String>> {
         match &command.control {
             ControlFlow::Goto(target) => Ok(vec![target.clone()]),
             ControlFlow::Return => {
@@ -460,7 +468,7 @@ impl<S: GraphState> CompiledGraphImpl<S> {
             }
             ControlFlow::Continue => {
                 // Follow graph edges
-                match self.edges.get(current_node) {
+                match edges.get(current_node) {
                     Some(EdgeTarget::Single(target)) => Ok(vec![target.clone()]),
                     Some(EdgeTarget::Parallel(targets)) => Ok(targets.clone()),
                     Some(EdgeTarget::Conditional(routes)) => {
@@ -591,7 +599,7 @@ impl<S: GraphState> CompiledGraphImpl<S> {
                 self.apply_updates(&mut state, &command.updates).await?;
 
                 // Get next nodes
-                current_nodes = self.get_next_nodes(&node_id, &command)?;
+                current_nodes = Self::resolve_next_nodes(&self.edges, &node_id, &command)?;
 
                 debug!(
                     "Node '{}' completed, next nodes: {:?}",
@@ -614,7 +622,7 @@ impl<S: GraphState> CompiledGraphImpl<S> {
                     self.apply_updates(&mut state, &command.updates).await?;
 
                     // Collect next nodes
-                    let next = self.get_next_nodes(&node_id, &command)?;
+                    let next = Self::resolve_next_nodes(&self.edges, &node_id, &command)?;
                     next_nodes.extend(next);
                 }
 
@@ -693,56 +701,7 @@ impl<S: GraphState + 'static> CompiledGraph<S, serde_json::Value> for CompiledGr
                 let mut state = input;
                 let mut current_nodes = vec![entry_point];
                 let default_policy = NodePolicy::default();
-
-            // Helper function to get next nodes based on command and edges
-            let get_next_nodes = |current_node: &str, command: &Command| -> AgentResult<Vec<String>> {
-                match &command.control {
-                    ControlFlow::Goto(target) => Ok(vec![target.clone()]),
-                    ControlFlow::Return => Ok(vec![]), // End execution
-                    ControlFlow::Send(sends) => {
-                        // MapReduce: create branches for each send target
-                        Ok(sends.iter().map(|s| s.target.clone()).collect())
-                    }
-                    ControlFlow::Continue => {
-                        // Follow graph edges
-                        match edges.get(current_node) {
-                            Some(EdgeTarget::Single(target)) => Ok(vec![target.clone()]),
-                            Some(EdgeTarget::Parallel(targets)) => Ok(targets.clone()),
-                            Some(EdgeTarget::Conditional(routes)) => {
-                                // Priority 1: explicit route decision
-                                if let Some(decision) = command.route_value()
-                                    && let Some(target) = routes.get(decision)
-                                {
-                                    return Ok(vec![target.clone()]);
-                                }
-                                // Priority 2: legacy key-name matching (backward compatible)
-                                for update in &command.updates {
-                                    if let Some(target) = routes.get(&update.key) {
-                                        return Ok(vec![target.clone()]);
-                                    }
-                                }
-                                // No route matched — report error instead of silent fallback
-                                let update_keys: Vec<&str> = command.updates.iter().map(|u| u.key.as_str()).collect();
-                                let route_keys: Vec<&String> = routes.keys().collect();
-                                warn!(
-                                    node_id = current_node,
-                                    ?update_keys,
-                                    ?route_keys,
-                                    "Conditional routing: no route matched for node"
-                                );
-                                Err(AgentError::Internal(format!(
-                                    "No conditional route matched for node '{}': update keys {:?}, available routes {:?}",
-                                    current_node, update_keys, route_keys
-                                )))
-                            }
-                            None => Ok(vec![]),
-                            _ => Ok(vec![]),
-                        }
-                    }
-                    _ => Ok(vec![]),
-                }
-            };
-
+            // Use the shared static routing method (see issue #1053)
             while !current_nodes.is_empty() {
                 // Check recursion limit
                 if ctx.is_recursion_limit_reached().await {
@@ -862,7 +821,7 @@ impl<S: GraphState + 'static> CompiledGraph<S, serde_json::Value> for CompiledGr
                         return;
                     }
 
-                    match get_next_nodes(&node_id, &command) {
+                    match CompiledGraphImpl::<S>::resolve_next_nodes(&edges, &node_id, &command) {
                         Ok(nodes) => next_nodes.extend(nodes),
                         Err(e) => {
                             let _ = tx
@@ -954,7 +913,7 @@ impl<S: GraphState + 'static> CompiledGraph<S, serde_json::Value> for CompiledGr
                             return;
                         }
 
-                        match get_next_nodes(&node_id, &command) {
+                        match CompiledGraphImpl::<S>::resolve_next_nodes(&edges, &node_id, &command) {
                             Ok(nodes) => next_nodes.extend(nodes),
                             Err(e) => {
                                 let _ = tx
@@ -1033,7 +992,7 @@ impl<S: GraphState + 'static> CompiledGraph<S, serde_json::Value> for CompiledGr
         self.apply_updates(&mut state, &command.updates).await?;
 
         // Get next nodes
-        let next_nodes = self.get_next_nodes(&node_id, &command)?;
+        let next_nodes = Self::resolve_next_nodes(&self.edges, &node_id, &command)?;
         let is_complete = next_nodes.is_empty();
         let next_node = next_nodes.into_iter().next();
 


### PR DESCRIPTION
## Summary

Extracts the duplicated routing logic from `CompiledGraphImpl` into a single shared static method `resolve_next_nodes()`, so that both `invoke()` and `stream()` use the same implementation.

**Closes #1053**

## Problem

The `stream()` method contained a **copy-pasted closure** (`get_next_nodes`, ~48 lines) that was identical to the `get_next_nodes(&self)` method used by `invoke()`. This meant any routing fix (e.g., #617 conditional routing fallthrough) had to be applied in two places — a maintenance hazard.

## Changes

### `crates/mofa-foundation/src/workflow/state_graph.rs`

- **Renamed** `get_next_nodes(&self, ...)` → `resolve_next_nodes(edges, ...)` — now a **static method** that accepts the edge map as a parameter
- **Removed** the 48-line duplicated closure from `stream()`
- **Updated all 5 call sites**:
  - `invoke()` single-node path (L609)
  - `invoke()` parallel path (L635)  
  - `stream()` single-node path (L843)
  - `stream()` parallel path (L935)
  - `step()` (L954)

## Stats

```
1 file changed, 17 insertions(+), 56 deletions(-)
```

Net reduction: **-39 lines**

## Testing

All **85 workflow tests pass** (0 failures), including the routing-specific tests:
- `test_conditional_routing_prefers_route_value_in_invoke`
- `test_conditional_routing_no_match_returns_error_invoke`
- `test_conditional_routing_no_match_returns_error_stream`
- `test_conditional_routing_stream_respects_route_value`
- `test_parallel_nodes_execute_concurrently_in_invoke`
- `test_parallel_nodes_use_state_snapshot_in_invoke_and_stream`

```
test result: ok. 85 passed; 0 failed; 0 ignored; 0 measured; 538 filtered out
```

Clippy: no new warnings on the modified file.