### PR TITLE
fix: Replace unwrap() with proper AgentError propagation in GraphState doc example

### DIFF
--- a/crates/mofa-kernel/src/workflow/state.rs
+++ b/crates/mofa-kernel/src/workflow/state.rs
@@ -51,7 +51,7 @@ use super::StateUpdate;
 ///                     .ok(),
 ///                     "result" => serde_json::to_value(&self.result)
 ///                     .map_err(|e| AgentError::SerializationError(e.to_string()))
-///                     .ok(),
+///                    .ok(),
 ///
 ///             _ => None,
 ///         }

--- a/crates/mofa-kernel/src/workflow/state.rs
+++ b/crates/mofa-kernel/src/workflow/state.rs
@@ -46,8 +46,13 @@ use super::StateUpdate;
 ///
 ///     fn get_value(&self, key: &str) -> Option<Value> {
 ///         match key {
-///             "messages" => Some(serde_json::to_value(&self.messages).unwrap()),
-///             "result" => Some(serde_json::to_value(&self.result).unwrap()),
+///                  "messages" => serde_json::to_value(&self.messages)
+///                     .map_err(|e| AgentError::SerializationError(e.to_string()))
+///                     .ok(),
+///                     "result" => serde_json::to_value(&self.result)
+///                     .map_err(|e| AgentError::SerializationError(e.to_string()))
+///                     .ok(),
+///
 ///             _ => None,
 ///         }
 ///     }


### PR DESCRIPTION
## Problem
Documentation example in `state.rs` used `.unwrap()` on 
`serde_json::to_value()` which causes runtime panics.

## Fix
Replaced `.unwrap()` with `.map_err()` and `.ok()` for 
proper AgentError::SerializationError propagation.

## Related Issue
Fixes #4