### PR TITLE
swarm: add SwarmAgentRegistry with DashMap and EWMA load scoring and concurrent dispatch

### DIFF
--- a/crates/mofa-foundation/src/swarm/mod.rs
+++ b/crates/mofa-foundation/src/swarm/mod.rs
@@ -4,6 +4,7 @@ pub mod analyzer;
 pub mod config;
 pub mod dag;
 pub mod patterns;
+pub mod registry;
 pub mod telemetry;
 
 // Re-export core types
@@ -14,5 +15,6 @@ pub use config::{
 };
 pub use dag::{DependencyEdge, DependencyKind, SwarmSubtask, SubtaskDAG, SubtaskStatus};
 pub use patterns::CoordinationPattern;
+pub use registry::{AgentCapabilitySpec, AgentRuntimeScore, RankedAgent, SwarmAgentLookup, compute_agent_score};
 pub use telemetry::{audit_to_debug, audit_batch_to_debug};
 

--- a/crates/mofa-foundation/src/swarm/registry.rs
+++ b/crates/mofa-foundation/src/swarm/registry.rs
@@ -1,0 +1,164 @@
+//! Swarm-specific agent scoring types and dispatch abstraction.
+//!
+//! This module defines the pure domain types and scoring policy
+//! for swarm-aware agent selection.
+//!
+//! ## quick start
+//!
+//! ```rust,ignore
+//! use mofa_foundation::swarm::{AgentCapabilitySpec, AgentRuntimeScore, compute_agent_score};
+//!
+//! let spec = AgentCapabilitySpec::new("summarizer", ["Summarise"], 4);
+//! let score_val = compute_agent_score(spec.max_concurrency, 1, 0.9);
+//! // score_val ≈ 0.675  (25 % load × 0.9 EWMA)
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+/// Core types
+/// Static description of an agent's capabilities and scheduling limits.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentCapabilitySpec {
+    pub id: String,
+    pub capabilities: Vec<String>,
+    pub max_concurrency: u32,
+    pub cost_per_token: Option<f64>,
+}
+
+impl AgentCapabilitySpec {
+    /// Create a new spec with default `cost_per_token = None`.
+    pub fn new(
+        id: impl Into<String>,
+        capabilities: impl IntoIterator<Item = impl Into<String>>,
+        max_concurrency: u32,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            capabilities: capabilities.into_iter().map(Into::into).collect(),
+            max_concurrency,
+            cost_per_token: None,
+        }
+    }
+
+    /// Returns `true` if this agent advertises the given capability tag.
+    pub fn has_capability(&self, cap: &str) -> bool {
+        self.capabilities.iter().any(|c| c == cap)
+    }
+}
+
+/// Runtime load and reliability snapshot for an agent.
+///
+/// Stored and updated by the runtime registry; passed into
+/// [`compute_agent_score`] to produce a comparable score.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub struct AgentRuntimeScore {
+    pub current_load: u32,
+    pub success_rate_ewma: f64,
+}
+
+impl Default for AgentRuntimeScore {
+    fn default() -> Self {
+        Self { current_load: 0, success_rate_ewma: 1.0 }
+    }
+}
+
+/// An agent together with its computed dispatch score.
+/// Returned by [`SwarmAgentLookup::find_best`]. Higher `score` is better.
+#[derive(Debug, Clone)]
+pub struct RankedAgent {
+    pub spec: AgentCapabilitySpec,
+    pub runtime: AgentRuntimeScore,
+    pub score: f64,
+}
+
+/// Scoring function
+/// Compute a dispatch score for an agent given its current load and EWMA.
+///
+/// `score = (1 − load_ratio) × success_rate_ewma`
+///
+/// - Returns `0.0` when `max_concurrency == 0` or `current_load >= max_concurrency`.
+/// - Both inputs are clamped to their valid ranges before use.
+///
+/// ## O-notation
+///
+/// This function is O(1). Callers are responsible for iterating over
+/// candidate agents; a typical `find_best` call is **O(k)** where *k*
+/// is the number of agents advertising the requested capability.
+/// ```
+pub fn compute_agent_score(max_concurrency: u32, current_load: u32, success_rate_ewma: f64) -> f64 {
+    if max_concurrency == 0 {
+        return 0.0;
+    }
+    let load_ratio = (current_load as f64 / max_concurrency as f64).clamp(0.0, 1.0);
+    (1.0 - load_ratio) * success_rate_ewma.clamp(0.0, 1.0)
+}
+
+// Lookup trait
+pub trait SwarmAgentLookup: Send + Sync {
+    fn register(&self, spec: AgentCapabilitySpec);
+    fn deregister(&self, agent_id: &str);
+    fn find_best(&self, capability: &str) -> Option<RankedAgent>;
+    fn record_outcome(&self, agent_id: &str, success: bool);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // AgentCapabilitySpec
+    #[test]
+    fn test_has_capability() {
+        let spec = AgentCapabilitySpec::new("a1", ["Summarise", "WebFetch"], 4);
+        assert!(spec.has_capability("Summarise"));
+        assert!(spec.has_capability("WebFetch"));
+        assert!(!spec.has_capability("CodeGen"));
+    }
+
+    // compute_agent_score
+    #[test]
+    fn test_score_zero_load_perfect_ewma() {
+        // 0 load, EWMA = 1.0 → score = 1.0
+        let s = compute_agent_score(4, 0, 1.0);
+        assert!((s - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_score_at_capacity_is_zero() {
+        assert_eq!(compute_agent_score(2, 2, 1.0), 0.0);
+        assert_eq!(compute_agent_score(0, 0, 1.0), 0.0);
+    }
+
+    #[test]
+    fn test_score_partial_load() {
+        // 1/4 load, EWMA 0.9 → (1 - 0.25) * 0.9 = 0.675
+        let s = compute_agent_score(4, 1, 0.9);
+        assert!((s - 0.675).abs() < 1e-9, "got {s}");
+    }
+
+    #[test]
+    fn test_score_clamps_ewma_above_one() {
+        // EWMA clamped to 1.0
+        let s = compute_agent_score(4, 0, 1.5);
+        assert!((s - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_score_low_ewma_penalises() {
+        let high = compute_agent_score(4, 0, 1.0);
+        let low  = compute_agent_score(4, 0, 0.3);
+        assert!(high > low);
+    }
+
+    #[test]
+    fn test_score_high_load_penalises() {
+        let light = compute_agent_score(4, 1, 1.0);
+        let heavy  = compute_agent_score(4, 3, 1.0);
+        assert!(light > heavy);
+    }
+
+    #[test]
+    fn test_runtime_score_default_is_optimistic() {
+        let rs = AgentRuntimeScore::default();
+        assert_eq!(rs.current_load, 0);
+        assert!((rs.success_rate_ewma - 1.0).abs() < 1e-9);
+    }
+}

--- a/crates/mofa-runtime/Cargo.toml
+++ b/crates/mofa-runtime/Cargo.toml
@@ -45,9 +45,15 @@ config.workspace = true
 regex.workspace = true
 chrono.workspace = true
 cron.workspace = true
+dashmap.workspace = true
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+reqwest = { workspace = true, features = ["json"] }
+tokio = { workspace = true, features = ["full"] }
+
 
 [features]
 dora = ["dora-node-api", "dora-operator-api", "dora-daemon", "dora-core", "dora-message"]

--- a/crates/mofa-runtime/src/agent/mod.rs
+++ b/crates/mofa-runtime/src/agent/mod.rs
@@ -19,6 +19,7 @@ pub mod config;
 pub mod execution;
 pub mod plugins;
 pub mod registry;
+pub mod swarm_registry;
 
 // 重新导出常用类型
 // Re-export commonly used types
@@ -29,3 +30,4 @@ pub use crate::runner::{
 pub use execution::{ExecutionEngine, ExecutionOptions, ExecutionResult, ExecutionStatus};
 pub use mofa_kernel::agent::registry::AgentFactory;
 pub use registry::{AgentRegistry, RegistryStats};
+pub use swarm_registry::SwarmAgentRegistry;

--- a/crates/mofa-runtime/src/agent/swarm_registry.rs
+++ b/crates/mofa-runtime/src/agent/swarm_registry.rs
@@ -1,0 +1,244 @@
+//! DashMap-backed swarm agent registry with EWMA load scoring.
+//!
+//! Implements [`SwarmAgentLookup`] for use by the swarm executor and composer.
+//! Stores agent specs and runtime state concurrently via [`DashMap`].
+
+use dashmap::DashMap;
+use mofa_foundation::swarm::{
+    AgentCapabilitySpec, AgentRuntimeScore, RankedAgent, SwarmAgentLookup, compute_agent_score,
+};
+
+// Internal state
+struct AgentState {
+    spec: AgentCapabilitySpec,
+    score: AgentRuntimeScore,
+}
+
+/// SwarmAgentRegistry
+/// Concurrent, load-aware agent registry for swarm scheduling.
+///
+/// # Design
+/// - `agents`: maps agent ID to `AgentState` (spec + EWMA score + current load).
+/// - `capability_index`: maps capability tag → list of agent IDs for O(k) lookup.
+/// - EWMA update: `ewma = alpha × outcome + (1 - alpha) × ewma`
+///
+/// ```
+pub struct SwarmAgentRegistry {
+    agents: DashMap<String, AgentState>,
+    capability_index: DashMap<String, Vec<String>>,
+    /// EWMA smoothing factor (0 < alpha ≤ 1). Default: 0.2.
+    ewma_alpha: f64,
+}
+
+impl SwarmAgentRegistry {
+    pub fn new(ewma_alpha: f64) -> Self {
+        assert!(ewma_alpha > 0.0 && ewma_alpha <= 1.0, "ewma_alpha must be in (0, 1]");
+        Self {
+            agents: DashMap::new(),
+            capability_index: DashMap::new(),
+            ewma_alpha,
+        }
+    }
+
+    /// Increment the active-task load counter for an agent.
+    pub fn increment_load(&self, agent_id: &str) {
+        if let Some(mut entry) = self.agents.get_mut(agent_id) {
+            entry.score.current_load += 1;
+        }
+    }
+
+    /// Read the current runtime score for an agent (load + EWMA).
+    pub fn get_score(&self, agent_id: &str) -> Option<AgentRuntimeScore> {
+        self.agents.get(agent_id).map(|e| e.score)
+    }
+
+    // Rebuild capability index entry for a single agent.
+    fn index_agent(&self, spec: &AgentCapabilitySpec) {
+        for cap in &spec.capabilities {
+            self.capability_index
+                .entry(cap.clone())
+                .or_default()
+                .push(spec.id.clone());
+        }
+    }
+
+    // Remove agent ID from all capability index entries.
+    fn unindex_agent(&self, spec: &AgentCapabilitySpec) {
+        for cap in &spec.capabilities {
+            if let Some(mut ids) = self.capability_index.get_mut(cap) {
+                ids.retain(|id| id != &spec.id);
+            }
+        }
+    }
+}
+
+// SwarmAgentLookup impl
+impl SwarmAgentLookup for SwarmAgentRegistry {
+    /// Register or update an agent. EWMA is **preserved** on re-registration
+    /// so that historical reliability survives agent restarts.
+    fn register(&self, spec: AgentCapabilitySpec) {
+        let preserved_ewma = self
+            .agents
+            .get(&spec.id)
+            .map(|e| e.score.success_rate_ewma)
+            .unwrap_or(1.0); // optimistic prior for new agents
+
+        // Remove old capability index entries before updating spec.
+        if let Some(existing) = self.agents.get(&spec.id) {
+            self.unindex_agent(&existing.spec);
+        }
+
+        self.index_agent(&spec);
+        self.agents.insert(
+            spec.id.clone(),
+            AgentState {
+                spec,
+                score: AgentRuntimeScore {
+                    current_load: 0,
+                    success_rate_ewma: preserved_ewma,
+                },
+            },
+        );
+    }
+
+    fn deregister(&self, agent_id: &str) {
+        if let Some((_, state)) = self.agents.remove(agent_id) {
+            self.unindex_agent(&state.spec);
+        }
+    }
+
+    /// Return the highest-scoring available agent for `capability`
+    fn find_best(&self, capability: &str) -> Option<RankedAgent> {
+        let ids = self.capability_index.get(capability)?;
+
+        ids.iter()
+            .filter_map(|id| {
+                let entry = self.agents.get(id)?;
+                let AgentState { spec, score } = &*entry;
+
+                if score.current_load >= spec.max_concurrency {
+                    return None;
+                }
+
+                let s = compute_agent_score(
+                    spec.max_concurrency,
+                    score.current_load,
+                    score.success_rate_ewma,
+                );
+                Some(RankedAgent {
+                    spec: spec.clone(),
+                    runtime: *score,
+                    score: s,
+                })
+            })
+            .max_by(|a, b| a.score.partial_cmp(&b.score).unwrap())
+    }
+
+    /// Update EWMA for `agent_id` and decrement its active load by one.
+    fn record_outcome(&self, agent_id: &str, success: bool) {
+        if let Some(mut entry) = self.agents.get_mut(agent_id) {
+            let outcome = if success { 1.0_f64 } else { 0.0_f64 };
+            let old = entry.score.success_rate_ewma;
+            entry.score.success_rate_ewma = self.ewma_alpha * outcome + (1.0 - self.ewma_alpha) * old;
+            entry.score.current_load = entry.score.current_load.saturating_sub(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mofa_foundation::swarm::AgentCapabilitySpec;
+
+    fn make_registry() -> SwarmAgentRegistry {
+        SwarmAgentRegistry::new(0.2)
+    }
+
+    fn agent(id: &str, caps: &[&str], max: u32) -> AgentCapabilitySpec {
+        AgentCapabilitySpec::new(id, caps.iter().copied(), max)
+    }
+
+    #[test]
+    fn test_find_best_returns_none_before_registration() {
+        let reg = make_registry();
+        assert!(reg.find_best("Summarise").is_none());
+    }
+
+    #[test]
+    fn test_find_best_prefers_low_load() {
+        let reg = make_registry();
+        reg.register(agent("a1", &["Summarise"], 4));
+        reg.register(agent("a2", &["Summarise"], 4));
+
+        // Artificially load a1 with 3 tasks.
+        reg.increment_load("a1");
+        reg.increment_load("a1");
+        reg.increment_load("a1");
+
+        let best = reg.find_best("Summarise").expect("should find one");
+        assert_eq!(best.spec.id, "a2", "a2 has lower load → higher score");
+    }
+
+    #[test]
+    fn test_find_best_returns_none_when_all_full() {
+        let reg = make_registry();
+        reg.register(agent("a1", &["Summarise"], 2));
+        reg.increment_load("a1");
+        reg.increment_load("a1");
+        assert!(reg.find_best("Summarise").is_none());
+    }
+
+    #[test]
+    fn test_ewma_decreases_on_failure() {
+        let reg = make_registry();
+        reg.register(agent("a1", &["Summarise"], 4));
+        reg.increment_load("a1");
+
+        let before = reg.agents.get("a1").unwrap().score.success_rate_ewma;
+        reg.record_outcome("a1", false);
+        let after = reg.agents.get("a1").unwrap().score.success_rate_ewma;
+
+        assert!(after < before, "EWMA should decrease after failure");
+    }
+
+    #[test]
+    fn test_ewma_preserved_on_reregister() {
+        let reg = make_registry();
+        reg.register(agent("a1", &["Summarise"], 4));
+        reg.increment_load("a1");
+        reg.record_outcome("a1", false); // lower EWMA from default 1.0
+
+        let ewma_before = reg.agents.get("a1").unwrap().score.success_rate_ewma;
+        assert!(ewma_before < 1.0);
+
+        // Re-register same agent (e.g. after restart).
+        reg.register(agent("a1", &["Summarise"], 4));
+        let ewma_after = reg.agents.get("a1").unwrap().score.success_rate_ewma;
+
+        assert_eq!(ewma_before, ewma_after, "EWMA must survive re-registration");
+    }
+
+    #[test]
+    fn test_capability_index_updated_on_deregister() {
+        let reg = make_registry();
+        reg.register(agent("a1", &["Summarise"], 4));
+
+        assert!(reg.find_best("Summarise").is_some());
+        reg.deregister("a1");
+        assert!(reg.find_best("Summarise").is_none());
+    }
+
+    #[test]
+    fn test_load_decremented_after_outcome() {
+        let reg = make_registry();
+        reg.register(agent("a1", &["Summarise"], 4));
+        reg.increment_load("a1");
+
+        let load_before = reg.agents.get("a1").unwrap().score.current_load;
+        assert_eq!(load_before, 1);
+
+        reg.record_outcome("a1", true);
+        let load_after = reg.agents.get("a1").unwrap().score.current_load;
+        assert_eq!(load_after, 0, "load should decrement after recording outcome");
+    }
+}


### PR DESCRIPTION
## Summary

Adds swarm-aware agent selection to `mofa-foundation` and `mofa-runtime`. The swarm executor needs to pick the best available agent per capability based on current load and historical reliability neither existing registry (`mofa-foundation/agent/builder.rs` or `mofa-runtime/agent/registry.rs`)
supports this.
Fixes: #1367

## Changes

**`crates/mofa-foundation/src/swarm/registry.rs`** (new)
- `AgentCapabilitySpec`: id, capabilities, max concurrency, cost hint
- `AgentRuntimeScore`: current load + EWMA success rate
- `RankedAgent`: spec + pre-computed score
- `compute_agent_score(max_concurrency, current_load, ewma) f64`
- `SwarmAgentLookup` trait: dispatcher abstraction for `DAGExecutor` / `SwarmComposer`

**`crates/mofa-runtime/src/agent/swarm_registry.rs`** (new)
- `SwarmAgentRegistry`: `DashMap`-backed concurrent registry
- Per-capability index for O(k) `find_best` lookup
- EWMA update on outcome: `α × outcome + (1−α) × ewma`
- EWMA preserved across re-registration (agent restarts don't reset history)

## Architecture

```mermaid
graph TD
    subgraph mofa-foundation
        A[AgentCapabilitySpec\nid · capabilities · max_concurrency] --> D[compute_agent_score]
        B[AgentRuntimeScore\ncurrent_load · ewma]               --> D
        D --> E[RankedAgent]
        E --> F[[SwarmAgentLookup trait\nregister · deregister\nfind_best · record_outcome]]
    end

    subgraph mofa-runtime
        F -->|implements| G[SwarmAgentRegistry]
        G --> H[(DashMap\nagents)]
        G --> I[(DashMap\ncapability_index)]
    end

    subgraph "Planned: plug into executor.rs"
        J["run_sequential\nrun_parallel"] -->|"dyn SwarmAgentLookup"| F
        K[SwarmComposer] -->|dyn SwarmAgentLookup| F
    end
```

## Agent lifecycle in SwarmAgentRegistry
```mermaid
flowchart TD
    REG([register spec]) --> ST

    ST[("Storage\nDashMap agents\ncapability_index")]

    ST -->|"ewma=1.0, load=0"| FB

    FB{{"find_best(capability)\nO(k) scan · score = 1-load/max × ewma"}}

    FB -->|"load < max_concurrency\nhighest score wins"| DISP["Dispatched\nload += 1"]
    FB -->|"all at capacity\nor outscored"| NONE([None])

    DISP --> EXEC[/"Task Executes\nLLM · tool · agent"/]

    EXEC -->|"outcome=1.0\n outcome=0.0"| RO

    RO(["record_outcome\newma = α·outcome + (1-α)·ewma\nload -= 1"])

    RO -->|"write back"| ST
    ST -.->|"ewma preserved\non re-register"| ST
```
## Tests

```
mofa-foundation  8/8 passing  (scoring function, capability matching)
mofa-runtime     7/7 passing  (selection, EWMA, load tracking, capacity)
```

## Live demo:

Two llama agents, 5 real summarisation tasks. `fast-agent` fails on tasks 1 to 2 (model not found), EWMA drops, then recovers as tasks 3 to 5 succeed, EWMA increases:
<img width="985" height="435" alt="EWMA drops if wrong agent" src="https://github.com/user-attachments/assets/6b62c641-70f5-43ed-9ea8-9434ebbe33cb" />