### PR TITLE
feat(testing): add MockAgentBus message filter methods

### DIFF
--- a/tests/src/bus.rs
+++ b/tests/src/bus.rs
@@ -59,6 +59,54 @@ impl MockAgentBus {
         self.inner.send_message(sender_id, mode, &message).await
     }
 
+    /// All captured messages sent by the given sender.
+    pub async fn messages_from(
+        &self,
+        sender_id: &str,
+    ) -> Vec<(String, CommunicationMode, AgentMessage)> {
+        self.captured_messages
+            .read()
+            .await
+            .iter()
+            .filter(|(sid, _, _)| sid == sender_id)
+            .cloned()
+            .collect()
+    }
+
+    /// All captured messages addressed to the given recipient.
+    pub async fn messages_to(
+        &self,
+        recipient_id: &str,
+    ) -> Vec<(String, CommunicationMode, AgentMessage)> {
+        self.captured_messages
+            .read()
+            .await
+            .iter()
+            .filter(|(_, mode, _)| match mode {
+                CommunicationMode::PointToPoint(target) => target == recipient_id,
+                _ => false,
+            })
+            .cloned()
+            .collect()
+    }
+
+    /// All captured messages matching a predicate.
+    pub async fn messages_matching<F>(
+        &self,
+        predicate: F,
+    ) -> Vec<(String, CommunicationMode, AgentMessage)>
+    where
+        F: Fn(&str, &CommunicationMode, &AgentMessage) -> bool,
+    {
+        self.captured_messages
+            .read()
+            .await
+            .iter()
+            .filter(|(s, m, msg)| predicate(s, m, msg))
+            .cloned()
+            .collect()
+    }
+
     /// Number of messages captured so far.
     pub async fn message_count(&self) -> usize {
         self.captured_messages.read().await.len()

--- a/tests/tests/bus_filter_tests.rs
+++ b/tests/tests/bus_filter_tests.rs
@@ -1,0 +1,148 @@
+use mofa_kernel::bus::CommunicationMode;
+use mofa_kernel::message::AgentMessage;
+use mofa_testing::bus::MockAgentBus;
+
+#[tokio::test]
+async fn messages_from_returns_only_from_sender() {
+    let bus = MockAgentBus::new();
+    let msg = AgentMessage::TaskRequest {
+        task_id: "t1".into(),
+        content: "c".into(),
+    };
+    
+    let _ = bus.send_and_capture("a", CommunicationMode::Broadcast, msg.clone()).await;
+    let _ = bus.send_and_capture("b", CommunicationMode::Broadcast, msg.clone()).await;
+    let _ = bus.send_and_capture("a", CommunicationMode::Broadcast, msg.clone()).await;
+
+    let from_a = bus.messages_from("a").await;
+    assert_eq!(from_a.len(), 2);
+    assert_eq!(from_a[0].0, "a");
+    assert_eq!(from_a[1].0, "a");
+
+    let from_b = bus.messages_from("b").await;
+    assert_eq!(from_b.len(), 1);
+    assert_eq!(from_b[0].0, "b");
+}
+
+#[tokio::test]
+async fn messages_from_returns_empty_when_unknown() {
+    let bus = MockAgentBus::new();
+    let msg = AgentMessage::TaskRequest {
+        task_id: "t1".into(),
+        content: "c".into(),
+    };
+    
+    let _ = bus.send_and_capture("a", CommunicationMode::Broadcast, msg).await;
+
+    let from_c = bus.messages_from("c").await;
+    assert_eq!(from_c.len(), 0);
+}
+
+#[tokio::test]
+async fn messages_to_filters_by_recipient() {
+    let bus = MockAgentBus::new();
+    let msg = AgentMessage::TaskRequest {
+        task_id: "t1".into(),
+        content: "c".into(),
+    };
+    
+    let _ = bus.send_and_capture("a", CommunicationMode::PointToPoint("target1".into()), msg.clone()).await;
+    let _ = bus.send_and_capture("a", CommunicationMode::PointToPoint("target2".into()), msg.clone()).await;
+    let _ = bus.send_and_capture("a", CommunicationMode::Broadcast, msg.clone()).await;
+
+    let to_target1 = bus.messages_to("target1").await;
+    assert_eq!(to_target1.len(), 1);
+    
+    if let CommunicationMode::PointToPoint(t) = &to_target1[0].1 {
+        assert_eq!(t, "target1");
+    } else {
+        panic!("Expected PointToPoint");
+    }
+
+    let to_target2 = bus.messages_to("target2").await;
+    assert_eq!(to_target2.len(), 1);
+}
+
+#[tokio::test]
+async fn messages_to_returns_empty_when_no_messages() {
+    let bus = MockAgentBus::new();
+    let msg = AgentMessage::TaskRequest {
+        task_id: "t1".into(),
+        content: "c".into(),
+    };
+    
+    let _ = bus.send_and_capture("a", CommunicationMode::Broadcast, msg.clone()).await;
+    let _ = bus.send_and_capture("a", CommunicationMode::PointToPoint("target1".into()), msg).await;
+
+    let to_unknown = bus.messages_to("unknown").await;
+    assert_eq!(to_unknown.len(), 0);
+}
+
+#[tokio::test]
+async fn messages_matching_predicate() {
+    let bus = MockAgentBus::new();
+    let msg1 = AgentMessage::TaskRequest {
+        task_id: "t1".into(),
+        content: "foo".into(),
+    };
+    let msg2 = AgentMessage::TaskRequest {
+        task_id: "t2".into(),
+        content: "bar".into(),
+    };
+    
+    let _ = bus.send_and_capture("a", CommunicationMode::Broadcast, msg1).await;
+    let _ = bus.send_and_capture("b", CommunicationMode::Broadcast, msg2).await;
+
+    let matches = bus.messages_matching(|_, _, m| {
+        if let AgentMessage::TaskRequest { task_id, .. } = m {
+            task_id == "t2"
+        } else {
+            false
+        }
+    }).await;
+
+    assert_eq!(matches.len(), 1);
+    assert_eq!(matches[0].0, "b");
+}
+
+#[tokio::test]
+async fn messages_matching_returns_empty_when_no_match() {
+    let bus = MockAgentBus::new();
+    let msg1 = AgentMessage::TaskRequest {
+        task_id: "t1".into(),
+        content: "foo".into(),
+    };
+    
+    let _ = bus.send_and_capture("a", CommunicationMode::Broadcast, msg1).await;
+
+    let matches = bus.messages_matching(|_, _, m| {
+        if let AgentMessage::TaskRequest { task_id, .. } = m {
+            task_id == "t999"
+        } else {
+            false
+        }
+    }).await;
+
+    assert_eq!(matches.len(), 0);
+}
+
+#[tokio::test]
+async fn filters_work_after_fail_next_send() {
+    let bus = MockAgentBus::new();
+    bus.fail_next_send(1, "network error").await;
+
+    let msg = AgentMessage::TaskRequest {
+        task_id: "t1".into(),
+        content: "foo".into(),
+    };
+
+    let res = bus.send_and_capture("a", CommunicationMode::PointToPoint("target1".into()), msg).await;
+    assert!(res.is_err()); // Send failed
+
+    // But should still be captured and filterable
+    let from_a = bus.messages_from("a").await;
+    assert_eq!(from_a.len(), 1);
+
+    let to_target1 = bus.messages_to("target1").await;
+    assert_eq!(to_target1.len(), 1);
+}


### PR DESCRIPTION

<img width="3037" height="2439" alt="pr1083" src="https://github.com/user-attachments/assets/6a716cc5-05e8-4564-b4cb-5844138fac6e" />





##  Summary

Add `messages_from(sender)`, `messages_to(recipient)`, and `messages_matching(predicate)` filter methods to `MockAgentBus` for targeted message assertions.

## Related Issues

Closes #1080 

---

## 🛠️ Changes

- **`tests/src/bus.rs`** — Added `messages_from()`, `messages_to()`, `messages_matching()`
- **`tests/tests/bus_filter_tests.rs`** — **New** 7 tests

*Design Note:* `messages_to()` correctly filters by `CommunicationMode::PointToPoint(target)`, mapping to the actual underlying routing semantics of `mofa-kernel`'s `AgentMessage` bus routing.

---

##   Testing

1. `cargo test -p mofa-testing --test bus_filter_tests` — **7 tests pass**
2. Tested sender/target filtering, type-predicate matching, and state continuity after simulated `fail_next_send()` network failures.

---



##  Checklist

- [x] Code follows Rust idioms and project conventions
- [x] `cargo clippy` passes without warnings
- [x] Tests added/updated
- [x] `cargo test` passes locally
```

---
