### PR TITLE
fix(foundation): stream ReAct steps in real-time during RunTaskStreaming

### DIFF
--- a/crates/mofa-foundation/src/react/actor.rs
+++ b/crates/mofa-foundation/src/react/actor.rs
@@ -258,19 +258,9 @@ async fn handle_message(
             // Execute task with step callbacks
             let result = match state.ensure_agent().await {
                 Ok(agent) => {
-                    // 运行任务
-                    // Run the task
-                    let result = agent.run(&task).await;
-
-                    // 发送所有步骤
-                    // Send all the steps
-                    if let Ok(ref res) = result {
-                        for step in &res.steps {
-                            let _ = step_tx.send(step.clone()).await;
-                        }
-                    }
-
-                    result
+                    // 使用流式方法运行任务 — 步骤在产生时实时发送
+                    // Use streaming method — steps are sent as they are produced
+                    agent.run_streaming(&task, step_tx).await
                 }
                 Err(e) => Err(e),
             };

--- a/crates/mofa-foundation/src/react/core.rs
+++ b/crates/mofa-foundation/src/react/core.rs
@@ -469,6 +469,105 @@ impl ReActAgent {
         ))
     }
 
+    /// 执行任务并实时流式返回步骤
+    /// Execute task and stream steps in real-time
+    pub async fn run_streaming(
+        &self,
+        task: impl Into<String>,
+        step_tx: tokio::sync::mpsc::Sender<ReActStep>,
+    ) -> LLMResult<ReActResult> {
+        let task = task.into();
+        let task_id = uuid::Uuid::now_v7().to_string();
+        let start_time = std::time::Instant::now();
+
+        let mut steps = Vec::new();
+        let mut step_number = 0;
+
+        let system_prompt = self.build_system_prompt().await;
+        let mut conversation = vec![format!("Task: {}", task)];
+
+        for iteration in 0..self.config.max_iterations {
+            step_number += 1;
+
+            let prompt = self.build_prompt(&system_prompt, &conversation).await;
+            let response = self.llm.ask(&prompt).await?;
+            let parsed = self.parse_response(&response);
+
+            match parsed {
+                ParsedResponse::Thought(thought) => {
+                    let step = ReActStep::thought(&thought, step_number);
+                    // Stream step immediately as it is produced
+                    let _ = step_tx.send(step.clone()).await;
+                    steps.push(step);
+                    conversation.push(format!("Thought: {}", thought));
+
+                    if self.config.verbose {
+                        tracing::info!("Thought: {}", thought);
+                    }
+                }
+                ParsedResponse::Action { tool, input } => {
+                    let step = ReActStep::action(&tool, &input, step_number);
+                    let _ = step_tx.send(step.clone()).await;
+                    steps.push(step);
+                    conversation.push(format!("Action: {}[{}]", tool, input));
+
+                    if self.config.verbose {
+                        tracing::info!("Action: {}[{}]", tool, input);
+                    }
+
+                    // Execute tool
+                    step_number += 1;
+                    let observation = self.execute_tool(&tool, &input).await;
+                    let obs_step = ReActStep::observation(&observation, step_number);
+                    let _ = step_tx.send(obs_step.clone()).await;
+                    steps.push(obs_step);
+                    conversation.push(format!("Observation: {}", observation));
+
+                    if self.config.verbose {
+                        tracing::info!("Observation: {}", observation);
+                    }
+                }
+                ParsedResponse::FinalAnswer(answer) => {
+                    let step = ReActStep::final_answer(&answer, step_number);
+                    let _ = step_tx.send(step.clone()).await;
+                    steps.push(step);
+
+                    if self.config.verbose {
+                        tracing::info!("Final Answer: {}", answer);
+                    }
+
+                    return Ok(ReActResult::success(
+                        task_id,
+                        &task,
+                        answer,
+                        steps,
+                        iteration + 1,
+                        start_time.elapsed().as_millis() as u64,
+                    ));
+                }
+                ParsedResponse::Error(err) => {
+                    return Ok(ReActResult::failed(
+                        task_id,
+                        &task,
+                        err,
+                        steps,
+                        iteration + 1,
+                        start_time.elapsed().as_millis() as u64,
+                    ));
+                }
+            }
+        }
+
+        Ok(ReActResult::failed(
+            task_id,
+            &task,
+            format!("Max iterations ({}) exceeded", self.config.max_iterations),
+            steps,
+            self.config.max_iterations,
+            start_time.elapsed().as_millis() as u64,
+        ))
+    }
+
     /// 构建系统提示词
     /// Build system prompt
     async fn build_system_prompt(&self) -> String {


### PR DESCRIPTION


## Summary

Fix the `RunTaskStreaming` handler in the ReAct Actor to stream steps in real-time as they are produced, instead of batching them all after execution completes.

## Motivation

The `RunTaskStreaming` message variant exists specifically to let consumers receive [ReActStep](cci:2://file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/react/core.rs:32:0-53:1)s incrementally as the agent reasons. However, the current implementation calls `agent.run()` (which collects all steps internally into a `Vec`), waits for it to finish, and *then* sends every step through the `mpsc` channel in a loop:

```rust
// ❌ Before — all steps arrive in a burst AFTER completion
let result = agent.run(&task).await;
if let Ok(ref res) = result {
    for step in &res.steps {
        let _ = step_tx.send(step.clone()).await;
    }
}
```

This defeats the purpose of streaming — the consumer sees nothing until the entire task is done, then receives every step at once.

## Changes

- **[core.rs](cci:7://file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/react/core.rs:0:0-0:0)** — Add `ReActAgent::run_streaming(&self, task, step_tx)` method that mirrors the existing [run()](cci:1://file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/react/actor.rs:485:4-533:5) loop but sends each step through the provided `mpsc::Sender<ReActStep>` immediately as it is produced (Thought, Action, Observation, FinalAnswer).
- **[actor.rs](cci:7://file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/react/actor.rs:0:0-0:0)** — Replace the run-then-forward pattern in the `RunTaskStreaming` handler with a single call to `agent.run_streaming(&task, step_tx).await`.

```rust
// ✅ After — steps stream in real-time
agent.run_streaming(&task, step_tx).await
```

## Related Issues

Closes the streaming steps bug in the ReAct Actor.

## Testing

1. `cargo check -p mofa-foundation` — compiles with zero warnings ✅
2. `cargo test -p mofa-foundation react` — all 14 tests pass ✅

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo check -p mofa-foundation` passes
- [x] `cargo test -p mofa-foundation react` passes (14/14)
- [x] Architecture layer rules respected (change is entirely within `mofa-foundation`)
- [x] No new dependencies added
- [x] PR is small and focused (one logical change, 2 files)
- [x] Commit message follows Conventional Commits
