### PR TITLE
fix: replace 124 unsafe millisecond casts missed by PR #1182 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5859,7 +5859,7 @@ version = "0.1.0"
 dependencies = [
  "async-openai",
  "async-trait",
- "axum 0.6.20",
+ "axum",
  "base64 0.22.1",
  "candle-core",
  "candle-transformers",

--- a/crates/mofa-cli/src/state/agent_state.rs
+++ b/crates/mofa-cli/src/state/agent_state.rs
@@ -72,10 +72,7 @@ pub struct AgentMetadata {
 impl AgentMetadata {
     /// Create new agent metadata
     pub fn new(id: String, name: String) -> Self {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64;
+        let now = mofa_kernel::utils::now_ms();
 
         Self {
             id,
@@ -106,10 +103,7 @@ impl AgentMetadata {
 
     /// Mark as started
     pub fn mark_started(&mut self, pid: u32) {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64;
+        let now = mofa_kernel::utils::now_ms();
         self.last_started = Some(now);
         self.process_id = Some(pid);
         self.last_state = AgentProcessState::Running;
@@ -118,10 +112,7 @@ impl AgentMetadata {
 
     /// Mark as stopped
     pub fn mark_stopped(&mut self) {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64;
+        let now = mofa_kernel::utils::now_ms();
         self.last_stopped = Some(now);
         self.process_id = None;
         self.last_state = AgentProcessState::Stopped;
@@ -342,7 +333,8 @@ mod tests {
             "tags": []
         }"#;
 
-        let metadata: AgentMetadata = serde_json::from_str(legacy).expect("legacy metadata should deserialize");
+        let metadata: AgentMetadata =
+            serde_json::from_str(legacy).expect("legacy metadata should deserialize");
         assert_eq!(metadata.last_state, AgentProcessState::Stopped);
         assert_eq!(metadata.id, "agent-legacy");
     }

--- a/crates/mofa-extra/src/rhai/engine.rs
+++ b/crates/mofa-extra/src/rhai/engine.rs
@@ -549,7 +549,7 @@ impl RhaiScriptEngine {
         // Execute the script
         let result = self.engine.eval_with_scope::<Dynamic>(&mut scope, source);
 
-        let execution_time_ms = start_time.elapsed().as_millis() as u64;
+        let execution_time_ms = u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX);
         let logs = self.logs.read().await.clone();
 
         match result {
@@ -607,7 +607,7 @@ impl RhaiScriptEngine {
             .engine
             .eval_ast_with_scope::<Dynamic>(&mut scope, &compiled.ast);
 
-        let execution_time_ms = start_time.elapsed().as_millis() as u64;
+        let execution_time_ms = u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX);
         let logs = self.logs.read().await.clone();
 
         match result {

--- a/crates/mofa-extra/src/rhai/rules.rs
+++ b/crates/mofa-extra/src/rhai/rules.rs
@@ -436,7 +436,8 @@ impl RuleEngine {
                             success: false,
                             result: serde_json::Value::Null,
                             error: result.error,
-                            execution_time_ms: start_time.elapsed().as_millis() as u64,
+                            execution_time_ms: u64::try_from(start_time.elapsed().as_millis())
+                                .unwrap_or(u64::MAX),
                             variable_updates,
                             triggered_events,
                         });
@@ -455,7 +456,8 @@ impl RuleEngine {
                                 "Invalid function name: '{}'. Must be a valid identifier.",
                                 function
                             )),
-                            execution_time_ms: start_time.elapsed().as_millis() as u64,
+                            execution_time_ms: u64::try_from(start_time.elapsed().as_millis())
+                                .unwrap_or(u64::MAX),
                             variable_updates,
                             triggered_events,
                         });
@@ -473,7 +475,8 @@ impl RuleEngine {
                             success: false,
                             result: serde_json::Value::Null,
                             error: result.error,
-                            execution_time_ms: start_time.elapsed().as_millis() as u64,
+                            execution_time_ms: u64::try_from(start_time.elapsed().as_millis())
+                                .unwrap_or(u64::MAX),
                             variable_updates,
                             triggered_events,
                         });
@@ -530,7 +533,8 @@ impl RuleEngine {
                 success: true,
                 result,
                 error: None,
-                execution_time_ms: start_time.elapsed().as_millis() as u64,
+                execution_time_ms: u64::try_from(start_time.elapsed().as_millis())
+                    .unwrap_or(u64::MAX),
                 variable_updates,
                 triggered_events,
             })
@@ -558,7 +562,8 @@ impl RuleEngine {
                         success: false,
                         result: serde_json::Value::Null,
                         error: result.error,
-                        execution_time_ms: start_time.elapsed().as_millis() as u64,
+                        execution_time_ms: u64::try_from(start_time.elapsed().as_millis())
+                            .unwrap_or(u64::MAX),
                         variable_updates,
                         triggered_events,
                     });
@@ -577,7 +582,8 @@ impl RuleEngine {
                             "Invalid function name: '{}'. Must be a valid identifier.",
                             function
                         )),
-                        execution_time_ms: start_time.elapsed().as_millis() as u64,
+                        execution_time_ms: u64::try_from(start_time.elapsed().as_millis())
+                            .unwrap_or(u64::MAX),
                         variable_updates,
                         triggered_events,
                     });
@@ -595,7 +601,8 @@ impl RuleEngine {
                         success: false,
                         result: serde_json::Value::Null,
                         error: result.error,
-                        execution_time_ms: start_time.elapsed().as_millis() as u64,
+                        execution_time_ms: u64::try_from(start_time.elapsed().as_millis())
+                            .unwrap_or(u64::MAX),
                         variable_updates,
                         triggered_events,
                     });
@@ -641,7 +648,7 @@ impl RuleEngine {
             success: true,
             result,
             error: None,
-            execution_time_ms: start_time.elapsed().as_millis() as u64,
+            execution_time_ms: u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX),
             variable_updates,
             triggered_events,
         })
@@ -694,7 +701,7 @@ impl RuleEngine {
                 final_result: None,
                 any_matched: false,
                 used_default: false,
-                total_time_ms: start_time.elapsed().as_millis() as u64,
+                total_time_ms: u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX),
             });
         }
 
@@ -722,7 +729,8 @@ impl RuleEngine {
             match_results.push(RuleMatchResult {
                 rule_id: rule.id.clone(),
                 matched,
-                evaluation_time_ms: eval_start.elapsed().as_millis() as u64,
+                evaluation_time_ms: u64::try_from(eval_start.elapsed().as_millis())
+                    .unwrap_or(u64::MAX),
             });
 
             if !matched {
@@ -792,7 +800,7 @@ impl RuleEngine {
             final_result,
             any_matched,
             used_default,
-            total_time_ms: start_time.elapsed().as_millis() as u64,
+            total_time_ms: u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX),
         })
     }
 

--- a/crates/mofa-extra/src/rhai/tools.rs
+++ b/crates/mofa-extra/src/rhai/tools.rs
@@ -628,7 +628,8 @@ impl ScriptToolRegistry {
                     success: true,
                     result: value,
                     error: None,
-                    execution_time_ms: start_time.elapsed().as_millis() as u64,
+                    execution_time_ms: u64::try_from(start_time.elapsed().as_millis())
+                        .unwrap_or(u64::MAX),
                     logs: Vec::new(),
                 }),
                 Err(_e) => {
@@ -641,7 +642,8 @@ impl ScriptToolRegistry {
                             success: true,
                             result: script_result.value,
                             error: None,
-                            execution_time_ms: start_time.elapsed().as_millis() as u64,
+                            execution_time_ms: u64::try_from(start_time.elapsed().as_millis())
+                                .unwrap_or(u64::MAX),
                             logs: script_result.logs,
                         })
                     } else {
@@ -650,7 +652,8 @@ impl ScriptToolRegistry {
                             success: false,
                             result: serde_json::Value::Null,
                             error: script_result.error,
-                            execution_time_ms: start_time.elapsed().as_millis() as u64,
+                            execution_time_ms: u64::try_from(start_time.elapsed().as_millis())
+                                .unwrap_or(u64::MAX),
                             logs: script_result.logs,
                         })
                     }
