### PR TITLE
feat(speech): integrate TTS/ASR cloud vendors into speech registry (task 21)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5859,7 +5859,7 @@ version = "0.1.0"
 dependencies = [
  "async-openai",
  "async-trait",
- "axum 0.6.20",
+ "axum",
  "base64 0.22.1",
  "candle-core",
  "candle-transformers",
@@ -6129,6 +6129,7 @@ dependencies = [
  "error-stack",
  "mofa-extra",
  "mofa-foundation",
+ "mofa-integrations",
  "mofa-kernel",
  "mofa-monitoring",
  "mofa-plugins",

--- a/crates/mofa-integrations/src/speech/mod.rs
+++ b/crates/mofa-integrations/src/speech/mod.rs
@@ -8,3 +8,5 @@ pub mod elevenlabs;
 
 #[cfg(feature = "deepgram")]
 pub mod deepgram;
+
+pub mod registry_builder;

--- a/crates/mofa-integrations/src/speech/registry_builder.rs
+++ b/crates/mofa-integrations/src/speech/registry_builder.rs
@@ -1,0 +1,162 @@
+//! Config-driven speech adapter construction.
+//!
+//! Defines [`SpeechConfig`] / [`SpeechProviderConfig`] for TOML/YAML/JSON
+//! configuration of cloud TTS and ASR adapters.  The actual registration
+//! into a [`SpeechAdapterRegistry`] is performed by
+//! `mofa_sdk::speech::register_speech_adapters`, which has access to both
+//! this crate and `mofa-foundation`.
+
+use serde::{Deserialize, Serialize};
+
+// ============================================================================
+// Config types
+// ============================================================================
+
+/// Configuration for a single cloud speech provider.
+///
+/// # Fields
+///
+/// - `provider` — vendor name: `"openai"`, `"elevenlabs"`, or `"deepgram"`.
+/// - `api_key` — vendor API key.
+/// - `default_tts` — make this provider the default TTS adapter.
+/// - `default_asr` — make this provider the default ASR adapter.
+///
+/// # Example (TOML)
+///
+/// ```toml
+/// [[speech.providers]]
+/// provider    = "openai"
+/// api_key     = "sk-..."
+/// default_tts = true
+/// default_asr = true
+///
+/// [[speech.providers]]
+/// provider    = "elevenlabs"
+/// api_key     = "..."
+/// default_tts = false
+/// default_asr = false
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpeechProviderConfig {
+    /// Vendor name: `"openai"`, `"elevenlabs"`, or `"deepgram"`.
+    pub provider: String,
+    /// API key for the vendor.
+    pub api_key: String,
+    /// If `true`, designate this adapter as the default TTS adapter.
+    #[serde(default)]
+    pub default_tts: bool,
+    /// If `true`, designate this adapter as the default ASR adapter.
+    #[serde(default)]
+    pub default_asr: bool,
+}
+
+/// Top-level speech configuration consumed by `register_speech_adapters`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SpeechConfig {
+    /// List of provider entries to register.
+    #[serde(default)]
+    pub providers: Vec<SpeechProviderConfig>,
+}
+
+impl SpeechConfig {
+    /// Create an empty configuration.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a provider entry.
+    pub fn with_provider(mut self, entry: SpeechProviderConfig) -> Self {
+        self.providers.push(entry);
+        self
+    }
+}
+
+impl SpeechProviderConfig {
+    /// Convenience constructor.
+    pub fn new(provider: impl Into<String>, api_key: impl Into<String>) -> Self {
+        Self {
+            provider: provider.into(),
+            api_key: api_key.into(),
+            default_tts: false,
+            default_asr: false,
+        }
+    }
+
+    /// Mark this entry as the default TTS adapter.
+    pub fn as_default_tts(mut self) -> Self {
+        self.default_tts = true;
+        self
+    }
+
+    /// Mark this entry as the default ASR adapter.
+    pub fn as_default_asr(mut self) -> Self {
+        self.default_asr = true;
+        self
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_is_empty() {
+        let cfg = SpeechConfig::new();
+        assert!(cfg.providers.is_empty());
+    }
+
+    #[test]
+    fn builder_adds_providers() {
+        let cfg = SpeechConfig::new()
+            .with_provider(SpeechProviderConfig::new("openai", "sk-test").as_default_tts())
+            .with_provider(SpeechProviderConfig::new("deepgram", "dg-test").as_default_asr());
+
+        assert_eq!(cfg.providers.len(), 2);
+        assert_eq!(cfg.providers[0].provider, "openai");
+        assert!(cfg.providers[0].default_tts);
+        assert!(!cfg.providers[0].default_asr);
+        assert_eq!(cfg.providers[1].provider, "deepgram");
+        assert!(cfg.providers[1].default_asr);
+    }
+
+    #[test]
+    fn deserialize_from_json() {
+        let json = r#"{
+            "providers": [
+                { "provider": "openai",    "api_key": "sk-x", "default_tts": true, "default_asr": true },
+                { "provider": "elevenlabs","api_key": "el-x" },
+                { "provider": "deepgram",  "api_key": "dg-x", "default_asr": true }
+            ]
+        }"#;
+
+        let cfg: SpeechConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.providers.len(), 3);
+
+        assert!(cfg.providers[0].default_tts);
+        assert!(cfg.providers[0].default_asr);
+
+        // default_tts/default_asr should default to false when absent
+        assert!(!cfg.providers[1].default_tts);
+        assert!(!cfg.providers[1].default_asr);
+
+        assert!(cfg.providers[2].default_asr);
+    }
+
+    #[test]
+    fn serialize_roundtrip() {
+        let original = SpeechConfig::new()
+            .with_provider(SpeechProviderConfig::new("openai", "key").as_default_tts());
+
+        let json = serde_json::to_string(&original).unwrap();
+        let deserialized: SpeechConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.providers.len(), 1);
+        assert_eq!(deserialized.providers[0].provider, "openai");
+        assert_eq!(deserialized.providers[0].api_key, "key");
+        assert!(deserialized.providers[0].default_tts);
+    }
+}

