### PR TITLE
fix(plugins): use char-boundary-safe truncation in shell and filesystem tools

### DIFF
--- a/crates/mofa-plugins/src/tools/filesystem.rs
+++ b/crates/mofa-plugins/src/tools/filesystem.rs
@@ -144,9 +144,15 @@ impl ToolExecutor for FileSystemTool {
             "read" => {
                 let content = fs::read_to_string(path).await?;
                 let truncated = if content.len() > 10000 {
+                    // Find the last valid char boundary at or before 10000
+                    // to avoid panicking on multi-byte UTF-8 characters.
+                    let mut end = 10000;
+                    while !content.is_char_boundary(end) {
+                        end -= 1;
+                    }
                     format!(
                         "{}... [truncated, total {} bytes]",
-                        &content[..10000],
+                        &content[..end],
                         content.len()
                     )
                 } else {

--- a/crates/mofa-plugins/src/tools/shell.rs
+++ b/crates/mofa-plugins/src/tools/shell.rs
@@ -109,11 +109,25 @@ impl ToolExecutor for ShellCommandTool {
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
 
+        let truncate = |s: String, limit: usize| -> String {
+            if s.len() > limit {
+                // Find the last valid char boundary at or before the limit
+                // to avoid panicking on multi-byte UTF-8 characters.
+                let mut end = limit;
+                while !s.is_char_boundary(end) {
+                    end -= 1;
+                }
+                format!("{}...[truncated]", &s[..end])
+            } else {
+                s
+            }
+        };
+
         Ok(json!({
             "success": output.status.success(),
             "exit_code": output.status.code(),
-            "stdout": if stdout.len() > 5000 { format!("{}...[truncated]", &stdout[..5000]) } else { stdout },
-            "stderr": if stderr.len() > 5000 { format!("{}...[truncated]", &stderr[..5000]) } else { stderr }
+            "stdout": truncate(stdout, 5000),
+            "stderr": truncate(stderr, 5000)
         }))
     }
 }


### PR DESCRIPTION
Closes #1064

## Problem

The shell tool truncates stdout/stderr at byte offset 5000 and the filesystem tool truncates file content at byte offset 10000 using direct slice indexing (`&s[..5000]`, `&content[..10000]`). Since `str::len()` returns byte count, not character count, these panic with `byte index N is not a char boundary` when the cutoff falls inside a multi-byte UTF-8 character.

Any shell command producing >5KB of output with non-ASCII characters (CJK, emoji, accented text) can trigger this, as can reading any file with multi-byte content over 10KB.

## Fix

Walk backwards from the byte limit to find the nearest valid char boundary before slicing, using `str::is_char_boundary()`. This is the same approach the http tool already uses (it has a `truncate_utf8` helper and a `truncates_utf8_without_panicking` test).

## Changes

- `tools/shell.rs` — extract truncation into a closure that respects char boundaries, apply to both stdout and stderr
- `tools/filesystem.rs` — add char boundary check before slicing file content