### PR TITLE
docs(sdk): remove Chinese comments from selected APIs

### DIFF
--- a/crates/mofa-sdk/src/lib.rs
+++ b/crates/mofa-sdk/src/lib.rs
@@ -497,19 +497,13 @@ pub mod llm {
     pub use mofa_foundation::llm::openai::{OpenAIConfig, OpenAIProvider};
     pub use mofa_foundation::llm::*;
 
-    /// 从环境变量创建 OpenAI 提供器
     /// Create OpenAI provider from environment variables
     ///
-    /// 自动读取以下环境变量:
     /// Automatically reads the following environment variables:
-    /// - OPENAI_API_KEY: API 密钥
     /// - OPENAI_API_KEY: API Key
-    /// - OPENAI_BASE_URL: 可选的 API 基础 URL
     /// - OPENAI_BASE_URL: Optional API Base URL
-    /// - OPENAI_MODEL: 可选的默认模型
     /// - OPENAI_MODEL: Optional default model
     ///
-    /// # 示例
     /// # Example
     ///
     /// ```rust,ignore
@@ -547,16 +541,11 @@ pub mod llm {
     }
 }
 
-/// 从环境变量创建 Anthropic 提供器
 /// Create Anthropic provider from environment variables
 ///
-/// 读取环境变量:
 /// Reads environment variables:
-/// - ANTHROPIC_API_KEY (必需)
 /// - ANTHROPIC_API_KEY (Required)
-/// - ANTHROPIC_BASE_URL (可选)
 /// - ANTHROPIC_BASE_URL (Optional)
