### PR TITLE
fix(executor): resume_from_checkpoint correctly preserves Paused status and emits WorkflowEnd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5877,6 +5877,7 @@ dependencies = [
  "config",
  "criterion",
  "cron",
+ "dashmap 5.5.3",
  "error-stack",
  "futures",
  "hex",

--- a/crates/mofa-foundation/src/workflow/executor.rs
+++ b/crates/mofa-foundation/src/workflow/executor.rs
@@ -634,19 +634,31 @@ impl WorkflowExecutor {
                 .as_millis() as u64,
         );
 
-        match result {
+        let final_status = match result {
             Ok(_) => {
-                execution_record.status = WorkflowStatus::Completed;
-                info!(
-                    "Workflow {} resumed and completed in {:?}",
-                    graph.name, duration
-                );
+                if execution_record.status != WorkflowStatus::Paused {
+                    execution_record.status = WorkflowStatus::Completed;
+                    info!(
+                        "Workflow {} resumed and completed in {:?}",
+                        graph.name, duration
+                    );
+                    "completed".to_string()
+                } else {
+                    info!(
+                        "Workflow {} resumed and paused again after {:?}",
+                        graph.name, duration
+                    );
+                    // Preserve context so the caller can resume again later
+                    execution_record.context = Some(ctx.clone());
+                    "paused".to_string()
+                }
             }
             Err(ref e) => {
                 execution_record.status = WorkflowStatus::Failed(e.clone());
                 error!("Workflow {} resumed and failed: {}", graph.name, e);
+                format!("failed: {}", e)
             }
-        }
+        };
 
         execution_record.outputs = ctx.get_all_outputs().await;
 
@@ -668,6 +680,15 @@ impl WorkflowExecutor {
                 .await;
             }
         }
+
+        // Emit debug telemetry: WorkflowEnd (was missing in resume path)
+        self.emit_debug(DebugEvent::WorkflowEnd {
+            workflow_id: graph.id.clone(),
+            execution_id: ctx.execution_id.clone(),
+            timestamp_ms: DebugEvent::now_ms(),
+            status: final_status,
+        })
+        .await;
 
         Ok(execution_record)
     }
