### PR TITLE
feat(testing): add MockLLMBackend per-prompt infer tracking

### DIFF
--- a/tests/src/backend.rs
+++ b/tests/src/backend.rs
@@ -27,6 +27,7 @@ pub struct MockLLMBackend {
     response_sequences: Arc<RwLock<ResponseSequences>>,
     call_count: Arc<AtomicUsize>,
     rate_limit: Arc<RwLock<Option<RateLimit>>>,
+    infer_history: Arc<RwLock<Vec<String>>>,
 }
 
 struct RateLimit {
@@ -55,7 +56,28 @@ impl MockLLMBackend {
             response_sequences: Arc::new(RwLock::new(Vec::new())),
             call_count: Arc::new(AtomicUsize::new(0)),
             rate_limit: Arc::new(RwLock::new(None)),
+            infer_history: Arc::new(RwLock::new(Vec::new())),
         }
+    }
+
+    /// All prompts passed to `infer()`, in call order.
+    pub fn infer_history(&self) -> Vec<String> {
+        self.infer_history.read().expect("lock poisoned").clone()
+    }
+
+    /// Number of `infer()` calls whose prompt contains the given substring.
+    pub fn infer_count_for(&self, prompt_substring: &str) -> usize {
+        self.infer_history
+            .read()
+            .expect("lock poisoned")
+            .iter()
+            .filter(|p| p.contains(prompt_substring))
+            .count()
+    }
+
+    /// Clear the infer history.
+    pub fn clear_infer_history(&self) {
+        self.infer_history.write().expect("lock poisoned").clear();
     }
 
     /// Append a response rule. Order determines priority (first match wins).
@@ -209,6 +231,10 @@ impl ModelOrchestrator for MockLLMBackend {
 
     async fn infer(&self, _model_id: &str, input: &str) -> OrchestratorResult<String> {
         self.call_count.fetch_add(1, Ordering::Relaxed);
+        self.infer_history
+            .write()
+            .expect("lock poisoned")
+            .push(input.to_string());
 
         // 1. Drain failure queue (FIFO)
         {

--- a/tests/tests/infer_tracking_tests.rs
+++ b/tests/tests/infer_tracking_tests.rs
@@ -1,0 +1,112 @@
+//! Tests for MockLLMBackend per-prompt tracking: infer_history(), infer_count_for(),
+//! clear_infer_history().
+
+use mofa_foundation::orchestrator::{
+    ModelOrchestrator, ModelProviderConfig, ModelType, OrchestratorError,
+};
+use mofa_testing::backend::MockLLMBackend;
+use std::collections::HashMap;
+
+fn make_config(name: &str) -> ModelProviderConfig {
+    ModelProviderConfig {
+        model_name: name.into(),
+        model_path: "/mock".into(),
+        device: "cpu".into(),
+        model_type: ModelType::Llm,
+        max_context_length: None,
+        quantization: None,
+        extra_config: HashMap::new(),
+    }
+}
+
+async fn setup_backend() -> MockLLMBackend {
+    let backend = MockLLMBackend::new();
+    backend.register_model(make_config("m")).await.unwrap();
+    backend.load_model("m").await.unwrap();
+    backend
+}
+
+#[tokio::test]
+async fn infer_history_is_empty_initially() {
+    let backend = MockLLMBackend::new();
+    assert!(backend.infer_history().is_empty());
+}
+
+#[tokio::test]
+async fn infer_history_records_all_prompts_in_order() {
+    let backend = setup_backend().await;
+
+    backend.infer("m", "summarize this").await.unwrap();
+    backend.infer("m", "translate to French").await.unwrap();
+    backend.infer("m", "summarize again").await.unwrap();
+
+    let history = backend.infer_history();
+    assert_eq!(history.len(), 3);
+    assert_eq!(history[0], "summarize this");
+    assert_eq!(history[1], "translate to French");
+    assert_eq!(history[2], "summarize again");
+}
+
+#[tokio::test]
+async fn infer_count_for_returns_zero_for_unmatched() {
+    let backend = setup_backend().await;
+
+    backend.infer("m", "hello world").await.unwrap();
+
+    assert_eq!(backend.infer_count_for("nonexistent"), 0);
+}
+
+#[tokio::test]
+async fn infer_count_for_counts_only_matching_prompts() {
+    let backend = setup_backend().await;
+
+    backend.infer("m", "summarize this").await.unwrap();
+    backend.infer("m", "translate to French").await.unwrap();
+    backend.infer("m", "summarize again").await.unwrap();
+
+    assert_eq!(backend.infer_count_for("summarize"), 2);
+    assert_eq!(backend.infer_count_for("translate"), 1);
+}
+
+#[tokio::test]
+async fn infer_count_for_works_after_fail_next() {
+    let backend = setup_backend().await;
+
+    backend.fail_next(1, OrchestratorError::InferenceFailed("boom".into()));
+
+    let _ = backend.infer("m", "summarize this").await;
+    backend.infer("m", "translate to French").await.unwrap();
+
+    assert_eq!(backend.infer_count_for("summarize"), 1);
+    assert_eq!(backend.infer_count_for("translate"), 1);
+    assert_eq!(backend.infer_history().len(), 2);
+}
+
+#[tokio::test]
+async fn clear_infer_history_resets_history_but_not_call_count() {
+    let backend = setup_backend().await;
+
+    backend.infer("m", "hello").await.unwrap();
+    backend.infer("m", "world").await.unwrap();
+
+    assert_eq!(backend.call_count(), 2);
+    assert_eq!(backend.infer_history().len(), 2);
+
+    backend.clear_infer_history();
+
+    assert!(backend.infer_history().is_empty());
+    assert_eq!(backend.call_count(), 2);
+}
+
+#[tokio::test]
+async fn overlapping_substrings_counted_correctly() {
+    let backend = setup_backend().await;
+
+    backend.infer("m", "summarize the text").await.unwrap();
+    backend.infer("m", "summarize and translate").await.unwrap();
+    backend.infer("m", "just translate").await.unwrap();
+
+    assert_eq!(backend.infer_count_for("summarize"), 2);
+    assert_eq!(backend.infer_count_for("translate"), 2);
+    assert_eq!(backend.infer_count_for("summarize and translate"), 1);
+}


### PR DESCRIPTION
## Summary

Add per-prompt infer tracking to `MockLLMBackend` with `infer_history()`, `infer_count_for(prompt_substring)`, and `clear_infer_history()` for more precise test assertions.

## Related Issues

Closes #1184 

---

## Changes

- `tests/src/backend.rs` - Added prompt history storage and accessor helpers on `MockLLMBackend`
- `tests/src/backend.rs` - Record prompts at the start of `infer()` so failed calls are still observable in test history
- `tests/tests/infer_tracking_tests.rs` - Added 7 tests covering ordered history, substring counting, overlap behavior, and history reset semantics

---

## Testing

1. `cargo test -p mofa-testing --test infer_tracking_tests` - 7 tests pass
2. `cargo test -p mofa-testing` - full `mofa-testing` suite passes locally
3. `cargo clippy -p mofa-testing --all-targets -- -D warnings` currently stops on unrelated pre-existing warnings in `crates/mofa-kernel/src/workflow/telemetry.rs`

---



## Checklist

- [x] Code follows Rust idioms and project conventions
- [x] Tests added/updated
- [x] `cargo test -p mofa-testing` passes locally
