### PR TITLE
feat(foundation): implement Gemini streaming support

### DIFF
--- a/crates/mofa-foundation/src/llm/google.rs
+++ b/crates/mofa-foundation/src/llm/google.rs
@@ -1,10 +1,12 @@
-//! Google Gemini Provider (experimental, text-only)
+//! Google Gemini Provider
 //!
-//! Implements Gemini Pro via Generative Language API v1beta.
+//! Implements Gemini Pro via Generative Language API v1beta with streaming support.
+//! Parses Gemini SSE events and maps them to `ChatCompletionChunk`.
 
 use super::provider::{ChatStream, LLMProvider, ModelCapabilities, ModelInfo};
 use super::types::*;
 use async_trait::async_trait;
+use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
@@ -87,7 +89,7 @@ impl GeminiConfig {
     }
 }
 
-/// Gemini provider (text-only, no tools for now)
+/// Gemini provider with streaming support
 pub struct GeminiProvider {
     client: reqwest::Client,
     config: GeminiConfig,
@@ -229,81 +231,9 @@ impl GeminiProvider {
         (system, contents)
     }
 
-    fn map_error(err: reqwest::Error) -> LLMError {
-        if err.is_timeout() {
-            LLMError::Timeout(err.to_string())
-        } else if err.is_connect() || err.is_request() {
-            LLMError::NetworkError(err.to_string())
-        } else {
-            LLMError::Other(err.to_string())
-        }
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct GeminiCandidate {
-    content: Option<GeminiContent>,
-    finish_reason: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GeminiContent {
-    parts: Vec<GeminiPart>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GeminiPart {
-    text: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GeminiUsage {
-    #[serde(rename = "promptTokenCount")]
-    prompt_tokens: u32,
-    #[serde(rename = "candidatesTokenCount")]
-    candidates_tokens: u32,
-    #[serde(rename = "totalTokenCount")]
-    total_tokens: u32,
-}
-
-#[derive(Debug, Deserialize)]
-struct GeminiResponse {
-    candidates: Vec<GeminiCandidate>,
-    #[serde(rename = "usageMetadata")]
-    usage: Option<GeminiUsage>,
-    model_version: Option<String>,
-}
-
-#[async_trait]
-impl LLMProvider for GeminiProvider {
-    fn name(&self) -> &str {
-        "gemini"
-    }
-
-    fn default_model(&self) -> &str {
-        &self.config.default_model
-    }
-
-    fn supports_streaming(&self) -> bool {
-        false
-    }
-
-    fn supports_tools(&self) -> bool {
-        false
-    }
-
-    fn supports_vision(&self) -> bool {
-        false
-    }
-
-    async fn chat(&self, request: ChatCompletionRequest) -> LLMResult<ChatCompletionResponse> {
+    /// Build the JSON request body (shared between chat and chat_stream)
+    fn build_request_body(&self, request: &ChatCompletionRequest) -> serde_json::Value {
         let (system, contents) = Self::convert_messages(&request.messages);
-
-        let model = if request.model.is_empty() {
-            self.config.default_model.clone()
-        } else {
-            request.model.clone()
-        };
 
         let mut body = serde_json::json!({
             "contents": contents,
@@ -328,6 +258,255 @@ impl LLMProvider for GeminiProvider {
         if let Some(stop) = request.stop.clone() {
             body["generationConfig"]["stopSequences"] = serde_json::json!(stop);
         }
+
+        body
+    }
+
+    fn map_error(err: reqwest::Error) -> LLMError {
+        if err.is_timeout() {
+            LLMError::Timeout(err.to_string())
+        } else if err.is_connect() || err.is_request() {
+            LLMError::NetworkError(err.to_string())
+        } else {
+            LLMError::Other(err.to_string())
+        }
+    }
+}
+
+// ============================================================================
+// Gemini response types (shared between non-streaming and streaming)
+// ============================================================================
+
+#[derive(Debug, Deserialize)]
+struct GeminiCandidate {
+    content: Option<GeminiContent>,
+    #[serde(rename = "finishReason")]
+    finish_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GeminiContent {
+    parts: Vec<GeminiPart>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GeminiPart {
+    text: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GeminiUsage {
+    #[serde(rename = "promptTokenCount", default)]
+    prompt_tokens: u32,
+    #[serde(rename = "candidatesTokenCount", default)]
+    candidates_tokens: u32,
+    #[serde(rename = "totalTokenCount", default)]
+    total_tokens: u32,
+}
+
+#[derive(Debug, Deserialize)]
+struct GeminiResponse {
+    candidates: Vec<GeminiCandidate>,
+    #[serde(rename = "usageMetadata")]
+    usage: Option<GeminiUsage>,
+    model_version: Option<String>,
+}
+
+/// A single streaming chunk from the Gemini API.
+///
+/// Gemini's `streamGenerateContent?alt=sse` endpoint sends newline-delimited
+/// JSON objects on `data:` lines. Each object has the same shape as the
+/// non-streaming response but contains partial content.
+#[derive(Debug, Deserialize)]
+struct GeminiStreamChunk {
+    candidates: Option<Vec<GeminiCandidate>>,
+    #[serde(rename = "usageMetadata")]
+    usage: Option<GeminiUsage>,
+}
+
+// ============================================================================
+// Gemini SSE streaming parser
+// ============================================================================
+
+/// Map Gemini finish reason strings to `FinishReason`
+fn map_gemini_finish_reason(reason: &str) -> Option<FinishReason> {
+    match reason {
+        "STOP" => Some(FinishReason::Stop),
+        "MAX_TOKENS" => Some(FinishReason::Length),
+        "SAFETY" | "RECITATION" | "OTHER" => Some(FinishReason::ContentFilter),
+        _ => None,
+    }
+}
+
+/// Convert a `GeminiStreamChunk` into a `ChatCompletionChunk`.
+///
+/// `is_first` controls whether the role field is populated (only on the first chunk).
+fn gemini_chunk_to_completion(
+    chunk: &GeminiStreamChunk,
+    model: &str,
+    is_first: bool,
+) -> ChatCompletionChunk {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    let (content, finish_reason) = chunk
+        .candidates
+        .as_ref()
+        .and_then(|cs| cs.first())
+        .map(|c| {
+            let text = c
+                .content
+                .as_ref()
+                .and_then(|cont| cont.parts.iter().filter_map(|p| p.text.clone()).next());
+            let fr = c
+                .finish_reason
+                .as_deref()
+                .and_then(map_gemini_finish_reason);
+            (text, fr)
+        })
+        .unwrap_or((None, None));
+
+    let usage = chunk.usage.as_ref().map(|u| Usage {
+        prompt_tokens: u.prompt_tokens,
+        completion_tokens: u.candidates_tokens,
+        total_tokens: u.total_tokens,
+    });
+
+    ChatCompletionChunk {
+        id: String::new(),
+        object: "chat.completion.chunk".to_string(),
+        created: now,
+        model: model.to_string(),
+        choices: vec![ChunkChoice {
+            index: 0,
+            delta: ChunkDelta {
+                role: if is_first { Some(Role::Assistant) } else { None },
+                content,
+                tool_calls: None,
+            },
+            finish_reason,
+        }],
+        usage,
+    }
+}
+
+/// Parse raw SSE lines from a Gemini streaming response into `ChatCompletionChunk` items.
+///
+/// Uses `futures::stream::unfold` with byte-level buffering, identical in
+/// structure to `parse_anthropic_sse` in `anthropic.rs`.
+fn parse_gemini_sse(resp: reqwest::Response, model: String) -> ChatStream {
+    let stream = futures::stream::unfold(
+        (resp, String::new(), model, true),
+        |(mut resp, mut buf, model, mut is_first)| async move {
+            loop {
+                // Try to extract a complete line from the buffer.
+                if let Some(newline_pos) = buf.find('\n') {
+                    let line = buf[..newline_pos].trim_end_matches('\r').to_string();
+                    buf = buf[newline_pos + 1..].to_string();
+
+                    if line.is_empty() {
+                        continue;
+                    }
+
+                    if let Some(json_str) = line.strip_prefix("data: ") {
+                        // Gemini sends `data: [DONE]` as the sentinel.
+                        if json_str.trim() == "[DONE]" {
+                            return None;
+                        }
+
+                        match serde_json::from_str::<GeminiStreamChunk>(json_str) {
+                            Ok(chunk) => {
+                                let completion =
+                                    gemini_chunk_to_completion(&chunk, &model, is_first);
+                                is_first = false;
+                                return Some((
+                                    Ok(completion),
+                                    (resp, buf, model, is_first),
+                                ));
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    "Skipping unparseable Gemini SSE chunk: {}",
+                                    e
+                                );
+                                continue;
+                            }
+                        }
+                    }
+
+                    // Skip non-data lines (e.g., comments, event types)
+                    continue;
+                }
+
+                // Need more bytes from the network.
+                match resp.chunk().await {
+                    Ok(Some(bytes)) => {
+                        buf.push_str(&String::from_utf8_lossy(&bytes));
+                    }
+                    Ok(None) => {
+                        // End of stream. If there is leftover data, try to parse it.
+                        if !buf.trim().is_empty() {
+                            if let Some(json_str) = buf.trim().strip_prefix("data: ") {
+                                if json_str.trim() != "[DONE]" {
+                                    if let Ok(chunk) =
+                                        serde_json::from_str::<GeminiStreamChunk>(json_str)
+                                    {
+                                        let completion =
+                                            gemini_chunk_to_completion(&chunk, &model, is_first);
+                                        return Some((
+                                            Ok(completion),
+                                            (resp, String::new(), model, false),
+                                        ));
+                                    }
+                                }
+                            }
+                        }
+                        return None;
+                    }
+                    Err(e) => {
+                        let err = LLMError::NetworkError(e.to_string());
+                        return Some((Err(err), (resp, buf, model, is_first)));
+                    }
+                }
+            }
+        },
+    );
+
+    Box::pin(stream)
+}
+
+#[async_trait]
+impl LLMProvider for GeminiProvider {
+    fn name(&self) -> &str {
+        "gemini"
+    }
+
+    fn default_model(&self) -> &str {
+        &self.config.default_model
+    }
+
+    fn supports_streaming(&self) -> bool {
+        true
+    }
+
+    fn supports_tools(&self) -> bool {
+        false
+    }
+
+    fn supports_vision(&self) -> bool {
+        false
+    }
+
+    async fn chat(&self, request: ChatCompletionRequest) -> LLMResult<ChatCompletionResponse> {
+        let model = if request.model.is_empty() {
+            self.config.default_model.clone()
+        } else {
+            request.model.clone()
+        };
+
+        let body = self.build_request_body(&request);
 
         let url = format!(
             "{}/v1beta/models/{}:generateContent?key={}",
@@ -357,14 +536,16 @@ impl LLMProvider for GeminiProvider {
         let parsed: GeminiResponse =
             serde_json::from_str(&text).map_err(|e| LLMError::SerializationError(e.to_string()))?;
 
-        let first = parsed
-            .candidates
-            .into_iter()
-            .find_map(|c| c.content)
-            .and_then(|c| c.parts.into_iter().find_map(|p| p.text))
+        let first_candidate = parsed.candidates.first();
+
+        let first = first_candidate
+            .and_then(|c| c.content.as_ref())
+            .and_then(|c| c.parts.iter().find_map(|p| p.text.clone()))
             .unwrap_or_default();
 
-        let finish_reason = None; // Gemini returns fine-grained reasons; map later if needed
+        let finish_reason = first_candidate
+            .and_then(|c| c.finish_reason.as_deref())
+            .and_then(map_gemini_finish_reason);
 
         let usage = parsed.usage.map(|u| Usage {
             prompt_tokens: u.prompt_tokens,
@@ -401,10 +582,40 @@ impl LLMProvider for GeminiProvider {
         })
     }
 
-    async fn chat_stream(&self, _request: ChatCompletionRequest) -> LLMResult<ChatStream> {
-        Err(LLMError::ProviderNotSupported(
-            "Gemini streaming not yet implemented".to_string(),
-        ))
+    async fn chat_stream(&self, request: ChatCompletionRequest) -> LLMResult<ChatStream> {
+        let model = if request.model.is_empty() {
+            self.config.default_model.clone()
+        } else {
+            request.model.clone()
+        };
+
+        let body = self.build_request_body(&request);
+
+        let url = format!(
+            "{}/v1beta/models/{}:streamGenerateContent?alt=sse&key={}",
+            self.config.base_url.trim_end_matches('/'),
+            model,
+            self.config.api_key
+        );
+
+        let resp = self
+            .client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(Self::map_error)?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().await.map_err(Self::map_error)?;
+            return Err(LLMError::ApiError {
+                code: Some(status.as_u16().to_string()),
+                message: text,
+            });
+        }
+
+        Ok(parse_gemini_sse(resp, model))
     }
 
     async fn health_check(&self) -> LLMResult<bool> {
@@ -423,7 +634,7 @@ impl LLMProvider for GeminiProvider {
             max_output_tokens: Some(self.config.default_max_tokens),
             training_cutoff: None,
             capabilities: ModelCapabilities {
-                streaming: false,
+                streaming: true,
                 tools: false,
                 vision: false,
                 json_mode: true,
@@ -436,6 +647,29 @@ impl LLMProvider for GeminiProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Helper: process raw SSE text and collect `ChatCompletionChunk` items.
+    fn process_gemini_sse_text(raw: &str, model: &str) -> Vec<ChatCompletionChunk> {
+        let mut chunks = Vec::new();
+        let mut is_first = true;
+
+        for line in raw.lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            if let Some(json_str) = line.strip_prefix("data: ") {
+                if json_str.trim() == "[DONE]" {
+                    break;
+                }
+                if let Ok(chunk) = serde_json::from_str::<GeminiStreamChunk>(json_str) {
+                    chunks.push(gemini_chunk_to_completion(&chunk, model, is_first));
+                    is_first = false;
+                }
+            }
+        }
+        chunks
+    }
 
     #[test]
     fn test_convert_messages_with_media() {
@@ -482,5 +716,124 @@ mod tests {
             parts[2]["inlineData"]["data"],
             "AAAAIGZ0eXBtcDQyAAAAAG1wNDJpc29tYXZjMQAAADhmoW9v..."
         );
+    }
+
+    #[test]
+    fn test_config_defaults() {
+        let config = GeminiConfig::default();
+        assert_eq!(
+            config.base_url,
+            "https://generativelanguage.googleapis.com"
+        );
+        assert_eq!(config.default_model, "gemini-1.5-pro-latest");
+        assert_eq!(config.default_max_tokens, 2048);
+        assert!((config.default_temperature - 0.7).abs() < f32::EPSILON);
+        assert_eq!(config.timeout_secs, 60);
+    }
+
+    #[test]
+    fn test_config_builder() {
+        let config = GeminiConfig::new("test-key")
+            .with_model("gemini-2.0-flash")
+            .with_temperature(0.5)
+            .with_max_tokens(1024)
+            .with_base_url("https://custom.api.com")
+            .with_timeout(120);
+
+        assert_eq!(config.api_key, "test-key");
+        assert_eq!(config.default_model, "gemini-2.0-flash");
+        assert!((config.default_temperature - 0.5).abs() < f32::EPSILON);
+        assert_eq!(config.default_max_tokens, 1024);
+        assert_eq!(config.base_url, "https://custom.api.com");
+        assert_eq!(config.timeout_secs, 120);
+    }
+
+    #[test]
+    fn test_supports_streaming() {
+        let provider = GeminiProvider::new("test-key");
+        assert_eq!(provider.name(), "gemini");
+        assert!(provider.supports_streaming());
+        assert!(!provider.supports_tools());
+        assert!(!provider.supports_vision());
+    }
+
+    #[test]
+    fn test_parse_gemini_sse_text_deltas() {
+        let sse_data = r#"data: {"candidates":[{"content":{"parts":[{"text":"Hello"}],"role":"model"},"finishReason":null}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":1,"totalTokenCount":11}}
+
+data: {"candidates":[{"content":{"parts":[{"text":" world"}],"role":"model"},"finishReason":null}]}
+
+data: {"candidates":[{"content":{"parts":[{"text":"!"}],"role":"model"},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":3,"totalTokenCount":13}}
+
+data: [DONE]"#;
+
+        let chunks = process_gemini_sse_text(sse_data, "gemini-1.5-pro-latest");
+        assert_eq!(chunks.len(), 3);
+
+        // First chunk: has role, content "Hello", and usage
+        assert_eq!(
+            chunks[0].choices[0].delta.role,
+            Some(Role::Assistant)
+        );
+        assert_eq!(
+            chunks[0].choices[0].delta.content.as_deref(),
+            Some("Hello")
+        );
+        assert!(chunks[0].usage.is_some());
+        let usage = chunks[0].usage.as_ref().unwrap();
+        assert_eq!(usage.prompt_tokens, 10);
+        assert_eq!(usage.completion_tokens, 1);
+        assert_eq!(usage.total_tokens, 11);
+
+        // Second chunk: no role, content " world", no usage
+        assert_eq!(chunks[1].choices[0].delta.role, None);
+        assert_eq!(
+            chunks[1].choices[0].delta.content.as_deref(),
+            Some(" world")
+        );
+        assert!(chunks[1].usage.is_none());
+
+        // Third chunk: content "!", finish_reason STOP, usage
+        assert_eq!(
+            chunks[2].choices[0].delta.content.as_deref(),
+            Some("!")
+        );
+        assert_eq!(
+            chunks[2].choices[0].finish_reason,
+            Some(FinishReason::Stop)
+        );
+        assert!(chunks[2].usage.is_some());
+    }
+
+    #[test]
+    fn test_parse_gemini_sse_finish_reasons() {
+        assert_eq!(map_gemini_finish_reason("STOP"), Some(FinishReason::Stop));
+        assert_eq!(
+            map_gemini_finish_reason("MAX_TOKENS"),
+            Some(FinishReason::Length)
+        );
+        assert_eq!(
+            map_gemini_finish_reason("SAFETY"),
+            Some(FinishReason::ContentFilter)
+        );
+        assert_eq!(
+            map_gemini_finish_reason("RECITATION"),
+            Some(FinishReason::ContentFilter)
+        );
+        assert_eq!(map_gemini_finish_reason("UNKNOWN"), None);
+    }
+
+    #[test]
+    fn test_parse_gemini_sse_usage_metadata() {
+        let sse_data = r#"data: {"candidates":[{"content":{"parts":[{"text":"Hi"}],"role":"model"},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":2,"totalTokenCount":7}}"#;
+
+        let chunks = process_gemini_sse_text(sse_data, "gemini-2.0-flash");
+        assert_eq!(chunks.len(), 1);
+
+        let usage = chunks[0].usage.as_ref().expect("usage should be present");
+        assert_eq!(usage.prompt_tokens, 5);
+        assert_eq!(usage.completion_tokens, 2);
+        assert_eq!(usage.total_tokens, 7);
+        assert_eq!(chunks[0].model, "gemini-2.0-flash");
     }
 }


### PR DESCRIPTION
### Summary
Implements SSE streaming support for the Gemini LLM provider (GeminiProvider::chat_stream) in the mofa-foundation crate. #1272 

### Motivation
This aligns with GSoC 2026 open task #30 (Streaming response optimization) and Idea #3 (Cognitive Compute Mesh/Multi-provider support). Previously, the Gemini 
chat_stream
 function returned an explicit ProviderNotSupported error. It now uses reqwest and futures::stream::unfold to parse Gemini SSE streams natively.

### Changes
1. Implemented  parse_gemini_sse to parse newline-delimited JSON alt=sse structures.
2. Extracted shared request body logic into build_request_body.
3. Updated GeminiProvider::chat_stream to connect to streamGenerateContent?alt=sse.
4. Added 6 synthetic unit tests to cover SSE parsing, configuration builders, and finish reasons.
5. Updated  supports_streaming to true and the ModelCapabilities accordingly.

### Related Issues
Closes #1272 

### Testing

- [x]  Added unit tests
- [ ]  Added integration tests
- [x] Tested locally (Passed cargo test -p mofa-foundation, cargo clippy, and cargo fmt) 
  
### Checklist

- [x]  I have read the CONTRIBUTING.md document.
- [x]  I have run cargo fmt --check and cargo clippy.
- [x]  I have added tests to cover my changes.
- [x]  I have updated the documentation accordingly.