### PR TITLE
fix(foundation): align reducer propagation across parallel/join execution #1281

### DIFF
--- a/crates/mofa-foundation/src/workflow/builder.rs
+++ b/crates/mofa-foundation/src/workflow/builder.rs
@@ -258,6 +258,7 @@ impl WorkflowBuilder {
             parent: self,
             parallel_node: id.to_string(),
             branches: Vec::new(),
+            reducer: None,
         }
     }
 
@@ -486,6 +487,7 @@ pub struct ParallelBuilder {
     parent: WorkflowBuilder,
     parallel_node: String,
     branches: Vec<String>,
+    reducer: Option<mofa_kernel::workflow::ReducerType>,
 }
 
 impl ParallelBuilder {
@@ -544,10 +546,24 @@ impl ParallelBuilder {
         self
     }
 
+    /// 设置并行分支的聚合策略 (Reducer)
+    /// Set reducer strategy for parallel branches
+    pub fn with_reducer(mut self, reducer: mofa_kernel::workflow::ReducerType) -> Self {
+        if let Some(node) = self.parent.graph.get_node_mut(&self.parallel_node) {
+            node.set_reducer(reducer.clone());
+        }
+        self.reducer = Some(reducer);
+        self
+    }
+
     /// 汇聚所有分支
     /// Join all branches
     pub fn join(mut self, id: &str, name: &str) -> WorkflowBuilder {
-        let node = WorkflowNode::join(id, name, self.branches.iter().map(|s| s.as_str()).collect());
+        let mut node =
+            WorkflowNode::join(id, name, self.branches.iter().map(|s| s.as_str()).collect());
+        if let Some(reducer) = self.reducer.take() {
+            node = node.with_reducer(reducer);
+        }
         self.parent.graph.add_node(node);
 
         for branch in &self.branches {
@@ -570,12 +586,15 @@ impl ParallelBuilder {
         F: Fn(HashMap<String, WorkflowValue>) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = WorkflowValue> + Send + 'static,
     {
-        let node = WorkflowNode::join_with_transform(
+        let mut node = WorkflowNode::join_with_transform(
             id,
             name,
             self.branches.iter().map(|s| s.as_str()).collect(),
             transform,
         );
+        if let Some(reducer) = self.reducer.take() {
+            node = node.with_reducer(reducer);
+        }
         self.parent.graph.add_node(node);
 
         for branch in &self.branches {
@@ -656,5 +675,28 @@ mod tests {
             .build();
 
         assert_eq!(graph.node_count(), 7);
+    }
+    #[test]
+    fn test_parallel_builder_with_reducer() {
+        let graph = WorkflowBuilder::new("test", "Parallel Workflow with Reducer")
+            .start()
+            .parallel("fork", "Fork")
+            .branch("a", "Branch A", |_ctx, _input| async move {
+                Ok(WorkflowValue::String("a".to_string()))
+            })
+            .branch("b", "Branch B", |_ctx, _input| async move {
+                Ok(WorkflowValue::String("b".to_string()))
+            })
+            .with_reducer(mofa_kernel::workflow::ReducerType::Append)
+            .join("join", "Join")
+            .end()
+            .build();
+
+        assert_eq!(graph.node_count(), 6);
+        let join_node = graph.get_node("join").expect("Join node should exist");
+        assert_eq!(
+            join_node.parallel_reducer(),
+            Some(&mofa_kernel::workflow::ReducerType::Append)
+        );
     }
 }

--- a/crates/mofa-foundation/src/workflow/executor.rs
+++ b/crates/mofa-foundation/src/workflow/executor.rs
@@ -827,9 +827,8 @@ impl WorkflowExecutor {
                 }
                 NodeType::Wait => self.execute_wait(ctx, node, current_input.clone()).await,
                 _ => {
-                    let node_timeout = std::time::Duration::from_millis(
-                        self.config.node_timeout_ms,
-                    );
+                    let node_timeout =
+                        std::time::Duration::from_millis(self.config.node_timeout_ms);
                     let result = match tokio::time::timeout(
                         node_timeout,
                         node.execute(ctx, current_input.clone()),
@@ -844,10 +843,7 @@ impl WorkflowExecutor {
                             );
                             NodeResult::failed(
                                 &current_node_id,
-                                &format!(
-                                    "Node timed out after {:?}",
-                                    node_timeout
-                                ),
+                                &format!("Node timed out after {:?}", node_timeout),
                                 node_timeout.as_millis() as u64,
                             )
                         }
@@ -1041,7 +1037,14 @@ impl WorkflowExecutor {
             }
 
             let result = self
-                .execute_branches_parallel(graph, ctx, &branch_ids, input, record)
+                .execute_branches_parallel(
+                    graph,
+                    ctx,
+                    &branch_ids,
+                    input,
+                    record,
+                    node.parallel_reducer().cloned(),
+                )
                 .await?;
             ctx.set_node_output(node.id(), result.clone()).await;
             ctx.set_node_status(node.id(), NodeStatus::Completed).await;
@@ -1049,7 +1052,14 @@ impl WorkflowExecutor {
         }
 
         let result = self
-            .execute_branches_parallel(graph, ctx, branches, input, record)
+            .execute_branches_parallel(
+                graph,
+                ctx,
+                branches,
+                input,
+                record,
+                node.parallel_reducer().cloned(),
+            )
             .await?;
         ctx.set_node_output(node.id(), result.clone()).await;
         ctx.set_node_status(node.id(), NodeStatus::Completed).await;
@@ -1065,6 +1075,7 @@ impl WorkflowExecutor {
         branches: &[String],
         input: WorkflowValue,
         _record: &mut ExecutionRecord,
+        reducer_type: Option<mofa_kernel::workflow::ReducerType>,
     ) -> Result<WorkflowValue, String> {
         let mut results = HashMap::new();
         let mut errors = Vec::new();
@@ -1124,9 +1135,9 @@ impl WorkflowExecutor {
             });
         }
 
-        // The result of parallel branches are merged into a single WorkflowValue::Map.
-        // State merging: later branches overwrite earlier ones on key collision (last-write-wins)
-        // TODO: Consider configurable reducers for custom merge logic
+        // The result of parallel branches are merged.
+        // If `parallel_reducer` is configured for this node, it's used to reduce individual branch outputs.
+        // Otherwise, it defaults to `WorkflowValue::Map` with branch IDs as keys.
         // If `stop_on_failure` is enabled, the first error cancels all remaining branches.
         while let Some(res_join) = join_set.join_next().await {
             let res = res_join.map_err(|e| format!("Join error or panic: {}", e))?;
@@ -1146,6 +1157,28 @@ impl WorkflowExecutor {
 
         if !errors.is_empty() && self.config.stop_on_failure {
             return Err(errors.join("; "));
+        }
+
+        if let Some(reducer_type) = reducer_type {
+            let reducer = crate::workflow::reducers::create_reducer(&reducer_type)
+                .map_err(|e| format!("Failed to create reducer: {:?}", e))?;
+            let mut current_val: Option<serde_json::Value> = None;
+
+            // Sort by branch ID for deterministic reduction order
+            let mut sorted_results: Vec<_> = results.into_iter().collect();
+            sorted_results.sort_by(|a, b| a.0.cmp(&b.0));
+
+            for (_, output) in sorted_results {
+                let val = serde_json::to_value(&output).unwrap_or(serde_json::Value::Null);
+                let new_val = reducer
+                    .reduce(current_val.as_ref(), &val)
+                    .await
+                    .map_err(|e| format!("Reducer error: {:?}", e))?;
+                current_val = Some(new_val);
+            }
+            return Ok(current_val
+                .map(WorkflowValue::Json)
+                .unwrap_or(WorkflowValue::Null));
         }
 
         Ok(WorkflowValue::Map(results))
@@ -1195,9 +1228,34 @@ impl WorkflowExecutor {
             .get_node_outputs(&wait_for.iter().map(|s| s.as_str()).collect::<Vec<_>>())
             .await;
 
+        // Apply custom reducer if specified, otherwise default to Map
+        let aggregated_input = if let Some(reducer_type) = node.parallel_reducer() {
+            let reducer = crate::workflow::reducers::create_reducer(reducer_type)
+                .map_err(|e| format!("Failed to create reducer: {:?}", e))?;
+            let mut current_val: Option<serde_json::Value> = None;
+
+            // Sort by branch ID for deterministic reduction order
+            let mut sorted_outputs: Vec<_> = outputs.into_iter().collect();
+            sorted_outputs.sort_by(|a, b| a.0.cmp(&b.0));
+
+            for (_, output) in sorted_outputs {
+                let val = serde_json::to_value(&output).unwrap_or(serde_json::Value::Null);
+                let new_val = reducer
+                    .reduce(current_val.as_ref(), &val)
+                    .await
+                    .map_err(|e| format!("Reducer error: {:?}", e))?;
+                current_val = Some(new_val);
+            }
+            current_val
+                .map(WorkflowValue::Json)
+                .unwrap_or(WorkflowValue::Null)
+        } else {
+            WorkflowValue::Map(outputs)
+        };
+
         // 执行节点（可能有转换函数）
         // Execute node (may contain transformation functions)
-        let result = node.execute(ctx, WorkflowValue::Map(outputs)).await;
+        let result = node.execute(ctx, aggregated_input).await;
 
         ctx.set_node_output(node.id(), result.output.clone()).await;
         ctx.set_node_status(node.id(), result.status.clone()).await;
@@ -1934,9 +1992,7 @@ mod tests {
         graph.add_node(WorkflowNode::task(
             "fast_task",
             "Fast Task",
-            |_ctx, _input| async move {
-                Ok(WorkflowValue::String("fast".to_string()))
-            },
+            |_ctx, _input| async move { Ok(WorkflowValue::String("fast".to_string())) },
         ));
         graph.add_node(WorkflowNode::end("end"));
         graph.connect("start", "fast_task");
@@ -1947,5 +2003,81 @@ mod tests {
             .await
             .expect("Should complete without timeout");
         assert!(matches!(result.status, WorkflowStatus::Completed));
+    }
+
+    #[tokio::test]
+    async fn test_parallel_reducer_execution() {
+        use crate::workflow::builder::WorkflowBuilder;
+        let graph = WorkflowBuilder::new("test_reducer", "Test Reducer")
+            .start()
+            .parallel("parallel_split", "Parallel Split")
+            .branch("branch_a", "Task A", |_ctx, _input| async move {
+                let mut map = std::collections::HashMap::new();
+                map.insert("a".to_string(), WorkflowValue::Int(10));
+                Ok(WorkflowValue::Map(map))
+            })
+            .branch("branch_b", "Task B", |_ctx, _input| async move {
+                let mut map = std::collections::HashMap::new();
+                map.insert("b".to_string(), WorkflowValue::Int(20));
+                Ok(WorkflowValue::Map(map))
+            })
+            .with_reducer(mofa_kernel::workflow::ReducerType::Merge { deep: false })
+            .join("join_node", "Join Node")
+            .end()
+            .build();
+
+        let executor = WorkflowExecutor::new(ExecutorConfig::default());
+        let result = executor
+            .execute(&graph, WorkflowValue::Null)
+            .await
+            .expect("execute should succeed");
+
+        assert!(matches!(result.status, WorkflowStatus::Completed));
+
+        if let Some(WorkflowValue::Json(val)) = result.outputs.get("end") {
+            assert_eq!(val["a"], 10);
+            assert_eq!(val["b"], 20);
+        } else {
+            panic!(
+                "Expected Json Object output from reducer, got {:?}",
+                result.outputs.get("end")
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_parallel_reducer_with_join_transform_execution() {
+        use crate::workflow::builder::WorkflowBuilder;
+
+        let graph = WorkflowBuilder::new("test_reducer_transform", "Test Reducer Transform")
+            .start()
+            .parallel("parallel_split", "Parallel Split")
+            .branch("branch_a", "Task A", |_ctx, _input| async move {
+                let mut map = std::collections::HashMap::new();
+                map.insert("a".to_string(), WorkflowValue::Int(10));
+                Ok(WorkflowValue::Map(map))
+            })
+            .branch("branch_b", "Task B", |_ctx, _input| async move {
+                let mut map = std::collections::HashMap::new();
+                map.insert("b".to_string(), WorkflowValue::Int(20));
+                Ok(WorkflowValue::Map(map))
+            })
+            .with_reducer(mofa_kernel::workflow::ReducerType::Merge { deep: false })
+            .join_with_transform("join_node", "Join Node", |inputs| async move {
+                let a = inputs.get("a").and_then(|v| v.as_i64()).unwrap_or_default();
+                let b = inputs.get("b").and_then(|v| v.as_i64()).unwrap_or_default();
+                WorkflowValue::Int(a + b)
+            })
+            .end()
+            .build();
+
+        let executor = WorkflowExecutor::new(ExecutorConfig::default());
+        let result = executor
+            .execute(&graph, WorkflowValue::Null)
+            .await
+            .expect("execute should succeed");
+
+        assert!(matches!(result.status, WorkflowStatus::Completed));
+        assert_eq!(result.outputs.get("end").and_then(|v| v.as_i64()), Some(30));
     }
 }

--- a/crates/mofa-foundation/src/workflow/node.rs
+++ b/crates/mofa-foundation/src/workflow/node.rs
@@ -255,6 +255,9 @@ pub struct WorkflowNode {
     /// 条件分支映射：条件名 -> 目标节点 ID
     /// Condition branch map: Name -> Target Node ID
     condition_branches: HashMap<String, String>,
+    /// 并行/聚合节点的配置聚合策略
+    /// Reducer strategy for parallel/join nodes
+    parallel_reducer: Option<mofa_kernel::workflow::ReducerType>,
 }
 
 impl WorkflowNode {
@@ -273,6 +276,7 @@ impl WorkflowNode {
             sub_workflow_id: None,
             wait_event_type: None,
             condition_branches: HashMap::new(),
+            parallel_reducer: None,
         }
     }
 
@@ -291,6 +295,7 @@ impl WorkflowNode {
             sub_workflow_id: None,
             wait_event_type: None,
             condition_branches: HashMap::new(),
+            parallel_reducer: None,
         }
     }
 
@@ -313,6 +318,7 @@ impl WorkflowNode {
             sub_workflow_id: None,
             wait_event_type: None,
             condition_branches: HashMap::new(),
+            parallel_reducer: None,
         }
     }
 
@@ -337,6 +343,7 @@ impl WorkflowNode {
             sub_workflow_id: None,
             wait_event_type: None,
             condition_branches: HashMap::new(),
+            parallel_reducer: None,
         }
     }
 
@@ -361,6 +368,7 @@ impl WorkflowNode {
             sub_workflow_id: None,
             wait_event_type: None,
             condition_branches: HashMap::new(),
+            parallel_reducer: None,
         }
     }
 
@@ -379,6 +387,7 @@ impl WorkflowNode {
             sub_workflow_id: None,
             wait_event_type: None,
             condition_branches: HashMap::new(),
+            parallel_reducer: None,
         }
     }
 
@@ -397,6 +406,7 @@ impl WorkflowNode {
             sub_workflow_id: None,
             wait_event_type: None,
             condition_branches: HashMap::new(),
+            parallel_reducer: None,
         }
     }
 
@@ -424,6 +434,7 @@ impl WorkflowNode {
             sub_workflow_id: None,
             wait_event_type: None,
             condition_branches: HashMap::new(),
+            parallel_reducer: None,
         }
     }
 
@@ -454,6 +465,7 @@ impl WorkflowNode {
             sub_workflow_id: None,
             wait_event_type: None,
             condition_branches: HashMap::new(),
+            parallel_reducer: None,
         }
     }
 
@@ -472,6 +484,7 @@ impl WorkflowNode {
             sub_workflow_id: Some(sub_workflow_id.to_string()),
             wait_event_type: None,
             condition_branches: HashMap::new(),
+            parallel_reducer: None,
         }
     }
 
@@ -490,6 +503,7 @@ impl WorkflowNode {
             sub_workflow_id: None,
             wait_event_type: Some(event_type.to_string()),
             condition_branches: HashMap::new(),
+            parallel_reducer: None,
         }
     }
 
@@ -512,6 +526,7 @@ impl WorkflowNode {
             sub_workflow_id: None,
             wait_event_type: None,
             condition_branches: HashMap::new(),
+            parallel_reducer: None,
         }
     }
 
@@ -549,6 +564,7 @@ impl WorkflowNode {
             sub_workflow_id: None,
             wait_event_type: None,
             condition_branches: HashMap::new(),
+            parallel_reducer: None,
         }
     }
 
