### PR TITLE
chore(ci): remove workspace lint suppressions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,6 @@ members = [
 ]
 exclude = ["examples"]
 [workspace.lints.rust]
-dead_code = "allow"
-unused_variables = "allow"
-unused = "allow"
-unexpected_cfgs = "allow"
 
 [workspace.package]
 version = "0.1.0"


### PR DESCRIPTION
## Summary

Removes the blanket workspace Rust lint suppressions from the root `Cargo.toml` so workspace-level `dead_code`, `unused_variables`, `unused`, and `unexpected_cfgs` can surface normally in linting and CI.

Closes #605.

## Changes

- deleted the four `allow` entries under `[workspace.lints.rust]`
- kept the change focused to the workspace lint configuration only

## Validation

- checked editor diagnostics after the change
- confirmed no diagnostics were reported in the workspace

## Notes

This intentionally leaves any genuinely necessary exceptions to be handled locally at the call site or crate level, which matches the issue guidance.