### PR TITLE
fix(foundation): enforce Critical priority memory reclamation before fallback/reject

### DIFF
--- a/crates/mofa-foundation/src/inference/orchestrator.rs
+++ b/crates/mofa-foundation/src/inference/orchestrator.rs
@@ -146,7 +146,26 @@ impl InferenceOrchestrator {
 
         // Step 2: Evaluate admission based on current memory state
         // Memory is always derived from ModelPool (single source of truth)
-        let admission = self.evaluate_admission(request);
+        let mut admission = self.evaluate_admission(request);
+
+        // Critical requests can reclaim memory via priority-aware eviction before
+        // we decide to reject/fallback. This is skipped for CloudOnly policy
+        // because local admission does not participate in routing there.
+        if request.priority == RequestPriority::Critical
+            && admission == AdmissionOutcome::Reject
+            && self.config.routing_policy != RoutingPolicy::CloudOnly
+        {
+            let (post_reclaim_admission, evicted_models) =
+                self.attempt_critical_reclamation(request);
+            if evicted_models > 0 {
+                tracing::warn!(
+                    model_id = %request.model_id,
+                    evicted_models,
+                    "critical request triggered priority-aware reclamation before routing"
+                );
+            }
+            admission = post_reclaim_admission;
+        }
 
         // Step 3: Resolve routing based on policy + admission + hardware
         let decision = routing::resolve(
@@ -356,6 +375,40 @@ impl InferenceOrchestrator {
                 }
             }
         }
+    }
+
+    /// Attempt to reclaim memory for a critical request by evicting
+    /// lower-resistance models (priority-aware LRU) before final routing.
+    ///
+    /// Returns the post-reclamation admission outcome and number of models evicted.
+    fn attempt_critical_reclamation(
+        &mut self,
+        request: &InferenceRequest,
+    ) -> (AdmissionOutcome, usize) {
+        // Fast-fail: if request cannot fit under reject threshold even on empty pool,
+        // do not evict existing models pointlessly.
+        if self.config.memory_capacity_mb == 0 {
+            return (AdmissionOutcome::Reject, 0);
+        }
+        let request_usage =
+            request.required_memory_mb as f64 / self.config.memory_capacity_mb as f64;
+        if request_usage > self.config.reject_threshold {
+            return (AdmissionOutcome::Reject, 0);
+        }
+
+        let mut evicted_models = 0usize;
+        while self.evaluate_admission(request) == AdmissionOutcome::Reject {
+            if self
+                .model_pool
+                .evict_lru_for_priority(request.priority)
+                .is_none()
+            {
+                break;
+            }
+            evicted_models += 1;
+        }
+
+        (self.evaluate_admission(request), evicted_models)
     }
 
     /// Get the current memory usage as a fraction of total capacity (0.0–1.0).
@@ -703,5 +756,59 @@ mod tests {
             },
             "Low priority in defer band should fall back to cloud"
         );
+    }
+
+    #[test]
+    fn test_critical_priority_reclaims_memory_before_fallback() {
+        let mut config = test_config();
+        config.memory_capacity_mb = 10_000;
+        config.defer_threshold = 0.70;
+        config.reject_threshold = 0.90;
+        let mut orch = InferenceOrchestrator::with_hardware(config, test_hardware());
+
+        // 60% usage -> admitted locally and loaded.
+        let fill = InferenceRequest::new("base-model", "warmup", 6_000)
+            .with_priority(RequestPriority::Low);
+        let fill_result = orch.infer(&fill);
+        assert!(matches!(fill_result.routed_to, RoutedBackend::Local { .. }));
+        assert_eq!(orch.allocated_memory_mb(), 6_000);
+
+        // Projected usage = 100% -> initial reject for Critical.
+        // Orchestrator should evict lower-priority model and admit locally.
+        let critical = InferenceRequest::new("critical-model", "urgent", 4_000)
+            .with_priority(RequestPriority::Critical);
+        let result = orch.infer(&critical);
+        assert_eq!(
+            result.routed_to,
+            RoutedBackend::Local {
+                model_id: "critical-model".into()
+            }
+        );
+        assert_eq!(orch.loaded_model_count(), 1);
+        assert_eq!(orch.allocated_memory_mb(), 4_000);
+    }
+
+    #[test]
+    fn test_critical_priority_does_not_evict_when_request_cannot_fit_even_empty_pool() {
+        let mut config = test_config();
+        config.memory_capacity_mb = 10_000;
+        config.defer_threshold = 0.70;
+        config.reject_threshold = 0.90;
+        config.routing_policy = RoutingPolicy::LocalOnly;
+        let mut orch = InferenceOrchestrator::with_hardware(config, test_hardware());
+
+        let fill = InferenceRequest::new("base-model", "warmup", 6_000);
+        let fill_result = orch.infer(&fill);
+        assert!(matches!(fill_result.routed_to, RoutedBackend::Local { .. }));
+
+        // 9_500 / 10_000 = 95% > reject threshold (90%), so impossible even if empty.
+        // Existing models should not be evicted.
+        let critical = InferenceRequest::new("oversized-critical", "urgent", 9_500)
+            .with_priority(RequestPriority::Critical);
+        let result = orch.infer(&critical);
+        assert!(matches!(result.routed_to, RoutedBackend::Rejected { .. }));
+
+        // base-model should still be present
+        assert_eq!(orch.unload_model("base-model"), 6_000);
     }
 }


