### PR TITLE
docs(monitoring): remove Chinese comments from instrumentation

### DIFF
--- a/crates/mofa-monitoring/src/tracing/instrumentation.rs
+++ b/crates/mofa-monitoring/src/tracing/instrumentation.rs
@@ -1,7 +1,5 @@
-//! 自动追踪集成
 //! Automatic Tracing Integration
 //!
-//! 为 Agent 和 Workflow 提供自动追踪功能
 //! Providing automatic tracing functionality for Agents and Workflows
 
 use super::context::SpanContext;
@@ -13,12 +11,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-/// Agent 追踪器
 /// Agent Tracer
 pub struct AgentTracer {
     tracer: Arc<Tracer>,
     propagator: Arc<dyn TracePropagator>,
-    /// 当前活动的 spans
     /// Currently active spans
     active_spans: Arc<RwLock<HashMap<String, Span>>>,
 }
@@ -37,7 +33,6 @@ impl AgentTracer {
         self
     }
 
-    /// 开始追踪 Agent 操作
     /// Start tracing an Agent operation
     pub async fn start_operation(
         &self,
@@ -50,12 +45,10 @@ impl AgentTracer {
             .tracer
             .start_span_with_kind(&span_name, SpanKind::Internal, parent_context);
 
-        // 设置 Agent 相关属性
         // Set Agent related attributes
         span.set_attribute("agent.id", agent_id).await;
         span.set_attribute("agent.operation", operation).await;
 
-        // 存储活动 span
         // Store active span
         let span_id = span.span_id().await.to_hex();
         self.active_spans
@@ -66,7 +59,6 @@ impl AgentTracer {
         span
     }
 
-    /// 追踪消息发送
     /// Trace message sending
     pub async fn trace_message_send(
         &self,
@@ -91,7 +83,6 @@ impl AgentTracer {
         span
     }
 
-    /// 追踪消息接收
     /// Trace message receiving
     pub async fn trace_message_receive(
         &self,
@@ -115,7 +106,6 @@ impl AgentTracer {
         span
     }
 
-    /// 追踪任务执行
     /// Trace task execution
     pub async fn trace_task_execution(
         &self,
@@ -137,7 +127,6 @@ impl AgentTracer {
         span
     }
 
-    /// 结束 span 并导出
     /// End span and export
     pub async fn end_span(&self, span: &Span) {
         let span_id = span.span_id().await.to_hex();
@@ -145,33 +134,27 @@ impl AgentTracer {
         self.tracer.end_span(span).await;
     }
 
-    /// 注入追踪上下文到 headers
     /// Inject trace context into headers
     pub fn inject_context(&self, span_context: &SpanContext, carrier: &mut dyn HeaderCarrier) {
         self.propagator.inject(span_context, carrier);
     }
 
-    /// 从 headers 提取追踪上下文
     /// Extract trace context from headers
     pub fn extract_context(&self, carrier: &dyn HeaderCarrier) -> Option<SpanContext> {
         self.propagator.extract(carrier)
     }
 
-    /// 获取 Tracer
     /// Get Tracer
     pub fn tracer(&self) -> Arc<Tracer> {
         self.tracer.clone()
     }
 }
 
-/// Workflow 追踪器
 /// Workflow Tracer
 pub struct WorkflowTracer {
     tracer: Arc<Tracer>,
-    /// 工作流执行的根 span
     /// Root span of workflow execution
     workflow_spans: Arc<RwLock<HashMap<String, Span>>>,
-    /// 节点执行的 spans
     /// Spans of node execution
     node_spans: Arc<RwLock<HashMap<String, Span>>>,
 }
@@ -185,7 +168,6 @@ impl WorkflowTracer {
         }
     }
 
-    /// 开始追踪工作流执行
     /// Start tracing workflow execution
     pub async fn start_workflow(
         &self,
@@ -214,7 +196,6 @@ impl WorkflowTracer {
         span
     }
 
-    /// 追踪节点执行
     /// Trace node execution
     pub async fn start_node(
         &self,
@@ -250,7 +231,6 @@ impl WorkflowTracer {
         span
     }
 
-    /// 结束节点执行
     /// End node execution
     pub async fn end_node(
         &self,
@@ -276,7 +256,6 @@ impl WorkflowTracer {
         }
     }
 
-    /// 结束工作流执行
     /// End workflow execution
     pub async fn end_workflow(&self, execution_id: &str, success: bool, error: Option<&str>) {
         if let Some(span) = self.workflow_spans.write().await.remove(execution_id) {
@@ -295,7 +274,6 @@ impl WorkflowTracer {
         }
     }
 
-    /// 记录工作流事件
     /// Record workflow event
     pub async fn record_event(&self, execution_id: &str, event_name: &str) {
         if let Some(span) = self.workflow_spans.read().await.get(execution_id) {
@@ -303,7 +281,6 @@ impl WorkflowTracer {
         }
     }
 
-    /// 设置工作流属性
     /// Set workflow attribute
     pub async fn set_attribute(
         &self,
@@ -316,14 +293,12 @@ impl WorkflowTracer {
         }
     }
 
-    /// 获取 Tracer
     /// Get Tracer
     pub fn tracer(&self) -> Arc<Tracer> {
         self.tracer.clone()
     }
 }
 
-/// 消息追踪器 - 用于追踪 Agent 间的消息传递
 /// Message Tracer - For tracing message passing between Agents
 pub struct MessageTracer {
     tracer: Arc<Tracer>,
@@ -338,7 +313,6 @@ impl MessageTracer {
         }
     }
 
-    /// 追踪消息发送，返回包含追踪上下文的 headers
     /// Trace message sending, returns headers containing trace context
     pub async fn trace_send(
         &self,
@@ -361,7 +335,6 @@ impl MessageTracer {
         span.set_attribute("messaging.destination", destination)
             .await;
 
-        // 注入追踪上下文
         // Inject trace context
         let mut headers = HashMap::new();
         let span_context = span.span_context().await;
@@ -370,7 +343,6 @@ impl MessageTracer {
         (span, headers)
     }
 
-    /// 追踪消息接收
     /// Trace message receiving
     pub async fn trace_receive(
         &self,
@@ -379,7 +351,6 @@ impl MessageTracer {
         destination: &str,
         headers: &HashMap<String, String>,
     ) -> Span {
-        // 提取追踪上下文
         // Extract trace context
         let parent_context = self.propagator.extract(headers);
 
@@ -400,14 +371,12 @@ impl MessageTracer {
         span
     }
 
-    /// 结束消息追踪
     /// End message tracing
     pub async fn end_span(&self, span: &Span) {
         self.tracer.end_span(span).await;
     }
 }
 
-/// 追踪的 Agent 包装器
 /// Traced Agent Wrapper
 pub struct TracedAgent<A> {
     agent: A,
@@ -440,7 +409,6 @@ impl<A> TracedAgent<A> {
         &self.agent_id
     }
 
-    /// 执行带追踪的操作
     /// Execute operation with tracing
     pub async fn traced_operation<F, Fut, R>(
         &self,
@@ -464,7 +432,6 @@ impl<A> TracedAgent<A> {
     }
 }
 
-/// 追踪的 Workflow 包装器
 /// Traced Workflow Wrapper
 pub struct TracedWorkflow<W> {
     workflow: W,
@@ -501,7 +468,6 @@ impl<W> TracedWorkflow<W> {
     }
 }
 
-/// 辅助函数：追踪 Agent 操作
 /// Helper function: trace Agent operation
 pub async fn trace_agent_operation<F, Fut, R>(
     tracer: &AgentTracer,
@@ -520,7 +486,6 @@ where
     result
 }
 
-/// 辅助函数：追踪 Workflow 执行
 /// Helper function: trace Workflow execution
 pub async fn trace_workflow_execution<F, Fut, R>(
     tracer: &WorkflowTracer,
@@ -541,7 +506,6 @@ where
     result
 }
 
-/// 创建默认的追踪设置
 /// Create default tracing setup
 pub fn create_default_tracing(
     service_name: &str,
@@ -553,7 +517,6 @@ pub fn create_default_tracing(
     let tracer_config = TracerConfig::new(service_name);
     let provider = Arc::new(TracerProvider::new(tracer_config, processor));
 
-    // 需要使用 futures 来同步获取 tracer
     // Need to use futures to synchronously get the tracer
     let tracer = futures::executor::block_on(provider.default_tracer());
 
@@ -625,23 +588,19 @@ mod tests {
 
         let message_tracer = MessageTracer::new(tracer);
 
-        // 发送消息
         // Send message
         let (send_span, headers) = message_tracer
             .trace_send("task_request", "agent-1", "agent-2", None)
             .await;
 
-        // 验证 headers 包含追踪信息
         // Verify headers contain trace information
         assert!(headers.contains_key("traceparent"));
 
-        // 接收消息
         // Receive message
         let receive_span = message_tracer
             .trace_receive("task_request", "agent-1", "agent-2", &headers)
             .await;
 
-        // 验证 trace_id 相同
         // Verify trace_id is the same
         assert_eq!(send_span.trace_id().await, receive_span.trace_id().await);
 


### PR DESCRIPTION
## Summary
- remove duplicated Chinese comments from the tracing instrumentation docs
- keep the existing English documentation intact
- keep the change limited to a single non-behavioral file for issue #608

## Testing
- editor diagnostics checked for the touched file

Part of #608