### PR TITLE
fix: drain dataflow router on shutdown instead of aborting

### DIFF
--- a/crates/mofa-runtime/src/native_dataflow/dataflow.rs
+++ b/crates/mofa-runtime/src/native_dataflow/dataflow.rs
@@ -24,7 +24,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::{Mutex, RwLock, mpsc};
 use tokio::task::JoinHandle;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 /// Configuration for a [`NativeDataflow`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -89,7 +89,7 @@ pub struct NativeDataflow {
     state: Arc<RwLock<DataflowState>>,
     nodes: Arc<RwLock<HashMap<String, Arc<NativeNode>>>>,
     connections: Arc<RwLock<Vec<NodeConnection>>>,
-    router_tx: mpsc::Sender<RouterMessage>,
+    router_tx: Mutex<Option<mpsc::Sender<RouterMessage>>>,
     router_rx: Mutex<Option<mpsc::Receiver<RouterMessage>>>,
     router_handle: Mutex<Option<JoinHandle<()>>>,
     forwarder_handles: Mutex<Vec<JoinHandle<()>>>,
@@ -104,7 +104,7 @@ impl NativeDataflow {
             state: Arc::new(RwLock::new(DataflowState::Created)),
             nodes: Arc::new(RwLock::new(HashMap::new())),
             connections: Arc::new(RwLock::new(Vec::new())),
-            router_tx,
+            router_tx: Mutex::new(Some(router_tx)),
             router_rx: Mutex::new(Some(router_rx)),
             router_handle: Mutex::new(None),
             forwarder_handles: Mutex::new(Vec::new()),
@@ -376,7 +376,13 @@ impl NativeDataflow {
             node.register_output_channel(source_output.clone(), tx)
                 .await?;
 
-            let router_tx = self.router_tx.clone();
+            let router_tx = self
+                .router_tx
+                .lock()
+                .await
+                .as_ref()
+                .expect("router_tx already closed")
+                .clone();
             let source_node_id = source_node.clone();
             let source_output_id = source_output.clone();
 
@@ -458,10 +464,18 @@ impl NativeDataflow {
         Ok(())
     }
 
-    /// Stop all nodes and abort the router task.
+    /// Stop all nodes and drain the router before shutting down.
+    ///
+    /// Shutdown order:
+    /// 1. Stop all nodes (no new work produced).
+    /// 2. Abort forwarder tasks and drop their cloned senders.
+    /// 3. Drop our own sender so the router channel closes.
+    /// 4. Await the router task (with timeout) so it can deliver any
+    ///    remaining queued messages before exiting.
     pub async fn stop(&self) -> DataflowResult<()> {
         *self.state.write().await = DataflowState::Stopping;
 
+        // 1. Stop all nodes.
         {
             let nodes = self.nodes.read().await;
             for node in nodes.values() {
@@ -469,13 +483,29 @@ impl NativeDataflow {
             }
         }
 
-        if let Some(handle) = self.router_handle.lock().await.take() {
-            handle.abort();
-        }
+        // 2. Abort forwarders — their cloned senders are dropped.
         {
             let mut forwarders = self.forwarder_handles.lock().await;
             for handle in forwarders.drain(..) {
                 handle.abort();
+            }
+        }
+
+        // 3. Drop the last sender so the router channel closes.
+        {
+            self.router_tx.lock().await.take();
+        }
+
+        // 4. Wait for the router to drain remaining messages.
+        if let Some(handle) = self.router_handle.lock().await.take() {
+            match tokio::time::timeout(std::time::Duration::from_secs(5), handle).await {
+                Ok(_) => {}
+                Err(_) => {
+                    warn!(
+                        "Dataflow '{}': router did not drain within 5s timeout",
+                        self.config.dataflow_id
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
# fix: drain dataflow router on shutdown instead of aborting

## Summary

`NativeDataflow::stop()` called `handle.abort()` on the router task, silently dropping any messages still queued in the channel. A node that had just produced output could have its result permanently lost if the message was buffered but not yet delivered to the target node.

## Problem

```rust
pub async fn stop(&self) -> DataflowResult<()> {
    // ...stop nodes...

    if let Some(handle) = self.router_handle.lock().await.take() {
        handle.abort(); // kills the router immediately, queued messages are dropped
    }
    // ...abort forwarders...
}
```

**Scenario:** Node A completes a critical subtask and sends output. The message enters the router's mpsc channel buffer. Before the router task processes it, `stop()` is called and `abort()` kills the router. Node B never receives Node A's result. The message is silently lost with no error or log entry.

## Fix

New shutdown order ensures in-flight messages are delivered:

1. **Stop all nodes** — no new work is produced
2. **Abort forwarder tasks** — their cloned channel senders are dropped
3. **Drop the struct's sender** — closes the mpsc channel (the router's `rx.recv()` will return `None` after draining)
4. **Await the router task** with a 5-second timeout — the router delivers all remaining queued messages before exiting naturally

To enable dropping the sender during shutdown, `router_tx` is wrapped in `Mutex<Option<mpsc::Sender<RouterMessage>>>`.

```rust
// 2. Abort forwarders — their cloned senders are dropped.
{
    let mut forwarders = self.forwarder_handles.lock().await;
    for handle in forwarders.drain(..) {
        handle.abort();
    }
}

// 3. Drop the last sender so the router channel closes.
{
    self.router_tx.lock().await.take();
}

// 4. Wait for the router to drain remaining messages.
if let Some(handle) = self.router_handle.lock().await.take() {
    match tokio::time::timeout(Duration::from_secs(5), handle).await {
        Ok(_) => {}
        Err(_) => {
            warn!("Dataflow '{}': router did not drain within 5s timeout", ...);
        }
    }
}
```

## Files Changed

| File | Change |
|------|--------|
| `crates/mofa-runtime/src/native_dataflow/dataflow.rs` | Graceful router shutdown with channel drain + timeout fallback |

## Test plan

- [x] `cargo check -p mofa-runtime` — clean compilation
- [x] `cargo test -p mofa-runtime -- dataflow` — all 20 dataflow tests pass
- [x] No new clippy warnings