@@ -600,6 +616,7 @@ impl WorkflowNode {
             sub_workflow_id: None,
             wait_event_type: None,
             condition_branches: HashMap::new(),
+            parallel_reducer: None,
         }
     }
 
@@ -621,6 +638,19 @@ impl WorkflowNode {
     /// Set timeout
     pub fn with_timeout(mut self, timeout_ms: u64) -> Self {
         self.config.timeout.execution_timeout_ms = timeout_ms;
+        self
+    }
+
+    /// 设置并行/聚合节点的聚合策略（可变借用）
+    /// Set the reducer strategy for parallel/join nodes (mutable reference)
+    pub fn set_reducer(&mut self, reducer: mofa_kernel::workflow::ReducerType) {
+        self.parallel_reducer = Some(reducer);
+    }
+
+    /// 设置聚合策略 (Reducer)
+    /// Set reducer strategy for parallel/join operations
+    pub fn with_reducer(mut self, reducer: mofa_kernel::workflow::ReducerType) -> Self {
+        self.parallel_reducer = Some(reducer);
         self
     }
 
@@ -672,6 +702,12 @@ impl WorkflowNode {
     /// Get wait event type
     pub fn wait_event_type(&self) -> Option<&str> {
         self.wait_event_type.as_deref()
+    }
+
+    /// 获取配置的 Reducer
+    /// Get configured reducer
+    pub fn parallel_reducer(&self) -> Option<&mofa_kernel::workflow::ReducerType> {
+        self.parallel_reducer.as_ref()
     }
 
     /// 执行节点
@@ -729,22 +765,36 @@ impl WorkflowNode {
             NodeType::Join => {
                 // 聚合节点等待所有依赖完成
                 // Join node waits for all dependencies
-                let outputs = ctx
-                    .get_node_outputs(
-                        &self
-                            .join_nodes
-                            .iter()
-                            .map(|s| s.as_str())
-                            .collect::<Vec<_>>(),
-                    )
-                    .await;
-
                 let result = if let Some(ref transform_fn) = self.transform {
+                    let outputs = match input {
+                        WorkflowValue::Map(m) => m,
+                        WorkflowValue::Json(serde_json::Value::Object(obj)) => obj
+                            .into_iter()
+                            .map(|(k, v)| {
+                                let val = serde_json::from_value::<WorkflowValue>(v.clone())
+                                    .unwrap_or(WorkflowValue::Json(v));
+                                (k, val)
+                            })
+                            .collect(),
+                        WorkflowValue::Null => {
+                            ctx.get_node_outputs(
+                                &self
+                                    .join_nodes
+                                    .iter()
+                                    .map(|s| s.as_str())
+                                    .collect::<Vec<_>>(),
+                            )
+                            .await
+                        }
+                        _ => {
+                            let mut map = HashMap::new();
+                            map.insert("_reduced".to_string(), input);
+                            map
+                        }
+                    };
                     transform_fn(outputs).await
                 } else {
-                    // 默认将所有输入合并为 Map
-                    // Merge all inputs into a Map by default
-                    WorkflowValue::Map(outputs)
+                    input
                 };
 
                 NodeResult::success(node_id, result, start_time.elapsed().as_millis() as u64)


### PR DESCRIPTION
## 📋 Summary

This PR completes configurable reducer integration for workflow parallel/join execution and fixes a reducer propagation gap in join transform flows.

## 🔗 Related Issues

Closes #1281

---

## 🧠 Context

Parallel reducer support was introduced, but execution semantics had two gaps:

1. reducer wiring needed to be picked up consistently by parallel execution
2. reduced values could be dropped when using join transforms

This PR aligns builder wiring and runtime behavior so reducer-configured workflows behave deterministically and end-to-end.  
This contribution is intentionally scoped to workflow reducer integration only.

---

## 🛠️ Changes

- Added reducer storage on workflow nodes and exposed setter/getter APIs.
- Updated parallel builder reducer wiring to attach reducer to the parallel split node.
- Kept reducer propagation on join nodes for join/join_with_transform consistency.
- Updated parallel execution to dynamically create and apply reducers via reducer factory dispatch.
- Updated join execution to aggregate predecessor outputs using configured reducer where present.
- Fixed join node runtime behavior to consume aggregated input in transform mode:
  - reduced JSON object is converted into transform input map
  - non-map reduced values are passed via `_reduced` key
- Added tests:
  - builder-level reducer configuration test
  - integration test for parallel reducer execution (merge)
  - regression test for reducer + join_with_transform composition

---

## 🧪 How you Tested

1. `cargo test -p mofa-foundation parallel_reducer -- --nocapture`
2. `cargo check -p mofa-foundation --all-features`
3. `cargo test --package mofa-foundation --all-features`

---

## 📸 Screenshots / Logs (if applicable)

N/A (core runtime behavior and unit/integration test updates)

---

## ⚠️ Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (describe below)

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [ ] `cargo clippy` passes without warnings

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [ ] Public APIs documented
- [ ] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---

## 🚀 Deployment Notes (if applicable)

No migration or config changes required.

---

## 🧩 Additional Notes for Reviewers

Key files:

- [crates/mofa-foundation/src/workflow/builder.rs](crates/mofa-foundation/src/workflow/builder.rs)
- [crates/mofa-foundation/src/workflow/node.rs](crates/mofa-foundation/src/workflow/node.rs)
- [crates/mofa-foundation/src/workflow/executor.rs](crates/mofa-foundation/src/workflow/executor.rs)

Please focus review on reducer semantics in:

- parallel split aggregation
- join aggregation
- join_with_transform input handling for reduced outputs