### PR TITLE
fix(vibe): save .env API key file to project root instead of CWD

### DIFF
--- a/mofa/commands/vibe.py
+++ b/mofa/commands/vibe.py
@@ -118,7 +118,7 @@ def _check_and_setup_api_key():
 
             # Ask if they want to save it
             if click.confirm("\nSave to .env file?", default=True):
-                env_file = os.path.join(os.getcwd(), '.env')
+                env_file = _get_env_file_path()
 
                 # Append to .env or create new one
                 with open(env_file, 'a') as f:


### PR DESCRIPTION
## Summary

This PR fixes an issue where the [vibe](cci:1://file:///c:/Users/Asus/OneDrive/Desktop/Mofa-org/mofa/mofa/commands/vibe.py:143:4-149:27) command would save the user's OpenAI API key to a `.env` file in the current working directory instead of the project root. This effectively resolves the problem of "lost" API keys when running the command from a subdirectory.


Closes #1258 
---

##  Context

During the interactive `mofa vibe` setup, if an OpenAI API key is missing, it prompts the user to enter and save it. Previously, the saving logic used `os.path.join(os.getcwd(), '.env')` while the loading logic correctly used the project root. 
If a user ran `mofa vibe` from a subdirectory (e.g., `examples/`), the key was written locally to that subdirectory. Subsequent runs from other directories would fail to locate the key, frustrating the user and continuously prompting for setup. This change unifies the file path logic.

---

## Changes

- Replaced the hardcoded `os.getcwd()` path in [mofa/commands/vibe.py](cci:7://file:///c:/Users/Asus/OneDrive/Desktop/Mofa-org/mofa/mofa/commands/vibe.py:0:0-0:0) with the existing [_get_env_file_path()](cci:1://file:///c:/Users/Asus/OneDrive/Desktop/Mofa-org/mofa/mofa/commands/vibe.py:9:0-11:45) helper.
- Ensures API keys are always appended or saved to the project root's `.env` file consistently.

---

##  How you Tested

1. Set a mock project_root and navigated to a different subdirectory (e.g., `cd /path/to/project/subdirectory`).
2. Cleared any existing `OPENAI_API_KEY` from the environment.
3. Invoked the `mofa vibe` CLI.
4. Entered a mock API key when prompted and selected `Y` to save it to `.env`.
5. Verified that the `.env` file was correctly generated in the project root, and no `.env` file was created in the immediate working directory.

---