### PR TITLE
feat(testing): add benchmark and regression harness for workflow evaluation

### DIFF
--- a/tests/src/benchmark/mod.rs
+++ b/tests/src/benchmark/mod.rs
@@ -1,0 +1,8 @@
+mod runner;
+mod types;
+
+pub use runner::{BenchmarkContext, BenchmarkRunner};
+pub use types::{
+    BenchmarkCaseConfig, BenchmarkCaseResult, BenchmarkReport, BenchmarkThresholds,
+    MetricThreshold, ToolCallMetric,
+};

--- a/tests/src/benchmark/runner.rs
+++ b/tests/src/benchmark/runner.rs
@@ -1,0 +1,229 @@
+use std::collections::{BTreeMap, HashMap};
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Instant;
+
+use anyhow::Result;
+
+use crate::backend::MockLLMBackend;
+use crate::bus::MockAgentBus;
+use crate::clock::{Clock, SystemClock};
+use crate::tools::MockTool;
+
+use super::types::{
+    BenchmarkCaseConfig, BenchmarkCaseResult, BenchmarkReport, BenchmarkThresholds, MetricThreshold,
+};
+
+#[derive(Clone)]
+pub struct BenchmarkContext {
+    pub backend: Arc<MockLLMBackend>,
+    pub bus: Arc<MockAgentBus>,
+    pub tools: HashMap<String, Arc<MockTool>>,
+    pub model_name: String,
+}
+
+impl BenchmarkContext {
+    pub fn new(
+        backend: Arc<MockLLMBackend>,
+        bus: Arc<MockAgentBus>,
+        tools: HashMap<String, Arc<MockTool>>,
+        model_name: impl Into<String>,
+    ) -> Self {
+        Self {
+            backend,
+            bus,
+            tools,
+            model_name: model_name.into(),
+        }
+    }
+
+    pub fn tool(&self, name: &str) -> Option<Arc<MockTool>> {
+        self.tools.get(name).cloned()
+    }
+}
+
+pub struct BenchmarkRunner {
+    suite_name: String,
+    clock: Arc<dyn Clock>,
+    started_at: Instant,
+    cases: Vec<BenchmarkCaseResult>,
+}
+
+impl BenchmarkRunner {
+    pub fn new(suite_name: impl Into<String>) -> Self {
+        Self {
+            suite_name: suite_name.into(),
+            clock: Arc::new(SystemClock),
+            started_at: Instant::now(),
+            cases: Vec::new(),
+        }
+    }
+
+    pub fn with_clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.clock = clock;
+        self
+    }
+
+    pub async fn run_case<Setup, Bench, Fut>(
+        mut self,
+        config: BenchmarkCaseConfig,
+        setup: Setup,
+        bench: Bench,
+    ) -> Result<Self>
+    where
+        Setup: Fn() -> BenchmarkContext,
+        Bench: Fn(BenchmarkContext) -> Fut,
+        Fut: Future<Output = Result<()>>,
+    {
+        let iterations = config.iterations.max(1);
+
+        for _ in 0..config.warmup_iterations {
+            let context = setup();
+            bench(context).await?;
+        }
+
+        let mut sample_latencies = Vec::with_capacity(iterations);
+        let mut total_infer_calls = 0_u64;
+        let mut total_bus_messages = 0_u64;
+        let mut total_tool_calls: BTreeMap<String, u64> = BTreeMap::new();
+
+        for _ in 0..iterations {
+            let context = setup();
+            let start = Instant::now();
+            bench(context.clone()).await?;
+            let elapsed = duration_to_micros(start.elapsed());
+            sample_latencies.push(elapsed);
+
+            total_infer_calls += context.backend.call_count() as u64;
+            total_bus_messages += context.bus.message_count().await as u64;
+
+            for (name, tool) in &context.tools {
+                let count = tool.call_count().await as u64;
+                if count > 0 {
+                    *total_tool_calls.entry(name.clone()).or_default() += count;
+                }
+            }
+        }
+
+        let mean_latency_micros = sample_latencies.iter().sum::<u64>() / iterations as u64;
+        let peak_latency_micros = sample_latencies.iter().copied().max().unwrap_or(0);
+        let infer_calls_per_iteration = total_infer_calls / iterations as u64;
+        let bus_messages_per_iteration = total_bus_messages / iterations as u64;
+        let tool_calls_per_iteration = total_tool_calls
+            .into_iter()
+            .map(|(name, total)| (name, total / iterations as u64))
+            .collect::<BTreeMap<_, _>>();
+
+        let regressions = evaluate_thresholds(
+            &config.thresholds,
+            mean_latency_micros,
+            peak_latency_micros,
+            infer_calls_per_iteration,
+            bus_messages_per_iteration,
+            &tool_calls_per_iteration,
+        );
+
+        self.cases.push(BenchmarkCaseResult {
+            name: config.name,
+            iterations,
+            warmup_iterations: config.warmup_iterations,
+            mean_latency_micros,
+            peak_latency_micros,
+            total_infer_calls,
+            infer_calls_per_iteration,
+            total_bus_messages,
+            bus_messages_per_iteration,
+            tool_calls_per_iteration,
+            sample_latencies_micros: sample_latencies,
+            regressions,
+        });
+
+        Ok(self)
+    }
+
+    pub fn build(self) -> BenchmarkReport {
+        BenchmarkReport {
+            suite_name: self.suite_name,
+            total_duration_micros: duration_to_micros(self.started_at.elapsed()),
+            timestamp: self.clock.now_millis(),
+            cases: self.cases,
+        }
+    }
+}
+
+fn evaluate_thresholds(
+    thresholds: &BenchmarkThresholds,
+    mean_latency_micros: u64,
+    peak_latency_micros: u64,
+    infer_calls_per_iteration: u64,
+    bus_messages_per_iteration: u64,
+    tool_calls_per_iteration: &BTreeMap<String, u64>,
+) -> Vec<String> {
+    let mut regressions = Vec::new();
+
+    push_threshold_failure(
+        &mut regressions,
+        "mean latency",
+        thresholds.max_mean_latency_micros.as_ref(),
+        mean_latency_micros,
+        "micros",
+    );
+    push_threshold_failure(
+        &mut regressions,
+        "peak latency",
+        thresholds.max_peak_latency_micros.as_ref(),
+        peak_latency_micros,
+        "micros",
+    );
+    push_threshold_failure(
+        &mut regressions,
+        "infer calls per iteration",
+        thresholds.max_infer_calls_per_iteration.as_ref(),
+        infer_calls_per_iteration,
+        "calls",
+    );
+    push_threshold_failure(
+        &mut regressions,
+        "bus messages per iteration",
+        thresholds.max_bus_messages_per_iteration.as_ref(),
+        bus_messages_per_iteration,
+        "messages",
+    );
+
+    for tool_metric in &thresholds.max_tool_calls_per_iteration {
+        let actual = tool_calls_per_iteration
+            .get(&tool_metric.name)
+            .copied()
+            .unwrap_or(0);
+
+        if actual > tool_metric.calls_per_iteration {
+            regressions.push(format!(
+                "tool '{}' exceeded threshold: {} calls > {} calls",
+                tool_metric.name, actual, tool_metric.calls_per_iteration
+            ));
+        }
+    }
+
+    regressions
+}
+
+fn push_threshold_failure(
+    regressions: &mut Vec<String>,
+    label: &str,
+    threshold: Option<&MetricThreshold>,
+    actual: u64,
+    unit: &str,
+) {
+    if let Some(threshold) = threshold {
+        if actual > threshold.max {
+            regressions.push(format!(
+                "{} exceeded threshold: {} {} > {} {}",
+                label, actual, unit, threshold.max, unit
+            ));
+        }
+    }
+}
+
+fn duration_to_micros(duration: std::time::Duration) -> u64 {
+    duration.as_micros().min(u64::MAX as u128) as u64
+}

