### PR TITLE
fix(extra): skip non-UTF-8 paths in Rhai tool directory loader

### DIFF
--- a/crates/mofa-extra/src/rhai/tools.rs
+++ b/crates/mofa-extra/src/rhai/tools.rs
@@ -549,12 +549,15 @@ impl ScriptToolRegistry {
 
         while let Some(entry) = entries.next_entry().await? {
             let path = entry.path();
-            if let (Some(ext), Some(path_str)) = (path.extension(), path.to_str()) {
-                let id = match ext.to_str() {
-                    Some("yaml") | Some("yml") => {
-                        self.load_from_yaml(path_str).await.ok()
-                    }
-                    Some("json") => self.load_from_json(path_str).await.ok(),
+            // Skip paths that are not valid UTF-8 (possible on Unix) instead
+            // of panicking via .unwrap().
+            let Some(path_str) = path.to_str() else {
+                continue;
+            };
+            if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+                let id = match ext {
+                    "yaml" | "yml" => self.load_from_yaml(path_str).await.ok(),
+                    "json" => self.load_from_json(path_str).await.ok(),
                     _ => None,
                 };
                 if let Some(id) = id {


### PR DESCRIPTION
Closes https://github.com/moxin-org/mofa/issues/1190

## Problem

`load_from_directory()` calls `path.to_str().unwrap()` which panics if the filesystem contains a non-UTF-8 filename (valid on Unix). The function is already in a fallible context (`RhaiResult`) so the panic is unnecessary.

## Fix

Extract the path string once at the top of the loop iteration using a `let-else` guard. Entries with non-UTF-8 paths are silently skipped. Also simplifies the extension matching by extracting `ext.to_str()` earlier.