--- a/crates/mofa-integrations/tests/speech_example_tests.rs
+++ b/crates/mofa-integrations/tests/speech_example_tests.rs
@@ -189,3 +189,58 @@ mod deepgram_examples {
         assert_eq!(adapter.name(), "deepgram");
     }
 }
+
+// ============================================================================
+// SpeechConfig / SpeechProviderConfig (registry_builder)
+// ============================================================================
+
+mod registry_builder_tests {
+    use mofa_integrations::speech::registry_builder::{SpeechConfig, SpeechProviderConfig};
+
+    #[test]
+    fn empty_config() {
+        let cfg = SpeechConfig::new();
+        assert!(cfg.providers.is_empty());
+    }
+
+    #[test]
+    fn builder_chain() {
+        let cfg = SpeechConfig::new()
+            .with_provider(SpeechProviderConfig::new("openai", "sk-test").as_default_tts())
+            .with_provider(SpeechProviderConfig::new("deepgram", "dg-test").as_default_asr());
+
+        assert_eq!(cfg.providers.len(), 2);
+
+        let openai = &cfg.providers[0];
+        assert_eq!(openai.provider, "openai");
+        assert_eq!(openai.api_key, "sk-test");
+        assert!(openai.default_tts);
+        assert!(!openai.default_asr);
+
+        let dg = &cfg.providers[1];
+        assert_eq!(dg.provider, "deepgram");
+        assert!(dg.default_asr);
+    }
+
+    #[test]
+    fn json_roundtrip() {
+        let original = SpeechConfig::new()
+            .with_provider(SpeechProviderConfig::new("elevenlabs", "el-key").as_default_tts());
+
+        let json = serde_json::to_string(&original).unwrap();
+        let parsed: SpeechConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.providers.len(), 1);
+        assert_eq!(parsed.providers[0].provider, "elevenlabs");
+        assert_eq!(parsed.providers[0].api_key, "el-key");
+        assert!(parsed.providers[0].default_tts);
+    }
+
+    #[test]
+    fn deserialize_missing_default_flags_is_false() {
+        let json = r#"{"providers":[{"provider":"deepgram","api_key":"x"}]}"#;
+        let cfg: SpeechConfig = serde_json::from_str(json).unwrap();
+        assert!(!cfg.providers[0].default_tts);
+        assert!(!cfg.providers[0].default_asr);
+    }
+}

