### PR TITLE
Refactor/prevention from single plugin freezing system

### DIFF
--- a/crates/mofa-plugins/src/lib.rs
+++ b/crates/mofa-plugins/src/lib.rs
@@ -28,7 +28,7 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use tokio::time::{timeout,Duration};
+use tokio::time::{Duration, timeout};
 use tracing::{debug, error, info, warn};
 // ============================================================================
 // LLM 插件
@@ -1106,9 +1106,8 @@ pub struct PluginManager {
     /// 事件发送器（用于克隆给插件）
     /// Event sender (for cloning to plugins)
     event_tx: tokio::sync::mpsc::Sender<PluginEvent>,
-    //Configurable shutdown timeout : utilized in stopping and unloading plugins 
-
-    shutdown_timeout_secs:u64,
+    //Configurable shutdown timeout : utilized in stopping and unloading plugins
+    shutdown_timeout_secs: u64,
 }
 
 impl PluginManager {
@@ -1172,19 +1171,18 @@ impl PluginManager {
         let mut plugins = self.plugins.write().await;
         let shutdown_timeout = Duration::from_secs(self.shutdown_timeout_secs);
         if let Some(mut entry) = plugins.remove(plugin_id) {
-            //stop->unload 
-            if let Err(_)= timeout(shutdown_timeout,entry.plugin.stop()).await{
-                error!("Plugin {} stop () timed out",plugin_id);
-
+            //stop->unload
+            if let Err(_) = timeout(shutdown_timeout, entry.plugin.stop()).await {
+                error!("Plugin {} stop () timed out", plugin_id);
             }
 
             // unload
             if let Err(_) = timeout(shutdown_timeout, entry.plugin.unload()).await {
                 error!("Plugin {} unload() timed out", plugin_id);
-            }            
+            }
             info!("Plugin {} unregistered", plugin_id);
-                }
-            Ok(())
+        }
+        Ok(())
     }
 
     /// 获取插件