@@ -663,7 +666,8 @@ impl ScriptToolRegistry {
                 success: script_result.success,
                 result: script_result.value,
                 error: script_result.error,
-                execution_time_ms: start_time.elapsed().as_millis() as u64,
+                execution_time_ms: u64::try_from(start_time.elapsed().as_millis())
+                    .unwrap_or(u64::MAX),
                 logs: script_result.logs,
             })
         }

--- a/crates/mofa-extra/src/rhai/workflow.rs
+++ b/crates/mofa-extra/src/rhai/workflow.rs
@@ -258,7 +258,8 @@ impl ScriptWorkflowNode {
                         success: true,
                         output: script_result.value,
                         error: None,
-                        execution_time_ms: start_time.elapsed().as_millis() as u64,
+                        execution_time_ms: u64::try_from(start_time.elapsed().as_millis())
+                            .unwrap_or(u64::MAX),
                         retry_count,
                         logs: script_result.logs,
                     });
@@ -285,7 +286,7 @@ impl ScriptWorkflowNode {
             success: false,
             output: serde_json::Value::Null,
             error: last_error,
-            execution_time_ms: start_time.elapsed().as_millis() as u64,
+            execution_time_ms: u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX),
             retry_count: retry_count.saturating_sub(1),
             logs: Vec::new(),
         })

--- a/crates/mofa-foundation/src/adapter/scheduler.rs
+++ b/crates/mofa-foundation/src/adapter/scheduler.rs
@@ -240,7 +240,7 @@ impl DeferredRequest {
 
     /// Get wait time in milliseconds
     pub fn wait_time_ms(&self) -> u64 {
-        self.enqueued_at.elapsed().as_millis() as u64
+        u64::try_from(self.enqueued_at.elapsed().as_millis()).unwrap_or(u64::MAX)
     }
 
     /// Increment retry count

--- a/crates/mofa-foundation/src/agent/components/tool.rs
+++ b/crates/mofa-foundation/src/agent/components/tool.rs
@@ -333,7 +333,7 @@ impl SimpleToolRegistry {
                     steps: vec![ExecutionStep {
                         step_id: format!("tool:{}", tool_name),
                         step_type: "tool_call".to_string(),
-                        timestamp_ms: chrono::Utc::now().timestamp_millis() as u64,
+                        timestamp_ms: mofa_kernel::utils::chrono_now_ms(),
                         input: Some(args_json.clone()),
                         output: None,
                         metadata: HashMap::new(),

--- a/crates/mofa-foundation/src/agent/context/rich.rs
+++ b/crates/mofa-foundation/src/agent/context/rich.rs
@@ -50,10 +50,7 @@ impl ExecutionMetrics {
     /// 创建新的指标
     /// Create new metrics
     pub fn new() -> Self {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64;
+        let now = mofa_kernel::utils::now_ms();
 
         Self {
             start_time_ms: now,
@@ -64,10 +61,7 @@ impl ExecutionMetrics {
     /// 获取执行时长 (毫秒)
     /// Get execution duration (ms)
     pub fn duration_ms(&self) -> u64 {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64;
+        let now = mofa_kernel::utils::now_ms();
 
         self.end_time_ms.unwrap_or(now) - self.start_time_ms
     }
@@ -131,10 +125,7 @@ impl RichAgentContext {
     /// 记录组件输出
     /// Record component output
     pub async fn record_output(&self, component: impl Into<String>, output: serde_json::Value) {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64;
+        let now = mofa_kernel::utils::now_ms();
 
         let mut outputs = self.outputs.write().await;
         outputs.push(ComponentOutput {
@@ -185,10 +176,7 @@ impl RichAgentContext {
     /// 结束执行 (记录结束时间)
     /// Finish execution (record end time)
     pub async fn finish(&self) {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64;
+        let now = mofa_kernel::utils::now_ms();
 
         let mut metrics = self.metrics.write().await;
         metrics.end_time_ms = Some(now);

--- a/crates/mofa-foundation/src/collaboration/mod.rs
+++ b/crates/mofa-foundation/src/collaboration/mod.rs
@@ -247,7 +247,7 @@ impl CollaborationProtocol for RequestResponseProtocol {
             // Received and processed request from {}
         };
 
-        let duration = start.elapsed().as_millis() as u64;
+        let duration = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
 
         Ok(
             CollaborationResult::success(content, duration, CollaborationMode::RequestResponse)
@@ -383,7 +383,7 @@ impl CollaborationProtocol for PublishSubscribeProtocol {
             // Message published to topic {:?}
         };
 
-        let duration = start.elapsed().as_millis() as u64;
+        let duration = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
 
         Ok(
             CollaborationResult::success(content, duration, CollaborationMode::PublishSubscribe)
@@ -510,7 +510,7 @@ impl CollaborationProtocol for ConsensusProtocol {
             // Participated in consensus decision, threshold: {}
         };
 
-        let duration = start.elapsed().as_millis() as u64;
+        let duration = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
 
         Ok(
             CollaborationResult::success(content, duration, CollaborationMode::Consensus)
@@ -633,7 +633,7 @@ impl CollaborationProtocol for DebateProtocol {
             // Participated in debate, max rounds: {}
         };
 
-        let duration = start.elapsed().as_millis() as u64;
+        let duration = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
 
         Ok(
             CollaborationResult::success(content, duration, CollaborationMode::Debate)
@@ -759,7 +759,7 @@ impl CollaborationProtocol for ParallelProtocol {
             ))
         };
 
-        let duration = start.elapsed().as_millis() as u64;
+        let duration = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
 
         Ok(
             CollaborationResult::success(content, duration, CollaborationMode::Parallel)
@@ -882,7 +882,7 @@ impl CollaborationProtocol for SequentialProtocol {
             // Sequential task chain executed
         };
 
-        let duration = start.elapsed().as_millis() as u64;
+        let duration = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
 
         Ok(
             CollaborationResult::success(content, duration, CollaborationMode::Sequential)

--- a/crates/mofa-foundation/src/collaboration/types.rs
+++ b/crates/mofa-foundation/src/collaboration/types.rs
@@ -260,10 +260,7 @@ impl CollaborationMessage {
         content: impl Into<CollaborationContent>,
         mode: CollaborationMode,
     ) -> Self {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64;
+        let now = mofa_kernel::utils::now_ms();
 
         Self {
             id: Uuid::now_v7().to_string(),
@@ -785,7 +782,7 @@ impl LLMDrivenCollaborationManager {
         // Process message
         let result = protocol.process_message(msg).await;
 
-        let duration = start.elapsed().as_millis() as u64;
+        let duration = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
 
         match result {
             Ok(mut result) => {

--- a/crates/mofa-foundation/src/react/actor.rs
+++ b/crates/mofa-foundation/src/react/actor.rs
@@ -498,7 +498,7 @@ impl AutoAgent {
                 mode: ExecutionMode::ReAct,
                 answer,
                 react_result: Some(result),
-                duration_ms: start.elapsed().as_millis() as u64,
+                duration_ms: u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
             });
         }
 
@@ -515,7 +515,7 @@ impl AutoAgent {
                     mode: ExecutionMode::Direct,
                     answer,
                     react_result: None,
-                    duration_ms: start.elapsed().as_millis() as u64,
+                    duration_ms: u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
                 })
             }
             TaskComplexity::RequiresTool | TaskComplexity::Complex => {
@@ -527,7 +527,7 @@ impl AutoAgent {
                     mode: ExecutionMode::ReAct,
                     answer,
                     react_result: Some(result),
-                    duration_ms: start.elapsed().as_millis() as u64,
+                    duration_ms: u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
                 })
             }
         }

--- a/crates/mofa-foundation/src/react/core.rs
+++ b/crates/mofa-foundation/src/react/core.rs
@@ -105,10 +105,7 @@ impl ReActStep {
     }
 
     fn current_timestamp() -> u64 {
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64
+        mofa_kernel::utils::now_ms()
     }
 }
 
@@ -441,7 +438,7 @@ impl ReActAgent {
                         answer,
                         steps,
                         iteration + 1,
-                        start_time.elapsed().as_millis() as u64,
+                        u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX),
                     ));
                 }
                 ParsedResponse::Error(err) => {
@@ -451,7 +448,7 @@ impl ReActAgent {
                         err,
                         steps,
                         iteration + 1,
-                        start_time.elapsed().as_millis() as u64,
+                        u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX),
                     ));
                 }
             }
@@ -465,7 +462,7 @@ impl ReActAgent {
             format!("Max iterations ({}) exceeded", self.config.max_iterations),
             steps,
             self.config.max_iterations,
-            start_time.elapsed().as_millis() as u64,
+            u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX),
         ))
     }
 
@@ -542,7 +539,7 @@ impl ReActAgent {
                         answer,
                         steps,
                         iteration + 1,
-                        start_time.elapsed().as_millis() as u64,
+                        u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX),
                     ));
                 }
                 ParsedResponse::Error(err) => {
@@ -552,7 +549,7 @@ impl ReActAgent {
                         err,
                         steps,
                         iteration + 1,
-                        start_time.elapsed().as_millis() as u64,
+                        u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX),
                     ));
                 }
             }
@@ -564,7 +561,7 @@ impl ReActAgent {
             format!("Max iterations ({}) exceeded", self.config.max_iterations),
             steps,
             self.config.max_iterations,
-            start_time.elapsed().as_millis() as u64,
+            u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX),
         ))
     }
 
