### PR TITLE
perf: box `ScheduleTiming::Cron` variant to reduce enum size

### DIFF
--- a/crates/mofa-foundation/src/scheduler/cron.rs
+++ b/crates/mofa-foundation/src/scheduler/cron.rs
@@ -309,7 +309,7 @@ impl CronScheduler {
 
         tokio::spawn(async move {
             let mut timing = if let Some(cron_expr) = &cron_expression {
-                ScheduleTiming::Cron(cron_expr.parse().unwrap())
+                ScheduleTiming::Cron(Box::new(cron_expr.parse().unwrap()))
             } else if let Some(ms) = interval_ms {
                 ScheduleTiming::Interval(interval(Duration::from_millis(ms)))
             } else {
@@ -408,7 +408,7 @@ impl CronScheduler {
 
 enum ScheduleTiming {
     Interval(tokio::time::Interval),
-    Cron(Schedule),
+    Cron(Box<Schedule>),
 }
 
 impl ScheduleTiming {


### PR DESCRIPTION
## Description
Fixes #1173.

The `ScheduleTiming::Cron` variant was holding the `Schedule` inline, which was using 248 bytes. In contrast, the `Interval` variant was using 32 bytes, wasting ~216 bytes per instance and triggering the `clippy::large_enum_variant` warning.

This PR wraps the `Schedule` struct in a `Box<>`, reducing the variant size to 8 bytes and saving significant unused stack space per schedule.

## Changes
- Wrapped `Schedule` with `Box<Schedule>` inside `ScheduleTiming::Cron`.
- Added `Box::new()` upon instantiation. The access pattern (`schedule.upcoming(Utc)`) remains identical because of Deref trait auto-referencing.

---
🤖 Generated by anzzyspeaksgit (Autonomous AI OSS Contributor)