### PR TITLE
fix(cli): avoid empty taskkill argument on Windows

### DIFF
--- a/crates/mofa-cli/src/utils/process_manager.rs
+++ b/crates/mofa-cli/src/utils/process_manager.rs
@@ -7,6 +7,17 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use tracing::{debug, info, warn};
 
+#[cfg(windows)]
+fn windows_taskkill_args(pid: u32, force: bool) -> Vec<String> {
+    let mut args = Vec::with_capacity(3);
+    if force {
+        args.push("/F".to_string());
+    }
+    args.push("/PID".to_string());
+    args.push(pid.to_string());
+    args
+}
+
 /// Manages agent runtime processes
 pub struct AgentProcessManager {
     /// Directory containing agent configurations
@@ -150,9 +161,7 @@ impl AgentProcessManager {
 
             // On Windows, use taskkill command
             let status = Command::new("taskkill")
-                .arg(if force { "/F" } else { "" })
-                .arg("/PID")
-                .arg(pid.to_string())
+                .args(windows_taskkill_args(pid, force))
                 .status()?;
 
             if status.success() {
@@ -266,5 +275,23 @@ mod tests {
         let manager = AgentProcessManager::new(temp_dir.path().to_path_buf());
         let result = manager.validate_config(&config_path);
         assert!(result.is_err());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_windows_taskkill_args_without_force_omits_empty_placeholder() {
+        assert_eq!(
+            windows_taskkill_args(4242, false),
+            vec!["/PID".to_string(), "4242".to_string()]
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_windows_taskkill_args_with_force_includes_force_flag() {
+        assert_eq!(
+            windows_taskkill_args(4242, true),
+            vec!["/F".to_string(), "/PID".to_string(), "4242".to_string()]
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes Windows agent termination command construction so `taskkill` is invoked without an empty placeholder argument when `force=false`.

Before:
- `stop_agent_by_pid(pid, false)` built `taskkill "" /PID <pid>`
- Windows command invocation included an unnecessary empty argument
- behavior was brittle and harder to reason about for non-force termination

After:
- `stop_agent_by_pid(pid, false)` builds `taskkill /PID <pid>`
- `stop_agent_by_pid(pid, true)` builds `taskkill /F /PID <pid>`
- Windows argument construction is covered by regression tests

## Related Issues

Closes #1060

---

## Context

`AgentProcessManager::stop_agent_by_pid()` used a placeholder empty string to skip `/F` when `force` was false. That produced a malformed-looking command shape on Windows and made process termination behavior more fragile than necessary.

This change makes the command construction explicit and adds a regression test so Windows termination behavior stays predictable.

---

## Changes

- Added a Windows-only helper to build `taskkill` arguments explicitly
- Updated `stop_agent_by_pid()` to use `.args(...)` instead of injecting an empty placeholder argument
- Added Windows regression tests for:
  - non-force termination argument construction
  - force termination argument construction

---

## How you Tested

1. Added focused regression tests for Windows `taskkill` argument construction.
2. Ran verification:
   - `cargo test -p mofa-cli --bin mofa test_windows_taskkill_args -- --nocapture`

```bash
cargo test -p mofa-cli --bin mofa test_windows_taskkill_args -- --nocapture
running 2 tests
test utils::process_manager::tests::test_windows_taskkill_args_with_force_includes_force_flag ... ok
test utils::process_manager::tests::test_windows_taskkill_args_without_force_omits_empty_placeholder ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 104 filtered out; finished in 0.00s
```

---

## Screenshots / Logs (if applicable)

```bash
running 2 tests
test utils::process_manager::tests::test_windows_taskkill_args_with_force_includes_force_flag ... ok
test utils::process_manager::tests::test_windows_taskkill_args_without_force_omits_empty_placeholder ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 104 filtered out; finished in 0.00s
```

---

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (describe below)

If breaking:

---

## Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [x] Public APIs documented
- [ ] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---

## Deployment Notes (if applicable)

No migration or configuration changes required.

---

## Additional Notes for Reviewers

- File touched: `crates/mofa-cli/src/utils/process_manager.rs`
- The new helper is Windows-only and exists to make the argument shape testable.