@@ -700,13 +697,11 @@ Rules:
 
         async {
             match maybe_tool {
-                Some(tool) => {
-                    match tokio::time::timeout(timeout_dur, tool.execute(input)).await {
-                        Ok(Ok(result)) => result,
-                        Ok(Err(e)) => format!("Tool error: {}", e),
-                        Err(_) => format!("Tool '{}' timed out after {:?}", tool_name, timeout_dur),
-                    }
-                }
+                Some(tool) => match tokio::time::timeout(timeout_dur, tool.execute(input)).await {
+                    Ok(Ok(result)) => result,
+                    Ok(Err(e)) => format!("Tool error: {}", e),
+                    Err(_) => format!("Tool '{}' timed out after {:?}", tool_name, timeout_dur),
+                },
                 None => {
                     let tools = self.tools.read().await;
                     format!(

--- a/crates/mofa-foundation/src/react/patterns.rs
+++ b/crates/mofa-foundation/src/react/patterns.rs
@@ -147,7 +147,7 @@ impl AgentUnit {
                     task,
                     success: true,
                     error: None,
-                    duration_ms: start.elapsed().as_millis() as u64,
+                    duration_ms: u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
                     metadata: None,
                 })
             }
@@ -376,7 +376,8 @@ impl ChainAgent {
                                 steps: step_results,
                                 success: false,
                                 error: output.error,
-                                total_duration_ms: start_time.elapsed().as_millis() as u64,
+                                total_duration_ms: u64::try_from(start_time.elapsed().as_millis())
+                                    .unwrap_or(u64::MAX),
                             });
                         }
                     }
@@ -419,7 +420,8 @@ impl ChainAgent {
                             steps: step_results,
                             success: false,
                             error: Some(e.to_string()),
-                            total_duration_ms: start_time.elapsed().as_millis() as u64,
+                            total_duration_ms: u64::try_from(start_time.elapsed().as_millis())
+                                .unwrap_or(u64::MAX),
                         });
                     }
                 }
@@ -433,7 +435,7 @@ impl ChainAgent {
             steps: step_results,
             success: all_success,
             error: None,
-            total_duration_ms: start_time.elapsed().as_millis() as u64,
+            total_duration_ms: u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX),
         })
     }
 
@@ -797,7 +799,7 @@ impl ParallelAgent {
             aggregated_output,
             individual_results: step_results,
             success: all_success,
-            total_duration_ms: start_time.elapsed().as_millis() as u64,
+            total_duration_ms: u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX),
         })
     }
 
@@ -1300,7 +1302,7 @@ impl MapReduceAgent {
             input,
             map_results,
             reduce_output,
-            total_duration_ms: start_time.elapsed().as_millis() as u64,
+            total_duration_ms: u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX),
         })
     }
 }

--- a/crates/mofa-foundation/src/react/reflection.rs
+++ b/crates/mofa-foundation/src/react/reflection.rs
@@ -235,7 +235,7 @@ impl ReflectionAgent {
             draft = refined;
         }
 
