### PR TITLE
fix(wasm): prevent u32 arithmetic overflow in memory region checks

### DIFF
--- a/crates/mofa-plugins/src/wasm_runtime/memory.rs
+++ b/crates/mofa-plugins/src/wasm_runtime/memory.rs
@@ -99,7 +99,9 @@ impl MemoryRegion {
     }
 
     pub fn contains(&self, addr: GuestPtr) -> bool {
-        addr.0 >= self.start.0 && addr.0 < self.start.0 + self.size
+        // Use subtraction instead of addition to avoid u32 overflow when the
+        // region is positioned near the top of the 32-bit address space.
+        addr.0 >= self.start.0 && addr.0 - self.start.0 < self.size
     }
 
     pub fn end(&self) -> GuestPtr {
@@ -137,7 +139,8 @@ impl WasmMemory {
 
     /// Get current size in bytes
     pub fn size(&self) -> u32 {
-        self.pages * Self::PAGE_SIZE
+        // saturating_mul prevents u32 overflow if pages ever approaches u32::MAX.
+        self.pages.saturating_mul(Self::PAGE_SIZE)
     }
 
     /// Get current size in pages
@@ -432,12 +435,13 @@ impl MemoryAllocator {
 
             // Check if blocks are adjacent
             if block.end() == coalesced.start {
-                // Block is immediately before
-                coalesced = MemoryRegion::new(block.start, block.size + coalesced.size);
+                // Block is immediately before; saturating_add avoids overflow
+                // when coalescing regions that span the end of the address space.
+                coalesced = MemoryRegion::new(block.start, block.size.saturating_add(coalesced.size));
                 self.free_blocks.remove(i);
             } else if coalesced.end() == block.start {
                 // Block is immediately after
-                coalesced = MemoryRegion::new(coalesced.start, coalesced.size + block.size);
+                coalesced = MemoryRegion::new(coalesced.start, coalesced.size.saturating_add(block.size));
                 self.free_blocks.remove(i);
             } else {
                 i += 1;
@@ -552,5 +556,58 @@ mod tests {
 
         buf.clear().await;
         assert!(buf.is_empty().await);
+    }
+
+    #[test]
+    fn contains_does_not_overflow_near_u32_max() {
+        // Regions near the top of the u32 address space previously caused
+        // `start + size` to wrap in release mode, making low-address pointers
+        // appear to be inside the region.
+        let region = MemoryRegion::new(GuestPtr::new(u32::MAX - 10), 11);
+
+        // Addresses that are genuinely inside the region.
+        assert!(region.contains(GuestPtr::new(u32::MAX - 10))); // start
+        assert!(region.contains(GuestPtr::new(u32::MAX - 5))); // mid-range
+        assert!(region.contains(GuestPtr::new(u32::MAX))); // last byte
+
+        // Low addresses must NOT be falsely matched after a wrap-around.
+        assert!(!region.contains(GuestPtr::new(0)));
+        assert!(!region.contains(GuestPtr::new(5)));
+        // One byte before the start also must not match.
+        assert!(!region.contains(GuestPtr::new(u32::MAX - 11)));
+    }
+
+    #[test]
+    fn wasm_memory_size_saturates_instead_of_overflowing() {
+        // `pages * PAGE_SIZE` would wrap to 0 with plain `*` if pages == 65536.
+        // With saturating_mul it must return u32::MAX instead of 0.
+        let mut mem = WasmMemory::new(0, None);
+        mem.pages = u32::MAX;
+        assert_eq!(mem.size(), u32::MAX);
+    }
+
+    #[test]
+    fn return_block_coalescing_saturates_instead_of_overflowing() {
+        let mut allocator = MemoryAllocator::new(16);
+
+        // Two adjacent regions whose combined size would overflow u32.
+        allocator.free_blocks.push(MemoryRegion {
+            start: GuestPtr::new(0),
+            size: u32::MAX - 10,
+            allocated: false,
+            tag: None,
+        });
+        let second = MemoryRegion {
+            start: GuestPtr::new(u32::MAX - 10),
+            size: 11,
+            allocated: false,
+            tag: None,
+        };
+
+        // Returning the second block triggers coalescing.  Must not panic or
+        // produce a wrapped-around (smaller) size.
+        allocator.return_block(second);
+        assert_eq!(allocator.free_blocks.len(), 1);
+        assert_eq!(allocator.free_blocks[0].size, u32::MAX);
     }
 }


### PR DESCRIPTION
Fixes #1303

Three sites in [wasm_runtime/memory.rs](cci:7://file:///c:/Users/aftab/mofa/crates/mofa-plugins/src/wasm_runtime/memory.rs:0:0-0:0) used unchecked u32 arithmetic that overflowed when memory regions were positioned near the end of the 32-bit address space:

- `MemoryRegion::contains`: rewrote `start + size` comparison using subtraction (`addr - start < size`) to avoid the addition that wraps.

- `WasmMemory::size`: replaced `pages * PAGE_SIZE` with `pages.saturating_mul(PAGE_SIZE)` to prevent wrapping when the simulated page count is extreme.

- `MemoryAllocator::return_block`: replaced `+` with `saturating_add` in both coalescing branches to prevent overflow when merging large adjacent free blocks.

Three unit tests are added to confirm each site no longer panics or produces incorrect results at the u32 boundary.

## 📋 Summary

<!--
Explain WHAT this PR does and WHY.
Focus on the motivation and impact rather than implementation details.
-->
This PR prevents arithmetic overflow bugs in the WASM memory management module. When memory regions hit the bounds of a 32-bit address space, unchecked addition/multiplication wrapped around to incorrect smaller numbers. This fixes the bounds-checking math to ensure memory safety isn't compromised at the edges.

## 🔗 Related Issues

Closes #1303



---

## 🧠 Context

<!--
Why is this change needed?
What problem does it solve?
Any relevant background or design decisions.
-->
Because Rust defaults to wrapping arithmetic in release mode and panicking in debug mode, operations near `u32::MAX` would result in either runtime crashes or incorrect security checks (e.g. low addresses matching incorrectly inside a wrapped high-address bounding box).

---

## 🛠️ Changes

<!--
High-level list of changes.
Avoid low-level diffs — reviewers can see those.
-->

- Rewrote `MemoryRegion::contains` inequality boundary check without addition.
- Added `saturating_mul` to `WasmMemory::size` and `saturating_add` to `MemoryAllocator::return_block`.
- Added new bounding-specific unit test assertions ensuring no panics occur near `u32::MAX`.

---

## 🧪 How you Tested

<!--
Provide clear steps for reviewers to validate the change.
Include commands, endpoints, or scenarios.
-->

1. Added programmatic isolation tests in [memory.rs](cci:7://file:///c:/Users/aftab/mofa/crates/mofa-plugins/src/wasm_runtime/memory.rs:0:0-0:0) that explicitly allocate boundary-adjacent regions and simulate crossing the 4GB boundary.
2. Verified unit tests run without failing (`cargo test -p mofa-plugins`)
3. `cargo clippy` run locally to ensure adherence to syntax constraints.

---

## 📸 Screenshots / Logs (if applicable)

<!-- CLI output, logs, or UI screenshots -->

---

## ⚠️ Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (describe below)

If breaking:

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [x] Public APIs documented
- [x] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---


