### PR TITLE
fix(examples): remove duplicate anyhow dependency

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -70,7 +70,6 @@ serde_yaml = "0.9"
 bincode = "1.3"
 tokio = { version = "1", features = ["full", "rt-multi-thread", "sync"] }
 tokio-stream = { version = "0.1", features = ["net"] }
-anyhow = "1.0"
 uuid = { version = "1.7", features = ["v4", "v7"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }


### PR DESCRIPTION
Fixes a duplicate anyhow key in examples/Cargo.toml which causes cargo check to fail.