### PR TITLE
perf: regex cache in RuleBasedRouter, fix duration overflow in workfl…

### DIFF
--- a/crates/mofa-foundation/src/secretary/agent_router.rs
+++ b/crates/mofa-foundation/src/secretary/agent_router.rs
@@ -56,6 +56,7 @@ use mofa_kernel::agent::types::error::{GlobalError, GlobalResult};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::RwLock as StdRwLock;
 use tokio::sync::RwLock;
 
 // =============================================================================
@@ -808,6 +809,9 @@ pub enum ConditionLogic {
     Any,
 }
 
+/// Maximum number of compiled regex patterns to cache (avoids unbounded growth).
+const REGEX_CACHE_MAX_SIZE: usize = 64;
+
 /// 基于规则的路由器
 /// Rule-based Router
 pub struct RuleBasedRouter {
@@ -820,6 +824,8 @@ pub struct RuleBasedRouter {
     /// 是否需要人类确认规则匹配
     /// Whether to require human confirmation on rule match
     confirm_on_match: bool,
+    /// Cached compiled regexes (avoids recompiling on every rule check).
+    regex_cache: StdRwLock<HashMap<String, Arc<regex::Regex>>>,
 }
 
 impl RuleBasedRouter {
@@ -828,7 +834,34 @@ impl RuleBasedRouter {
             rules: Arc::new(RwLock::new(Vec::new())),
             default_agent_id: None,
             confirm_on_match: false,
+            regex_cache: StdRwLock::new(HashMap::new()),
         }
+    }
+
+    /// Returns a compiled regex for the pattern, using cache to avoid repeated compilation.
+    fn get_or_compile_regex(&self, pattern: &str) -> Option<Arc<regex::Regex>> {
+        {
+            let cache = self
+                .regex_cache
+                .read()
+                .unwrap_or_else(|e| e.into_inner());
+            if let Some(re) = cache.get(pattern) {
+                return Some(Arc::clone(re));
+            }
+        }
+        let re = regex::Regex::new(pattern).ok()?;
+        let re = Arc::new(re);
+        {
+            let mut cache = self
+                .regex_cache
+                .write()
+                .unwrap_or_else(|e| e.into_inner());
+            if cache.len() >= REGEX_CACHE_MAX_SIZE {
+                cache.clear();
+            }
+            cache.insert(pattern.to_string(), Arc::clone(&re));
+        }
+        Some(re)
     }
 
     pub fn with_default_agent(mut self, agent_id: impl Into<String>) -> Self {
@@ -885,7 +918,8 @@ impl RuleBasedRouter {
             RuleOperator::NotContains => !field_value.contains(&condition.value),
             RuleOperator::StartsWith => field_value.starts_with(&condition.value),
             RuleOperator::EndsWith => field_value.ends_with(&condition.value),
-            RuleOperator::Regex => regex::Regex::new(&condition.value)
+            RuleOperator::Regex => self
+                .get_or_compile_regex(&condition.value)
                 .map(|re| re.is_match(&field_value))
                 .unwrap_or(false),
             RuleOperator::In => condition.value.split(',').any(|v| v.trim() == field_value),

--- a/crates/mofa-foundation/src/workflow/node.rs
+++ b/crates/mofa-foundation/src/workflow/node.rs
@@ -11,7 +11,14 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::time::Duration;
 use tracing::{debug, info, warn};
+
+/// Converts duration to u64 milliseconds, handling overflow per project standards.
+#[inline]
+fn duration_as_u64_ms(d: Duration) -> u64 {
+    u64::try_from(d.as_millis()).unwrap_or(u64::MAX)
+}
 
 /// 节点执行函数类型
 /// Node execution function type
@@ -686,12 +693,12 @@ impl WorkflowNode {
             NodeType::Start => {
                 // 开始节点直接传递输入
                 // Start node simply passes input through
-                NodeResult::success(node_id, input, start_time.elapsed().as_millis() as u64)
+                NodeResult::success(node_id, input, duration_as_u64_ms(start_time.elapsed()))
             }
             NodeType::End => {
                 // 结束节点直接传递输入
                 // End node simply passes input through
-                NodeResult::success(node_id, input, start_time.elapsed().as_millis() as u64)
+                NodeResult::success(node_id, input, duration_as_u64_ms(start_time.elapsed()))
             }
             NodeType::Task | NodeType::Agent => {
                 self.execute_with_retry(ctx, input, start_time).await
@@ -706,7 +713,7 @@ impl WorkflowNode {
                     NodeResult::success(
                         node_id,
                         WorkflowValue::String(branch.to_string()),
-                        start_time.elapsed().as_millis() as u64,
+                        duration_as_u64_ms(start_time.elapsed()),
                     )
                 } else {
                     NodeResult::failed(node_id, "No condition function", 0)
@@ -723,7 +730,7 @@ impl WorkflowNode {
                             .map(|b| WorkflowValue::String(b.clone()))
                             .collect(),
                     ),
-                    start_time.elapsed().as_millis() as u64,
+                    duration_as_u64_ms(start_time.elapsed()),
                 )
             }
             NodeType::Join => {
@@ -747,7 +754,7 @@ impl WorkflowNode {
                     WorkflowValue::Map(outputs)
                 };
 
-                NodeResult::success(node_id, result, start_time.elapsed().as_millis() as u64)
+                NodeResult::success(node_id, result, duration_as_u64_ms(start_time.elapsed()))
             }
             NodeType::Loop => self.execute_loop(ctx, input, start_time).await,
             NodeType::Transform => {
@@ -755,7 +762,7 @@ impl WorkflowNode {
                     let mut inputs = HashMap::new();
                     inputs.insert("input".to_string(), input);
                     let result = transform_fn(inputs).await;
-                    NodeResult::success(node_id, result, start_time.elapsed().as_millis() as u64)
+                    NodeResult::success(node_id, result, duration_as_u64_ms(start_time.elapsed()))
                 } else {
                     NodeResult::failed(node_id, "No transform function", 0)
                 }
@@ -763,12 +770,12 @@ impl WorkflowNode {
             NodeType::SubWorkflow => {
                 // 子工作流执行由 executor 处理
                 // Sub-workflow execution handled by executor
-                NodeResult::success(node_id, input, start_time.elapsed().as_millis() as u64)
+                NodeResult::success(node_id, input, duration_as_u64_ms(start_time.elapsed()))
             }
             NodeType::Wait => {
                 // 等待节点由 executor 处理
                 // Wait node handled by executor
-                NodeResult::success(node_id, input, start_time.elapsed().as_millis() as u64)
+                NodeResult::success(node_id, input, duration_as_u64_ms(start_time.elapsed()))
             }
         }
     }
@@ -796,7 +803,7 @@ impl WorkflowNode {
                     let mut result = NodeResult::success(
                         node_id,
                         output,
-                        start_time.elapsed().as_millis() as u64,
+                        duration_as_u64_ms(start_time.elapsed()),
                     );
                     result.retry_count = retry_count;
                     return result;
@@ -817,7 +824,7 @@ impl WorkflowNode {
                         let mut result = NodeResult::failed(
                             node_id,
                             &e,
-                            start_time.elapsed().as_millis() as u64,
+                            duration_as_u64_ms(start_time.elapsed()),
                         );
                         result.retry_count = retry_count;
                         return result;
@@ -875,7 +882,7 @@ impl WorkflowNode {
                     return NodeResult::failed(
                         node_id,
                         &format!("Loop failed at iteration {}: {}", iteration, e),
-                        start_time.elapsed().as_millis() as u64,
+                        duration_as_u64_ms(start_time.elapsed()),
                     );
                 }
             }
@@ -887,7 +894,7 @@ impl WorkflowNode {
             warn!("Loop {} reached max iterations: {}", node_id, max_iter);
         }
 
-        NodeResult::success(node_id, input, start_time.elapsed().as_millis() as u64)
+        NodeResult::success(node_id, input, duration_as_u64_ms(start_time.elapsed()))
     }
 }
 


### PR DESCRIPTION
# perf: regex cache in RuleBasedRouter, duration overflow safety in workflow node

## Summary

Two focused improvements: (1) cache compiled regexes in `RuleBasedRouter` to avoid recompilation on every rule check, and (2) handle duration-to-u64 overflow explicitly in workflow node latency reporting per project standards.

## Changes

### 1. Regex cache in RuleBasedRouter

**mofa-foundation** (`secretary/agent_router.rs`):

- Add bounded regex cache (`REGEX_CACHE_MAX_SIZE = 64`) using `StdRwLock<HashMap<String, Arc<regex::Regex>>>`
- Add `get_or_compile_regex()` to cache compiled patterns; evict all when full
- Replace `RuleOperator::Regex` path from `regex::Regex::new(&condition.value)` on every check to cached lookup
- Use `.unwrap_or_else(|e| e.into_inner())` for lock poison recovery on the cache

Routing rules with `RuleOperator::Regex` recompiled the pattern on every condition match. With many rules or frequent routing, this was wasteful. The cache avoids repeated compilation for repeated patterns.

### 2. Duration overflow safety in workflow node

**mofa-foundation** (`workflow/node.rs`):

- Add `duration_as_u64_ms(d: Duration) -> u64` using `u64::try_from(d.as_millis()).unwrap_or(u64::MAX)`
- Replace all `start_time.elapsed().as_millis() as u64` with `duration_as_u64_ms(start_time.elapsed())`

Per project standards: *"Numeric type conversions **MUST** explicitly handle potential overflow"*. `Duration::as_millis()` returns `u128`; a direct `as u64` cast can overflow. The helper uses `try_from` and falls back to `u64::MAX` on overflow.

## Files changed

| Crate          | File                         | Change                                                                 |
|----------------|------------------------------|-----------------------------------------------------------------------|
| mofa-foundation | `secretary/agent_router.rs`  | Regex cache for `RuleOperator::Regex`, lock poison recovery           |
| mofa-foundation | `workflow/node.rs`           | `duration_as_u64_ms()` helper, overflow-safe duration conversions     |

## Testing

- `cargo check -p mofa-foundation` succeeds
- No intended behavioral changes; existing tests remain valid