--- a/tests/src/benchmark/types.rs
+++ b/tests/src/benchmark/types.rs
@@ -1,0 +1,148 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use crate::report::{TestCaseResult, TestReport, TestStatus};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MetricThreshold {
+    pub max: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolCallMetric {
+    pub name: String,
+    pub calls_per_iteration: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct BenchmarkThresholds {
+    pub max_mean_latency_micros: Option<MetricThreshold>,
+    pub max_peak_latency_micros: Option<MetricThreshold>,
+    pub max_infer_calls_per_iteration: Option<MetricThreshold>,
+    pub max_bus_messages_per_iteration: Option<MetricThreshold>,
+    pub max_tool_calls_per_iteration: Vec<ToolCallMetric>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BenchmarkCaseConfig {
+    pub name: String,
+    pub iterations: usize,
+    pub warmup_iterations: usize,
+    pub thresholds: BenchmarkThresholds,
+}
+
+impl BenchmarkCaseConfig {
+    pub fn new(name: impl Into<String>, iterations: usize) -> Self {
+        Self {
+            name: name.into(),
+            iterations,
+            warmup_iterations: 0,
+            thresholds: BenchmarkThresholds::default(),
+        }
+    }
+
+    pub fn with_warmup_iterations(mut self, warmup_iterations: usize) -> Self {
+        self.warmup_iterations = warmup_iterations;
+        self
+    }
+
+    pub fn with_thresholds(mut self, thresholds: BenchmarkThresholds) -> Self {
+        self.thresholds = thresholds;
+        self
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BenchmarkCaseResult {
+    pub name: String,
+    pub iterations: usize,
+    pub warmup_iterations: usize,
+    pub mean_latency_micros: u64,
+    pub peak_latency_micros: u64,
+    pub total_infer_calls: u64,
+    pub infer_calls_per_iteration: u64,
+    pub total_bus_messages: u64,
+    pub bus_messages_per_iteration: u64,
+    pub tool_calls_per_iteration: BTreeMap<String, u64>,
+    pub sample_latencies_micros: Vec<u64>,
+    pub regressions: Vec<String>,
+}
+
+impl BenchmarkCaseResult {
+    pub fn passed(&self) -> bool {
+        self.regressions.is_empty()
+    }
+
+    pub fn to_test_case_result(&self) -> TestCaseResult {
+        let metadata = vec![
+            (
+                "mean_latency_micros".to_string(),
+                self.mean_latency_micros.to_string(),
+            ),
+            (
+                "peak_latency_micros".to_string(),
+                self.peak_latency_micros.to_string(),
+            ),
+            (
+                "infer_calls_per_iteration".to_string(),
+                self.infer_calls_per_iteration.to_string(),
+            ),
+            (
+                "bus_messages_per_iteration".to_string(),
+                self.bus_messages_per_iteration.to_string(),
+            ),
+        ];
+
+        TestCaseResult {
+            name: self.name.clone(),
+            status: if self.passed() {
+                TestStatus::Passed
+            } else {
+                TestStatus::Failed
+            },
+            duration: Duration::from_micros(self.mean_latency_micros),
+            error: if self.passed() {
+                None
+            } else {
+                Some(self.regressions.join("; "))
+            },
+            metadata,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BenchmarkReport {
+    pub suite_name: String,
+    pub total_duration_micros: u64,
+    pub timestamp: u64,
+    pub cases: Vec<BenchmarkCaseResult>,
+}
+
+impl BenchmarkReport {
+    pub fn total(&self) -> usize {
+        self.cases.len()
+    }
+
+    pub fn failed(&self) -> usize {
+        self.cases.iter().filter(|case| !case.passed()).count()
+    }
+
+    pub fn passed(&self) -> usize {
+        self.cases.iter().filter(|case| case.passed()).count()
+    }
+
+    pub fn to_test_report(&self) -> TestReport {
+        TestReport {
+            suite_name: self.suite_name.clone(),
+            results: self
+                .cases
+                .iter()
+                .map(BenchmarkCaseResult::to_test_case_result)
+                .collect(),
+            total_duration: Duration::from_micros(self.total_duration_micros),
+            timestamp: self.timestamp,
+        }
+    }
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -6,12 +6,17 @@
 pub mod adversarial;
 pub mod assertions;
 pub mod backend;
+pub mod benchmark;
 pub mod bus;
 pub mod clock;
 pub mod report;
 pub mod tools;
 
 pub use backend::MockLLMBackend;
+pub use benchmark::{
+    BenchmarkCaseConfig, BenchmarkCaseResult, BenchmarkContext, BenchmarkReport, BenchmarkRunner,
+    BenchmarkThresholds, MetricThreshold, ToolCallMetric,
+};
 pub use bus::MockAgentBus;
 pub use clock::{Clock, MockClock, SystemClock};
 pub use report::{

--- a/tests/tests/benchmark_harness_tests.rs
+++ b/tests/tests/benchmark_harness_tests.rs
@@ -1,0 +1,183 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use mofa_foundation::agent::components::tool::SimpleTool;
+use mofa_foundation::orchestrator::ModelOrchestrator;
+use mofa_kernel::agent::components::tool::ToolInput;
+use mofa_kernel::bus::CommunicationMode;
+use mofa_kernel::message::AgentMessage;
+use mofa_testing::{
+    BenchmarkCaseConfig, BenchmarkContext, BenchmarkRunner, BenchmarkThresholds, MetricThreshold,
+    MockAgentBus, MockClock, MockLLMBackend, MockTool, ToolCallMetric,
+};
+
+fn benchmark_context() -> BenchmarkContext {
+    let backend = Arc::new(MockLLMBackend::new());
+    backend.add_response("weather", "sunny");
+
+    let bus = Arc::new(MockAgentBus::new());
+
+    let tool = Arc::new(MockTool::new(
+        "search",
+        "Searches documents",
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "query": { "type": "string" }
+            },
+            "required": ["query"]
+        }),
+    ));
+
+    let mut tools = HashMap::new();
+    tools.insert("search".to_string(), tool);
+
+    BenchmarkContext::new(backend, bus, tools, "mock-model")
+}
+
+#[tokio::test]
+async fn benchmark_runner_collects_metrics_and_exports_report() -> Result<()> {
+    let report = BenchmarkRunner::new("agent benchmark suite")
+        .with_clock(Arc::new(MockClock::starting_at(Duration::from_millis(
+            1_710_000_000_000,
+        ))))
+        .run_case(
+            BenchmarkCaseConfig::new("search flow", 3).with_warmup_iterations(1),
+            benchmark_context,
+            |context| async move {
+                context
+                    .backend
+                    .infer(&context.model_name, "weather in paris")
+                    .await?;
+
+                let tool = context.tool("search").expect("tool should exist");
+                let result = tool
+                    .execute(ToolInput::from_json(serde_json::json!({
+                        "query": "weather in paris"
+                    })))
+                    .await;
+                assert!(result.success);
+
+                let _ = context
+                    .bus
+                    .send_and_capture(
+                        "planner",
+                        CommunicationMode::Broadcast,
+                        AgentMessage::TaskRequest {
+                            task_id: "task-1".to_string(),
+                            content: "weather in paris".to_string(),
+                        },
+                    )
+                    .await;
+
+                Ok(())
+            },
+        )
+        .await?
+        .build();
+
+    assert_eq!(report.suite_name, "agent benchmark suite");
+    assert_eq!(report.timestamp, 1_710_000_000_000);
+    assert_eq!(report.total(), 1);
+    assert_eq!(report.passed(), 1);
+
+    let case = &report.cases[0];
+    assert_eq!(case.name, "search flow");
+    assert_eq!(case.iterations, 3);
+    assert_eq!(case.warmup_iterations, 1);
+    assert_eq!(case.total_infer_calls, 3);
+    assert_eq!(case.infer_calls_per_iteration, 1);
+    assert_eq!(case.total_bus_messages, 3);
+    assert_eq!(case.bus_messages_per_iteration, 1);
+    assert_eq!(case.tool_calls_per_iteration.get("search"), Some(&1));
+    assert_eq!(case.sample_latencies_micros.len(), 3);
+    assert!(case.regressions.is_empty());
+
+    let json = serde_json::to_string(&report)?;
+    assert!(json.contains("\"suite_name\":\"agent benchmark suite\""));
+    assert!(json.contains("\"infer_calls_per_iteration\":1"));
+
+    let test_report = report.to_test_report();
+    assert_eq!(test_report.total(), 1);
+    assert_eq!(test_report.passed(), 1);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn benchmark_runner_reports_regressions_when_thresholds_are_exceeded() -> Result<()> {
+    let thresholds = BenchmarkThresholds {
+        max_mean_latency_micros: None,
+        max_peak_latency_micros: None,
+        max_infer_calls_per_iteration: Some(MetricThreshold { max: 1 }),
+        max_bus_messages_per_iteration: Some(MetricThreshold { max: 0 }),
+        max_tool_calls_per_iteration: vec![ToolCallMetric {
+            name: "search".to_string(),
+            calls_per_iteration: 0,
+        }],
+    };
+
+    let report = BenchmarkRunner::new("regression suite")
+        .run_case(
+            BenchmarkCaseConfig::new("chatty flow", 2).with_thresholds(thresholds),
+            benchmark_context,
+            |context| async move {
+                context
+                    .backend
+                    .infer(&context.model_name, "weather")
+                    .await?;
+                context
+                    .backend
+                    .infer(&context.model_name, "weather tomorrow")
+                    .await?;
+
+                let tool = context.tool("search").expect("tool should exist");
+                tool.execute(ToolInput::from_json(serde_json::json!({
+                    "query": "weather"
+                })))
+                .await;
+
+                let _ = context
+                    .bus
+                    .send_and_capture(
+                        "planner",
+                        CommunicationMode::Broadcast,
+                        AgentMessage::TaskRequest {
+                            task_id: "task-2".to_string(),
+                            content: "weather".to_string(),
+                        },
+                    )
+                    .await;
+
+                Ok(())
+            },
+        )
+        .await?
+        .build();
+
+    let case = &report.cases[0];
+    assert_eq!(report.failed(), 1);
+    assert_eq!(case.infer_calls_per_iteration, 2);
+    assert_eq!(case.bus_messages_per_iteration, 1);
+    assert_eq!(case.tool_calls_per_iteration.get("search"), Some(&1));
+    assert_eq!(case.regressions.len(), 3);
+    assert!(
+        case.regressions
+            .iter()
+            .any(|item| item.contains("infer calls per iteration exceeded threshold"))
+    );
+    assert!(
+        case.regressions
+            .iter()
+            .any(|item| item.contains("bus messages per iteration exceeded threshold"))
+    );
+    assert!(
+        case.regressions
+            .iter()
+            .any(|item| item.contains("tool 'search' exceeded threshold"))
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
### Summary
closes #1280 

Adds a structured benchmark and regression harness to `mofa-testing` so agent workflows can be evaluated not only for correctness, but also for performance characteristics like latency, infer counts, bus traffic, and tool-call overhead. Builds directly on the testing framework from [PR #486](https://github.com/mofa-org/mofa/pull/486), failure injection / deterministic timing from [PR #888](https://github.com/mofa-org/mofa/pull/888), and structured reporting from [PR #895](https://github.com/mofa-org/mofa/pull/895).

### Motivation

The testing crate already has the primitives needed to execute deterministic agent tests:

- **Mocks** from #486 make agent behavior reproducible
- **Failure injection + `MockClock`** from #888 make error paths and timing deterministic
- **Structured reports** from #895 make results machine-readable

What is still missing is a reusable way to measure and compare execution characteristics across runs.

This PR closes that gap by adding a benchmark harness that can:

- track latency over repeated iterations
- count infer calls per iteration
- count bus messages per iteration
- count per-tool calls per iteration
- detect regressions via configurable thresholds
- export results as machine-readable JSON
- convert results into `TestReport`

### What's New

| Component | Description |
|-----------|-------------|
| `BenchmarkContext` | Holds configured mock backend, bus, tools, and model name for each benchmark iteration |
| `BenchmarkRunner` | Fluent runner for repeated benchmark execution with optional injected clock |
| `BenchmarkCaseConfig` | Per-case config: name, iterations, warmup iterations, thresholds |
| `BenchmarkThresholds` | Thresholds for latency, infer calls, bus traffic, and tool-call counts |
| `BenchmarkCaseResult` | Per-case benchmark metrics + regression failures |
| `BenchmarkReport` | Benchmark suite output with JSON-friendly structure and `to_test_report()` bridge |



This PR does **not** overlap with [PR #1129](https://github.com/mofa-org/mofa/pull/1129).

- **#1129** adds an adversarial/security-style harness for prompt/policy evaluation
- **This PR** adds a benchmark/regression harness for measuring workflow performance characteristics

So the two are complementary:
- `adversarial/` = security/policy evaluation
- `benchmark/` = latency/call-count regression evaluation



running 15 tests (integration.rs)
all 15 existing tests pass unchanged
Total verified: 17 passed, 0 failed

Verification Checklist
 cargo test -p mofa-testing --test benchmark_harness_tests
 cargo test -p mofa-testing --test integration
 Only touches tests/ crate
