### PR TITLE
fix: cache regex compilation in router, remove unnecessary clone in t…

### DIFF
--- a/crates/mofa-extra/src/rhai/tools.rs
+++ b/crates/mofa-extra/src/rhai/tools.rs
@@ -549,12 +549,12 @@ impl ScriptToolRegistry {
 
         while let Some(entry) = entries.next_entry().await? {
             let path = entry.path();
-            if let Some(ext) = path.extension() {
+            if let (Some(ext), Some(path_str)) = (path.extension(), path.to_str()) {
                 let id = match ext.to_str() {
                     Some("yaml") | Some("yml") => {
-                        self.load_from_yaml(path.to_str().unwrap()).await.ok()
+                        self.load_from_yaml(path_str).await.ok()
                     }
-                    Some("json") => self.load_from_json(path.to_str().unwrap()).await.ok(),
+                    Some("json") => self.load_from_json(path_str).await.ok(),
                     _ => None,
                 };
                 if let Some(id) = id {

--- a/crates/mofa-foundation/src/prompt/template.rs
+++ b/crates/mofa-foundation/src/prompt/template.rs
@@ -446,16 +446,30 @@ impl PromptTemplate {
 
         // 收集所有未定义但在模板中出现的变量
         // Collect all undefined variables appearing in template
+        // Collect variable names from the template first, then apply replacements.
+        // This avoids cloning `result` just for regex iteration.
         let mut missing = Vec::new();
-        for cap in super::regex::VARIABLE_PLACEHOLDER_RE.captures_iter(&result.clone()) {
-            let var_name = &cap[1];
-            if !defined_vars.contains(var_name) {
-                if let Some(&value) = vars.get(var_name) {
-                    let placeholder = format!("{{{}}}", var_name);
-                    result = result.replace(&placeholder, value);
+        let var_names: Vec<(String, bool)> = super::regex::VARIABLE_PLACEHOLDER_RE
+            .captures_iter(&result)
+            .filter_map(|cap| {
+                let var_name = cap[1].to_string();
+                if !defined_vars.contains(var_name.as_str()) {
+                    let has_value = vars.contains_key(var_name.as_str());
+                    Some((var_name, has_value))
                 } else {
-                    missing.push(var_name.to_string());
+                    None
                 }
+            })
+            .collect();
+
+        for (var_name, has_value) in var_names {
+            if has_value {
+                let placeholder = format!("{{{}}}", var_name);
+                if let Some(&value) = vars.get(var_name.as_str()) {
+                    result = result.replace(&placeholder, value);
+                }
+            } else {
+                missing.push(var_name);
             }
         }
 

--- a/crates/mofa-foundation/src/secretary/agent_router.rs
+++ b/crates/mofa-foundation/src/secretary/agent_router.rs
@@ -56,6 +56,7 @@ use mofa_kernel::agent::types::error::{GlobalError, GlobalResult};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::Mutex;
 use tokio::sync::RwLock;
 
 // =============================================================================
@@ -820,6 +821,9 @@ pub struct RuleBasedRouter {
     /// 是否需要人类确认规则匹配
     /// Whether to require human confirmation on rule match
     confirm_on_match: bool,
+    /// Cache of compiled regex patterns keyed by their source string.
+    /// Avoids recompiling the same regex on every `check_condition` call.
+    regex_cache: Mutex<HashMap<String, regex::Regex>>,
 }
 
 impl RuleBasedRouter {
@@ -828,6 +832,7 @@ impl RuleBasedRouter {
             rules: Arc::new(RwLock::new(Vec::new())),
             default_agent_id: None,
             confirm_on_match: false,
+            regex_cache: Mutex::new(HashMap::new()),
         }
     }
 
@@ -885,9 +890,23 @@ impl RuleBasedRouter {
             RuleOperator::NotContains => !field_value.contains(&condition.value),
             RuleOperator::StartsWith => field_value.starts_with(&condition.value),
             RuleOperator::EndsWith => field_value.ends_with(&condition.value),
-            RuleOperator::Regex => regex::Regex::new(&condition.value)
-                .map(|re| re.is_match(&field_value))
-                .unwrap_or(false),
+            RuleOperator::Regex => {
+                let cache = self.regex_cache.lock().unwrap_or_else(|e| e.into_inner());
+                if let Some(re) = cache.get(&condition.value) {
+                    return re.is_match(&field_value);
+                }
+                drop(cache);
+                match regex::Regex::new(&condition.value) {
+                    Ok(re) => {
+                        let matched = re.is_match(&field_value);
+                        let mut cache =
+                            self.regex_cache.lock().unwrap_or_else(|e| e.into_inner());
+                        cache.insert(condition.value.clone(), re);
+                        matched
+                    }
+                    Err(_) => false,
+                }
+            }
             RuleOperator::In => condition.value.split(',').any(|v| v.trim() == field_value),
             RuleOperator::NotIn => !condition.value.split(',').any(|v| v.trim() == field_value),
         }


### PR DESCRIPTION
# fix: cache regex in router, remove unnecessary clone, prevent non-UTF-8 panic

## Summary

- **Cache compiled regex patterns in `RuleBasedRouter`**: `check_condition` was recompiling a `Regex` on every call to `check_condition`. Added a `Mutex<HashMap>` cache so each unique pattern is compiled only once, avoiding expensive regex compilation in the routing hot path.
- **Remove unnecessary `String::clone()` in `PromptTemplate::render_with_map`**: The entire result string was being cloned (`&result.clone()`) just to satisfy the borrow checker during regex iteration. Refactored to collect variable names into a `Vec` first, then apply replacements — eliminating the redundant full-string allocation.
- **Fix `path.to_str().unwrap()` panic in `RhaiToolRegistry::load_from_directory`**: Paths containing non-UTF-8 characters would cause a runtime panic via `.unwrap()`. Now the entry is gracefully skipped when `to_str()` returns `None`.

## Changes

| File | Fix | Type |
|------|-----|------|
| `crates/mofa-foundation/src/secretary/agent_router.rs` | Cache compiled regex per pattern in `RuleBasedRouter` | Performance |
| `crates/mofa-foundation/src/prompt/template.rs` | Remove unnecessary `.clone()` on result string during variable substitution | Performance |
| `crates/mofa-extra/src/rhai/tools.rs` | Replace `path.to_str().unwrap()` with safe `path.to_str()` check | Bug fix |

## Details

### 1. Regex cache in `RuleBasedRouter` (`agent_router.rs`)

**Before:** Every call to `check_condition` with a `RuleOperator::Regex` condition compiled a fresh `regex::Regex` from the pattern string. Regex compilation is expensive (parsing, NFA/DFA construction) and this sits in the routing hot path — called for every rule condition on every routing decision.

**After:** A `Mutex<HashMap<String, regex::Regex>>` field `regex_cache` is added to `RuleBasedRouter`. On first encounter of a pattern, the regex is compiled and cached. Subsequent checks with the same pattern reuse the compiled regex.

### 2. Unnecessary clone in `PromptTemplate::render_with_map` (`template.rs`)

**Before:**
```rust
for cap in super::regex::VARIABLE_PLACEHOLDER_RE.captures_iter(&result.clone()) {
    // mutates `result` inside the loop
}
```
The `.clone()` was used to avoid a simultaneous borrow (iterating over `result` while mutating it). However, this clones the entire template string — which can be large — on every render call.

**After:** Variable names and their resolution status are collected into a `Vec` first (borrowing `result` immutably), then replacements are applied in a separate loop. No clone needed.

### 3. Panic on non-UTF-8 paths in `RhaiToolRegistry::load_from_directory` (`tools.rs`)

**Before:**
```rust
self.load_from_yaml(path.to_str().unwrap()).await.ok()
```
`Path::to_str()` returns `None` for paths with invalid UTF-8 sequences. The `.unwrap()` causes a panic at runtime.

**After:**
```rust
if let (Some(ext), Some(path_str)) = (path.extension(), path.to_str()) {
```
Non-UTF-8 paths are silently skipped, matching the existing behavior of skipping unsupported file extensions.

## Test plan

- [x] `cargo check` — clean compilation, no errors
- [x] `cargo test -p mofa-extra` — all 33 tests pass
- [x] `cargo test -p mofa-foundation` — all tests pass
- [x] `cargo clippy -p mofa-foundation -p mofa-extra` — no new warnings introduced
