### PR TITLE
fix: Implement cooperative cancellation for ReAct Actor (Closes #951)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5894,6 +5894,7 @@ dependencies = [
  "tiktoken-rs",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "toml 0.8.23",
  "tracing",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ crossbeam-channel = "0.5"
 dashmap = "5.5"
 eyre = "0.6"
 flume = "0.10"
+tokio-util="0.7"
 
 # Hot-reload support
 notify = { version = "6.1", features = ["serde"] }

--- a/crates/mofa-foundation/Cargo.toml
+++ b/crates/mofa-foundation/Cargo.toml
@@ -57,6 +57,7 @@ tracing.workspace = true
 rand.workspace = true
 # YAML config parsing
 serde_yaml = "0.9"
+tokio-util.workspace=true
 
 # HTTP client (transcription + HTTP providers)
 reqwest = { workspace = true, features = [

--- a/crates/mofa-foundation/src/react/actor.rs
+++ b/crates/mofa-foundation/src/react/actor.rs
@@ -110,8 +110,8 @@ pub struct ReActActorState {
     current_task_id: Option<String>,
     /// 取消标志
     /// Cancellation flag
-    #[allow(dead_code)]
-    cancelled: bool,
+    /// cancellation token for the currently running task 
+    cancellation_token:Option<tokio_util::sync::CancellationToken>,
 }
 
 impl ReActActorState {
@@ -124,7 +124,7 @@ impl ReActActorState {
             is_running: false,
             completed_tasks: 0,
             current_task_id: None,
-            cancelled: false,
+            cancellation_token: None,
         }
     }
 
@@ -210,80 +210,83 @@ async fn handle_message(
     state: &mut ReActActorState,
 ) -> Result<(), ActorProcessingErr> {
     match message {
-        ReActMessage::RunTask { task, reply } => {
-            if state.is_running {
-                let _ = reply.send(Err(LLMError::Other(
-                    "Agent is already running a task".to_string(),
-                )));
-                return Ok(());
-            }
-
-            state.is_running = true;
-            state.cancelled = false;
-            state.current_task_id = Some(uuid::Uuid::now_v7().to_string());
-
-            let result = match state.ensure_agent().await {
-                Ok(agent) => agent.run(&task).await,
-                Err(e) => Err(e),
-            };
-
-            state.is_running = false;
-            state.current_task_id = None;
-
-            if result.is_ok() {
-                state.completed_tasks += 1;
-            }
-
-            let _ = reply.send(result);
+           ReActMessage::RunTask { task, reply } => {
+        if state.is_running {
+            let _ = reply.send(Err(LLMError::Other(
+                "Agent is already running a task".to_string(),
+            )));
+            return Ok(());
         }
 
-        ReActMessage::RunTaskStreaming {
-            task,
-            step_tx,
-            reply,
-        } => {
-            if state.is_running {
-                let _ = reply.send(Err(LLMError::Other(
-                    "Agent is already running a task".to_string(),
-                )));
-                return Ok(());
-            }
+        state.is_running = true;
+        
+        // Create token and store it
+        let token = tokio_util::sync::CancellationToken::new();
+        state.cancellation_token = Some(token.clone());
+        
+        state.current_task_id = Some(uuid::Uuid::now_v7().to_string());
 
-            state.is_running = true;
-            state.cancelled = false;
-            let task_id = uuid::Uuid::now_v7().to_string();
-            state.current_task_id = Some(task_id.clone());
+        let result = match state.ensure_agent().await {
+            Ok(agent) => agent.run_with_cancellation(&task, token).await,
+            Err(e) => Err(e),
+        };
 
-            // 执行带步骤回调的任务
-            // Execute task with step callbacks
-            let result = match state.ensure_agent().await {
-                Ok(agent) => {
-                    // 运行任务
-                    // Run the task
-                    let result = agent.run(&task).await;
+        state.is_running = false;
+        state.current_task_id = None;
+        state.cancellation_token = None;
 
-                    // 发送所有步骤
-                    // Send all the steps
-                    if let Ok(ref res) = result {
-                        for step in &res.steps {
-                            let _ = step_tx.send(step.clone()).await;
-                        }
+        if result.is_ok() {
+            state.completed_tasks += 1;
+        }
+
+        let _ = reply.send(result);
+    }
+
+            ReActMessage::RunTaskStreaming {
+        task,
+        step_tx,
+        reply,
+    } => {
+        if state.is_running {
+            let _ = reply.send(Err(LLMError::Other(
+                "Agent is already running a task".to_string(),
+            )));
+            return Ok(());
+        }
+
+        state.is_running = true;
+        
+        // Create token and store it
+        let token = tokio_util::sync::CancellationToken::new();
+        state.cancellation_token = Some(token.clone());
+        
+        let task_id = uuid::Uuid::now_v7().to_string();
+        state.current_task_id = Some(task_id.clone());
+
+        let result = match state.ensure_agent().await {
+            Ok(agent) => {
+                let result = agent.run_with_cancellation(&task, token).await;
+
+                if let Ok(ref res) = result {
+                    for step in &res.steps {
+                        let _ = step_tx.send(step.clone()).await;
                     }
-
-                    result
                 }
-                Err(e) => Err(e),
-            };
-
-            state.is_running = false;
-            state.current_task_id = None;
-
-            if result.is_ok() {
-                state.completed_tasks += 1;
+                result
             }
+            Err(e) => Err(e),
+        };
 
-            let _ = reply.send(result);
+        state.is_running = false;
+        state.current_task_id = None;
+        state.cancellation_token = None;
+
+        if result.is_ok() {
+            state.completed_tasks += 1;
         }
+
+        let _ = reply.send(result);
+    }
 
         ReActMessage::RegisterTool { tool } => {
             if let Some(ref agent) = state.agent {
@@ -312,7 +315,9 @@ async fn handle_message(
         }
 
         ReActMessage::CancelTask => {
-            state.cancelled = true;
+            if let Some(ref token)=state.cancellation_token{
+                token.cancel();
+            }
         }
 
         ReActMessage::Stop => {

--- a/crates/mofa-foundation/src/react/core.rs
+++ b/crates/mofa-foundation/src/react/core.rs
@@ -370,6 +370,8 @@ impl ReActAgent {
         tools.values().cloned().collect()
     }
 
+    
+  
     /// 执行任务
     /// Execute task
     pub async fn run(&self, task: impl Into<String>) -> LLMResult<ReActResult> {
@@ -468,6 +470,113 @@ impl ReActAgent {
             start_time.elapsed().as_millis() as u64,
         ))
     }
+
+      pub async fn run_with_cancellation(&self, task: impl Into<String>,cancel_token: tokio_util::sync::CancellationToken,) -> LLMResult<ReActResult> {
+        let task = task.into();
+        let task_id = uuid::Uuid::now_v7().to_string();
+        let start_time = std::time::Instant::now();
+
+        let mut steps = Vec::new();
+        let mut step_number = 0;
+
+        // 构建系统提示词
+        // Build system prompt
+        let system_prompt = self.build_system_prompt().await;
+
+        // 构建初始消息
+        // Build initial messages
+        let mut conversation = vec![format!("Task: {}", task)];
+
+        for iteration in 0..self.config.max_iterations {
+            step_number += 1;
+            if cancel_token.is_cancelled() {
+        return Ok(ReActResult::failed(
+            task_id, &task,
+            "Task was cancelled",
+            steps, iteration,
+            start_time.elapsed().as_millis() as u64,
+        ));
+    }
+
+            // 获取 LLM 响应
+            // Get LLM response
+            let prompt = self.build_prompt(&system_prompt, &conversation).await;
+            let response = self.llm.ask(&prompt).await?;
+
+            // 解析响应
+            // Parse response
+            let parsed = self.parse_response(&response);
+
+            match parsed {
+                ParsedResponse::Thought(thought) => {
+                    steps.push(ReActStep::thought(&thought, step_number));
+                    conversation.push(format!("Thought: {}", thought));
+
+                    if self.config.verbose {
+                        tracing::info!("Thought: {}", thought);
+                    }
+                }
+                ParsedResponse::Action { tool, input } => {
+                    steps.push(ReActStep::action(&tool, &input, step_number));
+                    conversation.push(format!("Action: {}[{}]", tool, input));
+
+                    if self.config.verbose {
+                        tracing::info!("Action: {}[{}]", tool, input);
+                    }
+
+                    // 执行工具
+                    // Execute tool
+                    step_number += 1;
+                    let observation = self.execute_tool(&tool, &input).await;
+                    steps.push(ReActStep::observation(&observation, step_number));
+                    conversation.push(format!("Observation: {}", observation));
+
+                    if self.config.verbose {
+                        tracing::info!("Observation: {}", observation);
+                    }
+                }
+                ParsedResponse::FinalAnswer(answer) => {
+                    steps.push(ReActStep::final_answer(&answer, step_number));
+
+                    if self.config.verbose {
+                        tracing::info!("Final Answer: {}", answer);
+                    }
+
+                    return Ok(ReActResult::success(
+                        task_id,
+                        &task,
+                        answer,
+                        steps,
+                        iteration + 1,
+                        start_time.elapsed().as_millis() as u64,
+                    ));
+                }
+                ParsedResponse::Error(err) => {
+                    return Ok(ReActResult::failed(
+                        task_id,
+                        &task,
+                        err,
+                        steps,
+                        iteration + 1,
+                        start_time.elapsed().as_millis() as u64,
+                    ));
+                }
+            }
+        }
+
+        // 达到最大迭代次数
+        // Max iterations reached
+        Ok(ReActResult::failed(
+            task_id,
+            &task,
+            format!("Max iterations ({}) exceeded", self.config.max_iterations),
+            steps,
+            self.config.max_iterations,
+            start_time.elapsed().as_millis() as u64,
+        ))
+    } 
+
+
 
     /// 构建系统提示词
     /// Build system prompt


### PR DESCRIPTION
## 📋 Summary
Fixes #951.The cancelled: bool field in ReActActorState was set but never read, making the cancel button non-functional.
Changes
Replaced cancelled: bool with tokio_util::sync::CancellationToken in ReActActorState.
Added run_with_cancellation method in core.rs to check for cancellation between ReAct steps.
Updated RunTask and RunTaskStreaming handlers to create tokens and pass them to the execution loop.
Updated CancelTask handler to trigger token.cancel().
Testing
cargo check passes.
cargo test --workspace passes.