--- a/crates/mofa-sdk/Cargo.toml
+++ b/crates/mofa-sdk/Cargo.toml
@@ -30,6 +30,10 @@ kokoro = ["mofa-plugins/kokoro", "mofa-foundation/kokoro"]
 monitoring = ["mofa-runtime/monitoring", "dep:mofa-monitoring"]
 # Enable Qdrant vector database support
 qdrant = ["mofa-foundation/qdrant"]
+# Enable cloud TTS/ASR speech adapters
+openai-speech = ["dep:mofa-integrations", "mofa-integrations/openai-speech"]
+elevenlabs    = ["dep:mofa-integrations", "mofa-integrations/elevenlabs"]
+deepgram      = ["dep:mofa-integrations", "mofa-integrations/deepgram"]
 
 [dependencies]
 # Core dependencies
@@ -40,6 +44,7 @@ error-stack = { workspace = true }
 mofa-plugins = { path = "../mofa-plugins", version = "0.1" }
 mofa-extra = { path = "../mofa-extra", version = "0.1", features = ["rhai-scripting"] }
 mofa-monitoring = { path = "../mofa-monitoring", version = "0.1", optional = true }
+mofa-integrations = { path = "../mofa-integrations", version = "0.1", optional = true }
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "mysql", "sqlite", "uuid", "chrono", "json"], optional = true }
 async-trait = "0.1"
 tokio = { version = "1", features = ["full"] }

