### PR TITLE
fix(swarm): treat failed dependencies as terminal in ready_tasks()

### DIFF
--- a/crates/mofa-foundation/src/swarm/dag.rs
+++ b/crates/mofa-foundation/src/swarm/dag.rs
@@ -162,8 +162,12 @@ impl SubtaskDAG {
                         let dep_edge = edge.weight();
                         match dep_edge.kind {
                             DependencyKind::Sequential | DependencyKind::DataFlow => {
-                                dep.status == SubtaskStatus::Completed
-                                    || dep.status == SubtaskStatus::Skipped
+                                matches!(
+                                    dep.status,
+                                    SubtaskStatus::Completed
+                                        | SubtaskStatus::Skipped
+                                        | SubtaskStatus::Failed(_)
+                                )
                             }
                             DependencyKind::Soft => true,
                         }
@@ -590,6 +594,55 @@ mod tests {
         // c depends on b which is Running, so cascade should not reach c through b
         assert_eq!(skipped, 0);
         assert_eq!(dag.get_task(b).unwrap().status, SubtaskStatus::Running);
+    }
+
+    #[test]
+    fn test_failed_dependency_unblocks_downstream() {
+        let mut dag = SubtaskDAG::new("fail-chain");
+        let a = dag.add_task(SwarmSubtask::new("a", "Fetch data"));
+        let b = dag.add_task(SwarmSubtask::new("b", "Process data"));
+        let c = dag.add_task(SwarmSubtask::new("c", "Generate report"));
+
+        dag.add_dependency(a, b).unwrap();
+        dag.add_dependency(b, c).unwrap();
+
+        // Only a is ready initially
+        assert_eq!(dag.ready_tasks(), vec![a]);
+
+        // a fails — b should become ready (not stuck forever)
+        dag.mark_failed(a, "connection timeout");
+        let ready = dag.ready_tasks();
+        assert_eq!(ready, vec![b], "b must become ready when its dependency fails");
+
+        // b also fails — c should become ready
+        dag.mark_failed(b, "no input data");
+        let ready = dag.ready_tasks();
+        assert_eq!(ready, vec![c], "c must become ready when its dependency fails");
+
+        dag.mark_skipped(c);
+        assert!(dag.is_complete());
+    }
+
+    #[test]
+    fn test_failed_dependency_diamond_dag() {
+        let mut dag = SubtaskDAG::new("fail-diamond");
+        let a = dag.add_task(SwarmSubtask::new("a", "Start"));
+        let b = dag.add_task(SwarmSubtask::new("b", "Path 1"));
+        let c = dag.add_task(SwarmSubtask::new("c", "Path 2"));
+        let d = dag.add_task(SwarmSubtask::new("d", "Merge"));
+
+        dag.add_dependency(a, b).unwrap();
+        dag.add_dependency(a, c).unwrap();
+        dag.add_dependency(b, d).unwrap();
+        dag.add_dependency(c, d).unwrap();
+
+        dag.mark_complete(a);
+        dag.mark_complete(b);
+        dag.mark_failed(c, "path 2 error");
+
+        // d depends on both b (Completed) and c (Failed) — should be ready
+        let ready = dag.ready_tasks();
+        assert_eq!(ready, vec![d], "d must become ready when all deps are terminal");
     }
 
     #[test]


### PR DESCRIPTION
Closes #1088

## Problem

`ready_tasks()` only considers `Completed` and `Skipped` as satisfied dependency states, but `is_complete()` treats `Failed` as terminal too. This creates a deadlock: when any task in a sequential chain fails, all downstream tasks are permanently stuck in `Pending` — they can never become ready, yet the DAG never completes.

Any real swarm execution where a single subtask fails will silently hang forever.

## Fix

Add `Failed(_)` to the satisfied-dependency check in `ready_tasks()`, consistent with `is_complete()`. The orchestrator can then decide whether to run or skip downstream tasks after a failure.

## Tests

- `test_failed_dependency_unblocks_downstream` — linear chain A→B→C, A fails, verifies B and C become sequentially ready
- `test_failed_dependency_diamond_dag` — diamond A→{B,C}→D, one path fails, verifies D becomes ready when all deps are terminal