### PR TITLE
fix: prevent panic in InMemoryStore::get_session_messages_paginated

### DIFF
--- a/crates/mofa-foundation/src/persistence/memory.rs
+++ b/crates/mofa-foundation/src/persistence/memory.rs
@@ -168,16 +168,17 @@ impl MessageStore for InMemoryStore {
         offset: i64,
         limit: i64,
     ) -> PersistenceResult<Vec<LLMMessage>> {
+        // Negative offset or limit cannot produce a valid page — return empty.
+        if offset < 0 || limit <= 0 {
+            return Ok(Vec::new());
+        }
+
         let all_messages = self.get_session_messages(session_id).await?;
 
         let start = offset as usize;
-        let end = (offset + limit) as usize;
+        let take = limit as usize;
 
-        Ok(all_messages
-            .into_iter()
-            .skip(start)
-            .take(end - start)
-            .collect())
+        Ok(all_messages.into_iter().skip(start).take(take).collect())
     }
 
     async fn delete_message(&self, id: Uuid) -> PersistenceResult<bool> {
@@ -977,5 +978,129 @@ mod tests {
             .await
             .expect("query should work");
         assert_eq!(messages.len(), 2);
+    }
+
+    // ---- Pagination tests --------------------------------------------------------
+
+    /// Helper: insert `n` messages into a store for a given session, returning
+    /// the (session_id, store) pair.  Messages are created with sequential
+    /// timestamps so ordering is deterministic.
+    async fn store_with_messages(n: usize) -> (Uuid, InMemoryStore) {
+        let store = InMemoryStore::new();
+        let (session_id, agent_id, user_id, tenant_id) = ids();
+
+        let base_time = chrono::Utc::now();
+        for i in 0..n {
+            let mut msg = LLMMessage::new(
+                session_id,
+                agent_id,
+                user_id,
+                tenant_id,
+                MessageRole::User,
+                MessageContent::text(format!("msg-{}", i)),
+            );
+            msg.create_time = base_time + chrono::Duration::seconds(i as i64);
+            MessageStore::save_message(&store, &msg)
+                .await
+                .expect("save should work");
+        }
+
+        (session_id, store)
+    }
+
+    #[tokio::test]
+    async fn paginated_basic_page() {
+        let (sid, store) = store_with_messages(5).await;
+
+        let page = MessageStore::get_session_messages_paginated(&store, sid, 0, 3)
+            .await
+            .unwrap();
+        assert_eq!(page.len(), 3);
+        assert_eq!(page[0].content.text.as_deref(), Some("msg-0"));
+        assert_eq!(page[2].content.text.as_deref(), Some("msg-2"));
+    }
+
+    #[tokio::test]
+    async fn paginated_second_page() {
+        let (sid, store) = store_with_messages(5).await;
+
+        let page = MessageStore::get_session_messages_paginated(&store, sid, 3, 3)
+            .await
+            .unwrap();
+        assert_eq!(page.len(), 2); // only 2 remaining
+        assert_eq!(page[0].content.text.as_deref(), Some("msg-3"));
+        assert_eq!(page[1].content.text.as_deref(), Some("msg-4"));
+    }
+
+    #[tokio::test]
+    async fn paginated_offset_beyond_length() {
+        let (sid, store) = store_with_messages(3).await;
+
+        let page = MessageStore::get_session_messages_paginated(&store, sid, 100, 10)
+            .await
+            .unwrap();
+        assert!(page.is_empty());
+    }
+
+    #[tokio::test]
+    async fn paginated_negative_offset_returns_empty() {
+        let (sid, store) = store_with_messages(3).await;
+
+        let page = MessageStore::get_session_messages_paginated(&store, sid, -1, 10)
+            .await
+            .unwrap();
+        assert!(page.is_empty());
+    }
+
+    #[tokio::test]
+    async fn paginated_negative_limit_returns_empty() {
+        let (sid, store) = store_with_messages(3).await;
+
+        let page = MessageStore::get_session_messages_paginated(&store, sid, 0, -5)
+            .await
+            .unwrap();
+        assert!(page.is_empty());
+    }
+
+    #[tokio::test]
+    async fn paginated_zero_limit_returns_empty() {
+        let (sid, store) = store_with_messages(3).await;
+
+        let page = MessageStore::get_session_messages_paginated(&store, sid, 0, 0)
+            .await
+            .unwrap();
+        assert!(page.is_empty());
+    }
+
+    #[tokio::test]
+    async fn paginated_large_offset_and_limit_no_panic() {
+        // This was the original panic scenario: offset + limit overflowing i64
+        let (sid, store) = store_with_messages(3).await;
+
+        let page = MessageStore::get_session_messages_paginated(&store, sid, i64::MAX, 1)
+            .await
+            .unwrap();
+        assert!(page.is_empty());
+    }
+
+    #[tokio::test]
+    async fn paginated_limit_larger_than_total() {
+        let (sid, store) = store_with_messages(2).await;
+
+        let page = MessageStore::get_session_messages_paginated(&store, sid, 0, 100)
+            .await
+            .unwrap();
+        assert_eq!(page.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn paginated_empty_session() {
+        let store = InMemoryStore::new();
+        let session_id = Uuid::now_v7();
+
+        let page = MessageStore::get_session_messages_paginated(&store, session_id, 0, 10)
+            .await
+            .unwrap();
+        assert!(page.is_empty());
     }
 }


### PR DESCRIPTION
### Problem #1174

`get_session_messages_paginated()` in `InMemoryStore` computes `end = (offset + limit) as usize` then `end - start`. This panics with a **usize subtraction overflow** when `offset + limit` overflows `i64` (e.g. `offset = i64::MAX, limit = 1`). Negative `offset`/`limit` values also produce silently wrong results via two's-complement wrapping when cast to `usize`.

### Fix

- Validate that `offset >= 0` and `limit > 0` upfront; return empty vec otherwise.
- Use `skip(start).take(limit as usize)` directly — no subtraction needed, no overflow possible.
- `BoundedInMemoryStore` delegates to `InMemoryStore`, so both are fixed.

### Tests added (9 new tests)

| Test | Validates |
|------|-----------|
| `paginated_basic_page` | Normal first-page retrieval |
| `paginated_second_page` | Offset into second page, partial results |
| `paginated_offset_beyond_length` | Offset past all messages returns empty |
| `paginated_negative_offset_returns_empty` | Negative offset returns empty (no panic) |
| `paginated_negative_limit_returns_empty` | Negative limit returns empty (no panic) |
| `paginated_zero_limit_returns_empty` | Zero limit returns empty |
| `paginated_large_offset_and_limit_no_panic` | `i64::MAX` offset with limit=1 — no panic |
| `paginated_limit_larger_than_total` | Limit exceeding total messages returns all |
| `paginated_empty_session` | Empty session returns empty |

All 12 memory persistence tests pass. No clippy warnings introduced.