### PR DESCRIPTION
## Summary

  This PR implements the documented RequestPriority::Critical contract in the inference orchestrator by adding a priority-aware memory reclamation step before final fallback/
  rejection routing.

  Previously, a Critical request that initially failed admission due to memory pressure would be routed immediately (cloud fallback or rejection depending on policy), without
  attempting to reclaim local capacity by evicting lower-priority models.

  Now, for Critical requests only, the orchestrator attempts local reclamation first, re-evaluates admission, and only then proceeds with routing.

  ## Linked Issue

  Closes #1346 

  ## Problem Statement

  The code and docs were inconsistent:

  - RequestPriority::Critical semantics describe stronger QoS behavior than High, including eviction/reclamation before final failure.
  - InferenceOrchestrator::infer did not attempt reclamation for Critical requests when admission returned Reject.
  - Result: Critical workloads could be sent to cloud/rejected even when local capacity was recoverable.

  This violated priority guarantees under memory pressure and weakened reliability for latency-sensitive/system-critical flows.

  ## Root Cause

  Admission and routing were evaluated in a single pass:

  1. evaluate_admission(request)
  2. routing::resolve(...)
  3. execute decision

  There was no intermediate path to reclaim memory for Critical requests after an initial Reject.

  ## What Changed

  ### 1. Critical-only reclamation hook in infer

  File: crates/mofa-foundation/src/inference/orchestrator.rs

  - After initial admission evaluation, if:
      - request.priority == Critical
      - admission == Reject
      - policy is not CloudOnly
  - then orchestrator calls attempt_critical_reclamation(...).
  - Admission is re-evaluated after reclamation and used for routing.

  ### 2. New helper: attempt_critical_reclamation

  File: crates/mofa-foundation/src/inference/orchestrator.rs

  Adds a focused helper that:

  - Performs priority-aware LRU eviction via model_pool.evict_lru_for_priority(...) while admission remains Reject.
  - Returns (post_reclaim_admission, evicted_models_count).

  Safety guard added:

  - If request cannot fit even with empty pool (i.e. required_memory / capacity > reject_threshold), helper exits early with no eviction to avoid destructive/no-op churn.

  ### 3. Observability

  - Emits a warning log when reclamation actually evicts models before routing, including model id and eviction count.

  ## Behavioral Impact

  ### Before

  Critical request on reject path:

  - No reclamation attempt
  - Immediate fallback/rejection

  ### After

  Critical request on reject path:

  - Attempt local priority-aware reclamation
  - Re-check admission
  - Route with updated memory state

  This improves adherence to priority semantics and increases local-serving success probability for critical traffic under pressure.

  ## Policy Scope / Non-Goals

  - This change applies only to Critical.
  - CloudOnly policy intentionally skips reclamation path.
  - No behavior change for Low, Normal, or High.
  - No changes to routing policy definitions, thresholds, or degradation ladder behavior.

  ## Tests Added

  1. test_critical_priority_reclaims_memory_before_fallback

  - Sets up memory pressure causing initial reject.
  - Confirms Critical request triggers reclamation and is admitted locally.

  2. test_critical_priority_does_not_evict_when_request_cannot_fit_even_empty_pool

  - Uses an oversized Critical request that cannot pass threshold even with empty pool.
  - Confirms no unnecessary eviction of existing models and final rejection behavior.

  ## Validation Performed

  - cargo build -p mofa-foundation ✅
  - cargo test -p mofa-foundation inference::orchestrator -- --nocapture ✅
  - cargo test -p mofa-foundation ✅

  Notes on repo-wide gates in this environment:

  - cargo fmt --check reports pre-existing unrelated formatting diffs in other crates.
  - cargo clippy -p mofa-foundation --all-features -- -D warnings reports pre-existing unrelated lint violations outside touched code.

  ## Risk Assessment

  - Main risk is admission/routing behavior shift for Critical workloads under pressure, which is intentional and covered by new tests.
  - No API changes.

  ## Migration / Compatibility

  - Backward compatible.
  - No configuration changes required.
  - Existing policies and request formats remain unchanged.

  ## Checklist

  - [x] Single-issue, focused fix
  - [x] Non-trivial behavior fix (not cosmetic)
  - [x] Tests added for success + edge-case failure path
  - [x] No unrelated source file modifications
  - [x] Build and tests pass for touched crate
  - [ ] Full workspace fmt/clippy gates (blocked by unrelated pre-existing issues)

  ———