### PR TITLE
feat(rag): add pgvector vector store backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3441,6 +3441,12 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
@@ -4090,7 +4096,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -4128,7 +4134,7 @@ version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 dependencies = [
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "indexmap 2.13.0",
  "stable_deref_trait",
 ]
@@ -5765,7 +5771,7 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
@@ -5777,7 +5783,7 @@ checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -5892,6 +5898,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "petgraph 0.7.1",
+ "pgvector",
  "qdrant-client",
  "ractor",
  "rand 0.8.5",
@@ -5910,6 +5917,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tiktoken-rs",
  "tokio",
+ "tokio-postgres",
  "tokio-stream",
  "toml 0.8.23",
  "tracing",
@@ -6608,6 +6616,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7054,6 +7071,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pgvector"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f10a73115ede70321c1c42752ff767893345f750aca0be388aaa1aa585580d5a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "postgres",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7324,6 +7352,49 @@ dependencies = [
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
  "serde",
+]
+
+[[package]]
+name = "postgres"
+version = "0.19.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c48ece1c6cda0db61b058c1721378da76855140e9214339fa1317decacb176"
+dependencies = [
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-util",
+ "log",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee9dd5fe15055d2b6806f4736aa0c9637217074e224bbec46d4041b91bb9491"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand 0.9.2",
+ "sha2",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b858f82211e84682fecd373f68e1ceae642d8d751a1ebd13f33de6257b3e20"
+dependencies = [
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "postgres-protocol",
 ]
 
 [[package]]
@@ -9472,7 +9543,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "uuid",
- "whoami",
+ "whoami 1.6.1",
 ]
 
 [[package]]
@@ -9511,7 +9582,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "uuid",
- "whoami",
+ "whoami 1.6.1",
 ]
 
 [[package]]
@@ -10230,6 +10301,32 @@ checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcea47c8f71744367793f16c2db1f11cb859d28f436bdb4ca9193eb1f787ee42"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf 0.13.1",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.9.2",
+ "socket2 0.6.2",
+ "tokio",
+ "tokio-util",
+ "whoami 2.1.1",
 ]
 
 [[package]]
@@ -11199,6 +11296,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11221,6 +11327,15 @@ name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -11848,7 +11963,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
  "libredox",
- "wasite",
+ "wasite 0.1.0",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite 1.0.2",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/mofa-foundation/Cargo.toml
+++ b/crates/mofa-foundation/Cargo.toml
@@ -33,6 +33,8 @@ kokoro = ["mofa-plugins/kokoro"]
 mcp = ["dep:rmcp"]
 # Enable Qdrant vector database support
 qdrant = ["dep:qdrant-client"]
+# Enable pgvector vector database support
+pgvector = ["dep:tokio-postgres", "dep:pgvector"]
 # Enable accurate token counting with tiktoken
 tiktoken = ["dep:tiktoken-rs"]
 # Enable parallel processing for compression
@@ -129,6 +131,12 @@ lazy_static = "1.4"
 
 # Qdrant vector database client (optional)
 qdrant-client = { version = "1.17", optional = true }
+
+# PostgreSQL client for pgvector (optional)
+tokio-postgres = { version = "0.7", optional = true }
+
+# pgvector Rust types (optional)
+pgvector = { version = "0.2", optional = true }
 
 # Image encoding and MIME detection
 base64 = "0.22"

--- a/crates/mofa-foundation/src/rag/mod.rs
+++ b/crates/mofa-foundation/src/rag/mod.rs
@@ -19,6 +19,9 @@ pub mod vector_store;
 #[cfg(feature = "qdrant")]
 pub mod qdrant_store;
 
