### PR TITLE
feat(testing): add ReAct assertion helpers

### DIFF
--- a/tests/src/assert/agent.rs
+++ b/tests/src/assert/agent.rs
@@ -1,0 +1,29 @@
+//! Agent-level assertions for [`mofa_foundation::react::ReActResult`].
+
+use mofa_foundation::react::ReActResult;
+
+use super::trace_summary;
+
+/// Assert that the final answer contains the expected text.
+#[track_caller]
+pub fn assert_response_contains(result: &ReActResult, needle: &str) {
+    if !result.answer.contains(needle) {
+        panic!(
+            "Expected final answer to contain {needle:?}, but actual answer was {:?}. Trace: {}",
+            result.answer,
+            trace_summary(result)
+        );
+    }
+}
+
+/// Assert that the final answer does not contain the given text.
+#[track_caller]
+pub fn assert_response_not_contains(result: &ReActResult, needle: &str) {
+    if result.answer.contains(needle) {
+        panic!(
+            "Expected final answer to not contain {needle:?}, but actual answer was {:?}. Trace: {}",
+            result.answer,
+            trace_summary(result)
+        );
+    }
+}

--- a/tests/src/assert/mod.rs
+++ b/tests/src/assert/mod.rs
@@ -1,0 +1,85 @@
+//! Assertion helpers for behavior-oriented ReAct tests.
+//!
+//! These assertions operate on [`mofa_foundation::react::ReActResult`] so test
+//! cases can verify tool usage and final responses without hand-writing trace
+//! traversal logic in every test.
+
+mod agent;
+mod tool;
+
+use mofa_foundation::react::{ReActResult, ReActStep, ReActStepType};
+
+pub use agent::{assert_response_contains, assert_response_not_contains};
+pub use tool::{
+    assert_tool_never_before, assert_tool_not_used, assert_tool_order, assert_tool_used,
+    assert_tool_used_n_times,
+};
+
+fn action_steps(result: &ReActResult) -> impl Iterator<Item = &ReActStep> {
+    result
+        .steps
+        .iter()
+        .filter(|step| matches!(step.step_type, ReActStepType::Action))
+}
+
+fn observed_tools(result: &ReActResult) -> Vec<&str> {
+    action_steps(result)
+        .filter_map(|step| step.tool_name.as_deref())
+        .collect()
+}
+
+fn tool_positions(result: &ReActResult, tool_name: &str) -> Vec<usize> {
+    action_steps(result)
+        .filter_map(|step| {
+            step.tool_name
+                .as_deref()
+                .filter(|name| *name == tool_name)
+                .map(|_| step.step_number)
+        })
+        .collect()
+}
+
+fn trace_summary(result: &ReActResult) -> String {
+    if result.steps.is_empty() {
+        return "<no ReAct steps recorded>".to_string();
+    }
+
+    result
+        .steps
+        .iter()
+        .map(format_step)
+        .collect::<Vec<_>>()
+        .join(" -> ")
+}
+
+fn format_step(step: &ReActStep) -> String {
+    match step.step_type {
+        ReActStepType::Thought => {
+            format!("#{} Thought({})", step.step_number, preview(&step.content))
+        }
+        ReActStepType::Action => format!(
+            "#{} Action({})",
+            step.step_number,
+            step.tool_name.as_deref().unwrap_or("<unknown>")
+        ),
+        ReActStepType::Observation => {
+            format!("#{} Observation({})", step.step_number, preview(&step.content))
+        }
+        ReActStepType::FinalAnswer => format!(
+            "#{} FinalAnswer({})",
+            step.step_number,
+            preview(&step.content)
+        ),
+    }
+}
+
+fn preview(value: &str) -> String {
+    let trimmed = value.trim();
+    let char_count = trimmed.chars().count();
+
+    if char_count <= 40 {
+        trimmed.to_string()
+    } else {
+        format!("{}…", trimmed.chars().take(40).collect::<String>())
+    }
+}

