### PR TITLE
fix(gateway): use next_index - 1 for heartbeat prev_log_index

### DIFF
--- a/crates/mofa-gateway/src/consensus/engine.rs
+++ b/crates/mofa-gateway/src/consensus/engine.rs
@@ -492,12 +492,19 @@ impl ConsensusEngine {
                 .copied()
                 .unwrap_or(prev_log_index);
 
+            // prev_log_index is the entry *before* next_index, i.e. next_index - 1.
+            // replicate_entry already does this correctly (saturating_sub(1)),
+            // but heartbeats were sending next_index raw, causing the follower's
+            // consistency check to always fail (it looks for an entry one past
+            // what actually exists).
+            let hb_prev_log_index = LogIndex::new(next_index.0.saturating_sub(1));
+
             // Read commit_index after getting prev_log info to ensure we have the latest
             let current_commit_index = state.read().await.commit_index;
             let heartbeat = AppendEntriesRequest {
                 term: current_term,
                 leader_id: node_id.clone(),
-                prev_log_index: next_index,
+                prev_log_index: hb_prev_log_index,
                 prev_log_term,
                 entries: Vec::new(), // Empty for heartbeat
                 leader_commit: current_commit_index,

--- a/crates/mofa-gateway/src/consensus/engine_tests.rs
+++ b/crates/mofa-gateway/src/consensus/engine_tests.rs
@@ -86,4 +86,71 @@ mod tests {
             crate::error::ConsensusError::NotLeader(_)
         ));
     }
+
+    /// Verify that heartbeats use `prev_log_index = next_index - 1`, not
+    /// `next_index` itself.  Before the fix, the leader sent `next_index`
+    /// raw, which is one past the follower's last entry.  The follower's
+    /// consistency check then looks for an entry that doesn't exist and
+    /// rejects every heartbeat.
+    #[tokio::test]
+    async fn test_heartbeat_prev_log_index_off_by_one() {
+        use crate::consensus::transport::{AppendEntriesRequest, AppendEntriesResponse};
+        use crate::types::{LogEntry, LogIndex, Term};
+
+        let node_id = NodeId::new("follower-1");
+        let storage = Arc::new(RaftStorage::new());
+        let transport = Arc::new(InMemoryTransport::new());
+        let config = RaftConfig::default();
+        let engine = ConsensusEngine::new(node_id.clone(), config, storage, transport);
+
+        // Populate the follower's log with 3 entries via AppendEntries.
+        let entries: Vec<LogEntry> = (1..=3)
+            .map(|i| LogEntry {
+                term: Term::new(1),
+                index: LogIndex::new(i),
+                data: Vec::new(),
+            })
+            .collect();
+
+        let populate = AppendEntriesRequest {
+            term: Term::new(1),
+            leader_id: NodeId::new("leader"),
+            prev_log_index: LogIndex::new(0), // empty log, start from beginning
+            prev_log_term: Term::new(0),
+            entries,
+            leader_commit: LogIndex::new(0),
+        };
+        let resp = engine.handle_append_entries(populate).await.unwrap();
+        assert!(resp.success, "populating the follower log must succeed");
+
+        // Heartbeat with correct prev_log_index (= next_index - 1 = 3).
+        // The follower has entries 1-3, so checking index 3 should succeed.
+        let good_heartbeat = AppendEntriesRequest {
+            term: Term::new(1),
+            leader_id: NodeId::new("leader"),
+            prev_log_index: LogIndex::new(3), // correct: last entry index
+            prev_log_term: Term::new(1),
+            entries: Vec::new(),
+            leader_commit: LogIndex::new(0),
+        };
+        let resp = engine.handle_append_entries(good_heartbeat).await.unwrap();
+        assert!(resp.success, "heartbeat with prev_log_index=3 (correct) must succeed");
+
+        // Heartbeat with the OLD buggy prev_log_index (= next_index = 4).
+        // The follower only has 3 entries, so checking index 4 should fail.
+        let bad_heartbeat = AppendEntriesRequest {
+            term: Term::new(1),
+            leader_id: NodeId::new("leader"),
+            prev_log_index: LogIndex::new(4), // buggy: one past last entry
+            prev_log_term: Term::new(1),
+            entries: Vec::new(),
+            leader_commit: LogIndex::new(0),
+        };
+        let resp = engine.handle_append_entries(bad_heartbeat).await.unwrap();
+        assert!(
+            !resp.success,
+            "heartbeat with prev_log_index=4 (off-by-one) must fail — \
+             this is the scenario the fix prevents on the sender side"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Heartbeats in `send_heartbeats()` were sending `next_index` as `prev_log_index`. Raft requires `prev_log_index = next_index - 1`. The same file already handles this correctly in `replicate_entry()` via `saturating_sub(1)`, but heartbeats used the raw value.

## Problem

The follower's consistency check (`handle_append_entries`) converts `prev_log_index` to an array index via `(prev_log_index - 1) as usize` and checks if that index exists. With the off-by-one, the check always looked for an entry one past the follower's last replicated entry, causing every heartbeat to fail.

When `success = false`, the leader's response handler skips updating `match_index` / `next_index`, so its view of follower replication progress goes stale during idle periods (no new proposals).

## Fix

- Changed `prev_log_index: next_index` to `prev_log_index: LogIndex::new(next_index.0.saturating_sub(1))`, matching the existing pattern in `replicate_entry()`
- Added a test that populates a follower's log and verifies:
  - Heartbeat with `prev_log_index = last_entry_index` (correct) → succeeds
  - Heartbeat with `prev_log_index = last_entry_index + 1` (old bug) → fails

## Testing

- `cargo test -p mofa-gateway` — all 49 unit tests + 17 integration tests pass

Closes #1126