### PR TITLE
fix(monitoring): use correct sentinel values in HistogramData Default

### DIFF
--- a/crates/mofa-monitoring/src/dashboard/metrics.rs
+++ b/crates/mofa-monitoring/src/dashboard/metrics.rs
@@ -54,13 +54,25 @@ impl MetricValue {
 }
 
 /// Histogram data
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HistogramData {
     pub count: u64,
     pub sum: f64,
     pub min: f64,
     pub max: f64,
     pub buckets: Vec<(f64, u64)>, // (upper_bound, count)
+}
+
+impl Default for HistogramData {
+    fn default() -> Self {
+        Self {
+            count: 0,
+            sum: 0.0,
+            min: f64::MAX,
+            max: f64::MIN,
+            buckets: Vec::new(),
+        }
+    }
 }
 
 /// Counter metric


### PR DESCRIPTION
Closes https://github.com/moxin-org/mofa/issues/1195

## Problem

The derived `Default` for `HistogramData` sets `min` and `max` to `0.0`, but `Histogram::new()` uses `f64::MAX` / `f64::MIN` as sentinels for tracking the actual range via `observe()`. After deserialization (which goes through `Default` for missing fields), `min` becomes 0.0 and is never corrected.

## Fix

Replace the `Default` derive with a manual impl that initializes `min` to `f64::MAX` and `max` to `f64::MIN`, matching the constructor.