### PR TITLE
test(foundation): add unit tests for InMemoryStorage basic operations

### DIFF
--- a/crates/mofa-foundation/src/agent/components/memory.rs
+++ b/crates/mofa-foundation/src/agent/components/memory.rs
@@ -730,3 +730,47 @@ impl Memory for FileBasedStorage {
         "file-based"
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_in_memory_basic_operations() {
+        let mut storage = InMemoryStorage::new();
+
+        // Test store and retrieve
+        storage.store("key1", MemoryValue::text("value1")).await.unwrap();
+        let val = storage
+            .retrieve("key1")
+            .await
+            .unwrap()
+            .expect("value for 'key1' should exist after storing");
+        assert_eq!(val.as_text(), Some("value1"));
+
+        // Test retrieve non-existent key
+        let missing = storage.retrieve("missing_key").await.unwrap();
+        assert!(missing.is_none());
+
+        // Test overwrite
+        storage.store("key1", MemoryValue::text("new_value")).await.unwrap();
+        let val2 = storage
+            .retrieve("key1")
+            .await
+            .unwrap()
+            .expect("value for 'key1' should exist after overwrite");
+        assert_eq!(val2.as_text(), Some("new_value"));
+
+        // Test remove
+        let removed = storage.remove("key1").await.unwrap();
+        assert!(removed);
+
+        // Verify removal
+        let val3 = storage.retrieve("key1").await.unwrap();
+        assert!(val3.is_none());
+
+        // Test remove non-existent key
+        let removed_again = storage.remove("key1").await.unwrap();
+        assert!(!removed_again);
+    }
+}


### PR DESCRIPTION
## Summary
Adds foundational unit tests for the core operations of the `InMemoryStorage` agent memory component.

## Changes
- **Basic Operations Tests:** Added `test_in_memory_basic_operations` to verify the functionality of `InMemoryStorage`, including:
  - Storing and correctly retrieving values.
  - Handling retrieval of non-existent keys.
  - Successfully overwriting existing keys with new data.
  - Removing keys and verifying their absence.
  - Gracefully handling removal of non-existent keys.

## Motivation
The `InMemoryStorage` implementation is a critical component for agent memory management. This PR ensures its core CRUD operations are robust and function exactly as expected.
