### PR TITLE
fix(gateway): guard against division by zero in Raft election timeout

### DIFF
--- a/crates/mofa-gateway/src/consensus/engine.rs
+++ b/crates/mofa-gateway/src/consensus/engine.rs
@@ -203,10 +203,14 @@ impl ConsensusEngine {
         // Use node ID hash to ensure different nodes get different timeouts
         // This prevents all nodes from timing out simultaneously
         let timeout_range = config.election_timeout_ms.1 - config.election_timeout_ms.0;
-        let mut hasher = DefaultHasher::new();
-        node_id.hash(&mut hasher);
-        let node_hash = hasher.finish();
-        let timeout_ms = config.election_timeout_ms.0 + (node_hash % timeout_range);
+        let timeout_ms = if timeout_range == 0 {
+            config.election_timeout_ms.0
+        } else {
+            let mut hasher = DefaultHasher::new();
+            node_id.hash(&mut hasher);
+            let node_hash = hasher.finish();
+            config.election_timeout_ms.0 + (node_hash % timeout_range)
+        };
         let timeout = Duration::from_millis(timeout_ms);
 
         debug!("Follower {} waiting {}ms for heartbeat", node_id, timeout_ms);


### PR DESCRIPTION
Closes #1066

## Problem

The follower loop in the Raft consensus engine calculates a randomized election timeout using `node_hash % timeout_range`. When `election_timeout_ms` is configured with equal min and max values (e.g. `(150, 150)` for a deterministic timeout), `timeout_range` is 0 and the modulo panics with division by zero.

This is a valid configuration — sometimes you want all nodes to use the same fixed election timeout (e.g. in testing or single-node setups).

## Fix

Skip the hash-based randomization when `timeout_range == 0` and use the fixed timeout value directly.