### PR TITLE
fix(orchestration): Improve pipeline coordination timeout and response handling

### DIFF
--- a/crates/mofa-foundation/src/coordination/mod.rs
+++ b/crates/mofa-foundation/src/coordination/mod.rs
@@ -7,6 +7,9 @@ use mofa_kernel::{AgentBus, CommunicationMode};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use tokio::time::{Duration, timeout};
+
+const PIPELINE_STAGE_TIMEOUT_SECS: u64 = 5;
 
 /// 协同策略枚举
 /// Enumeration of coordination strategies
@@ -37,6 +40,15 @@ pub struct AgentCoordinator {
 }
 
 impl AgentCoordinator {
+    fn extract_pipeline_task(task_msg: &AgentMessage) -> GlobalResult<(String, String)> {
+        match task_msg {
+            AgentMessage::TaskRequest { task_id, content } => Ok((task_id.clone(), content.clone())),
+            _ => Err(GlobalError::Other(
+                "Pipeline coordination only supports TaskRequest messages".to_string(),
+            )),
+        }
+    }
+
     /// 创建协同器
     /// Create a new coordinator
     pub async fn new(bus: Arc<AgentBus>, strategy: CoordinationStrategy) -> Self {
@@ -115,11 +127,13 @@ impl AgentCoordinator {
     /// 流水线模式协同逻辑（任务串行传递）
     /// Pipeline coordination logic (Serial task transmission)
     async fn pipeline_coordinate(&self, task_msg: &AgentMessage) -> GlobalResult<()> {
+        let (root_task_id, initial_content) = Self::extract_pipeline_task(task_msg)?;
         let role_map = self.role_mapping.read().await;
         // 按流水线阶段顺序获取角色（如 "stage1_extract" → "stage2_process" → "stage3_output"）
         // Get roles by pipeline sequence (e.g., "stage1_extract" -> "stage2_process" -> "stage3_output")
         let stages = vec!["stage1", "stage2", "stage3"];
-        let mut last_output: Option<String> = None;
+        // Carry the previous stage's output forward as the next stage's input.
+        let mut last_output: Option<String> = Some(initial_content);
 
         for stage in stages {
             let agents = role_map
@@ -128,13 +142,24 @@ impl AgentCoordinator {
             let agent_id = &agents[0];
             // 传递上一阶段输出作为当前阶段输入
             // Pass the output of the previous stage as current stage input
-            let current_msg = match last_output {
-                Some(ref output) => AgentMessage::TaskRequest {
-                    task_id: uuid::Uuid::now_v7().to_string(),
-                    content: output.clone(),
-                },
-                None => task_msg.clone(),
+            let current_msg = AgentMessage::TaskRequest {
+                // Keep one root task id across the full pipeline for traceability.
+                task_id: root_task_id.clone(),
+                content: last_output.clone().ok_or_else(|| {
+                    GlobalError::Other(format!("Pipeline stage {} has no upstream output", stage))
+                })?,
             };
+            let response_bus = self.bus.clone();
+            let response_agent_id = agent_id.to_string();
+            let response_handle = tokio::spawn(async move {
+                response_bus
+                    .receive_message(
+                        "coordinator",
+                        CommunicationMode::PointToPoint(response_agent_id),
+                    )
+                    .await
+            });
+            tokio::task::yield_now().await;
             // 点对点发送给当前阶段智能体
             // Send point-to-point to the agent of the current stage
             self.bus
@@ -145,18 +170,54 @@ impl AgentCoordinator {
                 )
                 .await
                 .map_err(|e| GlobalError::Other(e.to_string()))?;
-            // 接收当前阶段输出（简化示例）
-            // Receive current stage output (Simplified example)
-            if let Some(AgentMessage::TaskResponse { result, .. }) = self
-                .bus
-                .receive_message(
-                    agent_id,
-                    CommunicationMode::PointToPoint("coordinator".to_string()),
-                )
-                .await
-                .map_err(|e| GlobalError::Other(e.to_string()))?
-            {
-                last_output = Some(result);
+            // Wait on the coordinator side reply channel with a bounded timeout.
+            let stage_response = timeout(
+                Duration::from_secs(PIPELINE_STAGE_TIMEOUT_SECS),
+                response_handle,
+            )
+            .await
+            .map_err(|_| {
+                GlobalError::Other(format!(
+                    "Timed out waiting for pipeline stage {} ({})",
+                    stage, agent_id
+                ))
+            })?
+            .map_err(|e| GlobalError::Other(format!("Pipeline stage {} join failed: {}", stage, e)))?
+            .map_err(|e| GlobalError::Other(e.to_string()))?;
+
+            match stage_response {
+                Some(AgentMessage::TaskResponse {
+                    task_id,
+                    result,
+                    status,
+                }) => {
+                    // A stage must answer for the same root task the pipeline started with.
+                    if task_id != root_task_id {
+                        return Err(GlobalError::Other(format!(
+                            "Pipeline stage {} returned mismatched task id: expected {}, got {}",
+                            stage, root_task_id, task_id
+                        )));
+                    }
+                    if status != TaskStatus::Success {
+                        return Err(GlobalError::Other(format!(
+                            "Pipeline stage {} ({}) failed for task {}",
+                            stage, agent_id, root_task_id
+                        )));
+                    }
+                    last_output = Some(result);
+                }
+                Some(other) => {
+                    return Err(GlobalError::Other(format!(
+                        "Pipeline stage {} ({}) returned unexpected message: {:?}",
+                        stage, agent_id, other
+                    )));
+                }
+                None => {
+                    return Err(GlobalError::Other(format!(
+                        "Pipeline stage {} ({}) closed without a response",
+                        stage, agent_id
+                    )));
+                }
             }
         }
         Ok(())

--- a/crates/mofa-foundation/src/coordination/tests.rs
+++ b/crates/mofa-foundation/src/coordination/tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mofa_kernel::message::AgentMessage;
+    use mofa_kernel::message::{AgentMessage, TaskStatus};
     use mofa_kernel::AgentBus;
     use mofa_kernel::CommunicationMode;
     use mofa_kernel::agent::{AgentCapabilities, AgentMetadata, AgentState};
@@ -65,6 +65,10 @@ mod tests {
 
     // Register a point to point channel from coordinator to peer
     async fn register_peer_channel(bus: &AgentBus, id: &str) {
+        register_point_to_point_channel(bus, id, "coordinator").await;
+    }
+
+    async fn register_point_to_point_channel(bus: &AgentBus, id: &str, sender: &str) {
         let metadata = AgentMetadata {
             id: id.to_string(),
             name: id.to_string(),
@@ -75,7 +79,7 @@ mod tests {
         };
         bus.register_channel(
             &metadata,
-            CommunicationMode::PointToPoint("coordinator".to_string()),
+            CommunicationMode::PointToPoint(sender.to_string()),
         )
         .await
         .unwrap();
@@ -96,5 +100,246 @@ mod tests {
     #[tokio::test]
     async fn test_register_role() {
         assert!(true);
+    }
+
+    #[tokio::test]
+    async fn test_pipeline_preserves_root_task_id_across_stages() {
+        let bus = Arc::new(AgentBus::new());
+        for stage in ["stage1", "stage2", "stage3"] {
+            register_point_to_point_channel(&bus, stage, "coordinator").await;
+            register_point_to_point_channel(&bus, "coordinator", stage).await;
+        }
+
+        let coordinator = AgentCoordinator::new(bus.clone(), CoordinationStrategy::Pipeline).await;
+        coordinator.register_role("stage1", "stage1").await.unwrap();
+        coordinator.register_role("stage2", "stage2").await.unwrap();
+        coordinator.register_role("stage3", "stage3").await.unwrap();
+
+        // Each stage echoes the same root task id back to the coordinator
+        let root_task_id = "pipeline-root-123".to_string();
+        let expected_task_id = root_task_id.clone();
+        let bus_stage1 = bus.clone();
+        let bus_stage2 = bus.clone();
+        let bus_stage3 = bus.clone();
+
+        // Stage 1 turns the initial request into pipeline output for stage 2
+        let stage1 = tokio::spawn(async move {
+            let msg = bus_stage1
+                .receive_message("stage1", CommunicationMode::PointToPoint("coordinator".to_string()))
+                .await
+                .unwrap()
+                .unwrap();
+            let AgentMessage::TaskRequest { task_id, content } = msg else {
+                panic!("expected task request");
+            };
+            bus_stage1
+                .send_message(
+                    "stage1",
+                    CommunicationMode::PointToPoint("coordinator".to_string()),
+                    &AgentMessage::TaskResponse {
+                        task_id: task_id.clone(),
+                        result: format!("{content}-s1"),
+                        status: TaskStatus::Success,
+                    },
+                )
+                .await
+                .unwrap();
+            task_id
+        });
+
+        // Stage 2 should receive the same root task id, not a fresh generated id.
+        let stage2 = tokio::spawn(async move {
+            let msg = bus_stage2
+                .receive_message("stage2", CommunicationMode::PointToPoint("coordinator".to_string()))
+                .await
+                .unwrap()
+                .unwrap();
+            let AgentMessage::TaskRequest { task_id, content } = msg else {
+                panic!("expected task request");
+            };
+            bus_stage2
+                .send_message(
+                    "stage2",
+                    CommunicationMode::PointToPoint("coordinator".to_string()),
+                    &AgentMessage::TaskResponse {
+                        task_id: task_id.clone(),
+                        result: format!("{content}-s2"),
+                        status: TaskStatus::Success,
+                    },
+                )
+                .await
+                .unwrap();
+            task_id
+        });
+
+        // Stage 3 completes the chain and lets us assert lineage end to end.
+        let stage3 = tokio::spawn(async move {
+            let msg = bus_stage3
+                .receive_message("stage3", CommunicationMode::PointToPoint("coordinator".to_string()))
+                .await
+                .unwrap()
+                .unwrap();
+            let AgentMessage::TaskRequest { task_id, content } = msg else {
+                panic!("expected task request");
+            };
+            bus_stage3
+                .send_message(
+                    "stage3",
+                    CommunicationMode::PointToPoint("coordinator".to_string()),
+                    &AgentMessage::TaskResponse {
+                        task_id: task_id.clone(),
+                        result: format!("{content}-s3"),
+                        status: TaskStatus::Success,
+                    },
+                )
+                .await
+                .unwrap();
+            task_id
+        });
+
+        coordinator
+            .coordinate_task(&AgentMessage::TaskRequest {
+                task_id: root_task_id.clone(),
+                content: "input".to_string(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(stage1.await.unwrap(), expected_task_id);
+        assert_eq!(stage2.await.unwrap(), expected_task_id);
+        assert_eq!(stage3.await.unwrap(), expected_task_id);
+    }
+
+    #[tokio::test]
+    async fn test_pipeline_times_out_when_stage_never_responds() {
+        let bus = Arc::new(AgentBus::new());
+        register_point_to_point_channel(&bus, "stage1", "coordinator").await;
+        register_point_to_point_channel(&bus, "coordinator", "stage1").await;
+        register_point_to_point_channel(&bus, "stage2", "coordinator").await;
+        register_point_to_point_channel(&bus, "coordinator", "stage2").await;
+        register_point_to_point_channel(&bus, "stage3", "coordinator").await;
+        register_point_to_point_channel(&bus, "coordinator", "stage3").await;
+
+        let coordinator = AgentCoordinator::new(bus.clone(), CoordinationStrategy::Pipeline).await;
+        coordinator.register_role("stage1", "stage1").await.unwrap();
+        coordinator.register_role("stage2", "stage2").await.unwrap();
+        coordinator.register_role("stage3", "stage3").await.unwrap();
+
+        let bus_stage1 = bus.clone();
+        tokio::spawn(async move {
+            let msg = bus_stage1
+                .receive_message("stage1", CommunicationMode::PointToPoint("coordinator".to_string()))
+                .await
+                .unwrap()
+                .unwrap();
+            let AgentMessage::TaskRequest { task_id, content } = msg else {
+                panic!("expected task request");
+            };
+            bus_stage1
+                .send_message(
+                    "stage1",
+                    CommunicationMode::PointToPoint("coordinator".to_string()),
+                    &AgentMessage::TaskResponse {
+                        task_id,
+                        result: content,
+                        status: TaskStatus::Success,
+                    },
+                )
+                .await
+                .unwrap();
+        });
+
+        let bus_stage2 = bus.clone();
+        tokio::spawn(async move {
+            let _ = bus_stage2
+                .receive_message("stage2", CommunicationMode::PointToPoint("coordinator".to_string()))
+                .await
+                .unwrap()
+                .unwrap();
+            // Hold the stage open without replying so the coordinator hits its timeout path
+            tokio::time::sleep(Duration::from_secs(10)).await;
+        });
+
+        let err = coordinator
+            .coordinate_task(&AgentMessage::TaskRequest {
+                task_id: "pipeline-timeout".to_string(),
+                content: "input".to_string(),
+            })
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("Timed out waiting for pipeline stage stage2"));
+    }
+
+    #[tokio::test]
+    async fn test_pipeline_returns_stage_failure() {
+        let bus = Arc::new(AgentBus::new());
+        for stage in ["stage1", "stage2", "stage3"] {
+            register_point_to_point_channel(&bus, stage, "coordinator").await;
+            register_point_to_point_channel(&bus, "coordinator", stage).await;
+        }
+
+        let coordinator = AgentCoordinator::new(bus.clone(), CoordinationStrategy::Pipeline).await;
+        coordinator.register_role("stage1", "stage1").await.unwrap();
+        coordinator.register_role("stage2", "stage2").await.unwrap();
+        coordinator.register_role("stage3", "stage3").await.unwrap();
+
+        let bus_stage1 = bus.clone();
+        tokio::spawn(async move {
+            let msg = bus_stage1
+                .receive_message("stage1", CommunicationMode::PointToPoint("coordinator".to_string()))
+                .await
+                .unwrap()
+                .unwrap();
+            let AgentMessage::TaskRequest { task_id, content } = msg else {
+                panic!("expected task request");
+            };
+            bus_stage1
+                .send_message(
+                    "stage1",
+                    CommunicationMode::PointToPoint("coordinator".to_string()),
+                    &AgentMessage::TaskResponse {
+                        task_id,
+                        result: content,
+                        status: TaskStatus::Success,
+                    },
+                )
+                .await
+                .unwrap();
+        });
+
+        let bus_stage2 = bus.clone();
+        tokio::spawn(async move {
+            let msg = bus_stage2
+                .receive_message("stage2", CommunicationMode::PointToPoint("coordinator".to_string()))
+                .await
+                .unwrap()
+                .unwrap();
+            let AgentMessage::TaskRequest { task_id, .. } = msg else {
+                panic!("expected task request");
+            };
+            bus_stage2
+                .send_message(
+                    "stage2",
+                    CommunicationMode::PointToPoint("coordinator".to_string()),
+                    &AgentMessage::TaskResponse {
+                        task_id,
+                        result: "failed".to_string(),
+                        status: TaskStatus::Failed,
+                    },
+                )
+                .await
+                .unwrap();
+        });
+
+        let err = coordinator
+            .coordinate_task(&AgentMessage::TaskRequest {
+                task_id: "pipeline-failure".to_string(),
+                content: "input".to_string(),
+            })
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("Pipeline stage stage2 (stage2) failed"));
     }
 }


### PR DESCRIPTION
## Summary

This PR hardens pipeline coordination by adding bounded stage waits, preserving a stable root task ID across the full pipeline, and surfacing explicit stage failures instead of silently hanging or drifting task lineage.
Fixes: #1121

## Problem

`AgentCoordinator::pipeline_coordinate` had three reliability problems:

- it waited indefinitely for each stage response with no timeout
- it generated a new task ID for later stages, breaking end-to-end lineage
- it did not fail clearly when a stage returned no response, returned the wrong task ID, or responded with a failed status

This made the pipeline fragile and difficult to observe.

## Changes

- added a per-stage timeout in `crates/mofa-foundation/src/coordination/mod.rs`:
- preserved one root `task_id` across all pipeline stages
- added explicit pipeline errors for:
  - timeout waiting for a stage
  - closed channel / missing response
  - unexpected message type
  - mismatched response task ID
  - failed stage status
- fixed the reply path to listen on the coordinator-side endpoint
- subscribed to the reply channel before sending each stage request so fast responses are not lost

## Tests

Added focused coverage in `crates/mofa-foundation/src/coordination/tests.rs`:

- `test_pipeline_preserves_root_task_id_across_stages`
- `test_pipeline_times_out_when_stage_never_responds`
- `test_pipeline_returns_stage_failure`

Validated with:

```bash
cargo test -p mofa-foundation coordination::tests::
```

Result:

- `test_register_role` passed
- `test_peer_to_peer_coordination` passed
- `test_pipeline_preserves_root_task_id_across_stages` passed
- `test_pipeline_times_out_when_stage_never_responds` passed
- `test_pipeline_returns_stage_failure` passed

