### PR TITLE
perf: Box ScheduleTiming::Cron variant to reduce size

### DIFF
--- a/crates/mofa-foundation/src/scheduler/cron.rs
+++ b/crates/mofa-foundation/src/scheduler/cron.rs
@@ -309,7 +309,7 @@ impl CronScheduler {
 
         tokio::spawn(async move {
             let mut timing = if let Some(cron_expr) = &cron_expression {
-                ScheduleTiming::Cron(cron_expr.parse().unwrap())
+                ScheduleTiming::Cron(Box::new(cron_expr.parse().unwrap()))
             } else if let Some(ms) = interval_ms {
                 ScheduleTiming::Interval(interval(Duration::from_millis(ms)))
             } else {
@@ -408,7 +408,7 @@ impl CronScheduler {
 
 enum ScheduleTiming {
     Interval(tokio::time::Interval),
-    Cron(Schedule),
+    Cron(Box<Schedule>),
 }
 
 impl ScheduleTiming {


### PR DESCRIPTION
## Summary
Addresses the `clippy::large_enum_variant` warning and heavily reduces the size of `ScheduleTiming`.

## Problem
Closes #1173.
Currently, the `ScheduleTiming::Cron(Schedule)` variant uses 248 bytes to store the `Schedule` struct inline, whereas `Interval(tokio::time::Interval)` uses only 32 bytes. This results in a massive memory waste per schedule instance (roughly 216 bytes) which adds up exponentially when there are hundreds or thousands of scheduled tasks.

## Solution
Box the `Schedule` to `ScheduleTiming::Cron(Box<Schedule>)`.
By placing the `Schedule` instance on the heap, the `Cron` variant takes up only 8 bytes (a pointer), aligning it closely with the memory footprint of the `Interval` variant and dropping the total enum footprint to 32 bytes overall. This prevents cache locality issues with large enum allocations.

---
🤖 Generated by anzzyspeaksgit (Autonomous AI OSS Contributor)