-/// - ANTHROPIC_MODEL (可选)
 /// - ANTHROPIC_MODEL (Optional)
 pub fn anthropic_from_env() -> Result<crate::llm::AnthropicProvider, crate::llm::LLMError> {
     let api_key = std::env::var("ANTHROPIC_API_KEY").map_err(|_| {
@@ -576,16 +565,11 @@ pub fn anthropic_from_env() -> Result<crate::llm::AnthropicProvider, crate::llm:
     Ok(crate::llm::AnthropicProvider::with_config(cfg))
 }
 
-/// 从环境变量创建 Google Gemini 提供器
 /// Create Google Gemini provider from environment variables
 ///
-/// 读取环境变量:
 /// Reads environment variables:
-/// - GEMINI_API_KEY (必需)
 /// - GEMINI_API_KEY (Required)
-/// - GEMINI_BASE_URL (可选)
 /// - GEMINI_BASE_URL (Optional)
-/// - GEMINI_MODEL (可选)
 /// - GEMINI_MODEL (Optional)
 pub fn gemini_from_env() -> Result<crate::llm::GeminiProvider, crate::llm::LLMError> {
     let api_key = std::env::var("GEMINI_API_KEY").map_err(|_| {
@@ -605,26 +589,17 @@ pub fn gemini_from_env() -> Result<crate::llm::GeminiProvider, crate::llm::LLMEr
 
 // Re-export Secretary module from mofa-foundation (always available)
 pub mod secretary {
-    //! 秘书Agent模式 - 基于事件循环的智能助手
     //! Secretary Agent Mode - Intelligent assistant based on event loop
     //!
-    //! 秘书Agent是一个面向用户的智能助手，通过与LLM交互完成个人助理工作。
     //! Secretary Agent is a user-facing smart assistant completing personal aid tasks via LLM interaction.
-    //! 设计为与长连接配合使用，实现持续的交互式服务。
     //! Designed to work with long-lived connections for continuous interactive services.
     //!
-    //! ## 工作循环（5阶段事件循环）
     //! ## Work Cycle (5-phase event loop)
     //!
-    //! 1. **接收想法** → 记录并生成TODO
     //! 1. **Receive Ideas** → Log and generate TODOs
-    //! 2. **澄清需求** → 与用户交互，转换为项目文档
     //! 2. **Clarify Requirements** → Interact with user, convert to project docs
-    //! 3. **调度分配** → 调用对应的执行Agent
     //! 3. **Schedule & Allocate** → Invoke corresponding execution Agents
-    //! 4. **监控反馈** → 推送关键决策给人类
     //! 4. **Monitor Feedback** → Push critical decisions to humans
-    //! 5. **验收汇报** → 更新TODO，生成报告
     //! 5. **Acceptance & Reporting** → Update TODOs, generate reports
     //!
     //! # Quick Start
@@ -638,9 +613,8 @@ pub mod secretary {
     //!
     //! #[tokio::main]
     //! async fn main() -> GlobalResult<()> {
-    //!     // 1. 创建秘书Agent
     //!     // 1. Create Secretary Agent
-    //!     let mut backend_agent = AgentInfo::new("backend_agent", "后端Agent");
+    //!     let mut backend_agent = AgentInfo::new("backend_agent", "Backend Agent");
     //!     backend_agent.capabilities = vec!["backend".to_string()];
     //!     backend_agent.current_load = 0;
     //!     backend_agent.available = true;
@@ -648,38 +622,34 @@ pub mod secretary {
     //!
     //!     let secretary = DefaultSecretaryBuilder::new()
     //!         .with_id("my_secretary")
-    //!         .with_name("项目秘书")
+    //!         .with_name("Project Secretary")
     //!         .with_auto_clarify(true)
     //!         .with_executor(backend_agent)
     //!         .build()
     //!         .await;
     //!
-    //!     // 2. 创建通道连接
     //!     // 2. Create channel connection
     //!     let (conn, input_tx, mut output_rx) = ChannelConnection::new_pair(32);
     //!
-    //!     // 3. 启动事件循环
     //!     // 3. Start event loop
     //!     let handle = secretary.start(conn).await;
     //!
-    //!     // 4. 发送用户输入
     //!     // 4. Send user input
     //!     input_tx.send(DefaultInput::Idea {
-    //!         content: "开发一个REST API".to_string(),
+    //!         content: "Build a REST API".to_string(),
     //!         priority: Some(TodoPriority::High),
     //!         metadata: None,
     //!     }).await?;
     //!
-    //!     // 5. 处理秘书输出
     //!     // 5. Handle secretary output
     //!     while let Some(output) = output_rx.recv().await {
     //!         match output {
     //!             SecretaryOutput::Acknowledgment { message } => {
-    //!                 info!("秘书: {}", message);
+    //!                 info!("Secretary: {}", message);
     //!             }
     //!             SecretaryOutput::DecisionRequired { decision } => {
-    //!                 info!("需要决策: {}", decision.description);
-    //!                 // 处理决策...
+    //!                 info!("Decision required: {}", decision.description);
+    //!                 // Handle the decision...
     //!                 // Handle decision...
     //!             }
     //!             SecretaryOutput::Report { report } => {

--- a/crates/mofa-sdk/src/llm_tools.rs
+++ b/crates/mofa-sdk/src/llm_tools.rs
@@ -65,7 +65,7 @@ impl ToolPluginExecutor {
 impl ToolExecutor for ToolPluginExecutor {
     async fn execute(&self, name: &str, arguments: &str) -> LLMResult<String> {
         let args: serde_json::Value = serde_json::from_str(arguments)
-            .map_err(|e| LLMError::Other(format!("参数解析失败: {}", e)))?;
+            .map_err(|e| LLMError::Other(format!("Failed to parse arguments: {}", e)))?;
 
         let call = ToolCall {
             call_id: uuid::Uuid::now_v7().to_string(),
@@ -77,14 +77,14 @@ impl ToolExecutor for ToolPluginExecutor {
         let result = plugin
             .call_tool(call)
             .await
-            .map_err(|e| LLMError::Other(format!("工具执行失败: {}", e)))?;
+            .map_err(|e| LLMError::Other(format!("Tool execution failed: {}", e)))?;
 
         if result.success {
             serde_json::to_string(&result.result)
-                .map_err(|e| LLMError::Other(format!("结果序列化失败: {}", e)))
+                .map_err(|e| LLMError::Other(format!("Failed to serialize result: {}", e)))
         } else {
             Err(LLMError::Other(
-                result.error.unwrap_or_else(|| "未知错误".to_string()),
+                result.error.unwrap_or_else(|| "Unknown error".to_string()),
             ))
         }
     }

--- a/crates/mofa-sdk/src/skills/mod.rs
+++ b/crates/mofa-sdk/src/skills/mod.rs
@@ -1,20 +1,14 @@
-//! Agent Skills 管理 API
 //! Agent Skills Management API
 //!
-//! 提供 Skills 的统一管理接口，支持：
 //! Provides a unified management interface for Skills, supporting:
-//! - 渐进式披露（Progressive Disclosure）
 //! - Progressive Disclosure
-//! - 热更新支持
 //! - Hot update support
-//! - 搜索和加载
 //! - Search and loading
 
 pub mod manager;
 
 pub use manager::{SkillInfo, SkillsManager};
 
-// 重新导出 skill 相关类型
 // Re-export skill related types
 pub use mofa_plugins::skill::{
     DisclosureController, Requirement, RequirementCheck, SkillMetadata, SkillParser,
@@ -24,7 +18,6 @@ pub use mofa_plugins::skill::{
 use mofa_kernel::agent::types::error::GlobalResult;
 use std::path::PathBuf;
 
-/// Skills 管理器构建器
 /// Skills Manager Builder
 #[derive(Debug, Clone)]
 pub struct SkillsManagerBuilder {
@@ -32,7 +25,6 @@ pub struct SkillsManagerBuilder {
 }
 
 impl SkillsManagerBuilder {
-    /// 创建新的构建器
     /// Create a new builder
     pub fn new(skills_dir: impl Into<PathBuf>) -> Self {
         Self {
@@ -40,34 +32,29 @@ impl SkillsManagerBuilder {
         }
     }
 
-    /// 设置 skills 目录（单目录）
     /// Set skills directory (single directory)
     pub fn with_skills_dir(mut self, dir: impl Into<PathBuf>) -> Self {
         self.search_dirs = vec![dir.into()];
         self
     }
 
-    /// 添加搜索目录（多目录，按优先级排序）
     /// Add search directories (multiple directories, sorted by priority)
     pub fn with_search_dirs(mut self, dirs: Vec<PathBuf>) -> Self {
         self.search_dirs = dirs;
         self
     }
 
-    /// 添加一个搜索目录
     /// Add a single search directory
     pub fn add_search_dir(mut self, dir: impl Into<PathBuf>) -> Self {
         self.search_dirs.push(dir.into());
         self
     }
 
-    /// 构建 SkillsManager
     /// Build SkillsManager
     pub fn build(&self) -> GlobalResult<SkillsManager> {
         SkillsManager::new(&self.search_dirs[0])
     }
 
-    /// 构建支持多目录的 SkillsManager
     /// Build SkillsManager with multi-directory support
     pub fn build_multi(&self) -> GlobalResult<SkillsManager> {
         if self.search_dirs.len() == 1 {
@@ -78,7 +65,6 @@ impl SkillsManagerBuilder {
     }
 }
 
-/// 便捷函数：从目录创建 SkillsManager
 /// Convenience function: Create SkillsManager from a directory
 pub fn from_dir(skills_dir: impl AsRef<std::path::Path>) -> GlobalResult<SkillsManager> {
     SkillsManager::new(skills_dir)


### PR DESCRIPTION
## Summary

Removes Chinese comments and user-facing error text from a focused set of SDK entry points so these files align with the repository's English-only documentation guidance.

This is a scoped contribution toward #608.

## Changes

- cleaned up bilingual comments in `crates/mofa-sdk/src/skills/mod.rs`
- translated user-facing tool execution errors in `crates/mofa-sdk/src/llm_tools.rs`
- removed duplicated Chinese doc comments from selected environment-provider helpers and secretary docs in `crates/mofa-sdk/src/lib.rs`
- translated the secretary quick-start example strings in the same section

## Validation

- checked editor diagnostics for all changed files
- confirmed no diagnostics were reported

## Notes

This PR is intentionally narrow and reviewable. It does not try to close #608 by itself; it chips away at the remaining English-comment migration in a small, maintainable slice.