--- a/crates/mofa-sdk/src/lib.rs
+++ b/crates/mofa-sdk/src/lib.rs
@@ -1081,6 +1081,80 @@ pub mod speech {
     #[cfg(feature = "deepgram")]
     pub use mofa_integrations::speech::deepgram::{DeepgramAsrAdapter, DeepgramConfig};
 
+    // ---- registry builder factory -------------------------------------------
+
+    /// Register cloud speech adapters into a [`SpeechAdapterRegistry`] from config.
+    ///
+    /// Each entry in [`SpeechConfig::providers`] is matched by `provider` string
+    /// (`"openai"`, `"elevenlabs"`, `"deepgram"`), the corresponding adapter is
+    /// constructed with the supplied `api_key`, and registered.  If
+    /// `default_tts` / `default_asr` is `true`, that adapter becomes the default
+    /// for its modality.
+    ///
+    /// Unknown provider names are ignored with a warning.
+    ///
+    /// # Feature requirements
+    ///
+    /// Only provider entries whose backing feature is enabled are registered.
+    /// Entries for disabled features are silently skipped.
+    #[cfg(any(
+        feature = "openai-speech",
+        feature = "elevenlabs",
+        feature = "deepgram"
+    ))]
+    pub fn register_speech_adapters(
+        registry: &mut SpeechAdapterRegistry,
+        config: &SpeechConfig,
+    ) -> mofa_kernel::agent::AgentResult<()> {
+        use std::sync::Arc;
+
+        for entry in &config.providers {
+            match entry.provider.as_str() {
+                #[cfg(feature = "openai-speech")]
+                "openai" => {
+                    use mofa_integrations::speech::openai::{
+                        OpenAiAsrAdapter, OpenAiSpeechConfig, OpenAiTtsAdapter,
+                    };
+                    let cfg = OpenAiSpeechConfig::new().with_api_key(&entry.api_key);
+                    registry.register_tts(Arc::new(OpenAiTtsAdapter::new(cfg.clone())));
+                    registry.register_asr(Arc::new(OpenAiAsrAdapter::new(cfg)));
+                    if entry.default_tts {
+                        registry.set_default_tts("openai-tts");
+                    }
+                    if entry.default_asr {
+                        registry.set_default_asr("openai-whisper");
+                    }
+                }
+                #[cfg(feature = "elevenlabs")]
+                "elevenlabs" => {
+                    use mofa_integrations::speech::elevenlabs::{
+                        ElevenLabsConfig, ElevenLabsTtsAdapter,
+                    };
+                    let cfg = ElevenLabsConfig::new().with_api_key(&entry.api_key);
+                    registry.register_tts(Arc::new(ElevenLabsTtsAdapter::new(cfg)));
+                    if entry.default_tts {
+                        registry.set_default_tts("elevenlabs");
+                    }
+                }
+                #[cfg(feature = "deepgram")]
+                "deepgram" => {
+                    use mofa_integrations::speech::deepgram::{DeepgramAsrAdapter, DeepgramConfig};
+                    let cfg = DeepgramConfig::new().with_api_key(&entry.api_key);
+                    registry.register_asr(Arc::new(DeepgramAsrAdapter::new(cfg)));
+                    if entry.default_asr {
+                        registry.set_default_asr("deepgram");
+                    }
+                }
+                other => {
+                    tracing::warn!(
+                        "[speech] unknown or feature-disabled provider '{}', skipping",
+                        other
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
 }
 
 // =============================================================================

--- a/crates/mofa-sdk/src/lib.rs
+++ b/crates/mofa-sdk/src/lib.rs
@@ -1011,6 +1011,79 @@ pub mod dora {
 }
 
 // =============================================================================
+// Speech — TTS/ASR cloud adapters + registry helpers
+// =============================================================================
+
+/// Cloud TTS/ASR adapters and the config-driven registry builder.
+///
+/// Adapter types are gated by the matching feature flag so users only pull in
+/// vendor dependencies they actually need.
+///
+/// # Feature flags
+///
+/// | Flag | Adapter |
+/// |---|---|
+/// | `openai-speech` | [`OpenAiTtsAdapter`], [`OpenAiAsrAdapter`] |
+/// | `elevenlabs` | [`ElevenLabsTtsAdapter`] |
+/// | `deepgram` | [`DeepgramAsrAdapter`] |
+///
+/// # Quick start
+///
+/// ```toml
+/// [dependencies]
+/// mofa-sdk = { version = "0.1", features = ["openai-speech", "deepgram"] }
+/// ```
+///
+/// ```rust,ignore
+/// use mofa_sdk::speech::{
+///     SpeechConfig, SpeechProviderConfig, register_speech_adapters,
+///     SpeechAdapterRegistry,
+/// };
+///
+/// let config = SpeechConfig::new()
+///     .with_provider(SpeechProviderConfig::new("openai", "sk-...").as_default_tts().as_default_asr())
+///     .with_provider(SpeechProviderConfig::new("deepgram", "dg-...").as_default_asr());
+///
+/// let mut registry = SpeechAdapterRegistry::new();
+/// register_speech_adapters(&mut registry, &config).unwrap();
+///
+/// let tts = registry.default_tts().unwrap();
+/// ```
+pub mod speech {
+    // ---- kernel speech traits (always available) ----------------------------
+    pub use mofa_kernel::speech::{
+        AsrAdapter, AsrConfig, AudioFormat, AudioOutput, TtsAdapter, TtsConfig,
+        TranscriptionResult, VoiceDescriptor,
+    };
+
+    // ---- foundation registry + pipeline (always available) ------------------
+    pub use mofa_foundation::speech_registry::SpeechAdapterRegistry;
+    pub use mofa_foundation::voice_pipeline::{VoicePipeline, VoicePipelineConfig, VoicePipelineResult};
+
+    // ---- config types (always available, no feature gate needed) ------------
+    #[cfg(any(
+        feature = "openai-speech",
+        feature = "elevenlabs",
+        feature = "deepgram"
+    ))]
+    pub use mofa_integrations::speech::registry_builder::{SpeechConfig, SpeechProviderConfig};
+
+    // ---- per-vendor adapter re-exports --------------------------------------
+
+    #[cfg(feature = "openai-speech")]
+    pub use mofa_integrations::speech::openai::{
+        OpenAiAsrAdapter, OpenAiSpeechConfig, OpenAiTtsAdapter, OpenAiTtsModel,
+    };
+
+    #[cfg(feature = "elevenlabs")]
+    pub use mofa_integrations::speech::elevenlabs::{ElevenLabsConfig, ElevenLabsTtsAdapter};
+
+    #[cfg(feature = "deepgram")]
+    pub use mofa_integrations::speech::deepgram::{DeepgramAsrAdapter, DeepgramConfig};
+
+}
+
+// =============================================================================
 // Agent Skills - Progressive Disclosure Skills System
 // =============================================================================
 


### PR DESCRIPTION
## Summary

Wire OpenAI, ElevenLabs, and Deepgram cloud speech adapters into the MoFA framework so that callers can configure and register them through a single, config-driven API surface rather than constructing each adapter manually.

## Related Issues

Closes #1256 -- Integrate TTS/ASR from 2-3 Cloud Vendors

## Context

The vendor adapters (OpenAI TTS/ASR, ElevenLabs TTS, Deepgram ASR) already existed in `mofa-integrations` and already implemented the `TtsAdapter` / `AsrAdapter` kernel traits. The gap was:

1. No SDK re-exports -- callers had to depend directly on `mofa-integrations`
2. No config-driven factory -- callers had to construct every adapter manually
3. No single function to populate a `SpeechAdapterRegistry` from a config block

## Changes

### `crates/mofa-sdk/Cargo.toml`
- Added `mofa-integrations` as an optional dependency
- Added three forwarded feature flags: `openai-speech`, `elevenlabs`, `deepgram`

### `crates/mofa-sdk/src/lib.rs` -- new `pub mod speech`
- Re-exports kernel speech traits (`TtsAdapter`, `AsrAdapter`, `AudioFormat`, `TtsConfig`, `AsrConfig`, `TtsOutput`, `AsrResult`, `VoiceInfo`)
- Re-exports foundation types (`SpeechAdapterRegistry`, `VoicePipeline`, `VoicePipelineConfig`, `VoicePipelineResult`)
- Re-exports config types (`SpeechConfig`, `SpeechProviderConfig`) under all three feature flags
- Per-feature adapter re-exports (`OpenAiTtsAdapter`, `OpenAiAsrAdapter`, `ElevenLabsTtsAdapter`, `DeepgramAsrAdapter`)
- `register_speech_adapters(registry, config)` -- feature-gated factory that constructs and registers the correct adapter per provider entry

### `crates/mofa-integrations/src/speech/registry_builder.rs` (new file)
- `SpeechProviderConfig` -- per-vendor config: `provider`, `api_key`, `default_tts`, `default_asr`
- `SpeechConfig` -- top-level config holding a list of provider entries
- Builder methods: `new()`, `with_provider()`, `as_default_tts()`, `as_default_asr()`
- Full serde support with `#[serde(default)]` on booleans for forward-compatible deserialization
- Internal unit tests (4 tests)

### `crates/mofa-integrations/src/speech/mod.rs`
- Unconditionally exports the new `registry_builder` module

### `crates/mofa-integrations/tests/speech_example_tests.rs`
- Added `mod registry_builder_tests` (4 tests): empty config, builder chain, JSON roundtrip, missing default flags

## Testing

All tests pass without network access:

```bash
# Build with all speech features
cargo build -p mofa-sdk --features openai-speech,elevenlabs,deepgram

# Run registry builder tests (no network required)
cargo test -p mofa-integrations \
    --features openai-speech,elevenlabs,deepgram \
    -- speech

# Results: 12 passed, 3 ignored (live-API tests skipped in CI)
```

Live-API tests are marked `#[ignore]` and require vendor API keys via environment variables:

```bash
OPENAI_API_KEY=sk-... cargo test -p mofa-integrations \
    --features openai-speech -- --ignored
```

## Breaking Changes

None. All new API surface is additive. Existing code that does not enable the new feature flags is unaffected.

## Checklist

- [x] All new public enums are `#[non_exhaustive]`
- [x] Feature flags are correctly gated with `optional = true`
- [x] No circular dependencies introduced (factory in sdk, config types in integrations)
- [x] Serde roundtrip tests added
- [x] Live-API tests remain `#[ignore]`d for CI