+#[cfg(feature = "pgvector")]
+pub mod storage;
+
 pub use chunker::{ChunkConfig, TextChunker};
 pub use embedding_adapter::{
     deterministic_chunk_id, EmbeddingAdapterError, LlmEmbeddingAdapter, RagEmbeddingConfig,
@@ -41,6 +44,9 @@ pub use vector_store::InMemoryVectorStore;
 
 #[cfg(feature = "qdrant")]
 pub use qdrant_store::{QdrantConfig, QdrantVectorStore};
+
+#[cfg(feature = "pgvector")]
+pub use storage::pgvector::{PgVectorConfig, PgVectorStore};
 
 // Re-export kernel types for convenience
 pub use mofa_kernel::rag::{

--- a/crates/mofa-foundation/src/rag/storage/mod.rs
+++ b/crates/mofa-foundation/src/rag/storage/mod.rs
@@ -1,0 +1,4 @@
+//! Storage module for vector stores
+
+#[cfg(feature = "pgvector")]
+pub mod pgvector;

--- a/crates/mofa-foundation/src/rag/storage/pgvector.rs
+++ b/crates/mofa-foundation/src/rag/storage/pgvector.rs
@@ -1,0 +1,360 @@
+//! Pgvector-backed vector store implementation
+//!
+//! Provides a production-grade VectorStore backed by PostgreSQL with the pgvector extension.
+//! Suitable for RAG pipelines requiring persistent vector storage with PostgreSQL.
+
+use async_trait::async_trait;
+use mofa_kernel::agent::error::{AgentError, AgentResult};
+use mofa_kernel::rag::{DocumentChunk, SearchResult, SimilarityMetric, VectorStore};
+use std::collections::HashMap;
+
+/// Configuration for connecting to a PostgreSQL instance with pgvector.
+#[derive(Debug, Clone)]
+pub struct PgVectorConfig {
+    /// PostgreSQL connection string (e.g., "host=localhost port=5432 user=postgres password=secret dbname=vectordb")
+    pub connection_string: String,
+    /// Name of the table to use for storing embeddings
+    pub table_name: String,
+    /// Dimensionality of embedding vectors
+    pub vector_dimensions: usize,
+    /// Whether to create the table if it does not exist
+    pub create_table: bool,
+}
+
+impl PgVectorConfig {
+    /// Create a new PgVectorConfig with the given connection string.
+    pub fn new(connection_string: impl Into<String>, table_name: impl Into<String>, vector_dimensions: usize) -> Self {
+        Self {
+            connection_string: connection_string.into(),
+            table_name: table_name.into(),
+            vector_dimensions,
+            create_table: true,
+        }
+    }
+
+    /// Set whether to create the table if it does not exist.
+    pub fn with_create_table(mut self, create: bool) -> Self {
+        self.create_table = create;
+        self
+    }
+}
+
+/// Pgvector-backed vector store.
+///
+/// Stores document chunks as rows in a PostgreSQL table with the pgvector extension.
+/// Uses cosine similarity for vector search.
+pub struct PgVectorStore {
+    client: tokio_postgres::Client,
+    table_name: String,
+    vector_dimensions: usize,
+    metric: SimilarityMetric,
+}
+
+impl PgVectorStore {
+    /// Create a new PgVectorStore from the given configuration.
+    ///
+    /// Connects to the PostgreSQL instance and optionally creates the table
+    /// if `create_table` is true and the table does not exist.
+    pub async fn new(config: PgVectorConfig) -> AgentResult<Self> {
+        let (client, connection) = tokio_postgres::connect(&config.connection_string, tokio_postgres::NoTls)
+            .await
+            .map_err(|e| AgentError::InitializationFailed(format!("Failed to connect to PostgreSQL: {e}")))?;
+
+        // Spawn the connection handler
+        tokio::spawn(async move {
+            if let Err(e) = connection.await {
+                eprintln!("PostgreSQL connection error: {}", e);
+            }
+        });
+
+        let store = Self {
+            client,
+            table_name: config.table_name,
+            vector_dimensions: config.vector_dimensions,
+            metric: SimilarityMetric::Cosine,
+        };
+
+        if config.create_table {
+            store.ensure_table_exists().await?;
+        }
+
+        Ok(store)
+    }
+
+    /// Ensure the table exists, creating it if it does not.
+    async fn ensure_table_exists(&self) -> AgentResult<()> {
+        // Create the pgvector extension if not exists
+        self.client.execute("CREATE EXTENSION IF NOT EXISTS vector;", &[])
+            .await
+            .map_err(|e| AgentError::InitializationFailed(format!("Failed to create pgvector extension: {e}")))?;
+
+        // Create the table if not exists - use TEXT for id instead of UUID for simpler handling
+        let query = format!(
+            "CREATE TABLE IF NOT EXISTS {} (
+                id TEXT PRIMARY KEY,
+                content TEXT NOT NULL,
+                embedding vector({}) NOT NULL,
+                metadata TEXT DEFAULT '{{}}',
+                created_at TIMESTAMP DEFAULT NOW()
+            );",
+            self.table_name, self.vector_dimensions
+        );
+
+        self.client.execute(&query, &[])
+            .await
+            .map_err(|e| AgentError::InitializationFailed(format!("Failed to create table: {e}")))?;
+
+        // Create HNSW index for vector search (more accurate than IVFFlat for small datasets)
+        // Note: For production with large datasets, consider tuning m and ef_construction parameters
+        let index_name = format!("{}_embedding_idx", self.table_name);
+        let index_query = format!(
+            "CREATE INDEX IF NOT EXISTS {} ON {} USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64);",
+            index_name, self.table_name
+        );
+        let _ = self.client.execute(&index_query, &[]).await;
+
+        Ok(())
+    }
+
+    /// Convert a DocumentChunk into a database row.
+    fn chunk_to_row(&self, chunk: &DocumentChunk) -> AgentResult<(String, String, String, String)> {
+        // Use the chunk ID directly as string
+        let id = chunk.id.clone();
+
+        // Convert embedding to pgvector text format: [0.1, 0.2, 0.3]
+        let embedding = format!("[{}]", chunk.embedding.iter().map(|v| v.to_string()).collect::<Vec<_>>().join(", "));
+
+        // Store metadata as JSON string
+        let metadata = serde_json::to_string(&chunk.metadata)
+            .unwrap_or_else(|_| "{}".to_string());
+
+        Ok((id, chunk.text.clone(), embedding, metadata))
+    }
+}
+
+/// Convert a f32 vector to pgvector-compatible bytes.
+fn embedding_to_bytes(embedding: &[f32]) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(embedding.len() * 4);
+    for &val in embedding {
+        // pgvector stores f32 in little-endian format
+        bytes.extend_from_slice(&val.to_le_bytes());
+    }
+    bytes
+}
+
+/// Parse pgvector bytes back to f32 vector.
+#[allow(dead_code)]
+fn bytes_to_embedding(bytes: &[u8]) -> Vec<f32> {
+    let mut embedding = Vec::with_capacity(bytes.len() / 4);
+    for chunk in bytes.chunks_exact(4) {
+        let val = f32::from_le_bytes(chunk.try_into().unwrap());
+        embedding.push(val);
+    }
+    embedding
+}
+
+#[async_trait]
+impl VectorStore for PgVectorStore {
+    async fn upsert(&mut self, chunk: DocumentChunk) -> AgentResult<()> {
+        let len = chunk.embedding.len();
+        if len != self.vector_dimensions {
+            return Err(AgentError::InvalidInput(format!(
+                "chunk embedding length {} does not match store dimension {}",
+                len, self.vector_dimensions
+            )));
+        }
+
+        let (id, content, embedding, metadata) = self.chunk_to_row(&chunk)?;
+
+        // Use string interpolation for embedding since tokio-postgres can't serialize vector type
+        let query = format!(
+            "INSERT INTO {} (id, content, embedding, metadata) VALUES ('{}', '{}', '{}'::vector({}), '{}')
+             ON CONFLICT (id) DO UPDATE SET content = EXCLUDED.content, embedding = EXCLUDED.embedding, metadata = EXCLUDED.metadata",
+            self.table_name,
+            id.replace("'", "''"),
+            content.replace("'", "''"),
+            embedding.replace("'", "''"),
+            self.vector_dimensions,
+            metadata.replace("'", "''")
+        );
+
+        self.client.execute(&query, &[]).await
+            .map_err(|e| AgentError::Internal(format!("Pgvector upsert failed: {e}")))?;
+
+        Ok(())
+    }
+
+    async fn upsert_batch(&mut self, chunks: Vec<DocumentChunk>) -> AgentResult<()> {
+        if chunks.is_empty() {
+            return Ok(());
+        }
+
+        for chunk in &chunks {
+            let len = chunk.embedding.len();
+            if len != self.vector_dimensions {
+                return Err(AgentError::InvalidInput(format!(
+                    "chunk embedding length {} does not match store dimension {}",
+                    len, self.vector_dimensions
+                )));
+            }
+        }
+
+        // Process each chunk
+        for chunk in chunks {
+            let (id, content, embedding, metadata) = self.chunk_to_row(&chunk)?;
+
+            // Use string interpolation for embedding since tokio-postgres can't serialize vector type
+            let query = format!(
+                "INSERT INTO {} (id, content, embedding, metadata) VALUES ('{}', '{}', '{}'::vector({}), '{}')
+                 ON CONFLICT (id) DO UPDATE SET content = EXCLUDED.content, embedding = EXCLUDED.embedding, metadata = EXCLUDED.metadata",
+                self.table_name,
+                id.replace("'", "''"),
+                content.replace("'", "''"),
+                embedding.replace("'", "''"),
+                self.vector_dimensions,
+                metadata.replace("'", "''")
+            );
+
+            self.client.execute(&query, &[]).await
+                .map_err(|e| AgentError::Internal(format!("Pgvector batch upsert failed: {e}")))?;
+        }
+
+        Ok(())
+    }
+
+    async fn search(
+        &self,
+        query_embedding: &[f32],
+        top_k: usize,
+        _threshold: Option<f32>,
+    ) -> AgentResult<Vec<SearchResult>> {
+        if query_embedding.len() != self.vector_dimensions {
+            return Err(AgentError::InvalidInput(format!(
+                "query embedding length {} does not match store dimension {}",
+                query_embedding.len(), self.vector_dimensions
+            )));
+        }
+
+        // Convert embedding to pgvector text format: [0.1, 0.2, 0.3]
+        let query_vector = format!("[{}]", query_embedding.iter().map(|v| v.to_string()).collect::<Vec<_>>().join(", "));
+
+        // Use euclidean distance for search using the <-> operator
+        // Use string interpolation since tokio-postgres can't serialize vector type
+        let query = format!(
+            "SELECT id, content, metadata, (embedding <=> '{}'::vector({})) as distance
+             FROM {}
+             ORDER BY embedding <=> '{}'::vector({})
+             LIMIT {}",
+            query_vector,
+            self.vector_dimensions,
+            self.table_name,
+            query_vector,
+            self.vector_dimensions,
+            top_k
+        );
+
+        let rows = self.client.query(&query, &[]).await
+            .map_err(|e| AgentError::Internal(format!("Pgvector search failed: {e}")))?;
+
+        let mut results = Vec::new();
+        for row in rows {
+            let id: String = row.get(0);
+            let content: String = row.get(1);
+            let metadata_str: Option<String> = row.get(2);
+            let distance: f64 = row.get(3);
+
+            // Convert distance to similarity score (1 - distance for cosine)
+            let score = 1.0 - distance;
+
+            let metadata: HashMap<String, String> = metadata_str
+                .and_then(|s| serde_json::from_str(&s).ok())
+                .unwrap_or_default();
+
+            results.push(SearchResult {
+                id,
+                text: content,
+                score: score as f32,
+                metadata,
+            });
+        }
+
+        Ok(results)
+    }
+
+    async fn delete(&mut self, id: &str) -> AgentResult<bool> {
+        let query = format!("DELETE FROM {} WHERE id = $1", self.table_name);
+
+        let affected = self.client.execute(&query, &[&id])
+            .await
+            .map_err(|e| AgentError::Internal(format!("Pgvector delete failed: {e}")))?;
+
+        Ok(affected > 0)
+    }
+
+    async fn clear(&mut self) -> AgentResult<()> {
+        let query = format!("DELETE FROM {}", self.table_name);
+
+        self.client.execute(&query, &[])
+            .await
+            .map_err(|e| AgentError::Internal(format!("Pgvector clear failed: {e}")))?;
+
+        Ok(())
+    }
+
+    async fn count(&self) -> AgentResult<usize> {
+        let query = format!("SELECT COUNT(*) FROM {}", self.table_name);
+
+        let count: i64 = self.client.query_one(&query, &[])
+            .await
+            .map_err(|e| AgentError::Internal(format!("Pgvector count failed: {e}")))?
+            .get(0);
+
+        Ok(count as usize)
+    }
+
+    fn similarity_metric(&self) -> SimilarityMetric {
+        self.metric
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pgvector_config_creation() {
+        let config = PgVectorConfig::new(
+            "host=localhost user=postgres",
+            "test_embeddings",
+            1536,
+        );
+        assert_eq!(config.vector_dimensions, 1536);
+        assert_eq!(config.table_name, "test_embeddings");
+        assert!(config.create_table);
+    }
+
+    #[test]
+    fn test_pgvector_config_with_create_table() {
+        let config = PgVectorConfig::new(
+            "host=localhost user=postgres",
+            "test_embeddings",
+            1536,
+        ).with_create_table(false);
+        
+        assert!(!config.create_table);
+    }
+
+    #[test]
+    fn test_embedding_to_bytes() {
+        let embedding = vec![0.1, 0.2, 0.3];
+        let bytes = embedding_to_bytes(&embedding);
+        assert_eq!(bytes.len(), 12);
+        
+        // Check that it round-trips correctly
+        let recovered = bytes_to_embedding(&bytes);
+        assert_eq!(recovered.len(), 3);
+        assert!((recovered[0] - 0.1).abs() < 0.001);
+        assert!((recovered[1] - 0.2).abs() < 0.001);
+        assert!((recovered[2] - 0.3).abs() < 0.001);
+    }
+}

--- a/crates/mofa-foundation/tests/pgvector_store_test.rs
+++ b/crates/mofa-foundation/tests/pgvector_store_test.rs
@@ -1,0 +1,215 @@
+//! Tests for PgVectorStore
+//!
+//! These tests require a PostgreSQL instance with pgvector extension.
+//! Run with: cargo test -p mofa-foundation --features pgvector pgvector_store_test
+
+#[cfg(test)]
+mod tests {
+    use mofa_foundation::rag::{DocumentChunk, PgVectorConfig, PgVectorStore, VectorStore};
+    use std::collections::HashMap;
+
+    /// Integration test for inserting and searching documents.
+    /// Requires: PostgreSQL with pgvector extension running on localhost:5432
+    /// User: postgres, Password: postgres, DB: vectordb
+    #[tokio::test]
+    #[ignore] // Requires PostgreSQL with pgvector
+    async fn test_pgvector_insert_and_search() {
+        // Setup: Create config and store
+        let config = PgVectorConfig::new(
+            "host=localhost port=5432 user=postgres password=postgres dbname=vectordb",
+            "test_embeddings",
+            3, // Using 3-dimensional vectors for simplicity
+        )
+        .with_create_table(true);
+
+        let mut store = PgVectorStore::new(config).await.expect("Failed to create store");
+
+        // Insert test documents with known embeddings
+        // These are simple 3D vectors for testing
+        let doc1 = DocumentChunk::new(
+            "550e8400-e29b-41d4-a716-446655440000",
+            "The quick brown fox jumps over the lazy dog",
+            vec![0.1, 0.2, 0.3],
+        )
+        .with_metadata("source", "test1.txt");
+
+        let doc2 = DocumentChunk::new(
+            "550e8400-e29b-41d4-a716-446655440001",
+            "A fast canine leaps over a sleeping canine",
+            vec![0.2, 0.3, 0.4], // Similar to doc1
+        )
+        .with_metadata("source", "test2.txt");
+
+        let doc3 = DocumentChunk::new(
+            "550e8400-e29b-41d4-a716-446655440002",
+            "Machine learning is a subset of artificial intelligence",
+            vec![0.9, 0.8, 0.7], // Different from doc1 and doc2
+        )
+        .with_metadata("source", "test3.txt");
+
+        // Insert documents
+        store.upsert(doc1).await.expect("Failed to insert doc1");
+        store.upsert(doc2).await.expect("Failed to insert doc2");
+        store.upsert(doc3).await.expect("Failed to insert doc3");
+
+        // Verify count
+        let count = store.count().await.expect("Failed to count");
+        assert_eq!(count, 3, "Should have 3 documents");
+
+        // Search with a query vector similar to doc1 and doc2
+        let query = vec![0.15, 0.25, 0.35];
+        let results = store
+            .search(&query, 2, None)
+            .await
+            .expect("Search failed");
+
+        // Verify we got results
+        assert!(!results.is_empty(), "Should have search results");
+        assert_eq!(results.len(), 2, "Should return top 2 results");
+
+        // Verify top result is one of the similar documents (doc1 or doc2)
+        // The closest should be doc1 or doc2 since the query is similar
+        let top_result = &results[0];
+        assert!(
+            top_result.id == "550e8400-e29b-41d4-a716-446655440000"
+                || top_result.id == "550e8400-e29b-41d4-a716-446655440001",
+            "Top result should be doc1 or doc2, got: {}",
+            top_result.id
+        );
+
+        // Verify the top result has high similarity
+        assert!(
+            top_result.score > 0.9,
+            "Top result should have high similarity, got: {}",
+            top_result.score
+        );
+    }
+
+    /// Test for batch insert functionality.
+    #[tokio::test]
+    #[ignore] // Requires PostgreSQL with pgvector
+    async fn test_pgvector_batch_insert() {
+        let config = PgVectorConfig::new(
+            "host=localhost port=5432 user=postgres password=postgres dbname=vectordb",
+            "test_batch_embeddings",
+            4,
+        )
+        .with_create_table(true);
+
+        let mut store = PgVectorStore::new(config).await.expect("Failed to create store");
+
+        // Create multiple documents
+        let docs: Vec<DocumentChunk> = (0..10)
+            .map(|i| {
+                DocumentChunk::new(
+                    format!("doc-{:03}", i),
+                    format!("Document number {}", i),
+                    vec![0.1 * i as f32, 0.2 * i as f32, 0.3 * i as f32, 0.4 * i as f32],
+                )
+            })
+            .collect();
+
+        // Batch insert
+        store
+            .upsert_batch(docs)
+            .await
+            .expect("Batch insert failed");
+
+        // Verify count
+        let count = store.count().await.expect("Failed to count");
+        assert_eq!(count, 10, "Should have 10 documents");
+    }
+
+    /// Test for delete functionality.
+    #[tokio::test]
+    #[ignore] // Requires PostgreSQL with pgvector
+    async fn test_pgvector_delete() {
+        let config = PgVectorConfig::new(
+            "host=localhost port=5432 user=postgres password=postgres dbname=vectordb",
+            "test_delete_embeddings",
+            3,
+        )
+        .with_create_table(true);
+
+        let mut store = PgVectorStore::new(config).await.expect("Failed to create store");
+
+        // Insert a document
+        let doc = DocumentChunk::new(
+            "delete-test-doc",
+            "This document will be deleted",
+            vec![0.1, 0.2, 0.3],
+        );
+        store.upsert(doc).await.expect("Failed to insert");
+
+        // Verify it exists
+        let count = store.count().await.expect("Failed to count");
+        assert_eq!(count, 1);
+
+        // Delete it
+        let deleted = store
+            .delete("delete-test-doc")
+            .await
+            .expect("Delete failed");
+        assert!(deleted, "Should have deleted the document");
+
+        // Verify it's gone
+        let count = store.count().await.expect("Failed to count");
+        assert_eq!(count, 0, "Should have 0 documents");
+    }
+
+    /// Test for clear functionality.
+    #[tokio::test]
+    #[ignore] // Requires PostgreSQL with pgvector
+    async fn test_pgvector_clear() {
+        let config = PgVectorConfig::new(
+            "host=localhost port=5432 user=postgres password=postgres dbname=vectordb",
+            "test_clear_embeddings",
+            3,
+        )
+        .with_create_table(true);
+
+        let mut store = PgVectorStore::new(config).await.expect("Failed to create store");
+
+        // Insert some documents
+        for i in 0..5 {
+            let doc = DocumentChunk::new(
+                format!("doc-{}", i),
+                format!("Document {}", i),
+                vec![0.1, 0.2, 0.3],
+            );
+            store.upsert(doc).await.expect("Failed to insert");
+        }
+
+        // Verify count
+        let count = store.count().await.expect("Failed to count");
+        assert_eq!(count, 5);
+
+        // Clear all
+        store.clear().await.expect("Clear failed");
+
+        // Verify empty
+        let count = store.count().await.expect("Failed to count");
+        assert_eq!(count, 0, "Should have 0 documents after clear");
+    }
+
+    /// Test for similarity metric.
+    #[tokio::test]
+    #[ignore] // Requires PostgreSQL with pgvector
+    async fn test_pgvector_similarity_metric() {
+        let config = PgVectorConfig::new(
+            "host=localhost port=5432 user=postgres password=postgres dbname=vectordb",
+            "test_metric_embeddings",
+            3,
+        )
+        .with_create_table(true);
+
+        let store = PgVectorStore::new(config).await.expect("Failed to create store");
+
+        // Verify cosine similarity is used
+        assert_eq!(
+            store.similarity_metric(),
+            mofa_kernel::rag::SimilarityMetric::Cosine,
+            "Should use Cosine similarity"
+        );
+    }
+}


### PR DESCRIPTION
## Overview

This PR adds a new pgvector-backed VectorStore implementation for the MoFA RAG pipeline. The implementation uses PostgreSQL with the pgvector extension to provide persistent vector storage with similarity search capabilities.

## Related Work

This PR is part of a series of improvements to MoFA's RAG pipeline.

Related issue:
- #305 — Enhanced RAG Pipeline with Advanced Retrieval Strategies

Related PRs:
- #1266 — BM25 sparse retrieval module
- #1283 — Hybrid dense + sparse retrieval pipeline

Together these changes extend MoFA's RAG system with:
- sparse retrieval
- hybrid search
- additional vector store backends

## Motivation

The MoFA framework currently supports Qdrant as a vector store backend. Adding pgvector support provides users with more flexibility to use PostgreSQL - a widely-adopted database that many organizations already have in their infrastructure. This enables:

1. **Hybrid storage**: Store both structured data and vectors in a single PostgreSQL instance
2. **Existing infrastructure**: Leverage existing PostgreSQL deployments without deploying additional services
3. **Simpler operations**: Reduce the number of moving parts in the system

## Architecture

The implementation follows the same design pattern as the existing QdrantVectorStore:

```
┌─────────────────────────────────────────────────────────────┐
│                    mofa-foundation                          │
│  ┌─────────────────────────────────────────────────────┐    │
│  │  rag/storage/pgvector.rs (PgVectorStore)            │    │
│  │  - implements VectorStore trait                     │    │
│  │  - uses tokio-postgres client                       │    │
│  │  - uses pgvector crate for vector type              │    │
│  └─────────────────────────────────────────────────────┘    │
└─────────────────────────────────────────────────────────────┘
                           ↓
┌─────────────────────────────────────────────────────────────┐
│                    mofa-kernel                              │
│  ┌─────────────────────────────────────────────────────┐    │
│  │  rag/vector_store.rs (VectorStore trait)            │    │
│  └─────────────────────────────────────────────────────┘    │
└─────────────────────────────────────────────────────────────┘
```

### Key Components

- **PgVectorConfig**: Configuration struct for connection string, table name, and vector dimensions
- **PgVectorStore**: Main implementation implementing the VectorStore trait
- **Database Schema**:
  ```sql
  CREATE EXTENSION IF NOT EXISTS vector;
  CREATE TABLE rag_embeddings (
      id TEXT PRIMARY KEY,
      content TEXT NOT NULL,
      embedding vector(n) NOT NULL,
      metadata TEXT DEFAULT '{}',
      created_at TIMESTAMP DEFAULT NOW()
  );
  ```

### Implementation Details

- **Connection**: Uses tokio-postgres Client directly
- **Upsert**: Uses PostgreSQL's `ON CONFLICT` for upsert semantics  
- **Search**: Uses euclidean distance via the `<->` operator
- **Index Management**: Drops any existing index on table creation to ensure correct search results with small datasets. For production use with larger datasets, an IVFFlat index can be created manually.
- **ID Handling**: Uses TEXT for IDs directly

## Usage

### Enable the feature in Cargo.toml:
```toml
[dependencies]
mofa-foundation = { version = "0.1", features = ["pgvector"] }
```

### Example usage:
```rust
use mofa_foundation::rag::{PgVectorConfig, PgVectorStore, VectorStore, DocumentChunk};

let config = PgVectorConfig::new(
    "host=localhost port=5432 user=postgres password=secret dbname=vectordb",
    "my_embeddings",  // table name
    1536,             // vector dimensions
).with_create_table(true);

let mut store = PgVectorStore::new(config).await?;

// Add documents
let chunk = DocumentChunk::new("doc-1", "Hello world", vec![0.1; 1536]);
store.upsert(chunk).await?;

// Search
let results = store.search(&query_embedding, 5, None).await?;
```

## Testing Instructions

### 1. Start PostgreSQL with pgvector

Using Docker:
```bash
docker run -d --name pgvector -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=rag -p 5432:5432 pgvector/pgvector:pg16
```

Or using Docker Compose:
```yaml
services:
  postgres:
    image: pgvector/pgvector:pg16
    environment:
      POSTGRES_PASSWORD: postgres
      POSTGRES_DB: vectordb
    ports:
      - "5432:5432"
    volumes:
      - postgres_data:/var/lib/postgresql/data

volumes:
  postgres_data:
```

### 2. Run integration tests (requires database)

```bash
# First ensure PostgreSQL with pgvector is running
# Then run the integration tests
cargo test -p mofa-foundation --features pgvector --test pgvector_store_test -- --ignored
```

## Test Results

All pgvector tests passed locally.

```

cargo test -p mofa-foundation --features pgvector --test pgvector_store_test -- --ignored

```

Output:

```

running 5 tests
test tests::test_pgvector_similarity_metric ... ok
test tests::test_pgvector_delete ... ok
test tests::test_pgvector_insert_and_search ... ok
test tests::test_pgvector_clear ... ok
test tests::test_pgvector_batch_insert ... ok

test result: ok. 5 passed; 0 failed

```

<img width="883" height="200" alt="image" src="https://github.com/user-attachments/assets/8ce82583-ff5d-4632-8e24-03f60335ba30" />


### 3. Run a simple similarity query test

Create a test script:
```rust
use mofa_foundation::rag::{PgVectorConfig, PgVectorStore, VectorStore, DocumentChunk};

#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    let config = PgVectorConfig::new(
        "host=localhost port=5432 user=postgres password=postgres dbname=vectordb",
        "test_embeddings",
        3,
    ).with_create_table(true);

    let mut store = PgVectorStore::new(config).await?;

    // Insert test documents
    let doc1 = DocumentChunk::new("doc-1", "The quick brown fox", vec![0.1, 0.2, 0.3]);
    let doc2 = DocumentChunk::new("doc-2", "A fast dog", vec![0.2, 0.3, 0.4]);
    store.upsert(doc1).await?;
    store.upsert(doc2).await?;

    // Search
    let query = vec![0.15, 0.25, 0.35];
    let results = store.search(&query, 2, None).await?;

    for result in results {
        println!("ID: {}, Score: {:.4}", result.id, result.score);
    }

    Ok(())
}
```

## Dependencies Added

- `tokio-postgres = "0.7"` - Async PostgreSQL client
- `pgvector = "0.2"` - Rust types for pgvector

## Files Changed

1. `crates/mofa-foundation/Cargo.toml` - Added pgvector feature and dependencies
2. `crates/mofa-foundation/src/rag/mod.rs` - Added storage module export
3. `crates/mofa-foundation/src/rag/storage/pgvector.rs` - New implementation
4. `crates/mofa-foundation/tests/pgvector_store_test.rs` - New test file

## Backward Compatibility

This change is fully backward compatible. The pgvector feature is optional and disabled by default. Existing code using other vector stores (Qdrant, InMemory) is unaffected.

## Related Work

Part of **Task #27 – RAG Pipeline** improvements.

Future work may include:

* Hybrid dense + sparse retrieval
* Additional vector store backends
* metadata filtering