--- a/tests/src/assert/tool.rs
+++ b/tests/src/assert/tool.rs
@@ -1,0 +1,126 @@
+//! Tool-level assertions for [`mofa_foundation::react::ReActResult`].
+
+use mofa_foundation::react::ReActResult;
+
+use super::{observed_tools, tool_positions, trace_summary};
+
+/// Assert that a tool appears at least once in the ReAct trace.
+#[track_caller]
+pub fn assert_tool_used(result: &ReActResult, tool_name: &str) {
+    let positions = tool_positions(result, tool_name);
+    if positions.is_empty() {
+        panic!(
+            "Expected tool '{tool_name}' to be used at least once, but it was never used. \
+Observed tools: {:?}. Trace: {}",
+            observed_tools(result),
+            trace_summary(result)
+        );
+    }
+}
+
+/// Assert that a tool never appears in the ReAct trace.
+#[track_caller]
+pub fn assert_tool_not_used(result: &ReActResult, tool_name: &str) {
+    let positions = tool_positions(result, tool_name);
+    if !positions.is_empty() {
+        panic!(
+            "Expected tool '{tool_name}' to never be used, but it appeared at steps {:?}. \
+Observed tools: {:?}. Trace: {}",
+            positions,
+            observed_tools(result),
+            trace_summary(result)
+        );
+    }
+}
+
+/// Assert that a tool appears exactly `expected_count` times in the ReAct trace.
+#[track_caller]
+pub fn assert_tool_used_n_times(result: &ReActResult, tool_name: &str, expected_count: usize) {
+    let positions = tool_positions(result, tool_name);
+    let actual_count = positions.len();
+
+    if actual_count != expected_count {
+        panic!(
+            "Expected tool '{tool_name}' to be used {expected_count} time(s), but it was used \
+{actual_count} time(s) at steps {:?}. Observed tools: {:?}. Trace: {}",
+            positions,
+            observed_tools(result),
+            trace_summary(result)
+        );
+    }
+}
+
+/// Assert that at least one call to `first` occurs before a call to `second`.
+#[track_caller]
+pub fn assert_tool_order(result: &ReActResult, first: &str, second: &str) {
+    let first_positions = tool_positions(result, first);
+    let second_positions = tool_positions(result, second);
+
+    if first_positions.is_empty() {
+        panic!(
+            "Expected tool '{first}' to appear before '{second}', but '{first}' was never used. \
+Observed tools: {:?}. Trace: {}",
+            observed_tools(result),
+            trace_summary(result)
+        );
+    }
+
+    if second_positions.is_empty() {
+        panic!(
+            "Expected tool '{first}' to appear before '{second}', but '{second}' was never used. \
+Observed tools: {:?}. Trace: {}",
+            observed_tools(result),
+            trace_summary(result)
+        );
+    }
+
+    let ordered = first_positions
+        .iter()
+        .any(|first_step| second_positions.iter().any(|second_step| first_step < second_step));
+
+    if !ordered {
+        panic!(
+            "Expected tool '{first}' to be called before '{second}', but observed positions were \
+{first:?} -> {:?} and {second:?} -> {:?}. Trace: {}",
+            first_positions,
+            second_positions,
+            trace_summary(result)
+        );
+    }
+}
+
+/// Assert that `forbidden_before` never appears before the first call to `reference`.
+#[track_caller]
+pub fn assert_tool_never_before(
+    result: &ReActResult,
+    forbidden_before: &str,
+    reference: &str,
+) {
+    let forbidden_positions = tool_positions(result, forbidden_before);
+    let reference_positions = tool_positions(result, reference);
+
+    if reference_positions.is_empty() {
+        panic!(
+            "Expected reference tool '{reference}' to appear in the trace, but it was never used. \
+Observed tools: {:?}. Trace: {}",
+            observed_tools(result),
+            trace_summary(result)
+        );
+    }
+
+    let first_reference = reference_positions[0];
+    let violating_positions: Vec<usize> = forbidden_positions
+        .into_iter()
+        .filter(|position| *position < first_reference)
+        .collect();
+
+    if !violating_positions.is_empty() {
+        panic!(
+            "Expected tool '{forbidden_before}' to never appear before '{reference}', but it \
+appeared earlier at steps {:?} while '{reference}' first appeared at step {}. Trace: {}",
+            violating_positions,
+            first_reference,
+            trace_summary(result)
+        );
+    }
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -4,6 +4,7 @@
 //! control for testing MoFA agents.
 
 pub mod adversarial;
+pub mod assert;
 pub mod assertions;
 pub mod backend;
 pub mod bus;
@@ -11,6 +12,10 @@ pub mod clock;
 pub mod report;
 pub mod tools;
 
+pub use assert::{
+    assert_response_contains, assert_response_not_contains, assert_tool_never_before,
+    assert_tool_not_used, assert_tool_order, assert_tool_used, assert_tool_used_n_times,
+};
 pub use backend::MockLLMBackend;
 pub use bus::MockAgentBus;
 pub use clock::{Clock, MockClock, SystemClock};

--- a/tests/tests/assertions.rs
+++ b/tests/tests/assertions.rs
@@ -1,0 +1,101 @@
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+use mofa_foundation::react::{ReActResult, ReActStep};
+use mofa_testing::assert::{
+    assert_response_contains, assert_response_not_contains, assert_tool_never_before,
+    assert_tool_not_used, assert_tool_order, assert_tool_used, assert_tool_used_n_times,
+};
+
+fn sample_result() -> ReActResult {
+    ReActResult::success(
+        "task-1",
+        "Summarize Rust async traits",
+        "Summary ready with cited docs.",
+        vec![
+            ReActStep::thought("Need to gather relevant material", 1),
+            ReActStep::action("search", "Rust async traits", 2),
+            ReActStep::observation("Collected two official references", 3),
+            ReActStep::action("summarize", "official references", 4),
+            ReActStep::final_answer("Summary ready with cited docs.", 5),
+        ],
+        2,
+        84,
+    )
+}
+
+fn out_of_order_result() -> ReActResult {
+    ReActResult::success(
+        "task-2",
+        "Check ordering",
+        "Done",
+        vec![
+            ReActStep::action("summarize", "draft", 1),
+            ReActStep::action("search", "docs", 2),
+            ReActStep::final_answer("Done", 3),
+        ],
+        2,
+        21,
+    )
+}
+
+fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
+    match payload.downcast::<String>() {
+        Ok(message) => *message,
+        Err(payload) => match payload.downcast::<&'static str>() {
+            Ok(message) => (*message).to_string(),
+            Err(_) => "<non-string panic payload>".to_string(),
+        },
+    }
+}
+
+#[test]
+fn tool_usage_assertions_pass_for_expected_trace() {
+    let result = sample_result();
+
+    assert_tool_used(&result, "search");
+    assert_tool_used_n_times(&result, "search", 1);
+    assert_tool_not_used(&result, "calculator");
+}
+
+#[test]
+fn tool_order_assertions_pass_for_expected_trace() {
+    let result = sample_result();
+
+    assert_tool_order(&result, "search", "summarize");
+    assert_tool_never_before(&result, "summarize", "search");
+}
+
+#[test]
+fn response_assertions_pass_for_expected_answer() {
+    let result = sample_result();
+
+    assert_response_contains(&result, "cited docs");
+    assert_response_not_contains(&result, "unsafe shell command");
+}
+
+#[test]
+fn tool_order_failure_message_is_human_readable() {
+    let result = out_of_order_result();
+    let panic = catch_unwind(AssertUnwindSafe(|| {
+        assert_tool_order(&result, "search", "summarize");
+    }))
+    .expect_err("assertion should fail for reversed tool order");
+
+    let message = panic_message(panic);
+    assert!(message.contains("search"));
+    assert!(message.contains("summarize"));
+    assert!(message.contains("Trace:"));
+}
+
+#[test]
+fn response_failure_message_is_human_readable() {
+    let result = sample_result();
+    let panic = catch_unwind(AssertUnwindSafe(|| {
+        assert_response_not_contains(&result, "cited docs");
+    }))
+    .expect_err("assertion should fail when forbidden content is present");
+
+    let message = panic_message(panic);
+    assert!(message.contains("cited docs"));
+    assert!(message.contains("Trace:"));
+}


### PR DESCRIPTION
## Summary
- add a new `mofa_testing::assert` module for behavior-oriented `ReActResult` assertions
- cover tool usage, ordering, and response content checks with human-readable failure messages
- add integration tests exercising the new assertion API

## Details
This introduces the following public helpers:
- `assert_tool_used`
- `assert_tool_not_used`
- `assert_tool_used_n_times`
- `assert_tool_order`
- `assert_tool_never_before`
- `assert_response_contains`
- `assert_response_not_contains`

The helpers summarize the observed tool trace in failure output so agent tests stay concise while still being easy to debug.

Closes #1078.

## Validation
- editor diagnostics for the changed files are clean
- `cargo test -p mofa-testing` could not be executed in this environment because the Rust toolchain (`cargo`) is not installed locally