-        let duration_ms = start.elapsed().as_millis() as u64;
+        let duration_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
         if self.config.verbose {
             tracing::info!(
                 "[Reflection] Completed in {} rounds, {}ms",

--- a/crates/mofa-foundation/src/scheduler/deferred.rs
+++ b/crates/mofa-foundation/src/scheduler/deferred.rs
@@ -35,7 +35,7 @@ impl DeferredRequest {
 
     /// How long this request has been waiting (milliseconds).
     pub fn wait_time_ms(&self) -> u64 {
-        self.enqueued_at.elapsed().as_millis() as u64
+        u64::try_from(self.enqueued_at.elapsed().as_millis()).unwrap_or(u64::MAX)
     }
 
     /// Increment the retry counter.

--- a/crates/mofa-foundation/src/secretary/core.rs
+++ b/crates/mofa-foundation/src/secretary/core.rs
@@ -387,7 +387,8 @@ where
                     // 没有输入，执行定时检查
                     // No input, perform periodic check
                     if self.config.enable_periodic_check {
-                        let elapsed = last_periodic_check.elapsed().as_millis() as u64;
+                        let elapsed = u64::try_from(last_periodic_check.elapsed().as_millis())
+                            .unwrap_or(u64::MAX);
                         if elapsed >= self.config.periodic_check_interval_ms {
                             last_periodic_check = std::time::Instant::now();
 

--- a/crates/mofa-foundation/src/workflow/executor.rs
+++ b/crates/mofa-foundation/src/workflow/executor.rs
@@ -184,7 +184,7 @@ impl WorkflowExecutor {
                     steps.push(ExecutionStep {
                         step_id: nid.clone(),
                         step_type: "workflow_node".to_string(),
-                        timestamp_ms: chrono::Utc::now().timestamp_millis() as u64,
+                        timestamp_ms: mofa_kernel::utils::chrono_now_ms(),
                         input: None,
                         output: serde_json::to_value(&output).ok(),
                         metadata: HashMap::new(),
@@ -197,7 +197,7 @@ impl WorkflowExecutor {
         steps.push(ExecutionStep {
             step_id: node_id.to_string(),
             step_type: "review_node".to_string(),
-            timestamp_ms: chrono::Utc::now().timestamp_millis() as u64,
+            timestamp_ms: mofa_kernel::utils::chrono_now_ms(),
             input: serde_json::to_value(input).ok(),
             output: None,
             metadata: HashMap::new(),
@@ -206,7 +206,15 @@ impl WorkflowExecutor {
         // Calculate duration from paused_at if available
         let duration_ms = if let Some(paused_at) = *ctx.paused_at.read().await {
             let now = chrono::Utc::now();
-            now.signed_duration_since(paused_at).num_milliseconds() as u64
+            // num_milliseconds() returns i64 and can be negative if the clock
+            // jumped forward while the workflow was paused (NTP correction).
+            // Clamp to 0 before converting so we never wrap to near u64::MAX.
+            u64::try_from(
+                now.signed_duration_since(paused_at)
+                    .num_milliseconds()
+                    .max(0),
+            )
+            .unwrap_or(0)
         } else {
             0
         };
@@ -270,10 +278,7 @@ impl WorkflowExecutor {
         self.emit_event(ExecutionEvent::WorkflowStarted {
             workflow_id: graph.id.clone(),
             workflow_name: graph.name.clone(),
-            started_at: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as u64,
+            started_at: mofa_kernel::utils::now_ms(),
         })
         .await;
 
@@ -309,10 +314,7 @@ impl WorkflowExecutor {
         let mut execution_record = ExecutionRecord {
             execution_id: ctx.execution_id.clone(),
             workflow_id: graph.id.clone(),
-            started_at: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as u64,
+            started_at: mofa_kernel::utils::now_ms(),
             ended_at: None,
             status: WorkflowStatus::Running,
             node_records: Vec::new(),
@@ -342,12 +344,7 @@ impl WorkflowExecutor {
         };
 
         let duration = start_time.elapsed();
-        execution_record.ended_at = Some(
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as u64,
-        );
+        execution_record.ended_at = Some(mofa_kernel::utils::now_ms());
 
         let final_status = match result {
             Ok(_) => {
@@ -376,7 +373,7 @@ impl WorkflowExecutor {
                 self.emit_event(ExecutionEvent::WorkflowFailed {
                     workflow_id: graph.id.clone(),
                     error: e.clone(),
-                    total_duration_ms: duration.as_millis() as u64,
+                    total_duration_ms: u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
                 })
                 .await;
             }
@@ -384,7 +381,7 @@ impl WorkflowExecutor {
                 self.emit_event(ExecutionEvent::WorkflowCompleted {
                     workflow_id: graph.id.clone(),
                     final_output: None,
-                    total_duration_ms: duration.as_millis() as u64,
+                    total_duration_ms: u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
                 })
                 .await;
             }
@@ -477,10 +474,7 @@ impl WorkflowExecutor {
         let mut execution_record = ExecutionRecord {
             execution_id: ctx.execution_id.clone(),
             workflow_id: graph.id.clone(),
-            started_at: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as u64,
+            started_at: mofa_kernel::utils::now_ms(),
             ended_at: None,
             status: WorkflowStatus::Running,
             node_records: Vec::new(),
@@ -505,12 +499,7 @@ impl WorkflowExecutor {
             .await;
 
         let duration = start_time.elapsed();
-        execution_record.ended_at = Some(
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as u64,
-        );
+        execution_record.ended_at = Some(mofa_kernel::utils::now_ms());
 
         let final_status = match result {
             Ok(_) => {
@@ -535,7 +524,7 @@ impl WorkflowExecutor {
                 self.emit_event(ExecutionEvent::WorkflowFailed {
                     workflow_id: graph.id.clone(),
                     error: e.clone(),
-                    total_duration_ms: duration.as_millis() as u64,
+                    total_duration_ms: u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
                 })
                 .await;
             }
@@ -543,7 +532,7 @@ impl WorkflowExecutor {
                 self.emit_event(ExecutionEvent::WorkflowCompleted {
                     workflow_id: graph.id.clone(),
                     final_output: None,
-                    total_duration_ms: duration.as_millis() as u64,
+                    total_duration_ms: u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
                 })
                 .await;
             }
@@ -571,10 +560,7 @@ impl WorkflowExecutor {
         self.emit_event(ExecutionEvent::WorkflowStarted {
             workflow_id: graph.id.clone(),
             workflow_name: graph.name.clone(),
-            started_at: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as u64,
+            started_at: mofa_kernel::utils::now_ms(),
         })
         .await;
 
@@ -607,10 +593,7 @@ impl WorkflowExecutor {
         let mut execution_record = ExecutionRecord {
             execution_id: ctx.execution_id.clone(),
             workflow_id: graph.id.clone(),
-            started_at: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as u64,
+            started_at: mofa_kernel::utils::now_ms(),
             ended_at: None,
             status: WorkflowStatus::Running,
             node_records: Vec::new(),
@@ -630,12 +613,7 @@ impl WorkflowExecutor {
             .await;
 
         let duration = start_time.elapsed();
-        execution_record.ended_at = Some(
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as u64,
-        );
+        execution_record.ended_at = Some(mofa_kernel::utils::now_ms());
 
         match result {
             Ok(_) => {
@@ -658,7 +636,7 @@ impl WorkflowExecutor {
                 self.emit_event(ExecutionEvent::WorkflowFailed {
                     workflow_id: graph.id.clone(),
                     error: e.clone(),
-                    total_duration_ms: duration.as_millis() as u64,
+                    total_duration_ms: u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
                 })
                 .await;
             }
@@ -666,7 +644,7 @@ impl WorkflowExecutor {
                 self.emit_event(ExecutionEvent::WorkflowCompleted {
                     workflow_id: graph.id.clone(),
                     final_output: None,
-                    total_duration_ms: duration.as_millis() as u64,
+                    total_duration_ms: u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
                 })
                 .await;
             }
@@ -801,10 +779,7 @@ impl WorkflowExecutor {
             })
             .await;
 
-            let start_time = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as u64;
+            let start_time = mofa_kernel::utils::now_ms();
 
             ctx.set_node_status(&current_node_id, NodeStatus::Running)
                 .await;
@@ -827,9 +802,8 @@ impl WorkflowExecutor {
                 }
                 NodeType::Wait => self.execute_wait(ctx, node, current_input.clone()).await,
                 _ => {
-                    let node_timeout = std::time::Duration::from_millis(
-                        self.config.node_timeout_ms,
-                    );
+                    let node_timeout =
+                        std::time::Duration::from_millis(self.config.node_timeout_ms);
                     let result = match tokio::time::timeout(
                         node_timeout,
                         node.execute(ctx, current_input.clone()),
@@ -844,11 +818,8 @@ impl WorkflowExecutor {
                             );
                             NodeResult::failed(
                                 &current_node_id,
-                                &format!(
-                                    "Node timed out after {:?}",
-                                    node_timeout
-                                ),
-                                node_timeout.as_millis() as u64,
+                                &format!("Node timed out after {:?}", node_timeout),
+                                u64::try_from(node_timeout.as_millis()).unwrap_or(u64::MAX),
                             )
                         }
                     };
@@ -856,10 +827,7 @@ impl WorkflowExecutor {
                         .await;
                     ctx.set_node_status(&current_node_id, result.status.clone())
                         .await;
-                    let node_end_ms = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_millis() as u64;
+                    let node_end_ms = mofa_kernel::utils::now_ms();
                     self.emit_event(ExecutionEvent::NodeCompleted {
                         node_id: current_node_id.clone(),
                         output: serde_json::to_value(&result.output).ok(),
@@ -874,10 +842,7 @@ impl WorkflowExecutor {
                 }
             };
 
-            let end_time = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as u64;
+            let end_time = mofa_kernel::utils::now_ms();
 
             // Emit debug telemetry: NodeEnd
             self.emit_debug(DebugEvent::NodeEnd {
@@ -1324,10 +1289,7 @@ impl WorkflowExecutor {
         let mut execution_record = ExecutionRecord {
             execution_id: ctx.execution_id.clone(),
             workflow_id: graph.id.clone(),
-            started_at: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as u64,
+            started_at: mofa_kernel::utils::now_ms(),
             ended_at: None,
             status: WorkflowStatus::Running,
             node_records: Vec::new(),
@@ -1357,10 +1319,7 @@ impl WorkflowExecutor {
                     .collect();
 
                 join_set.spawn(async move {
-                    let node_start_time = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_millis() as u64;
+                    let node_start_time = mofa_kernel::utils::now_ms();
                     let _permit = match semaphore.acquire_owned().await {
                         Ok(permit) => permit,
                         Err(e) => {
@@ -1418,10 +1377,7 @@ impl WorkflowExecutor {
                         NodeResult::failed(&n_id, "Node not found", 0)
                     };
 
-                    let node_end_time = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_millis() as u64;
+                    let node_end_time = mofa_kernel::utils::now_ms();
 
                     tracing::debug!(
                         "Branch {} completed in {}ms",
@@ -1464,12 +1420,7 @@ impl WorkflowExecutor {
                     execution_record.status = WorkflowStatus::Failed(
                         result.error.unwrap_or_else(|| "Unknown error".to_string()),
                     );
-                    execution_record.ended_at = Some(
-                        std::time::SystemTime::now()
-                            .duration_since(std::time::UNIX_EPOCH)
-                            .unwrap_or_default()
-                            .as_millis() as u64,
-                    );
+                    execution_record.ended_at = Some(mofa_kernel::utils::now_ms());
                     execution_record.outputs = ctx_ref.get_all_outputs().await;
                     return Ok(execution_record);
                 }
@@ -1478,12 +1429,7 @@ impl WorkflowExecutor {
 
         let duration = start_time.elapsed();
         execution_record.status = WorkflowStatus::Completed;
-        execution_record.ended_at = Some(
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as u64,
-        );
+        execution_record.ended_at = Some(mofa_kernel::utils::now_ms());
 
         execution_record.outputs = ctx.get_all_outputs().await;
 
@@ -1934,9 +1880,7 @@ mod tests {
         graph.add_node(WorkflowNode::task(
             "fast_task",
             "Fast Task",
-            |_ctx, _input| async move {
-                Ok(WorkflowValue::String("fast".to_string()))
-            },
+            |_ctx, _input| async move { Ok(WorkflowValue::String("fast".to_string())) },
         ));
         graph.add_node(WorkflowNode::end("end"));
         graph.connect("start", "fast_task");

--- a/crates/mofa-foundation/src/workflow/fault_tolerance.rs
+++ b/crates/mofa-foundation/src/workflow/fault_tolerance.rs
@@ -234,7 +234,7 @@ pub(crate) async fn execute_with_policy<S: GraphState>(
                         node_id = node_id,
                         attempt = attempt + 1,
                         max_attempts = max_attempts,
-                        delay_ms = delay.as_millis() as u64,
+                        delay_ms = u64::try_from(delay.as_millis()).unwrap_or(u64::MAX),
                         error = %err_msg,
                         "Retrying node after transient failure"
                     );
@@ -318,4 +318,3 @@ pub(crate) enum NodeExecutionOutcome {
 }
 
 // ────────────────────── Tests ──────────────────────
-

--- a/crates/mofa-foundation/src/workflow/node.rs
+++ b/crates/mofa-foundation/src/workflow/node.rs
@@ -686,12 +686,20 @@ impl WorkflowNode {
             NodeType::Start => {
                 // 开始节点直接传递输入
                 // Start node simply passes input through
-                NodeResult::success(node_id, input, start_time.elapsed().as_millis() as u64)
+                NodeResult::success(
+                    node_id,
+                    input,
+                    u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX),
+                )
             }
             NodeType::End => {
                 // 结束节点直接传递输入
                 // End node simply passes input through
-                NodeResult::success(node_id, input, start_time.elapsed().as_millis() as u64)
+                NodeResult::success(
+                    node_id,
+                    input,
+                    u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX),
+                )
             }
             NodeType::Task | NodeType::Agent => {
                 self.execute_with_retry(ctx, input, start_time).await
@@ -706,7 +714,7 @@ impl WorkflowNode {
                     NodeResult::success(
                         node_id,
                         WorkflowValue::String(branch.to_string()),
-                        start_time.elapsed().as_millis() as u64,
+                        u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX),
                     )
                 } else {
                     NodeResult::failed(node_id, "No condition function", 0)
@@ -723,7 +731,7 @@ impl WorkflowNode {
                             .map(|b| WorkflowValue::String(b.clone()))
                             .collect(),
                     ),
-                    start_time.elapsed().as_millis() as u64,
+                    u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX),
                 )
             }
             NodeType::Join => {
@@ -747,7 +755,11 @@ impl WorkflowNode {
                     WorkflowValue::Map(outputs)
                 };
 
-                NodeResult::success(node_id, result, start_time.elapsed().as_millis() as u64)
+                NodeResult::success(
+                    node_id,
+                    result,
+                    u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX),
+                )
             }
             NodeType::Loop => self.execute_loop(ctx, input, start_time).await,
             NodeType::Transform => {
@@ -755,7 +767,11 @@ impl WorkflowNode {
                     let mut inputs = HashMap::new();
                     inputs.insert("input".to_string(), input);
                     let result = transform_fn(inputs).await;
-                    NodeResult::success(node_id, result, start_time.elapsed().as_millis() as u64)
+                    NodeResult::success(
+                        node_id,
+                        result,
+                        u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX),
+                    )
                 } else {
                     NodeResult::failed(node_id, "No transform function", 0)
                 }
@@ -763,12 +779,20 @@ impl WorkflowNode {
             NodeType::SubWorkflow => {
                 // 子工作流执行由 executor 处理
                 // Sub-workflow execution handled by executor
-                NodeResult::success(node_id, input, start_time.elapsed().as_millis() as u64)
+                NodeResult::success(
+                    node_id,
+                    input,
+                    u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX),
+                )
             }
             NodeType::Wait => {
                 // 等待节点由 executor 处理
                 // Wait node handled by executor
-                NodeResult::success(node_id, input, start_time.elapsed().as_millis() as u64)
+                NodeResult::success(
+                    node_id,
+                    input,
+                    u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX),
+                )
             }
         }
     }
@@ -796,7 +820,7 @@ impl WorkflowNode {
                     let mut result = NodeResult::success(
                         node_id,
                         output,
-                        start_time.elapsed().as_millis() as u64,
+                        u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX),
                     );
                     result.retry_count = retry_count;
                     return result;
@@ -817,7 +841,7 @@ impl WorkflowNode {
                         let mut result = NodeResult::failed(
                             node_id,
                             &e,
-                            start_time.elapsed().as_millis() as u64,
+                            u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX),
                         );
                         result.retry_count = retry_count;
                         return result;
@@ -875,7 +899,7 @@ impl WorkflowNode {
                     return NodeResult::failed(
                         node_id,
                         &format!("Loop failed at iteration {}: {}", iteration, e),
-                        start_time.elapsed().as_millis() as u64,
+                        u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX),
                     );
                 }
             }
@@ -887,7 +911,11 @@ impl WorkflowNode {
             warn!("Loop {} reached max iterations: {}", node_id, max_iter);
         }
 
-        NodeResult::success(node_id, input, start_time.elapsed().as_millis() as u64)
+        NodeResult::success(
+            node_id,
+            input,
+            u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX),
+        )
     }
 }
 

--- a/crates/mofa-foundation/src/workflow/state.rs
+++ b/crates/mofa-foundation/src/workflow/state.rs
@@ -452,10 +452,7 @@ impl WorkflowContext {
     pub async fn create_checkpoint(&self, label: &str) {
         let checkpoint = CheckpointData {
             label: label.to_string(),
-            timestamp: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as u64,
+            timestamp: mofa_kernel::utils::now_ms(),
             node_outputs: self.node_outputs.read().await.clone(),
             node_statuses: self.node_statuses.read().await.clone(),
             variables: self.variables.read().await.clone(),

--- a/crates/mofa-gateway/src/handlers/chat.rs
+++ b/crates/mofa-gateway/src/handlers/chat.rs
@@ -111,7 +111,7 @@ pub async fn chat(
             .await
             .map_err(|e| GatewayError::AgentOperationFailed(e.to_string()))?
     };
-    let duration_ms = start.elapsed().as_millis() as u64;
+    let duration_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
 
     tracing::info!(
         agent_id = %id,
@@ -120,8 +120,8 @@ pub async fn chat(
         "chat request completed"
     );
 
-    let output_value = serde_json::to_value(&output.content)
-        .unwrap_or_else(|_| json!(output.content.to_text()));
+    let output_value =
+        serde_json::to_value(&output.content).unwrap_or_else(|_| json!(output.content.to_text()));
 
     let response = ChatResponse {
         agent_id: id,

--- a/crates/mofa-gateway/src/openai_compat/handler.rs
+++ b/crates/mofa-gateway/src/openai_compat/handler.rs
@@ -203,7 +203,7 @@ pub async fn chat_completions(
             let mut orch = state.orchestrator.write().await;
             orch.infer_stream(&inference_req)
         };
-        let latency_ms = start.elapsed().as_millis() as u64;
+        let latency_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
 
         let backend_label = result.routed_to.to_string();
         let model_used = req.model.clone();
@@ -215,7 +215,7 @@ pub async fn chat_completions(
             let mut orch = state.orchestrator.write().await;
             orch.infer(&inference_req)
         };
-        let latency_ms = start.elapsed().as_millis() as u64;
+        let latency_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
 
         let backend_label = result.routed_to.to_string();
         let output_text = result.output.clone();

--- a/crates/mofa-kernel/src/agent/types/error.rs
+++ b/crates/mofa-kernel/src/agent/types/error.rs
@@ -350,10 +350,7 @@ pub struct ErrorContext {
 impl ErrorContext {
     /// Create new error context (auto-captures timestamp)
     pub fn new(message: impl Into<String>) -> Self {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64;
+        let now = crate::utils::now_ms();
         Self {
             message: message.into(),
             location: None,

--- a/crates/mofa-kernel/src/hitl/audit.rs
+++ b/crates/mofa-kernel/src/hitl/audit.rs
@@ -72,7 +72,7 @@ impl ReviewAuditEvent {
             node_id: None,
             tenant_id: None,
             actor,
-            timestamp_ms: chrono::Utc::now().timestamp_millis() as u64,
+            timestamp_ms: crate::utils::chrono_now_ms(),
             data: HashMap::new(),
             ip_address: None,
             user_agent: None,

--- a/crates/mofa-kernel/src/utils.rs
+++ b/crates/mofa-kernel/src/utils.rs
@@ -11,6 +11,25 @@ pub fn now_ms() -> u64 {
     u64::try_from(millis).unwrap_or(0)
 }
 
+/// Get the current timestamp in milliseconds since the Unix epoch using
+/// `chrono::Utc::now()`, safely avoiding signed-to-unsigned wraparound.
+///
+/// `chrono::DateTime::timestamp_millis()` returns `i64`. On hosts where the
+/// system clock is set before the Unix epoch (misconfigured CI, NTP backward
+/// jump, VM clock skew), that value is negative. Casting a negative `i64`
+/// to `u64` with `as` wraps it to near `u64::MAX`, silently corrupting any
+/// timestamp stored from the result. This function clamps such cases to 0.
+///
+/// Use this instead of `chrono::Utc::now().timestamp_millis() as u64`.
+pub fn chrono_now_ms() -> u64 {
+    // try_into() uses TryFrom<i64> for u64, which fails for negative values.
+    // We want 0 in that case — not u64::MAX — so we unwrap_or(0).
+    chrono::Utc::now()
+        .timestamp_millis()
+        .try_into()
+        .unwrap_or(0)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -18,8 +37,6 @@ mod tests {
     #[test]
     fn now_ms_returns_reasonable_epoch_millis() {
         let ms = now_ms();
-        // Must be after 2020-01-01 (~1_577_836_800_000 ms) and before some far
-        // future date.  This validates the safe u128→u64 conversion path.
         assert!(
             ms > 1_577_836_800_000,
             "now_ms() returned {ms}, expected > 2020-01-01 epoch millis"
@@ -31,5 +48,32 @@ mod tests {
         let a = now_ms();
         let b = now_ms();
         assert!(b >= a);
+    }
+
+    #[test]
+    fn chrono_now_ms_returns_reasonable_epoch_millis() {
+        let ms = chrono_now_ms();
+        assert!(
+            ms > 1_577_836_800_000,
+            "chrono_now_ms() returned {ms}, expected > 2020-01-01 epoch millis"
+        );
+    }
+
+    #[test]
+    fn chrono_now_ms_is_monotonically_non_decreasing() {
+        let a = chrono_now_ms();
+        let b = chrono_now_ms();
+        assert!(b >= a);
+    }
+
+    #[test]
+    fn chrono_now_ms_consistent_with_now_ms() {
+        let a = now_ms();
+        let b = chrono_now_ms();
+        let diff = a.abs_diff(b);
+        assert!(
+            diff < 200,
+            "now_ms()={a} and chrono_now_ms()={b} differ by {diff}ms"
+        );
     }
 }

--- a/crates/mofa-plugins/src/rhai_runtime/plugin.rs
+++ b/crates/mofa-plugins/src/rhai_runtime/plugin.rs
@@ -715,7 +715,7 @@ impl AgentPlugin for RhaiPlugin {
         // --- stats: start wall-clock timer ---
         let timer = Instant::now();
         let result = self.execute_script(input).await;
-        let latency_ms = timer.elapsed().as_millis() as u64;
+        let latency_ms = u64::try_from(timer.elapsed().as_millis()).unwrap_or(u64::MAX);
         self.stats.record(latency_ms, result.is_err());
         result
     }

--- a/crates/mofa-plugins/src/wasm_runtime/host.rs
+++ b/crates/mofa-plugins/src/wasm_runtime/host.rs
@@ -251,10 +251,7 @@ impl HostFunctions for DefaultHostFunctions {
         let msg = HostMessage {
             target: target.to_string(),
             payload: payload.to_vec(),
-            timestamp: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as u64,
+            timestamp: mofa_kernel::utils::now_ms(),
         };
 
         self.context.message_queue.write().await.push(msg);
@@ -315,10 +312,7 @@ impl HostFunctions for DefaultHostFunctions {
     }
 
     async fn now_ms(&self) -> WasmResult<u64> {
-        Ok(std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64)
+        Ok(mofa_kernel::utils::now_ms())
     }
 
     async fn random_bytes(&self, len: u32) -> WasmResult<Vec<u8>> {

--- a/crates/mofa-plugins/src/wasm_runtime/manager.rs
+++ b/crates/mofa-plugins/src/wasm_runtime/manager.rs
@@ -393,7 +393,8 @@ impl WasmPluginManager {
         {
             let mut stats = self.stats.write().await;
             stats.total_calls += 1;
-            stats.total_execution_time_ms += duration.as_millis() as u64;
+            stats.total_execution_time_ms +=
+                u64::try_from(duration.as_millis()).unwrap_or(u64::MAX);
             if result.is_err() {
                 stats.failed_calls += 1;
             }
@@ -403,7 +404,7 @@ impl WasmPluginManager {
         let _ = self.event_tx.send(PluginEvent::Executed {
             plugin_id: handle.id().to_string(),
             function: function.to_string(),
-            duration_ms: duration.as_millis() as u64,
+            duration_ms: u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
             success: result.is_ok(),
         });
 
@@ -427,7 +428,8 @@ impl WasmPluginManager {
         {
             let mut stats = self.stats.write().await;
             stats.total_calls += 1;
-            stats.total_execution_time_ms += duration.as_millis() as u64;
+            stats.total_execution_time_ms +=
+                u64::try_from(duration.as_millis()).unwrap_or(u64::MAX);
             if result.is_err() {
                 stats.failed_calls += 1;
             }
@@ -437,7 +439,7 @@ impl WasmPluginManager {
         let _ = self.event_tx.send(PluginEvent::Executed {
             plugin_id: handle.id().to_string(),
             function: function.to_string(),
-            duration_ms: duration.as_millis() as u64,
+            duration_ms: u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
             success: result.is_ok(),
         });
 

--- a/crates/mofa-plugins/src/wasm_runtime/runtime.rs
+++ b/crates/mofa-plugins/src/wasm_runtime/runtime.rs
@@ -361,7 +361,7 @@ impl WasmRuntime {
         let start = Instant::now();
         let module = Module::new(&self.engine, bytes)
             .map_err(|e| WasmError::CompilationError(e.to_string()))?;
-        let compile_time = start.elapsed().as_millis() as u64;
+        let compile_time = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
 
         let compiled = CompiledModule::new(name, module, bytes, compile_time);
 

--- a/crates/mofa-runtime/src/dora_adapter/channel.rs
+++ b/crates/mofa-runtime/src/dora_adapter/channel.rs
@@ -80,10 +80,7 @@ impl MessageEnvelope {
             sender_id: sender_id.to_string(),
             receiver_id: None,
             topic: None,
-            timestamp: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as u64,
+            timestamp: mofa_kernel::utils::now_ms(),
             payload,
             metadata: HashMap::new(),
         }

--- a/crates/mofa-runtime/src/native_dataflow/channel.rs
+++ b/crates/mofa-runtime/src/native_dataflow/channel.rs
@@ -73,10 +73,7 @@ impl MessageEnvelope {
             sender_id: sender_id.to_string(),
             receiver_id: None,
             topic: None,
-            timestamp: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as u64,
+            timestamp: mofa_kernel::utils::now_ms(),
             payload,
             metadata: HashMap::new(),
         }
@@ -101,10 +98,7 @@ impl MessageEnvelope {
     }
 
     /// Serialize an [`AgentMessage`] into an envelope.
-    pub fn from_agent_message(
-        sender_id: &str,
-        message: &AgentMessage,
-    ) -> DataflowResult<Self> {
+    pub fn from_agent_message(sender_id: &str, message: &AgentMessage) -> DataflowResult<Self> {
         let payload = bincode::serialize(message)?;
         Ok(Self::new(sender_id, payload))
     }
@@ -158,7 +152,10 @@ impl NativeChannel {
             receivers.insert(agent_id.to_string(), Arc::new(Mutex::new(rx)));
         }
 
-        info!("Agent '{}' registered to channel '{}'", agent_id, self.config.channel_id);
+        info!(
+            "Agent '{}' registered to channel '{}'",
+            agent_id, self.config.channel_id
+        );
         Ok(())
     }
 
@@ -223,10 +220,9 @@ impl NativeChannel {
 
     /// Send a point-to-point message to the receiver specified in the envelope.
     pub async fn send_p2p(&self, envelope: MessageEnvelope) -> DataflowResult<()> {
-        let receiver_id = envelope
-            .receiver_id
-            .clone()
-            .ok_or_else(|| DataflowError::ChannelError("No receiver specified for P2P".to_string()))?;
+        let receiver_id = envelope.receiver_id.clone().ok_or_else(|| {
+            DataflowError::ChannelError("No receiver specified for P2P".to_string())
+        })?;
 
         let senders = self.p2p_senders.read().await;
         let tx = senders.get(&receiver_id).ok_or_else(|| {
@@ -252,10 +248,9 @@ impl NativeChannel {
 
     /// Publish a message to all subscribers of the topic set in the envelope.
     pub async fn publish(&self, envelope: MessageEnvelope) -> DataflowResult<()> {
-        let topic = envelope
-            .topic
-            .clone()
-            .ok_or_else(|| DataflowError::ChannelError("No topic specified for publish".to_string()))?;
+        let topic = envelope.topic.clone().ok_or_else(|| {
+            DataflowError::ChannelError("No topic specified for publish".to_string())
+        })?;
 
         let topic_channels = self.topic_channels.read().await;
         let tx = topic_channels
@@ -273,10 +268,7 @@ impl NativeChannel {
     ///
     /// Returns `Err(DataflowError::Timeout)` if no message arrives within the
     /// channel's configured timeout.
-    pub async fn receive_p2p(
-        &self,
-        agent_id: &str,
-    ) -> DataflowResult<Option<MessageEnvelope>> {
+    pub async fn receive_p2p(&self, agent_id: &str) -> DataflowResult<Option<MessageEnvelope>> {
         let rx = {
             let receivers = self.receivers.read().await;
             receivers.get(agent_id).cloned().ok_or_else(|| {
@@ -293,10 +285,7 @@ impl NativeChannel {
     }
 
     /// Non-blocking poll on the P2P queue of `agent_id`.
-    pub async fn try_receive_p2p(
-        &self,
-        agent_id: &str,
-    ) -> DataflowResult<Option<MessageEnvelope>> {
+    pub async fn try_receive_p2p(&self, agent_id: &str) -> DataflowResult<Option<MessageEnvelope>> {
         let rx = {
             let receivers = self.receivers.read().await;
             receivers.get(agent_id).cloned().ok_or_else(|| {
@@ -308,9 +297,9 @@ impl NativeChannel {
         match guard.try_recv() {
             Ok(env) => Ok(Some(env)),
             Err(mpsc::error::TryRecvError::Empty) => Ok(None),
-            Err(mpsc::error::TryRecvError::Disconnected) => {
-                Err(DataflowError::ChannelError("Channel disconnected".to_string()))
-            }
+            Err(mpsc::error::TryRecvError::Disconnected) => Err(DataflowError::ChannelError(
+                "Channel disconnected".to_string(),
+            )),
         }
     }
 

--- a/crates/mofa-runtime/src/retry.rs
+++ b/crates/mofa-runtime/src/retry.rs
@@ -230,9 +230,13 @@ mod tests {
         let max_ms = 5_000;
 
         // Without jitter
-        let p = RetryPolicy::ExponentialBackoff { base_ms, max_ms, jitter: false };
+        let p = RetryPolicy::ExponentialBackoff {
+            base_ms,
+            max_ms,
+            jitter: false,
+        };
         for attempt in 0..20 {
-            let delay = p.delay_for(attempt).as_millis() as u64;
+            let delay = u64::try_from(p.delay_for(attempt).as_millis()).unwrap_or(u64::MAX);
             assert!(
                 delay <= max_ms,
                 "attempt {attempt}: delay {delay} ms exceeded max {max_ms} ms (no jitter)",
@@ -240,9 +244,13 @@ mod tests {
         }
 
         // With jitter
-        let p = RetryPolicy::ExponentialBackoff { base_ms, max_ms, jitter: true };
+        let p = RetryPolicy::ExponentialBackoff {
+            base_ms,
+            max_ms,
+            jitter: true,
+        };
         for attempt in 0..20 {
-            let delay = p.delay_for(attempt).as_millis() as u64;
+            let delay = u64::try_from(p.delay_for(attempt).as_millis()).unwrap_or(u64::MAX);
             assert!(
                 delay <= max_ms,
                 "attempt {attempt}: delay {delay} ms exceeded max {max_ms} ms (jitter)",
@@ -254,10 +262,14 @@ mod tests {
     fn test_jitter_stays_within_bounds() {
         let base_ms = 200;
         let max_ms = 10_000;
-        let p = RetryPolicy::ExponentialBackoff { base_ms, max_ms, jitter: true };
+        let p = RetryPolicy::ExponentialBackoff {
+            base_ms,
+            max_ms,
+            jitter: true,
+        };
 
         for attempt in 0..20 {
-            let delay = p.delay_for(attempt).as_millis() as u64;
+            let delay = u64::try_from(p.delay_for(attempt).as_millis()).unwrap_or(u64::MAX);
 
             // Recompute the non-jittered capped value to derive bounds.
             let exp = 1u64
@@ -283,11 +295,15 @@ mod tests {
     fn test_monotonic_growth_before_saturation_no_jitter() {
         let base_ms = 50;
         let max_ms = 3_200;
-        let p = RetryPolicy::ExponentialBackoff { base_ms, max_ms, jitter: false };
+        let p = RetryPolicy::ExponentialBackoff {
+            base_ms,
+            max_ms,
+            jitter: false,
+        };
 
         let mut prev_delay = 0u64;
         for attempt in 0..20 {
-            let delay = p.delay_for(attempt).as_millis() as u64;
+            let delay = u64::try_from(p.delay_for(attempt).as_millis()).unwrap_or(u64::MAX);
             assert!(
                 delay >= prev_delay,
                 "attempt {attempt}: delay {delay} ms decreased from previous {prev_delay} ms",

--- a/examples/multi_agent_coordination/src/main.rs
+++ b/examples/multi_agent_coordination/src/main.rs
@@ -546,7 +546,7 @@ impl WorkerAgent {
             .send()
             .await?;
 
-        let processing_time_ms = start_time.elapsed().as_millis() as u64;
+        let processing_time_ms = u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX);
         let content = response.content().unwrap_or("").to_string();
 
         self.stats.tasks_completed += 1;

--- a/examples/visual_debugger_demo/src/main.rs
+++ b/examples/visual_debugger_demo/src/main.rs
@@ -27,10 +27,7 @@ use tracing::info;
 /// 4. process - Processes the data
 /// 5. output - Produces final output
 fn create_demo_workflow_events(execution_id: &str) -> Vec<DebugEvent> {
-    let base_time = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as u64;
+    let base_time = mofa_kernel::utils::now_ms();
     
     vec![
         DebugEvent::WorkflowStart {

--- a/examples/workflow_viz/src/main.rs
+++ b/examples/workflow_viz/src/main.rs
@@ -564,7 +564,10 @@ async fn simulate_execution(
 // ---------------------------------------------------------------------------
 
 fn now_ms() -> u64 {
-    chrono::Utc::now().timestamp_millis() as u64
+    chrono::Utc::now()
+        .timestamp_millis()
+        .try_into()
+        .unwrap_or(0)
 }
 
 /// Deterministic pseudo-random from a string (for consistent simulation behaviour)

--- a/tests/src/clock.rs
+++ b/tests/src/clock.rs
@@ -37,27 +37,32 @@ impl MockClock {
     /// Create a clock starting at the given duration from epoch.
     pub fn starting_at(start: Duration) -> Self {
         Self {
-            current_ms: AtomicU64::new(start.as_millis() as u64),
+            current_ms: AtomicU64::new(u64::try_from(start.as_millis()).unwrap_or(u64::MAX)),
             auto_advance_ms: RwLock::new(None),
         }
     }
 
     /// Advance the clock by the given duration.
     pub fn advance(&self, duration: Duration) {
-        self.current_ms
-            .fetch_add(duration.as_millis() as u64, Ordering::Relaxed);
+        self.current_ms.fetch_add(
+            u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
+            Ordering::Relaxed,
+        );
     }
 
     /// Set the clock to an exact time.
     pub fn set(&self, duration: Duration) {
-        self.current_ms
-            .store(duration.as_millis() as u64, Ordering::Relaxed);
+        self.current_ms.store(
+            u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
+            Ordering::Relaxed,
+        );
     }
 
     /// Enable auto-advance: each call to [`now_millis`](Clock::now_millis)
     /// automatically moves time forward by the given step.
     pub fn set_auto_advance(&self, step: Duration) {
-        *self.auto_advance_ms.write().expect("lock poisoned") = Some(step.as_millis() as u64);
+        *self.auto_advance_ms.write().expect("lock poisoned") =
+            Some(u64::try_from(step.as_millis()).unwrap_or(u64::MAX));
     }
 
     /// Disable auto-advance.
@@ -81,10 +86,6 @@ pub struct SystemClock;
 
 impl Clock for SystemClock {
     fn now_millis(&self) -> u64 {
-        use std::time::{SystemTime, UNIX_EPOCH};
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64
+        mofa_kernel::utils::now_ms()
     }
 }

--- a/tests/src/report/format.rs
+++ b/tests/src/report/format.rs
@@ -19,7 +19,7 @@ impl ReportFormatter for JsonFormatter {
                 let mut obj = serde_json::json!({
                     "name": r.name,
                     "status": r.status.to_string(),
-                    "duration_ms": r.duration.as_millis() as u64,
+                    "duration_ms": u64::try_from(r.duration.as_millis()).unwrap_or(u64::MAX),
                 });
                 if let Some(err) = &r.error {
                     obj["error"] = serde_json::Value::String(err.clone());
@@ -45,7 +45,7 @@ impl ReportFormatter for JsonFormatter {
         let root = serde_json::json!({
             "suite": report.suite_name,
             "timestamp": report.timestamp,
-            "total_duration_ms": report.total_duration.as_millis() as u64,
+            "total_duration_ms": u64::try_from(report.total_duration.as_millis()).unwrap_or(u64::MAX),
             "summary": {
                 "total": total,
                 "passed": passed,


### PR DESCRIPTION
## 📋 Summary

Fixes all 124 unsafe millisecond `as u64` casts that PR #1182 missed. Six of them are real correctness bugs that silently corrupt timestamps or analytics counters when the system clock is misconfigured. The remaining 118 are coding-standard violations (`u128 → u64` without overflow handling).

## 🔗 Related Issues

Closes #1290

Related to #394, #1172, #1182

---

## 🧠 Context

PR #1182 replaced `as u64` casts with `u64::try_from()` in 4 files (`mofa-kernel` and `mofa-runtime`), but the same unsafe pattern survived in 38 more files across 8 crates. A workspace-wide `grep` turned up 124 remaining sites split into three risk categories:

- **Flavour A** (5 lines): `chrono::Utc::now().timestamp_millis() as u64` — `timestamp_millis()` returns `i64`, so any pre-epoch clock wraps to near `u64::MAX`, corrupting audit trails and HITL telemetry.
- **Flavour C** (1 line): `signed_duration_since().num_milliseconds() as u64` — negative durations from NTP clock skew wrap `total_wait_time_ms` to ~`u64::MAX`.
- **Flavour B** (118 lines): `Duration::as_millis() as u64` — `u128 → u64` without overflow handling, prohibited by coding standard §VII.2.

---

## 🛠️ Changes

- **Added `chrono_now_ms()`** to `mofa-kernel/src/utils.rs` — a safe counterpart to the existing `now_ms()`, using `try_into().unwrap_or(0)` to prevent signed→unsigned wraparound on `chrono` timestamps. Includes 3 new unit tests.
- **Replaced 5 Flavour A sites** (in `hitl/audit.rs`, `workflow/executor.rs`, `agent/components/tool.rs`, `workflow_viz/main.rs`) with `chrono_now_ms()` or inline safe casts.
- **Fixed the Flavour C site** in `workflow/executor.rs` with `.max(0)` clamp before `try_into()` to prevent NTP-skew-induced wraparound.
- **Replaced 118 Flavour B sites** across `mofa-foundation`, `mofa-extra`, `mofa-plugins`, `mofa-gateway`, `mofa-cli`, `mofa-runtime`, `tests/`, and `examples/` with either `u64::try_from(...).unwrap_or(u64::MAX)` or `mofa_kernel::utils::now_ms()` for multi-line `SystemTime` chains.
- **Fixed `tests/src/clock.rs` MockClock** to use proper `u64::try_from()` wrapping inside `AtomicU64` operations.
- **Ran `cargo fmt`** on all touched files.

---

## 🧪 How you Tested

1. `cargo check --workspace` — zero errors, only pre-existing `ambiguous_glob_reexports` warning
2. `cargo test --workspace` — all ~1200 tests pass, 0 failures
3. `cargo test -p mofa-kernel -- utils` — specifically validates the 3 new `chrono_now_ms()` tests
4. Verified zero remaining unsafe casts:
   ```bash
   grep -rn "timestamp_millis() as u64\|\.as_millis() as u64\|num_milliseconds() as u64" \
     --include="*.rs" crates/ tests/ examples/ | grep -v target/
   # Returns 0 results
   ```

---

## 📸 Screenshots / Logs (if applicable)

```
cargo test --workspace
...
test result: ok. 124 passed; 0 failed; ...  (mofa-kernel)
test result: ok. 742 passed; 0 failed; ...  (mofa-foundation)
test result: ok. 86 passed; 0 failed; ...   (mofa-runtime)
... all crates pass ...
```

---

## ⚠️ Breaking Changes

- [x] No breaking changes

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [x] Public APIs documented
- [x] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---

## 🚀 Deployment Notes (if applicable)

None — all changes are internal type-conversion improvements. No API, config, or schema changes.

---

## 🧩 Additional Notes for Reviewers

- The `chrono_now_ms()` function in `mofa-kernel/src/utils.rs` mirrors the existing `now_ms()` (which uses `SystemTime`) but for `chrono::Utc::now()`.
- Multi-line `SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_millis() as u64` chains were replaced wholesale with `mofa_kernel::utils::now_ms()` since that function does exactly the same thing, safely.
- Inside `mofa-kernel` itself, references use `crate::utils::now_ms()` (not `mofa_kernel::`).
- The `tests/src/clock.rs` MockClock needed manual restructuring because the `AtomicU64` method calls (`new()`, `fetch_add()`, `store()`) had the `as u64` cast as an argument, not a chain suffix.