@@ -1944,5 +1965,245 @@ mod tests {
             .await
             .expect("Should complete without timeout");
         assert!(matches!(result.status, WorkflowStatus::Completed));
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests for fix #994: resume_from_checkpoint must preserve Paused status
+    // and emit WorkflowEnd telemetry.
+    // -------------------------------------------------------------------------
+
+    /// Build a simple graph that goes: start → task → wait → end.
+    /// The wait node simulates the point at which a human-in-the-loop review
+    /// would pause the workflow.
+    fn make_wait_graph(id: &str) -> WorkflowGraph {
+        let mut graph = WorkflowGraph::new(id, "Wait-node workflow");
+        graph.add_node(WorkflowNode::start("start"));
+        graph.add_node(WorkflowNode::task(
+            "task1",
+            "First task",
+            |_ctx, _input| async move { Ok(WorkflowValue::String("step1_done".into())) },
+        ));
+        graph.add_node(WorkflowNode::wait(
+            "wait_review",
+            "Await review",
+            "human_review",
+        ));
+        graph.add_node(WorkflowNode::end("end"));
+
+        graph.connect("start", "task1");
+        graph.connect("task1", "wait_review");
+        graph.connect("wait_review", "end");
+        graph
+    }
+
+    /// Bug regression guard: the old code unconditionally set status to
+    /// `Completed` inside `resume_from_checkpoint`, even when the execution hit
+    /// another Wait node and set the status to `Paused`.
+    ///
+    /// After the fix, when `execute_from_node` marks the record as `Paused`,
+    /// `resume_from_checkpoint` must NOT overwrite it with `Completed`.
+    #[tokio::test]
+    async fn test_resume_from_checkpoint_preserves_paused_status() {
+        let executor = WorkflowExecutor::new(ExecutorConfig::default());
+        let graph = make_wait_graph("resume_paused_wf");
+
+        // --- First run: execute until the Wait node pauses the workflow ---
+        let first_run = executor
+            .execute(&graph, WorkflowValue::Null)
+            .await
+            .expect("First execute should succeed");
+
+        assert!(
+            matches!(first_run.status, WorkflowStatus::Paused),
+            "Expected Paused after reaching Wait node, got: {:?}",
+            first_run.status
+        );
+        assert!(
+            first_run.context.is_some(),
+            "ExecutionRecord.context must be populated when workflow is Paused"
+        );
+
+        // --- Build a checkpoint from the node outputs collected so far ---
+        //     In a real application this would come from a persisted store; we
+        //     synthesise it from the first run's outputs to verify the path.
+        let checkpoint = ExecutionCheckpoint {
+            execution_id: first_run.execution_id.clone(),
+            workflow_id: "resume_paused_wf".to_string(),
+            // The task node completed; the wait node did NOT complete.
+            completed_nodes: vec!["start".to_string(), "task1".to_string()],
+            node_outputs: first_run.outputs.clone(),
+            variables: std::collections::HashMap::new(),
+            timestamp: 0,
+        };
+
+        // --- Resume from checkpoint: the workflow will hit the Wait node again ---
+        let resumed = executor
+            .resume_from_checkpoint(&graph, checkpoint)
+            .await
+            .expect("resume_from_checkpoint should return Ok");
+
+        // Core invariant: status must still be Paused, NOT Completed.
+        assert!(
+            matches!(resumed.status, WorkflowStatus::Paused),
+            "BUG #994: resume_from_checkpoint must keep Paused when a Wait node \
+             is encountered during resume. Got: {:?}",
+            resumed.status
+        );
+
+        // The context must be preserved for a subsequent resume cycle.
+        assert!(
+            resumed.context.is_some(),
+            "ExecutionRecord.context must be set when resume ends with Paused"
+        );
+    }
+
+    /// A workflow with NO wait nodes should reach `Completed` when resumed from
+    /// a checkpoint, confirming the fix does not regress the happy path.
+    #[tokio::test]
+    async fn test_resume_from_checkpoint_completes_when_no_wait_node() {
+        let executor = WorkflowExecutor::new(ExecutorConfig::default());
+
+        let mut graph = WorkflowGraph::new("resume_complete_wf", "No-wait workflow");
+        graph.add_node(WorkflowNode::start("start"));
+        graph.add_node(WorkflowNode::task(
+            "task1",
+            "Task 1",
+            |_ctx, _input| async move { Ok(WorkflowValue::String("result".into())) },
+        ));
+        graph.add_node(WorkflowNode::end("end"));
+        graph.connect("start", "task1");
+        graph.connect("task1", "end");
+
+        // Build a checkpoint that simulates having already completed `start`.
+        let checkpoint = ExecutionCheckpoint {
+            execution_id: uuid::Uuid::now_v7().to_string(),
+            workflow_id: "resume_complete_wf".to_string(),
+            completed_nodes: vec!["start".to_string()],
+            node_outputs: std::collections::HashMap::new(),
+            variables: std::collections::HashMap::new(),
+            timestamp: 0,
+        };
+
+        let record = executor
+            .resume_from_checkpoint(&graph, checkpoint)
+            .await
+            .expect("resume should succeed");
+
+        assert!(
+            matches!(record.status, WorkflowStatus::Completed),
+            "Expected Completed for no-wait resume, got: {:?}",
+            record.status
+        );
+    }
+
+    /// `resume_from_checkpoint` must surface `Failed` status when a task node
+    /// returns an error – the fix must not break error propagation.
+    #[tokio::test]
+    async fn test_resume_from_checkpoint_propagates_failure() {
+        let executor = WorkflowExecutor::new(ExecutorConfig::default());
+
+        let mut graph = WorkflowGraph::new("resume_fail_wf", "Failing resume workflow");
+        graph.add_node(WorkflowNode::start("start"));
+        graph.add_node(WorkflowNode::task(
+            "bad_task",
+            "Bad task",
+            |_ctx, _input| async move { Err("intentional failure".to_string()) },
+        ));
+        graph.add_node(WorkflowNode::end("end"));
+        graph.connect("start", "bad_task");
+        graph.connect("bad_task", "end");
+
+        let checkpoint = ExecutionCheckpoint {
+            execution_id: uuid::Uuid::now_v7().to_string(),
+            workflow_id: "resume_fail_wf".to_string(),
+            completed_nodes: vec!["start".to_string()],
+            node_outputs: std::collections::HashMap::new(),
+            variables: std::collections::HashMap::new(),
+            timestamp: 0,
+        };
+
+        let record = executor
+            .resume_from_checkpoint(&graph, checkpoint)
+            .await
+            .expect("resume_from_checkpoint itself should return Ok");
+
+        match &record.status {
+            WorkflowStatus::Failed(msg) => {
+                assert!(
+                    msg.contains("intentional failure"),
+                    "Unexpected failure message: {}",
+                    msg
+                );
+            }
+            other => panic!("Expected Failed status from resume, got: {:?}", other),
+        }
+    }
+
+    /// Verify that `WorkflowEnd` telemetry is emitted during
+    /// `resume_from_checkpoint`.  We attach a simple in-memory collector and
+    /// confirm that at least one `WorkflowEnd` event is recorded after resume.
+    #[tokio::test]
+    async fn test_resume_from_checkpoint_emits_workflow_end_telemetry() {
+        use mofa_kernel::workflow::telemetry::{DebugEvent, TelemetryEmitter};
+        use std::sync::Arc;
+        use tokio::sync::RwLock;
+
+        // Minimal in-process collector
+        #[derive(Clone)]
+        struct TestEmitter {
+            events: Arc<RwLock<Vec<String>>>,
+        }
+
+        #[async_trait::async_trait]
+        impl TelemetryEmitter for TestEmitter {
+            async fn emit(&self, event: DebugEvent) {
+                if matches!(event, DebugEvent::WorkflowEnd { .. }) {
+                    self.events.write().await.push("WorkflowEnd".to_string());
+                }
+            }
+            fn is_enabled(&self) -> bool {
+                true
+            }
+        }
+
+        let collected: Arc<RwLock<Vec<String>>> = Arc::new(RwLock::new(Vec::new()));
+        let emitter = Arc::new(TestEmitter {
+            events: collected.clone(),
+        });
+
+        let executor = WorkflowExecutor::new(ExecutorConfig::default()).with_telemetry(emitter);
+
+        let mut graph = WorkflowGraph::new("telemetry_resume_wf", "Telemetry resume test");
+        graph.add_node(WorkflowNode::start("start"));
+        graph.add_node(WorkflowNode::task(
+            "task1",
+            "Task 1",
+            |_ctx, _input| async move { Ok(WorkflowValue::String("ok".into())) },
+        ));
+        graph.add_node(WorkflowNode::end("end"));
+        graph.connect("start", "task1");
+        graph.connect("task1", "end");
+
+        let checkpoint = ExecutionCheckpoint {
+            execution_id: uuid::Uuid::now_v7().to_string(),
+            workflow_id: "telemetry_resume_wf".to_string(),
+            completed_nodes: vec!["start".to_string()],
+            node_outputs: std::collections::HashMap::new(),
+            variables: std::collections::HashMap::new(),
+            timestamp: 0,
+        };
+
+        executor
+            .resume_from_checkpoint(&graph, checkpoint)
+            .await
+            .expect("resume should succeed");
+
+        let events = collected.read().await;
+        assert!(
+            events.iter().any(|e| e == "WorkflowEnd"),
+            "Expected WorkflowEnd telemetry event from resume_from_checkpoint, \
+             got events: {:?}",
+            *events
+        );
     }
 }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -53,6 +53,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "adversarial_testing_demo"
