### PR TITLE
docs(monitoring): remove Chinese tracing comments

### DIFF
--- a/crates/mofa-monitoring/src/tracing/context.rs
+++ b/crates/mofa-monitoring/src/tracing/context.rs
@@ -1,7 +1,5 @@
-//! Trace Context 定义
 //! Trace Context Definition
 //!
-//! 实现 W3C Trace Context 标准
 //! Implementation of the W3C Trace Context standard
 
 use rand::Rng;
@@ -9,13 +7,11 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
 
-/// Trace ID - 16字节 (128位)
 /// Trace ID - 16 bytes (128 bits)
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct TraceId([u8; 16]);
 
 impl TraceId {
-    /// 创建新的随机 Trace ID
     /// Create a new random Trace ID
     pub fn new() -> Self {
         let mut rng = rand::thread_rng();
@@ -24,13 +20,11 @@ impl TraceId {
         Self(bytes)
     }
 
-    /// 从字节数组创建
     /// Create from a byte array
     pub fn from_bytes(bytes: [u8; 16]) -> Self {
         Self(bytes)
     }
 
-    /// 从十六进制字符串创建
     /// Create from a hexadecimal string
     pub fn from_hex(hex: &str) -> Result<Self, String> {
         if hex.len() != 32 {
@@ -42,25 +36,21 @@ impl TraceId {
         Ok(Self(arr))
     }
 
-    /// 转换为十六进制字符串
     /// Convert to a hexadecimal string
     pub fn to_hex(&self) -> String {
         hex::encode(self.0)
     }
 
-    /// 获取字节
     /// Get the bytes
     pub fn as_bytes(&self) -> &[u8; 16] {
         &self.0
     }
 
-    /// 是否有效（非全零）
     /// Whether it is valid (not all zeros)
     pub fn is_valid(&self) -> bool {
         self.0.iter().any(|&b| b != 0)
     }
 
-    /// 无效的 Trace ID
     /// Invalid Trace ID
     pub const INVALID: TraceId = TraceId([0u8; 16]);
 }
@@ -91,13 +81,11 @@ impl FromStr for TraceId {
     }
 }
 
-/// Span ID - 8字节 (64位)
 /// Span ID - 8 bytes (64 bits)
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct SpanId([u8; 8]);
 
 impl SpanId {
-    /// 创建新的随机 Span ID
     /// Create a new random Span ID
     pub fn new() -> Self {
         let mut rng = rand::thread_rng();
@@ -106,13 +94,11 @@ impl SpanId {
         Self(bytes)
     }
 
-    /// 从字节数组创建
     /// Create from a byte array
     pub fn from_bytes(bytes: [u8; 8]) -> Self {
         Self(bytes)
     }
 
-    /// 从十六进制字符串创建
     /// Create from a hexadecimal string
     pub fn from_hex(hex: &str) -> Result<Self, String> {
         if hex.len() != 16 {
@@ -124,25 +110,21 @@ impl SpanId {
         Ok(Self(arr))
     }
 
-    /// 转换为十六进制字符串
     /// Convert to a hexadecimal string
     pub fn to_hex(&self) -> String {
         hex::encode(self.0)
     }
 
-    /// 获取字节
     /// Get the bytes
     pub fn as_bytes(&self) -> &[u8; 8] {
         &self.0
     }
 
-    /// 是否有效（非全零）
     /// Whether it is valid (not all zeros)
     pub fn is_valid(&self) -> bool {
         self.0.iter().any(|&b| b != 0)
     }
 
-    /// 无效的 Span ID
     /// Invalid Span ID
     pub const INVALID: SpanId = SpanId([0u8; 8]);
 }
@@ -173,32 +155,26 @@ impl FromStr for SpanId {
     }
 }
 
-/// Trace Flags - 采样标志
 /// Trace Flags - Sampling flags
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TraceFlags(u8);
 
 impl TraceFlags {
-    /// 已采样标志
     /// Sampled flag
     pub const SAMPLED: TraceFlags = TraceFlags(0x01);
-    /// 无标志
     /// No flags
     pub const NONE: TraceFlags = TraceFlags(0x00);
 
-    /// 创建新的 TraceFlags
     /// Create new TraceFlags
     pub fn new(flags: u8) -> Self {
         Self(flags)
     }
 
-    /// 是否已采样
     /// Whether it is sampled
     pub fn is_sampled(&self) -> bool {
         self.0 & 0x01 != 0
     }
 
-    /// 设置采样
     /// Set sampling
     pub fn with_sampled(mut self, sampled: bool) -> Self {
         if sampled {
@@ -209,7 +185,6 @@ impl TraceFlags {
         self
     }
 
-    /// 获取原始值
     /// Get the raw value
     pub fn as_u8(&self) -> u8 {
         self.0
@@ -228,7 +203,6 @@ impl fmt::Display for TraceFlags {
     }
 }
 
-/// Trace State - 供应商特定的追踪数据
 /// Trace State - Vendor-specific tracing data
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct TraceState {
@@ -236,7 +210,6 @@ pub struct TraceState {
 }
 
 impl TraceState {
-    /// 创建空的 TraceState
     /// Create an empty TraceState
     pub fn new() -> Self {
         Self {
@@ -244,23 +217,19 @@ impl TraceState {
         }
     }
 
-    /// 从键值对创建
     /// Create from key-value pairs
     pub fn from_entries(entries: Vec<(String, String)>) -> Self {
         Self { entries }
     }
 
-    /// 添加条目
     /// Add an entry
     pub fn insert(&mut self, key: impl Into<String>, value: impl Into<String>) {
         let key = key.into();
-        // 移除已存在的同名条目
         // Remove existing entry with the same name
         self.entries.retain(|(k, _)| k != &key);
         self.entries.push((key, value.into()));
     }
 
-    /// 获取条目
     /// Get an entry
     pub fn get(&self, key: &str) -> Option<&str> {
         self.entries
@@ -269,25 +238,21 @@ impl TraceState {
             .map(|(_, v)| v.as_str())
     }
 
-    /// 移除条目
     /// Remove an entry
     pub fn remove(&mut self, key: &str) {
         self.entries.retain(|(k, _)| k != key);
     }
 
-    /// 获取所有条目
     /// Get all entries
     pub fn entries(&self) -> &[(String, String)] {
         &self.entries
     }
 
-    /// 是否为空
     /// Whether it is empty
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
 
-    /// 转换为 header 格式字符串
     /// Convert to header format string
     pub fn to_header(&self) -> String {
         self.entries
@@ -297,7 +262,6 @@ impl TraceState {
             .join(",")
     }
 
-    /// 从 header 格式字符串解析
     /// Parse from header format string
     pub fn from_header(header: &str) -> Self {
         let entries = header
@@ -317,29 +281,22 @@ impl TraceState {
     }
 }
 
-/// Span Context - Span 的不可变上下文信息
 /// Span Context - Immutable context information of a Span
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SpanContext {
     /// Trace ID
-    /// Trace ID
     pub trace_id: TraceId,
-    /// Span ID
     /// Span ID
     pub span_id: SpanId,
     /// Trace Flags
-    /// Trace Flags
     pub trace_flags: TraceFlags,
     /// Trace State
-    /// Trace State
     pub trace_state: TraceState,
-    /// 是否远程（从其他服务传播过来）
     /// Whether it is remote (propagated from another service)
     pub is_remote: bool,
 }
 
 impl SpanContext {
-    /// 创建新的 SpanContext
     /// Create a new SpanContext
     pub fn new(
         trace_id: TraceId,
@@ -356,7 +313,6 @@ impl SpanContext {
         }
     }
 
-    /// 创建无效的 SpanContext
     /// Create an invalid SpanContext
     pub fn invalid() -> Self {
         Self {
@@ -368,19 +324,16 @@ impl SpanContext {
         }
     }
 
-    /// 是否有效
     /// Whether it is valid
     pub fn is_valid(&self) -> bool {
         self.trace_id.is_valid() && self.span_id.is_valid()
     }
 
-    /// 是否已采样
     /// Whether it is sampled
     pub fn is_sampled(&self) -> bool {
         self.trace_flags.is_sampled()
     }
 
-    /// 设置 TraceState
     /// Set TraceState
     pub fn with_trace_state(mut self, trace_state: TraceState) -> Self {
         self.trace_state = trace_state;
@@ -394,32 +347,24 @@ impl Default for SpanContext {
     }
 }
 
-/// Trace Context - 完整的追踪上下文
 /// Trace Context - Complete tracing context
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TraceContext {
-    /// 当前 Span 上下文
     /// Current Span Context
     pub span_context: SpanContext,
-    /// 父 Span 上下文
     /// Parent Span Context
     pub parent_span_context: Option<SpanContext>,
-    /// 服务名称
     /// Service name
     pub service_name: String,
-    /// 操作名称
     /// Operation name
     pub operation_name: String,
-    /// 开始时间
     /// Start time
     pub start_time: chrono::DateTime<chrono::Utc>,
-    /// 额外属性
     /// Additional attributes
     pub attributes: std::collections::HashMap<String, String>,
 }
 
 impl TraceContext {
-    /// 创建新的根追踪上下文
     /// Create a new root trace context
     pub fn new_root(service_name: &str, operation_name: &str) -> Self {
         Self {
@@ -437,7 +382,6 @@ impl TraceContext {
         }
     }
 
-    /// 创建子追踪上下文
     /// Create a child trace context
     pub fn new_child(&self, operation_name: &str) -> Self {
         Self {
@@ -455,7 +399,6 @@ impl TraceContext {
         }
     }
 
-    /// 从远程 SpanContext 创建
     /// Create from a remote SpanContext
     pub fn from_remote(
         span_context: SpanContext,
@@ -480,37 +423,31 @@ impl TraceContext {
         }
     }
 
-    /// 获取 Trace ID
     /// Get Trace ID
     pub fn trace_id(&self) -> TraceId {
         self.span_context.trace_id
     }
 
-    /// 获取 Span ID
     /// Get Span ID
     pub fn span_id(&self) -> SpanId {
         self.span_context.span_id
     }
 
-    /// 获取父 Span ID
     /// Get Parent Span ID
     pub fn parent_span_id(&self) -> Option<SpanId> {
         self.parent_span_context.as_ref().map(|ctx| ctx.span_id)
     }
 
-    /// 设置属性
     /// Set an attribute
     pub fn set_attribute(&mut self, key: impl Into<String>, value: impl Into<String>) {
         self.attributes.insert(key.into(), value.into());
     }
 
-    /// 获取属性
     /// Get an attribute
     pub fn get_attribute(&self, key: &str) -> Option<&str> {
         self.attributes.get(key).map(|s| s.as_str())
     }
 
-    /// 计算持续时间
     /// Calculate duration
     pub fn duration(&self) -> chrono::Duration {
         chrono::Utc::now() - self.start_time

--- a/crates/mofa-monitoring/src/tracing/mod.rs
+++ b/crates/mofa-monitoring/src/tracing/mod.rs
@@ -1,15 +1,9 @@
-//! 分布式追踪模块
 //! Distributed tracing module
 //!
-//! 提供分布式追踪功能，支持:
 //! Provides distributed tracing functionality, supporting:
-//! - Trace Context 传播
 //! - Trace Context propagation
-//! - Span 管理
 //! - Span management
-//! - 多种导出器 (Console, Jaeger, OTLP)
 //! - Multiple exporters (Console, Jaeger, OTLP)
-//! - Agent 和 Workflow 的自动追踪
 //! - Automatic tracing for Agents and Workflows
 
 mod context;


### PR DESCRIPTION
## Summary\n- remove duplicated Chinese tracing comments from the tracing context types\n- keep the existing English documentation intact in the tracing module\n- keep the change limited to non-behavioral documentation cleanup for issue #608\n\n## Testing\n- editor diagnostics checked for the touched files\n\nPart of #608