### PR TITLE
implement PeerToPeer strategy in AgentCoordinator

### DIFF
--- a/crates/mofa-foundation/src/coordination/mod.rs
+++ b/crates/mofa-foundation/src/coordination/mod.rs
@@ -1,5 +1,7 @@
 use mofa_kernel::agent::types::error::{GlobalError, GlobalResult};
 mod scheduler;
+#[cfg(test)]
+mod tests;
 use mofa_kernel::message::{AgentMessage, TaskRequest, TaskStatus};
 use mofa_kernel::{AgentBus, CommunicationMode};
 use std::collections::HashMap;
@@ -65,7 +67,7 @@ impl AgentCoordinator {
         match &self.strategy {
             CoordinationStrategy::MasterSlave => self.master_slave_coordinate(task_msg).await,
             CoordinationStrategy::Pipeline => self.pipeline_coordinate(task_msg).await,
-            _ => Ok(()),
+            CoordinationStrategy::PeerToPeer => self.peer_to_peer_coordinate(task_msg).await,
         }
     }
 
@@ -155,6 +157,37 @@ impl AgentCoordinator {
                 .map_err(|e| GlobalError::Other(e.to_string()))?
             {
                 last_output = Some(result);
+            }
+        }
+        Ok(())
+    }
+
+    /// Peer-to-peer coordination logic
+    async fn peer_to_peer_coordinate(&self, task_msg: &AgentMessage) -> GlobalResult<()> {
+        let role_map = self.role_mapping.read().await;
+
+        let peers = role_map
+            .get("peer")
+            .ok_or_else(|| GlobalError::Other("No peer agents registered".to_string()))?;
+
+        // Send point to point to all peers to avoid broadcast leakage
+        for peer_id in peers {
+            self.bus
+                .send_message(
+                    "coordinator",
+                    CommunicationMode::PointToPoint(peer_id.clone()),
+                    task_msg,
+                )
+                .await
+                .map_err(|e| GlobalError::Other(e.to_string()))?;
+        }
+
+        // Track task status
+        if let AgentMessage::TaskRequest { task_id, .. } = task_msg {
+            let mut tracker = self.task_tracker.write().await;
+            let entries = tracker.entry(task_id.clone()).or_default();
+            for peer_id in peers {
+                entries.push((peer_id.clone(), TaskStatus::Pending));
             }
         }
         Ok(())

--- a/crates/mofa-foundation/src/coordination/tests.rs
+++ b/crates/mofa-foundation/src/coordination/tests.rs
@@ -1,0 +1,100 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mofa_kernel::message::AgentMessage;
+    use mofa_kernel::AgentBus;
+    use mofa_kernel::CommunicationMode;
+    use mofa_kernel::agent::{AgentCapabilities, AgentMetadata, AgentState};
+    use std::sync::Arc;
+    use tokio::time::{Duration, timeout};
+
+    use crate::coordination::{AgentCoordinator, CoordinationStrategy};
+    #[tokio::test]
+    async fn test_peer_to_peer_coordination() {
+        let bus = Arc::new(AgentBus::new());
+        register_peer_channel(&bus, "peer_1").await;
+        register_peer_channel(&bus, "peer_2").await;
+        register_peer_channel(&bus, "peer_3").await;
+
+        let coordinator = AgentCoordinator::new(bus.clone(), CoordinationStrategy::PeerToPeer).await;
+
+        coordinator.register_role("peer_1", "peer").await.unwrap();
+        coordinator.register_role("peer_2", "peer").await.unwrap();
+        coordinator.register_role("peer_3", "peer").await.unwrap();
+
+        let task_msg = in_memory_message();
+        let bus_1 = bus.clone();
+        let bus_2 = bus.clone();
+        let bus_3 = bus.clone();
+        let recv_1 = tokio::spawn(async move { receive_peer(&bus_1, "peer_1").await });
+        let recv_2 = tokio::spawn(async move { receive_peer(&bus_2, "peer_2").await });
+        let recv_3 = tokio::spawn(async move { receive_peer(&bus_3, "peer_3").await });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        // Send after receivers are subscribed
+        let result = coordinator.coordinate_task(&task_msg).await;
+        
+        assert!(result.is_ok());
+
+        let msg_1 = timeout(Duration::from_secs(1), recv_1).await.unwrap().unwrap();
+        let msg_2 = timeout(Duration::from_secs(1), recv_2).await.unwrap().unwrap();
+        let msg_3 = timeout(Duration::from_secs(1), recv_3).await.unwrap().unwrap();
+        assert!(msg_1.expect("peer_1 missing message").is_some());
+        assert!(msg_2.expect("peer_2 missing message").is_some());
+        assert!(msg_3.expect("peer_3 missing message").is_some());
+
+        if let AgentMessage::TaskRequest { task_id, .. } = &task_msg {
+            let tracker = coordinator.task_tracker.read().await;
+            let entries = tracker.get(task_id).expect("Task ID should be in tracker");
+            assert_eq!(entries.len(), 3, "Should track all peers");
+            let tracked_peers: Vec<_> = entries.iter().map(|(id, _)| id.clone()).collect();
+            assert!(tracked_peers.contains(&"peer_1".to_string()));
+            assert!(tracked_peers.contains(&"peer_2".to_string()));
+            assert!(tracked_peers.contains(&"peer_3".to_string()));
+        } else {
+            panic!("Expected TaskRequest message");
+        }
+    }
+
+    fn in_memory_message() -> AgentMessage {
+        AgentMessage::TaskRequest {
+            task_id: "test-task-123".to_string(),
+            content: "Please do the work".to_string(),
+        }
+    }
+
+    // Register a point to point channel from coordinator to peer
+    async fn register_peer_channel(bus: &AgentBus, id: &str) {
+        let metadata = AgentMetadata {
+            id: id.to_string(),
+            name: id.to_string(),
+            description: None,
+            version: None,
+            capabilities: AgentCapabilities::default(),
+            state: AgentState::Ready,
+        };
+        bus.register_channel(
+            &metadata,
+            CommunicationMode::PointToPoint("coordinator".to_string()),
+        )
+        .await
+        .unwrap();
+    }
+
+    // Receive one message for a peer
+    async fn receive_peer(
+        bus: &AgentBus,
+        id: &str,
+    ) -> Result<Option<AgentMessage>, mofa_kernel::bus::BusError> {
+        bus.receive_message(
+            id,
+            CommunicationMode::PointToPoint("coordinator".to_string()),
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_register_role() {
+        assert!(true);
+    }
+}


### PR DESCRIPTION
## Problem
The Peer-to-Peer coordination strategy existed as a variant but was either unimplemented or not wired into the coordinator flow. As a result, selecting `CoordinationStrategy::PeerToPeer` did not reliably dispatch tasks or track peer execution.

## Solution
This PR implements a proper Peer-to-Peer strategy in `AgentCoordinator` and ensures it is invoked when selected. It delivers tasks directly to peer agents via point-to-point channels to avoid broadcasting to unrelated agents, and records task tracking for each peer recipient.
Closes: #1094

## What Changed
- `AgentCoordinator::coordinate_task` now routes `CoordinationStrategy::PeerToPeer` to a dedicated handler.
- `peer_to_peer_coordinate` sends point-to-point messages to each peer and updates the task tracker for all recipients.
- Added a focused unit test that:
  - Registers point-to-point channels for peers.
  - Sends a task through the coordinator.
  - Verifies each peer receives a message.
  - Confirms task tracking includes all peers.

Broadcast delivery is global and can reach non-peer agents, and it also depends on active broadcast subscribers. Point-to-point delivery is explicit, scoped to peers, and aligns with the intended peer-to-peer semantics.

## Files Changed
- `crates/mofa-foundation/src/coordination/mod.rs`: Route Peer-to-Peer strategy and send point-to-point to peers with tracking.
- `crates/mofa-foundation/src/coordination/tests.rs`: Add peer delivery assertions and tracking verification.

## Testing
- `cargo test -p mofa-foundation test_peer_to_peer_coordination`
- All tests passed.