### PR TITLE
perf: eliminate unnecessary Vec<char> allocation in expression evaluator

### DIFF
--- a/crates/mofa-cli/src/commands/rag.rs
+++ b/crates/mofa-cli/src/commands/rag.rs
@@ -323,10 +323,14 @@ fn print_results(query: &str, results: &[SearchResult]) {
 }
 
 fn truncate_text(input: &str, max_chars: usize) -> String {
-    if input.chars().count() <= max_chars {
-        return input.to_string();
+    // Single pass: take up to max_chars characters. If we consumed the
+    // entire input the string is short enough — return it directly.
+    let truncated: String = input.chars().take(max_chars).collect();
+    if truncated.len() == input.len() {
+        return truncated;
     }
-    let mut output = input.chars().take(max_chars).collect::<String>();
+    // Input was longer; append ellipsis.
+    let mut output = truncated;
     output.push_str("...");
     output
 }

--- a/crates/mofa-foundation/src/react/tools.rs
+++ b/crates/mofa-foundation/src/react/tools.rs
@@ -85,20 +85,22 @@ fn evaluate_expression(expr: &str) -> Result<f64, String> {
     let mut last_add_sub = None;
     let mut last_mul_div = None;
 
-    let chars: Vec<char> = expr.chars().collect();
-    for (i, &c) in chars.iter().enumerate() {
-        match c {
-            '(' => paren_depth += 1,
-            ')' => paren_depth -= 1,
-            '+' | '-' if paren_depth == 0 && i > 0 => {
+    // All operator and grouping characters are single-byte ASCII, so we
+    // iterate over bytes directly instead of collecting into a Vec<char>.
+    let bytes = expr.as_bytes();
+    for (i, &b) in bytes.iter().enumerate() {
+        match b {
+            b'(' => paren_depth += 1,
+            b')' => paren_depth -= 1,
+            b'+' | b'-' if paren_depth == 0 && i > 0 => {
                 // 确保不是负号
                 // Ensure it is not a negative sign
-                let prev = chars.get(i.saturating_sub(1)).copied().unwrap_or(' ');
-                if !matches!(prev, '+' | '-' | '*' | '/' | '(') {
+                let prev = if i > 0 { bytes[i - 1] } else { b' ' };
+                if !matches!(prev, b'+' | b'-' | b'*' | b'/' | b'(') {
                     last_add_sub = Some(i);
                 }
             }
-            '*' | '/' if paren_depth == 0 => {
+            b'*' | b'/' if paren_depth == 0 => {
                 last_mul_div = Some(i);
             }
             _ => {}
@@ -110,9 +112,9 @@ fn evaluate_expression(expr: &str) -> Result<f64, String> {
     if let Some(pos) = last_add_sub {
         let left = evaluate_expression(&expr[..pos])?;
         let right = evaluate_expression(&expr[pos + 1..])?;
-        return match chars[pos] {
-            '+' => Ok(left + right),
-            '-' => Ok(left - right),
+        return match bytes[pos] {
+            b'+' => Ok(left + right),
+            b'-' => Ok(left - right),
             _ => unreachable!(),
         };
     }
@@ -120,9 +122,9 @@ fn evaluate_expression(expr: &str) -> Result<f64, String> {
     if let Some(pos) = last_mul_div {
         let left = evaluate_expression(&expr[..pos])?;
         let right = evaluate_expression(&expr[pos + 1..])?;
-        return match chars[pos] {
-            '*' => Ok(left * right),
-            '/' => {
+        return match bytes[pos] {
+            b'*' => Ok(left * right),
+            b'/' => {
                 if right == 0.0 {
                     Err("Division by zero".to_string())
                 } else {


### PR DESCRIPTION
# PR: perf: eliminate unnecessary allocations in expression evaluator and CLI truncate

**Branch:** `perf/eliminate-unnecessary-allocations`
**Base:** `main`
**Files changed:** `crates/mofa-foundation/src/react/tools.rs`, `crates/mofa-cli/src/commands/rag.rs`

---

## Title

```
perf: eliminate unnecessary Vec<char> allocation in expression evaluator and double iteration in truncate_text
```

## Body

### Summary

- Replace `Vec<char>` heap allocation with direct byte-slice iteration in the math expression evaluator
- Replace double `.chars()` iteration with a single-pass approach in the CLI `truncate_text` helper

### Fix 1: Expression evaluator — `evaluate_expression()`

**File:** `crates/mofa-foundation/src/react/tools.rs`

The recursive expression evaluator collected all characters into a `Vec<char>` on every call to scan for operators. Since this function is recursive (called once per operator in the expression tree), the allocation happened at every level of recursion.

All operator characters (`+`, `-`, `*`, `/`, `(`, `)`) and numeric characters are single-byte ASCII, so we can iterate over `as_bytes()` directly — zero allocation, same semantics.

| | Before | After |
|--|--------|-------|
| Allocation | `Vec<char>` per recursive call | None — `as_bytes()` borrows |
| Indexing | `chars[pos]` (requires collected Vec) | `bytes[pos]` (direct slice) |
| String slicing | `&expr[..pos]` (byte index — already assumed ASCII) | Same — now consistent with byte iteration |

### Fix 2: CLI truncate — `truncate_text()`

**File:** `crates/mofa-cli/src/commands/rag.rs`

The function iterated over characters **twice**: once with `.chars().count()` to check length, then again with `.chars().take(n)` to actually truncate. Now it does a single `.chars().take(n).collect()` and checks if the full input was consumed by comparing byte lengths.

| | Before | After |
|--|--------|-------|
| Char iterations | 2 (count + take) | 1 (take only) |
| Short-string fast path | `chars().count()` (full scan) | `truncated.len() == input.len()` (O(1)) |

### Test plan

- [x] `cargo test -p mofa-foundation -- react` — 15/15 pass (including `test_calculator`)
- [x] `cargo check -p mofa-cli` — clean compilation
- [x] No clippy warnings on changed files
