### PR TITLE
align UniFFI UDL with implemented FFI API and add contract hardening guard

### DIFF
--- a/crates/mofa-ffi/src/mofa.udl
+++ b/crates/mofa-ffi/src/mofa.udl
@@ -95,6 +95,18 @@ dictionary ChatMessage {
     string content;
 };
 
+// LLM configuration for constructing agents
+dictionary LLMConfig {
+    LLMProviderType provider;
+    string? model;
+    string? api_key;
+    string? base_url;
+    string? deployment;
+    float? temperature;
+    u32? max_tokens;
+    string? system_prompt;
+};
+
 // ============================================================================
 // Session Management Types
 // ============================================================================
@@ -167,6 +179,14 @@ interface LLMAgentBuilder {
     // Set context window size (in rounds)
     LLMAgentBuilder set_context_window_size(u32 size);
 
+    // Set OpenAI provider configuration
+    [Throws=MoFaError]
+    LLMAgentBuilder set_openai_provider(
+        string api_key,
+        string? base_url,
+        string? model
+    );
+
     // Build the LLMAgent synchronously
     [Throws=MoFaError]
     LLMAgent build();
@@ -178,6 +198,14 @@ interface LLMAgentBuilder {
 
 // LLM Agent - the main interface for LLM interactions
 interface LLMAgent {
+    // Create from configuration file (agent.yml)
+    [Throws=MoFaError, Name=from_config_file]
+    constructor(string config_path);
+
+    // Create from config dictionary and explicit identity
+    [Throws=MoFaError, Name=from_config]
+    constructor(LLMConfig config, string agent_id, string name);
+
     // Get agent ID
     [Throws=MoFaError]
     string agent_id();

--- a/crates/mofa-ffi/src/uniffi_bindings.rs
+++ b/crates/mofa-ffi/src/uniffi_bindings.rs
@@ -280,17 +280,17 @@ pub trait FfiToolCallback: Send + Sync {
 // =============================================================================
 
 /// Get MoFA version
-pub fn get_version() -> String {
+pub(crate) fn get_version() -> String {
     env!("CARGO_PKG_VERSION").to_string()
 }
 
 /// Check if Dora runtime support is available
-pub fn is_dora_available() -> bool {
+pub(crate) fn is_dora_available() -> bool {
     cfg!(feature = "dora")
 }
 
 /// Create a new LLM Agent Builder
-pub fn new_llm_agent_builder() -> Result<std::sync::Arc<LLMAgentBuilder>, MoFaError> {
+pub(crate) fn new_llm_agent_builder() -> Result<std::sync::Arc<LLMAgentBuilder>, MoFaError> {
     LLMAgentBuilder::create()
 }
 
@@ -590,7 +590,7 @@ pub struct LLMAgentBuilder {
 
 impl LLMAgentBuilder {
     /// Create a new builder
-    pub fn create() -> Result<Arc<Self>, MoFaError> {
+    pub(crate) fn create() -> Result<Arc<Self>, MoFaError> {
         let runtime =
             tokio::runtime::Runtime::new().map_err(|e| MoFaError::RuntimeError(e.to_string()))?;
         Ok(Arc::new(Self {
@@ -1162,5 +1162,24 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("Runtime error:"));
         assert!(msg.contains("get_last_output is not yet supported"));
+    }
+
+    #[test]
+    fn udl_contract_includes_required_ffi_surface() {
+        // Contract guard: CI should fail when critical UDL entries drift from
+        // the implemented UniFFI
+        let udl = include_str!("mofa.udl");
+
+        for required in [
+            "dictionary LLMConfig",
+            "[Throws=MoFaError, Name=from_config_file]",
+            "[Throws=MoFaError, Name=from_config]",
+            "LLMAgentBuilder set_openai_provider(",
+        ] {
+            assert!(
+                udl.contains(required),
+                "missing required UDL contract marker: {required}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes the primary UniFFI contract drift in `mofa-ffi` by updating `mofa.udl` to match APIs that already exist in `uniffi_bindings.rs`.
Fixes: #1101

Both Phase 1 + Phase 2 scope: contract alignment and hardening.

## What changed

**File changed:** `crates/mofa-ffi/src/mofa.udl`:

1. Added missing `LLMConfig` dictionary used by FFI constructor paths.
2. Added `LLMAgent` constructors that map to existing Rust methods:
   - `from_config_file(string config_path)`
   - `from_config(LLMConfig config, string agent_id, string name)`
3. Added missing builder API export:
   - `set_openai_provider(string api_key, string? base_url, string? model)`

`crates/mofa-ffi/src/uniffi_bindings.rs`:

4. Added UDL contract guard test:
   - `udl_contract_includes_required_ffi_surface`
   - Verifies required UDL markers for:
     - `LLMConfig`
     - `from_config_file`
     - `from_config`
     - `set_openai_provider`
5. Reduced visibility of implementation-only helpers from `pub` to `pub(crate)`:
   - `get_version`
   - `is_dora_available`
   - `new_llm_agent_builder`
   - `LLMAgentBuilder::create`

## Testing

Executed:

```bash
cargo test -p mofa-ffi --features uniffi -- --nocapture
```

- Build succeeded
- UniFFI scaffolding generation succeeded
- Test result: `2 passed; 0 failed`