+version = "0.1.0"
+dependencies = [
+ "mofa-testing",
+ "serde_json",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,6 +961,18 @@ version = "0.1.0"
 dependencies = [
  "serde_json",
  "tempfile",
+]
+
+[[package]]
+name = "cloud_voice_demo"
+version = "0.1.0"
+dependencies = [
+ "dotenvy",
+ "mofa-kernel",
+ "mofa-plugins",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -2634,12 +2654,12 @@ name = "hitl_workflow"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "axum 0.7.9",
+ "axum",
  "chrono",
  "clap",
  "mofa-foundation",
  "mofa-kernel",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -3868,11 +3888,12 @@ version = "0.1.0"
 dependencies = [
  "async-openai",
  "async-trait",
- "axum 0.7.9",
+ "axum",
  "base64 0.22.1",
  "chrono",
  "config 0.14.1",
  "cron",
+ "dashmap 5.5.3",
  "error-stack",
  "futures",
  "hex",
@@ -4096,6 +4117,20 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "mofa-testing"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "mofa-foundation",
+ "mofa-kernel",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -5706,6 +5741,19 @@ dependencies = [
  "pin-project-lite",
  "reqwest",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "resume_from_checkpoint"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "mofa-foundation",
+ "mofa-kernel",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.22",
+ "uuid",
 ]
 
 [[package]]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -57,6 +57,7 @@ members = [
     "rag_retrieval_demo",
     "rag_indexing_demo",
     "adversarial_testing_demo",
+    "resume_from_checkpoint",
 ]
 
 [workspace.package]

--- a/examples/resume_from_checkpoint/Cargo.toml
+++ b/examples/resume_from_checkpoint/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "resume_from_checkpoint"
+version.workspace = true
+edition = "2021"
+
+[dependencies]
+mofa-foundation = { path = "../../crates/mofa-foundation" }
+mofa-kernel = { path = "../../crates/mofa-kernel" }
+async-trait.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+uuid.workspace = true

--- a/examples/resume_from_checkpoint/src/main.rs
+++ b/examples/resume_from_checkpoint/src/main.rs
@@ -1,0 +1,267 @@
+//! # Resume-from-Checkpoint Example
+//!
+//! Demonstrates the corrected behaviour of `resume_from_checkpoint` (fix #994).
+//!
+//! ## What this example shows
+//!
+//! * A workflow that pauses at a `Wait` (human-review) node.
+//! * How to serialise the mid-execution state into an `ExecutionCheckpoint`.
+//! * How `resume_from_checkpoint` correctly **preserves** `Paused` status when
+//!   the resumed execution hits another Wait node, instead of incorrectly
+//!   overwriting it with `Completed`.
+//! * How to supply the human decision and drive the workflow through to
+//!   `Completed` via a second resume cycle.
+//! * The `WorkflowEnd` debug-telemetry event being emitted on both the initial
+//!   execute path and the resume path.
+//!
+//! ## Running
+//!
+//! ```bash
+//! cargo run --example resume_from_checkpoint
+//! ```
+//!
+//! ## Workflow graph
+//!
+//! ```text
+//! start ──► validate_input ──► wait_for_approval ──► finalize ──► end
+//!                    (automatic)          (pauses)       (automatic)
+//! ```
+
+use mofa_foundation::workflow::{
+    ExecutionCheckpoint, ExecutorConfig, WorkflowExecutor, WorkflowGraph, WorkflowNode,
+    WorkflowStatus, WorkflowValue,
+};
+use mofa_foundation::workflow::{DebugEvent, TelemetryEmitter};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::{info, Level};
+
+// ---------------------------------------------------------------------------
+// Minimal in-process telemetry collector
+// ---------------------------------------------------------------------------
+
+/// Records the names of emitted `DebugEvent` variants so we can print them.
+#[derive(Clone)]
+struct ConsoleTelemetry {
+    events: Arc<RwLock<Vec<String>>>,
+}
+
+impl ConsoleTelemetry {
+    fn new() -> Self {
+        Self {
+            events: Arc::new(RwLock::new(Vec::new())),
+        }
+    }
+
+    async fn print_summary(&self) {
+        let events = self.events.read().await;
+        println!("\n📡 Telemetry events captured ({} total):", events.len());
+        for e in events.iter() {
+            println!("   • {e}");
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl TelemetryEmitter for ConsoleTelemetry {
+    async fn emit(&self, event: DebugEvent) {
+        let label = match &event {
+            DebugEvent::WorkflowStart { workflow_id, .. } => {
+                format!("WorkflowStart  [wf={workflow_id}]")
+            }
+            DebugEvent::WorkflowEnd { workflow_id, status, .. } => {
+                format!("WorkflowEnd    [wf={workflow_id}, status={status}]")
+            }
+            DebugEvent::NodeStart { node_id, .. } => format!("NodeStart      [node={node_id}]"),
+            DebugEvent::NodeEnd { node_id, .. } => format!("NodeEnd        [node={node_id}]"),
+            _ => "Other".to_string(),
+        };
+        self.events.write().await.push(label);
+    }
+
+    fn is_enabled(&self) -> bool {
+        true
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Build the workflow graph
+// ---------------------------------------------------------------------------
+
+fn build_approval_workflow() -> WorkflowGraph {
+    let mut graph = WorkflowGraph::new("approval_wf", "Approval Workflow");
+
+    // Start node
+    graph.add_node(WorkflowNode::start("start"));
+
+    // Automatic validation step
+    graph.add_node(WorkflowNode::task(
+        "validate_input",
+        "Validate Input",
+        |_ctx, input| async move {
+            println!("  🔍  validate_input: received input = {input:?}");
+            // Simulate basic validation delay
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            Ok(WorkflowValue::String("validated".to_string()))
+        },
+    ));
+
+    // Wait node: execution pauses here until a human approves
+    graph.add_node(WorkflowNode::wait(
+        "wait_for_approval",
+        "Wait For Approval",
+        "human_approval", // event type tag
+    ));
+
+    // Second automatic step, only reached after approval
+    graph.add_node(WorkflowNode::task(
+        "finalize",
+        "Finalize",
+        |_ctx, input| async move {
+            println!("  ✅  finalize: running with approval = {input:?}");
+            Ok(WorkflowValue::String("done".to_string()))
+        },
+    ));
+
+    graph.add_node(WorkflowNode::end("end"));
+
+    graph.connect("start", "validate_input");
+    graph.connect("validate_input", "wait_for_approval");
+    graph.connect("wait_for_approval", "finalize");
+    graph.connect("finalize", "end");
+
+    graph
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_max_level(Level::INFO)
+        .with_target(false)
+        .init();
+
+    let telemetry = Arc::new(ConsoleTelemetry::new());
+
+    let executor = WorkflowExecutor::new(ExecutorConfig::default())
+        .with_telemetry(telemetry.clone());
+
+    let graph = build_approval_workflow();
+
+    // -----------------------------------------------------------------------
+    // Phase 1: Initial execution — pauses at `wait_for_approval`
+    // -----------------------------------------------------------------------
+    println!("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("Phase 1: Initial execution");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+
+    let first_run = executor
+        .execute(&graph, WorkflowValue::String("order-42".to_string()))
+        .await
+        .expect("execute() must not return Err");
+
+    println!("\n  Status after Phase 1: {:?}", first_run.status);
+    assert!(
+        matches!(first_run.status, WorkflowStatus::Paused),
+        "Workflow should be Paused at the Wait node"
+    );
+    assert!(
+        first_run.context.is_some(),
+        "ExecutionRecord.context must be set so we can resume"
+    );
+
+    info!("Phase 1 complete — workflow is paused waiting for human approval.");
+
+    // -----------------------------------------------------------------------
+    // Phase 2: Simulate the system restarting (checkpoint-based resume)
+    //
+    // In production the `WorkflowContext` snapshot would be persisted to a
+    // database between Phase 1 and Phase 2.  Here we construct the checkpoint
+    // directly from the first run's outputs to keep the example self-contained.
+    // -----------------------------------------------------------------------
+    println!("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("Phase 2: Resume from checkpoint (before human provides input)");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+
+    // Nodes that finished during Phase 1
+    let checkpoint = ExecutionCheckpoint {
+        execution_id: first_run.execution_id.clone(),
+        workflow_id: "approval_wf".to_string(),
+        // `start` and `validate_input` completed; `wait_for_approval` did NOT.
+        completed_nodes: vec!["start".to_string(), "validate_input".to_string()],
+        node_outputs: first_run.outputs.clone(),
+        variables: std::collections::HashMap::new(),
+        timestamp: 0,
+    };
+
+    let resumed = executor
+        .resume_from_checkpoint(&graph, checkpoint)
+        .await
+        .expect("resume_from_checkpoint must not return Err");
+
+    println!("\n  Status after Phase 2 resume: {:?}", resumed.status);
+
+    // ✅ Key invariant guaranteed by fix #994:
+    // The resumed execution hit `wait_for_approval` again, so status must be
+    // Paused — NOT incorrectly overwritten to Completed.
+    assert!(
+        matches!(resumed.status, WorkflowStatus::Paused),
+        "BUG #994 regression: status must remain Paused after checkpoint \
+         resume that encounters a Wait node. Got: {:?}",
+        resumed.status
+    );
+    assert!(
+        resumed.context.is_some(),
+        "context must be set so we can do another resume cycle"
+    );
+
+    info!("Phase 2 complete — status correctly preserved as Paused.");
+
+    // -----------------------------------------------------------------------
+    // Phase 3: Human provides approval → resume with human input
+    //
+    // Now that a human has approved, we use `resume_with_human_input` to
+    // continue past the Wait node and drive the workflow to Completed.
+    // -----------------------------------------------------------------------
+    println!("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("Phase 3: Human approves → resume_with_human_input");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+
+    // Retrieve the live context that was saved on the last Paused record
+    let live_ctx = resumed.context.expect("context must be present");
+
+    let final_record = executor
+        .resume_with_human_input(
+            &graph,
+            live_ctx,
+            "wait_for_approval",
+            WorkflowValue::String("approved by alice".to_string()),
+        )
+        .await
+        .expect("resume_with_human_input must not return Err");
+
+    println!("\n  Status after Phase 3: {:?}", final_record.status);
+    assert!(
+        matches!(final_record.status, WorkflowStatus::Completed),
+        "Expected Completed after human approval. Got: {:?}",
+        final_record.status
+    );
+
+    // Show final outputs
+    println!("\n  Final outputs:");
+    for (node_id, value) in &final_record.outputs {
+        println!("    {node_id} → {value:?}");
+    }
+
+    info!("Phase 3 complete — workflow reached Completed. ✓");
+
+    // -----------------------------------------------------------------------
+    // Print telemetry summary
+    // -----------------------------------------------------------------------
+    telemetry.print_summary().await;
+
+    println!("\n✅  All phases completed successfully!\n");
+}


### PR DESCRIPTION
## 📋 Summary

Fixes a bug where [resume_from_checkpoint()](cci:1://file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/workflow/executor.rs:429:4-561:5) in the workflow executor incorrectly overwrites the workflow status to `Completed` even when the executing node legitimately paused the workflow (such as encountering another HITL Wait node). Also adds missing `DebugEvent::WorkflowEnd` emission for consistent telemetry.

## 🔗 Related Issues

Closes #994

---

## 🧠 Context

When an execution graph resumes from a checkpoint, and the workflow hits a `Wait` node during that resumption, the executor's [execute_from_node](cci:1://file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/workflow/executor.rs:587:4-818:5) correctly sets the status to `WorkflowStatus::Paused`. However, [resume_from_checkpoint](cci:1://file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/workflow/executor.rs:429:4-561:5) unconditionally overwrote this with `WorkflowStatus::Completed` before returning. This caused the workflow state to be inaccurately reflected and dropped valid contexts. The sibling methods ([execute()](cci:1://file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/workflow/executor.rs:168:4-314:5) and [resume_with_human_input()](cci:1://file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/workflow/executor.rs:316:4-427:5)) correctly handled this.

---

## 🛠️ Changes

- In [crates/mofa-foundation/src/workflow/executor.rs](cci:7://file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/workflow/executor.rs:0:0-0:0), replaced [resume_from_checkpoint](cci:1://file:///Users/mustafahussain/mofa/crates/mofa-foundation/src/workflow/executor.rs:429:4-561:5) unconditional `Ok(_)` evaluation with an explicit check for `WorkflowStatus::Paused`. 
- Added missing `self.emit_debug(DebugEvent::WorkflowEnd)` to the method immediately preceding the return `Ok(execution_record)` so it has identically structured telemetry to other execution patterns.
- Formatted unstyled lines inside `mofa-foundation`.

---

## 🧪 How you Tested

1. Verified local compilation via `cargo build -p mofa-foundation`.
2. Verified all framework test suites pass directly by executing `cargo test -p mofa-foundation`.
3. Verified local `cargo fmt -p mofa-foundation` has properly sorted and grouped new edits cleanly. 

---

## ⚠️ Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (describe below)

---