### PR TITLE
perf: cache compiled regex in RuleBasedRouter and Rhai ToolParameter …

### DIFF
--- a/crates/mofa-extra/src/rhai/tools.rs
+++ b/crates/mofa-extra/src/rhai/tools.rs
@@ -18,9 +18,14 @@ use super::error::{RhaiError, RhaiResult};
 use rhai::{Dynamic, Engine, Map, Scope};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock, Mutex};
 use tokio::sync::RwLock;
 use tracing::info;
+
+/// Process-wide cache for compiled regex patterns used in ToolParameter
+/// validation, avoiding recompilation on every `validate()` call.
+static TOOL_PARAM_REGEX_CACHE: LazyLock<Mutex<HashMap<String, regex::Regex>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 // ============================================================================
 // 工具参数定义
@@ -203,13 +208,26 @@ impl ToolParameter {
                     self.name, max
                 )));
             }
-            // 检查正则表达式
-            // Check regex pattern
+            // 检查正则表达式 (cached)
+            // Check regex pattern (cached)
             if let Some(ref pattern) = self.pattern {
-                let re = regex::Regex::new(pattern).map_err(|e| {
-                    RhaiError::ValidationError(format!("Invalid regex pattern: {}", e))
-                })?;
-                if !re.is_match(s) {
+                let cache = TOOL_PARAM_REGEX_CACHE
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner());
+                let is_match = if let Some(re) = cache.get(pattern.as_str()) {
+                    re.is_match(s)
+                } else {
+                    drop(cache);
+                    let re = regex::Regex::new(pattern).map_err(|e| {
+                        RhaiError::ValidationError(format!("Invalid regex pattern: {}", e))
+                    })?;
+                    let matched = re.is_match(s);
+                    if let Ok(mut cache) = TOOL_PARAM_REGEX_CACHE.lock() {
+                        cache.insert(pattern.clone(), re);
+                    }
+                    matched
+                };
+                if !is_match {
                     return Err(RhaiError::ValidationError(format!(
                         "Parameter '{}' does not match pattern: {}",
                         self.name, pattern

--- a/crates/mofa-foundation/src/secretary/agent_router.rs
+++ b/crates/mofa-foundation/src/secretary/agent_router.rs
@@ -820,6 +820,9 @@ pub struct RuleBasedRouter {
     /// 是否需要人类确认规则匹配
     /// Whether to require human confirmation on rule match
     confirm_on_match: bool,
+    /// Cache for compiled regex patterns used in RuleOperator::Regex
+    /// conditions, keyed by the pattern string.
+    regex_cache: std::sync::Mutex<HashMap<String, regex::Regex>>,
 }
 
 impl RuleBasedRouter {
@@ -828,6 +831,7 @@ impl RuleBasedRouter {
             rules: Arc::new(RwLock::new(Vec::new())),
             default_agent_id: None,
             confirm_on_match: false,
+            regex_cache: std::sync::Mutex::new(HashMap::new()),
         }
     }
 
@@ -885,9 +889,24 @@ impl RuleBasedRouter {
             RuleOperator::NotContains => !field_value.contains(&condition.value),
             RuleOperator::StartsWith => field_value.starts_with(&condition.value),
             RuleOperator::EndsWith => field_value.ends_with(&condition.value),
-            RuleOperator::Regex => regex::Regex::new(&condition.value)
-                .map(|re| re.is_match(&field_value))
-                .unwrap_or(false),
+            RuleOperator::Regex => {
+                let cache = self.regex_cache.lock().unwrap_or_else(|e| e.into_inner());
+                if let Some(re) = cache.get(&condition.value) {
+                    re.is_match(&field_value)
+                } else {
+                    drop(cache);
+                    match regex::Regex::new(&condition.value) {
+                        Ok(re) => {
+                            let matched = re.is_match(&field_value);
+                            if let Ok(mut cache) = self.regex_cache.lock() {
+                                cache.insert(condition.value.clone(), re);
+                            }
+                            matched
+                        }
+                        Err(_) => false,
+                    }
+                }
+            }
             RuleOperator::In => condition.value.split(',').any(|v| v.trim() == field_value),
             RuleOperator::NotIn => !condition.value.split(',').any(|v| v.trim() == field_value),
         }


### PR DESCRIPTION
# PR: perf: cache compiled regex in RuleBasedRouter and Rhai ToolParameter validation

**Branch:** `perf/cache-regex-in-router-and-rhai`
**Base:** `main`
**Files changed:** `crates/mofa-foundation/src/secretary/agent_router.rs`, `crates/mofa-extra/src/rhai/tools.rs`

---

## Title

```
perf: cache compiled regex in RuleBasedRouter and Rhai ToolParameter validation
```

## Body

### Summary

- Cache compiled regex patterns in `RuleBasedRouter::check_condition()` and `ToolParameter::validate()` to avoid recompiling the same pattern on every invocation
- `RuleBasedRouter` gets an instance-level `Mutex<HashMap<String, Regex>>` cache
- `ToolParameter` uses a module-level `LazyLock<Mutex<HashMap>>` static cache (since the struct derives `Serialize/Deserialize`)

### Problem

Both `RuleBasedRouter::check_condition()` (agent routing) and `ToolParameter::validate()` (Rhai tool parameter validation) call `regex::Regex::new()` on every invocation. Regex compilation costs ~microseconds per pattern, and these methods are called in hot evaluation loops:

- **Agent routing**: `check_condition()` is called for every condition in every rule for every routing decision. With N rules having M regex conditions, that's N×M compilations per route.
- **Tool validation**: `validate()` is called for every parameter on every tool invocation. Tools with regex patterns recompile on every call.

**Before (agent_router.rs:888):**
```rust
RuleOperator::Regex => regex::Regex::new(&condition.value)
    .map(|re| re.is_match(&field_value))
    .unwrap_or(false),
```

**Before (rhai/tools.rs:209):**
```rust
let re = regex::Regex::new(pattern).map_err(|e| {
    RhaiError::ValidationError(format!("Invalid regex pattern: {}", e))
})?;
```

### What changed

| Location | Before | After |
|----------|--------|-------|
| `agent_router.rs` | `Regex::new()` per `check_condition()` call | Instance-level `Mutex<HashMap>` cache on `RuleBasedRouter` |
| `rhai/tools.rs` | `Regex::new()` per `validate()` call | Module-level `TOOL_PARAM_REGEX_CACHE` static |

Both caches use the same lock-then-lookup pattern:
1. Acquire lock, check if pattern exists in cache
2. If hit → use cached regex (fast path)
3. If miss → release lock, compile regex, re-acquire lock, insert

This matches the caching pattern already established in `prompt/regex.rs`.

### Test plan

- [x] `cargo test -p mofa-extra -- rhai::tools` — 6/6 pass
- [x] `cargo test -p mofa-foundation -- secretary::agent_router` — passes
- [x] `cargo check -p mofa-foundation -p mofa-extra` — clean compilation
- [x] No clippy warnings on changed files