@@ -1293,7 +1291,7 @@ impl PluginManager {
         let mut plugins = self.plugins.write().await;
         let shutdown_timeout = Duration::from_secs(self.shutdown_timeout_secs);
         for (id, entry) in plugins.iter_mut() {
-            if let Err(e) = timeout(shutdown_timeout,entry.plugin.stop()).await {
+            if let Err(e) = timeout(shutdown_timeout, entry.plugin.stop()).await {
                 warn!("Failed to stop plugin {}: {}", id, e);
             }
         }
@@ -1307,7 +1305,7 @@ impl PluginManager {
         let mut plugins = self.plugins.write().await;
         let shutdown_timeout = Duration::from_secs(self.shutdown_timeout_secs);
         for (id, entry) in plugins.iter_mut() {
-            if let Err(e) = timeout(shutdown_timeout,entry.plugin.unload()).await {
+            if let Err(e) = timeout(shutdown_timeout, entry.plugin.unload()).await {
                 warn!("Failed to unload plugin {}: {}", id, e);
             }
         }
@@ -1368,11 +1366,9 @@ impl PluginManager {
         self.event_rx.take()
     }
 
-
-    /// Set Shutdown Timeout in runtime 
-    pub fn set_shutdown_timeout(&mut self,secs:u64){
-        self.shutdown_timeout_secs=secs;
-
+    /// Set Shutdown Timeout in runtime
+    pub fn set_shutdown_timeout(&mut self, secs: u64) {
+        self.shutdown_timeout_secs = secs;
     }
 }
 

--- a/crates/mofa-plugins/src/lib.rs
+++ b/crates/mofa-plugins/src/lib.rs
@@ -28,6 +28,7 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use tokio::time::{timeout,Duration};
 use tracing::{debug, error, info, warn};
 // ============================================================================
 // LLM 插件
@@ -1105,6 +1106,9 @@ pub struct PluginManager {
     /// 事件发送器（用于克隆给插件）
     /// Event sender (for cloning to plugins)
     event_tx: tokio::sync::mpsc::Sender<PluginEvent>,
+    //Configurable shutdown timeout : utilized in stopping and unloading plugins 
+
+    shutdown_timeout_secs:u64,
 }
 
 impl PluginManager {
@@ -1119,6 +1123,7 @@ impl PluginManager {
             context,
             event_rx: Some(event_rx),
             event_tx,
+            shutdown_timeout_secs: 5,
         }
     }
 
@@ -1165,11 +1170,21 @@ impl PluginManager {
     /// Unregister plugin
     pub async fn unregister(&self, plugin_id: &str) -> PluginResult<()> {
         let mut plugins = self.plugins.write().await;
+        let shutdown_timeout = Duration::from_secs(self.shutdown_timeout_secs);
         if let Some(mut entry) = plugins.remove(plugin_id) {
-            entry.plugin.unload().await?;
+            //stop->unload 
+            if let Err(_)= timeout(shutdown_timeout,entry.plugin.stop()).await{
+                error!("Plugin {} stop () timed out",plugin_id);
+
+            }
+
+            // unload
+            if let Err(_) = timeout(shutdown_timeout, entry.plugin.unload()).await {
+                error!("Plugin {} unload() timed out", plugin_id);
+            }            
             info!("Plugin {} unregistered", plugin_id);
-        }
-        Ok(())
+                }
+            Ok(())
     }
 
     /// 获取插件
@@ -1276,8 +1291,9 @@ impl PluginManager {
     /// Stop all plugins
     pub async fn stop_all(&self) -> PluginResult<()> {
         let mut plugins = self.plugins.write().await;
+        let shutdown_timeout = Duration::from_secs(self.shutdown_timeout_secs);
         for (id, entry) in plugins.iter_mut() {
-            if let Err(e) = entry.plugin.stop().await {
+            if let Err(e) = timeout(shutdown_timeout,entry.plugin.stop()).await {
                 warn!("Failed to stop plugin {}: {}", id, e);
             }
         }
@@ -1289,8 +1305,9 @@ impl PluginManager {
     /// Unload all plugins
     pub async fn unload_all(&self) -> PluginResult<()> {
         let mut plugins = self.plugins.write().await;
+        let shutdown_timeout = Duration::from_secs(self.shutdown_timeout_secs);
         for (id, entry) in plugins.iter_mut() {
-            if let Err(e) = entry.plugin.unload().await {
+            if let Err(e) = timeout(shutdown_timeout,entry.plugin.unload()).await {
                 warn!("Failed to unload plugin {}: {}", id, e);
             }
         }
@@ -1349,6 +1366,13 @@ impl PluginManager {
     /// Take event receiver
     pub fn take_event_receiver(&mut self) -> Option<tokio::sync::mpsc::Receiver<PluginEvent>> {
         self.event_rx.take()
+    }
+
+
+    /// Set Shutdown Timeout in runtime 
+    pub fn set_shutdown_timeout(&mut self,secs:u64){
+        self.shutdown_timeout_secs=secs;
+
     }
 }
 


### PR DESCRIPTION
## 📋 Summary
Currently, PluginManager stop and unload operations can hang if a plugin takes too long. This PR adds a shutdown timeout feature to prevent the system from hanging due to a misbehaving plugin.

It mainly:

- Wraps stop() and unload() calls in tokio::time::timeout
- Uses a default timeout of 5 seconds
- Allows users to change the timeout at runtime via 
- set_shutdown_timeout(secs)
- Logs errors if plugins exceed the timeout

## 🔗 Related Issues

Closes #
None

Related to #
Mofa-Plugins

---

## 🧠 Context

Previously, plugins could block stop() or unload() indefinitely, which could hang the runtime. This PR ensures that long-running plugin operations are safely bounded and improves overall stability.

---

## 🛠️ Changes

Changes are made only in one file:

- `mofa-plugins/src/lib.rs` – added timeout handling and set_shutdown_timeout() method

The main feature is in PluginManager, where plugin stop() and unload() operations are wrapped with a timeout, and errors are logged if exceeded.
- Changes in precision : 
    - Added extra variable in plugin manager , shutdown_timeout_secs,whose value can be changed by its setter ` set_shutdown_timeout`
    - Functions stop_all ,unload_all and plugin unregistering , utilizes this to , use tokio::Timeout 
    - Which shutdown ,if the time taken is more than specified

---

## 🧪 How you Tested


1. Cargo check
2. Cargo test

---

## 📸 Screenshots / Logs (if applicable)

1.Cargo Check
<img width="824" height="240" alt="cargo_check" src="https://github.com/user-attachments/assets/09089e18-71da-4b34-8aac-ee0a43a4fb87" />

2.Cargo test
<img width="895" height="244" alt="cargo_test" src="https://github.com/user-attachments/assets/0ef22d37-5629-46b9-afeb-dc3dbefc1d5c" />

---

## ⚠️ Breaking Changes

- [ ] No breaking changes
- [ ] Breaking change (describe below)

If breaking:

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [ ] `cargo clippy` passes without warnings

### Testing
- [ ] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [ ] Public APIs documented
- [ ] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---

## 🚀 Deployment Notes (if applicable)

<!-- migrations, config changes, env vars, rollout steps -->

---

## 🧩 Additional Notes for Reviewers
I am willing to maintain and support the new feature introduced in this contribution and would love feedback regarding it. :>