### PR TITLE
feat(plugin): Runtime hot-reload for MofaApp plugins without shell restart

### DIFF
--- a/.github/workflows/adversarial-gate.yml
+++ b/.github/workflows/adversarial-gate.yml
@@ -21,7 +21,7 @@ jobs:
       PASS_RATE_MIN: "1.0"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6 
 
       - name: Install system dependencies
         run: |
@@ -29,10 +29,10 @@ jobs:
           sudo apt-get install -y libasound2-dev
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203  
 
       - name: Cache dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v5  
         with:
           path: |
             ~/.cargo/registry
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload SecurityReport Artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b  # v4
         with:
           name: SecurityReport
           path: |

--- a/.github/workflows/automated-issue-triage.yml
+++ b/.github/workflows/automated-issue-triage.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
 
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
@@ -37,7 +37,7 @@ jobs:
         id: issue_details
         env:
           ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v7  
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -65,7 +65,7 @@ jobs:
 
       - name: Get repository labels
         id: get_labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@v7  
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -232,7 +232,7 @@ jobs:
         env:
           ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
           TRIAGE_RESULT: ${{ steps.triage.outputs.result }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v7  
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6  
 
       - name: Install system dependencies
         run: |
@@ -23,12 +23,12 @@ jobs:
           sudo apt-get install -y libasound2-dev
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203  # stable
         with:
           components: rustfmt, clippy
 
       - name: Cache dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v5  
         with:
           path: |
             ~/.cargo/registry
@@ -57,7 +57,7 @@ jobs:
           sudo apt-get install -y libasound2-dev
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203  # stable
 
       - name: Cache dependencies
         uses: actions/cache@v5
@@ -93,7 +93,7 @@ jobs:
           sudo apt-get install -y libasound2-dev
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203  # stable
 
       - name: Cache dependencies
         uses: actions/cache@v5

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -30,10 +30,10 @@ jobs:
         working-directory: docs/mofa-doc
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6  
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203  # stable
 
       - name: Install mdBook
         run: |
@@ -44,7 +44,7 @@ jobs:
         run: ./scripts/build-docs.sh
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v4  
         with:
           path: docs/mofa-doc/book
 
@@ -58,4 +58,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v4  

--- a/.github/workflows/duplicate-detection.yml
+++ b/.github/workflows/duplicate-detection.yml
@@ -13,15 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
 
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
 
       - name: Get current issue details
         id: current_issue
-        uses: actions/github-script@v7
-        with:
+        uses: actions/github-script@v7  
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const issue = context.payload.issue;
@@ -35,7 +34,7 @@ jobs:
         env:
           CURRENT_ISSUE_TITLE: ${{ steps.current_issue.outputs.title }}
           CURRENT_ISSUE_NUMBER: ${{ steps.current_issue.outputs.number }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v7  
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -214,7 +213,7 @@ jobs:
 
       - name: Close duplicate issue
         if: steps.analyze_duplicates.outcome == 'success' && steps.analyze_duplicates.outputs.result != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v7  
         env:
           DUPLICATE_RESULT: ${{ steps.analyze_duplicates.outputs.result }}
           CURRENT_ISSUE_NUMBER: ${{ steps.current_issue.outputs.number }}

--- a/.github/workflows/examples-check.yml
+++ b/.github/workflows/examples-check.yml
@@ -14,13 +14,13 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
 
       - name: install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev
 
       - name: setup rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203  # stable
         with:
           toolchain: stable
 

--- a/.github/workflows/publish-all.yml
+++ b/.github/workflows/publish-all.yml
@@ -23,27 +23,27 @@ jobs:
     name: Validate & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6  
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203  # stable
         with:
           components: rustfmt, clippy
 
       - name: Cache Cargo registry
-        uses: actions/cache@v5
+        uses: actions/cache@v5  # TODO: pin to SHA — verify at https://github.com/actions/cache/tags
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache Cargo index
-        uses: actions/cache@v5
+        uses: actions/cache@v5  # TODO: pin to SHA — verify at https://github.com/actions/cache/tags
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache Cargo build
-        uses: actions/cache@v5
+        uses: actions/cache@v5  # TODO: pin to SHA — verify at https://github.com/actions/cache/tags
         with:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
@@ -64,25 +64,25 @@ jobs:
     needs: validate
     environment: crates-io
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6  
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203  # stable
 
       - name: Cache Cargo registry
-        uses: actions/cache@v5
+        uses: actions/cache@v5  
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache Cargo index
-        uses: actions/cache@v5
+        uses: actions/cache@v5  
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache Cargo build
-        uses: actions/cache@v5
+        uses: actions/cache@v5  
         with:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
@@ -116,13 +116,13 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6  
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203 
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v6  
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -151,13 +151,13 @@ jobs:
     needs: validate
     environment: maven-central
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6  # TODO: pin to SHA — verify at https://github.com/actions/checkout/tags
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203  # stable
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5  # TODO: pin to SHA — verify at https://github.com/actions/setup-java/tags
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -167,7 +167,7 @@ jobs:
           gpg-passphrase: GPG_PASSPHRASE
 
       - name: Cache Maven packages
-        uses: actions/cache@v5
+        uses: actions/cache@v5  # TODO: pin to SHA — verify at https://github.com/actions/cache/tags
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -199,10 +199,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: validate
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6  # TODO: pin to SHA — verify at https://github.com/actions/checkout/tags
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203  # stable
 
       - name: Generate Go bindings
         run: |
@@ -237,7 +237,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6  # TODO: pin to SHA — verify at https://github.com/actions/checkout/tags
 
       - name: Get version from tag
         id: get_version
@@ -251,7 +251,7 @@ jobs:
           ./scripts/release.sh "$VERSION" --skip-tests --skip-build
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2  # TODO: pin to SHA — verify at https://github.com/softprops/action-gh-release/tags
         with:
           files: target/release-${{ steps.get_version.outputs.version }}/*
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,15 +20,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6  
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203  # stable
         with:
           components: rustfmt, clippy
 
       - name: Cache dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v5  
         with:
           path: |
             ~/.cargo/registry
@@ -73,15 +73,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6  
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203  # stable
         with:
           targets: ${{ matrix.target }}
 
       - name: Cache dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v5  
         with:
           path: |
             ~/.cargo/registry
@@ -102,7 +102,7 @@ jobs:
           fi
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v6 
         with:
           name: ${{ matrix.asset_name }}
           path: target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6  
 
       - name: Extract version
         id: version
@@ -125,7 +125,7 @@ jobs:
           fi
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v7 
         with:
           path: ./artifacts
 
@@ -173,7 +173,7 @@ jobs:
           echo "$NOTES" > release_notes.md
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2 
         with:
           tag_name: v${{ steps.version.outputs.version }}
           name: Release v${{ steps.version.outputs.version }}
@@ -190,13 +190,13 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6  
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203  # stable
 
       - name: Cache dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v5 
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/scheduled-issue-triage.yml
+++ b/.github/workflows/scheduled-issue-triage.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
 
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
@@ -71,7 +71,7 @@ jobs:
 
       - name: Get repository labels
         id: get_labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@v7  
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -99,7 +99,7 @@ jobs:
         id: issue_details
         env:
           ISSUES_JSON: ${{ steps.find_issues.outputs.issues_to_triage }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v7 
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -222,7 +222,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Apply labels to issues
-        uses: actions/github-script@v7
+        uses: actions/github-script@v7 
         env:
           TRIAGE_RESULT: ${{ steps.triage.outputs.result }}
         with:

--- a/.github/workflows/self-assign.yml
+++ b/.github/workflows/self-assign.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Handle /assign and /unassign commands
-        uses: actions/github-script@v7
+        uses: actions/github-script@v7  
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/APP_DEVELOPMENT_GUIDE.md
+++ b/APP_DEVELOPMENT_GUIDE.md
@@ -20,7 +20,6 @@ In `crates/mofa-myplugin/Cargo.toml` set the crate type to `cdylib`:
 crate-type = ["cdylib"]
 
 [dependencies]
-# … your plugin dependencies
 ```
 
 ---
@@ -30,11 +29,6 @@ crate-type = ["cdylib"]
 Every plugin **must** export a `mofa_app_create` symbol with a stable C ABI:
 
 ```rust
-// crates/mofa-myplugin/src/lib.rs
-
-/// # Safety
-/// Called by mofa-plugin-loader to construct the plugin.
-/// The returned pointer is owned by the caller.
 #[no_mangle]
 pub extern "C" fn mofa_app_create() -> *mut () {
     let app = Box::new(MyPlugin::new());
@@ -59,9 +53,9 @@ Place a `plugin.toml` next to the compiled shared library:
 
 ```toml
 [plugin]
-id      = "mofa-myplugin"   # unique id
+id      = "mofa-myplugin"
 version = "0.1.0"
-entry   = "libmofa_myplugin.so"   # or .dylib on macOS
+entry   = "libmofa_myplugin.so"
 ```
 
 For a typical `cargo build --release` the library lands in
@@ -78,7 +72,7 @@ use mofa_plugin_loader::{load_all_plugins, PluginRegistry};
 use std::path::Path;
 
 let registry = PluginRegistry::new();
-let plugin_dir = Path::new("plugins"); // directory containing plugin sub-dirs
+let plugin_dir = Path::new("plugins");
 
 let n = load_all_plugins(plugin_dir, &registry);
 println!("Loaded {n} plugins");
@@ -117,10 +111,8 @@ When enabled, the shell:
 ### Typical iteration loop
 
 ```bash
-# Terminal 1 — run the shell with hot-reload
 MOFA_HOT_RELOAD=1 cargo run -p mofa-studio-shell
 
-# Terminal 2 — rebuild your plugin; the shell reloads it automatically
 cargo build -p mofa-myplugin
 cp target/debug/libmofa_myplugin.so plugins/mofa-myplugin/
 ```
@@ -147,12 +139,10 @@ if hot_reload_enabled() {
         registry.clone(),
         |info| {
             println!("Reloaded plugin: {} v{}", info.id, info.version);
-            // Trigger a Makepad live_design! refresh here.
         },
     )
     .expect("failed to start hot-reload watcher");
 
-    // Keep `_guard` alive for the duration of the shell.
 }
 ```
 

--- a/APP_DEVELOPMENT_GUIDE.md
+++ b/APP_DEVELOPMENT_GUIDE.md
@@ -1,0 +1,184 @@
+# MoFA App Development Guide
+
+This guide walks you through creating a new MofaApp plugin and using the
+**runtime hot-reload** workflow to iterate quickly without restarting the shell.
+
+---
+
+## 1. Plugin crate setup
+
+Create a new library crate for your plugin:
+
+```bash
+cargo new --lib crates/mofa-myplugin
+```
+
+In `crates/mofa-myplugin/Cargo.toml` set the crate type to `cdylib`:
+
+```toml
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+# … your plugin dependencies
+```
+
+---
+
+## 2. Implement the C-ABI entry point
+
+Every plugin **must** export a `mofa_app_create` symbol with a stable C ABI:
+
+```rust
+// crates/mofa-myplugin/src/lib.rs
+
+/// # Safety
+/// Called by mofa-plugin-loader to construct the plugin.
+/// The returned pointer is owned by the caller.
+#[no_mangle]
+pub extern "C" fn mofa_app_create() -> *mut () {
+    let app = Box::new(MyPlugin::new());
+    Box::into_raw(app) as *mut ()
+}
+
+struct MyPlugin;
+
+impl MyPlugin {
+    fn new() -> Self { MyPlugin }
+}
+```
+
+> **ABI stability:** Use `extern "C"` for all exported symbols.  Rust's default
+> ABI is not stable across compiler versions.
+
+---
+
+## 3. Add a `plugin.toml` manifest
+
+Place a `plugin.toml` next to the compiled shared library:
+
+```toml
+[plugin]
+id      = "mofa-myplugin"   # unique id
+version = "0.1.0"
+entry   = "libmofa_myplugin.so"   # or .dylib on macOS
+```
+
+For a typical `cargo build --release` the library lands in
+`target/release/libmofa_myplugin.so` (Linux) or `.dylib` (macOS).
+
+Copy `plugin.toml` there, or use a build script to do it automatically.
+
+---
+
+## 4. Load plugins at shell startup
+
+```rust
+use mofa_plugin_loader::{load_all_plugins, PluginRegistry};
+use std::path::Path;
+
+let registry = PluginRegistry::new();
+let plugin_dir = Path::new("plugins"); // directory containing plugin sub-dirs
+
+let n = load_all_plugins(plugin_dir, &registry);
+println!("Loaded {n} plugins");
+```
+
+Each plugin lives in its own sub-directory inside `plugins/`:
+
+```
+plugins/
+  mofa-fm/
+    plugin.toml
+    libmofa_fm.so
+  mofa-settings/
+    plugin.toml
+    libmofa_settings.so
+```
+
+---
+
+## 5. Enable hot-reload during development
+
+Hot-reload is **off by default**.  Enable it with the environment variable:
+
+```bash
+MOFA_HOT_RELOAD=1 cargo run
+```
+
+When enabled, the shell:
+
+1. Watches the plugin directory for `.so` / `.dylib` changes.
+2. On change: drops the old `PluginHandle` (unloads the library).
+3. Calls `PluginHandle::load()` to load the new version.
+4. Re-registers the plugin in the `PluginRegistry`.
+5. Calls your `on_reload` callback so the UI can refresh.
+
+### Typical iteration loop
+
+```bash
+# Terminal 1 — run the shell with hot-reload
+MOFA_HOT_RELOAD=1 cargo run -p mofa-studio-shell
+
+# Terminal 2 — rebuild your plugin; the shell reloads it automatically
+cargo build -p mofa-myplugin
+cp target/debug/libmofa_myplugin.so plugins/mofa-myplugin/
+```
+
+Or automate with `cargo-watch`:
+
+```bash
+cargo watch -w crates/mofa-myplugin/src \
+  -s 'cargo build -p mofa-myplugin && \
+      cp target/debug/libmofa_myplugin.so plugins/mofa-myplugin/'
+```
+
+---
+
+## 6. Spawning the hot-reload thread
+
+```rust
+use mofa_plugin_loader::{hot_reload_enabled, spawn_hot_reload_thread};
+use std::path::PathBuf;
+
+if hot_reload_enabled() {
+    let _guard = spawn_hot_reload_thread(
+        PathBuf::from("plugins"),
+        registry.clone(),
+        |info| {
+            println!("Reloaded plugin: {} v{}", info.id, info.version);
+            // Trigger a Makepad live_design! refresh here.
+        },
+    )
+    .expect("failed to start hot-reload watcher");
+
+    // Keep `_guard` alive for the duration of the shell.
+}
+```
+
+> **Note:** Plugin state is **lost** on reload.  This is intentional for dev
+> mode.  Production deployments should leave `MOFA_HOT_RELOAD` unset.
+
+---
+
+## 7. Safety considerations
+
+| Concern | Mitigation |
+|---|---|
+| `unsafe` in `PluginHandle::load` | Contained inside the loader crate; plugin ABI contract is enforced by `extern "C"` |
+| Use-after-free on reload | Old `PluginHandle` is dropped before the new one is registered; `Library` is kept alive by the handle |
+| Production risk | Feature is fully disabled unless `MOFA_HOT_RELOAD=1` is explicitly set |
+| Symbol name clashes | Each plugin exports a single well-known symbol; namespacing via plugin id prevents conflicts |
+
+---
+
+## 8. Platform notes
+
+| Platform | Library extension | Status |
+|---|---|---|
+| Linux | `.so` | ✅ Supported |
+| macOS | `.dylib` | ✅ Supported |
+| Windows | `.dll` | 🚧 Planned |
+
+The file watcher (`notify` crate) uses `inotify` on Linux and `FSEvents` on
+macOS, both of which are zero-overhead in normal operation.

--- a/integration_test.rs
+++ b/integration_test.rs
@@ -1,0 +1,60 @@
+// mofa-plugin-loader/tests/integration_test.rs
+//
+// Smoke tests for the plugin loader.
+// These tests do NOT require an actual compiled .so; they test the error paths
+// and the env-gate logic.
+
+use mofa_plugin_loader::{hot_reload_enabled, load_all_plugins, PluginRegistry};
+use tempfile::TempDir;
+use std::fs;
+
+#[test]
+fn hot_reload_disabled_by_default() {
+    // Unset the variable in case the test runner accidentally set it.
+    std::env::remove_var("MOFA_HOT_RELOAD");
+    assert!(!hot_reload_enabled());
+}
+
+#[test]
+fn hot_reload_enabled_when_var_is_one() {
+    std::env::set_var("MOFA_HOT_RELOAD", "1");
+    assert!(hot_reload_enabled());
+    std::env::remove_var("MOFA_HOT_RELOAD");
+}
+
+#[test]
+fn load_all_plugins_empty_dir_returns_zero() {
+    let dir = TempDir::new().unwrap();
+    let registry = PluginRegistry::new();
+    let loaded = load_all_plugins(dir.path(), &registry);
+    assert_eq!(loaded, 0);
+}
+
+#[test]
+fn load_all_plugins_skips_dirs_without_manifest() {
+    let dir = TempDir::new().unwrap();
+    // A sub-dir with no plugin.toml should be silently skipped.
+    fs::create_dir(dir.path().join("no_manifest")).unwrap();
+    let registry = PluginRegistry::new();
+    let loaded = load_all_plugins(dir.path(), &registry);
+    assert_eq!(loaded, 0);
+}
+
+#[test]
+fn load_plugin_handle_missing_lib_returns_error() {
+    let dir = TempDir::new().unwrap();
+    // Write a manifest that points to a non-existent entry.
+    fs::write(
+        dir.path().join("plugin.toml"),
+        r#"
+[plugin]
+id      = "test-plugin"
+version = "0.1.0"
+entry   = "libdoes_not_exist.so"
+"#,
+    )
+    .unwrap();
+
+    let result = mofa_plugin_loader::PluginHandle::load(dir.path());
+    assert!(result.is_err(), "expected an error when .so is missing");
+}

--- a/integration_test.rs
+++ b/integration_test.rs
@@ -1,16 +1,9 @@
-// mofa-plugin-loader/tests/integration_test.rs
-//
-// Smoke tests for the plugin loader.
-// These tests do NOT require an actual compiled .so; they test the error paths
-// and the env-gate logic.
-
 use mofa_plugin_loader::{hot_reload_enabled, load_all_plugins, PluginRegistry};
 use tempfile::TempDir;
 use std::fs;
 
 #[test]
 fn hot_reload_disabled_by_default() {
-    // Unset the variable in case the test runner accidentally set it.
     std::env::remove_var("MOFA_HOT_RELOAD");
     assert!(!hot_reload_enabled());
 }
@@ -33,7 +26,6 @@ fn load_all_plugins_empty_dir_returns_zero() {
 #[test]
 fn load_all_plugins_skips_dirs_without_manifest() {
     let dir = TempDir::new().unwrap();
-    // A sub-dir with no plugin.toml should be silently skipped.
     fs::create_dir(dir.path().join("no_manifest")).unwrap();
     let registry = PluginRegistry::new();
     let loaded = load_all_plugins(dir.path(), &registry);
@@ -43,7 +35,6 @@ fn load_all_plugins_skips_dirs_without_manifest() {
 #[test]
 fn load_plugin_handle_missing_lib_returns_error() {
     let dir = TempDir::new().unwrap();
-    // Write a manifest that points to a non-existent entry.
     fs::write(
         dir.path().join("plugin.toml"),
         r#"

--- a/lib.rs
+++ b/lib.rs
@@ -1,0 +1,161 @@
+// mofa-plugin-loader/src/lib.rs
+//
+// Public API for the mofa-plugin-loader crate.
+//
+// Hot-reload is guarded by the `MOFA_HOT_RELOAD=1` environment variable.
+// Nothing runs in production unless that variable is explicitly set.
+
+mod plugin_loader;
+mod watcher;
+
+pub use plugin_loader::{PluginHandle, PluginInfo, PluginLoadError, PluginRegistry};
+pub use watcher::{watch_plugin_dir, HotReloadEvent, WatcherGuard};
+
+use std::{
+    path::{Path, PathBuf},
+    sync::mpsc::TryRecvError,
+    thread,
+    time::Duration,
+};
+
+/// Returns `true` when `MOFA_HOT_RELOAD=1` is set in the environment.
+///
+/// All hot-reload functionality should be gated on this check so production
+/// deployments are unaffected by accident.
+pub fn hot_reload_enabled() -> bool {
+    std::env::var("MOFA_HOT_RELOAD")
+        .map(|v| v.trim() == "1")
+        .unwrap_or(false)
+}
+
+/// Convenience: scan `plugin_dir` for every sub-directory that contains a
+/// `plugin.toml` and load them all into `registry`.
+///
+/// Returns the number of plugins successfully loaded.
+pub fn load_all_plugins(
+    plugin_dir: &Path,
+    registry: &PluginRegistry,
+) -> usize {
+    let mut loaded = 0usize;
+
+    let entries = match std::fs::read_dir(plugin_dir) {
+        Ok(e) => e,
+        Err(err) => {
+            tracing::error!(
+                path = %plugin_dir.display(),
+                error = %err,
+                "failed to read plugin directory"
+            );
+            return 0;
+        }
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() && path.join("plugin.toml").exists() {
+            match PluginHandle::load(&path) {
+                Ok(handle) => {
+                    tracing::info!(
+                        id = %handle.info.id,
+                        version = %handle.info.version,
+                        path = %path.display(),
+                        "plugin loaded"
+                    );
+                    registry.register(handle);
+                    loaded += 1;
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        path = %path.display(),
+                        error = %err,
+                        "failed to load plugin"
+                    );
+                }
+            }
+        }
+    }
+
+    loaded
+}
+
+/// Spawn a background thread that:
+/// 1. Watches `plugin_dir` for `.so` / `.dylib` changes.
+/// 2. On change: finds the parent plugin directory, drops the old handle,
+///    loads the new one, and re-registers it.
+///
+/// **Only call this when `hot_reload_enabled()` returns `true`.**
+///
+/// Returns a `WatcherGuard`; drop it to stop the watcher thread.
+///
+/// The `on_reload` callback is invoked on the background thread each time a
+/// plugin is successfully reloaded.  Use it to refresh UI state.
+pub fn spawn_hot_reload_thread<F>(
+    plugin_dir: PathBuf,
+    registry: PluginRegistry,
+    on_reload: F,
+) -> Result<WatcherGuard, notify::Error>
+where
+    F: Fn(&PluginInfo) + Send + 'static,
+{
+    let (guard, rx) = watch_plugin_dir(&plugin_dir)?;
+
+    thread::spawn(move || {
+        loop {
+            match rx.try_recv() {
+                Ok(HotReloadEvent::Updated(lib_path)) => {
+                    // The .so lives inside a plugin sub-dir; walk up to find it.
+                    let dir = lib_path
+                        .parent()
+                        .map(PathBuf::from)
+                        .unwrap_or_else(|| plugin_dir.clone());
+
+                    // Small delay so the linker has finished writing the file.
+                    thread::sleep(Duration::from_millis(200));
+
+                    match PluginHandle::load(&dir) {
+                        Ok(handle) => {
+                            tracing::info!(
+                                id = %handle.info.id,
+                                version = %handle.info.version,
+                                "hot-reloaded plugin"
+                            );
+                            on_reload(&handle.info);
+                            registry.register(handle);
+                        }
+                        Err(err) => {
+                            tracing::warn!(
+                                path = %dir.display(),
+                                error = %err,
+                                "hot-reload failed"
+                            );
+                        }
+                    }
+                }
+                Ok(HotReloadEvent::Removed(lib_path)) => {
+                    // Best-effort: try to figure out plugin id from path stem.
+                    let stem = lib_path
+                        .file_stem()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or("");
+                    tracing::info!(stem, "plugin library removed; unregistering");
+                    // Registry keys are plugin ids, not file stems, so we do a
+                    // best-effort search.
+                    for id in registry.get_ids() {
+                        if stem.contains(&id) {
+                            registry.unregister(&id);
+                        }
+                    }
+                }
+                Err(TryRecvError::Empty) => {
+                    thread::sleep(Duration::from_millis(100));
+                }
+                Err(TryRecvError::Disconnected) => {
+                    tracing::info!("hot-reload watcher channel closed; exiting thread");
+                    break;
+                }
+            }
+        }
+    });
+
+    Ok(guard)
+}

--- a/lib.rs
+++ b/lib.rs
@@ -1,10 +1,3 @@
-// mofa-plugin-loader/src/lib.rs
-//
-// Public API for the mofa-plugin-loader crate.
-//
-// Hot-reload is guarded by the `MOFA_HOT_RELOAD=1` environment variable.
-// Nothing runs in production unless that variable is explicitly set.
-
 mod plugin_loader;
 mod watcher;
 
@@ -18,20 +11,12 @@ use std::{
     time::Duration,
 };
 
-/// Returns `true` when `MOFA_HOT_RELOAD=1` is set in the environment.
-///
-/// All hot-reload functionality should be gated on this check so production
-/// deployments are unaffected by accident.
 pub fn hot_reload_enabled() -> bool {
     std::env::var("MOFA_HOT_RELOAD")
         .map(|v| v.trim() == "1")
         .unwrap_or(false)
 }
 
-/// Convenience: scan `plugin_dir` for every sub-directory that contains a
-/// `plugin.toml` and load them all into `registry`.
-///
-/// Returns the number of plugins successfully loaded.
 pub fn load_all_plugins(
     plugin_dir: &Path,
     registry: &PluginRegistry,
@@ -78,17 +63,6 @@ pub fn load_all_plugins(
     loaded
 }
 
-/// Spawn a background thread that:
-/// 1. Watches `plugin_dir` for `.so` / `.dylib` changes.
-/// 2. On change: finds the parent plugin directory, drops the old handle,
-///    loads the new one, and re-registers it.
-///
-/// **Only call this when `hot_reload_enabled()` returns `true`.**
-///
-/// Returns a `WatcherGuard`; drop it to stop the watcher thread.
-///
-/// The `on_reload` callback is invoked on the background thread each time a
-/// plugin is successfully reloaded.  Use it to refresh UI state.
 pub fn spawn_hot_reload_thread<F>(
     plugin_dir: PathBuf,
     registry: PluginRegistry,
@@ -103,13 +77,11 @@ where
         loop {
             match rx.try_recv() {
                 Ok(HotReloadEvent::Updated(lib_path)) => {
-                    // The .so lives inside a plugin sub-dir; walk up to find it.
                     let dir = lib_path
                         .parent()
                         .map(PathBuf::from)
                         .unwrap_or_else(|| plugin_dir.clone());
 
-                    // Small delay so the linker has finished writing the file.
                     thread::sleep(Duration::from_millis(200));
 
                     match PluginHandle::load(&dir) {
@@ -132,14 +104,11 @@ where
                     }
                 }
                 Ok(HotReloadEvent::Removed(lib_path)) => {
-                    // Best-effort: try to figure out plugin id from path stem.
                     let stem = lib_path
                         .file_stem()
                         .and_then(|s| s.to_str())
                         .unwrap_or("");
                     tracing::info!(stem, "plugin library removed; unregistering");
-                    // Registry keys are plugin ids, not file stems, so we do a
-                    // best-effort search.
                     for id in registry.get_ids() {
                         if stem.contains(&id) {
                             registry.unregister(&id);

--- a/plugin.toml.example
+++ b/plugin.toml.example
@@ -1,0 +1,16 @@
+# plugin.toml — place this file in your plugin's output directory
+# alongside the compiled shared library.
+#
+# Example for a plugin called "mofa-fm":
+#
+#   Linux build:   cargo build -p mofa-fm --release
+#   macOS build:   cargo build -p mofa-fm --release
+#
+# The `entry` field must match the actual filename produced by `cargo build`:
+#   Linux  → libmofa_fm.so
+#   macOS  → libmofa_fm.dylib
+
+[plugin]
+id      = "mofa-fm"       # must be unique across all loaded plugins
+version = "0.3.0"
+entry   = "libmofa_fm.so" # or libmofa_fm.dylib on macOS

--- a/plugin.toml.example
+++ b/plugin.toml.example
@@ -1,16 +1,4 @@
-# plugin.toml — place this file in your plugin's output directory
-# alongside the compiled shared library.
-#
-# Example for a plugin called "mofa-fm":
-#
-#   Linux build:   cargo build -p mofa-fm --release
-#   macOS build:   cargo build -p mofa-fm --release
-#
-# The `entry` field must match the actual filename produced by `cargo build`:
-#   Linux  → libmofa_fm.so
-#   macOS  → libmofa_fm.dylib
-
 [plugin]
-id      = "mofa-fm"       # must be unique across all loaded plugins
+id      = "mofa-fm"
 version = "0.3.0"
-entry   = "libmofa_fm.so" # or libmofa_fm.dylib on macOS
+entry   = "libmofa_fm.so"

--- a/plugin_loader.rs
+++ b/plugin_loader.rs
@@ -1,7 +1,4 @@
-// mofa-plugin-loader/src/plugin_loader.rs
-//
-// Runtime hot-reload for MofaApp plugins.
-// Enabled only when MOFA_HOT_RELOAD=1 is set (off by default).
+
 
 use std::{
     collections::HashMap,
@@ -11,20 +8,17 @@ use std::{
 
 use libloading::{Library, Symbol};
 
-/// Metadata exposed by every plugin `.so` / `.dylib`.
 #[derive(Clone, Debug)]
 pub struct PluginInfo {
     pub id: String,
     pub version: String,
 }
 
-/// A loaded plugin.  Keeps the `Library` alive so symbols stay valid.
+
 pub struct PluginHandle {
     _lib: Library,
     pub info: PluginInfo,
-    /// C-ABI constructor: `extern "C" fn() -> *mut dyn MofaApp`
-    ///
-    /// Callers cast the raw pointer to the concrete app type they expect.
+    
     pub create_raw: unsafe extern "C" fn() -> *mut (),
 }
 
@@ -36,7 +30,7 @@ impl std::fmt::Debug for PluginHandle {
     }
 }
 
-/// Errors that can arise while loading a plugin.
+
 #[derive(Debug, thiserror::Error)]
 pub enum PluginLoadError {
     #[error("libloading error: {0}")]
@@ -58,8 +52,6 @@ pub enum PluginLoadError {
     MissingSymbol { symbol: String, path: PathBuf },
 }
 
-// ── plugin.toml schema ────────────────────────────────────────────────────────
-
 #[derive(serde::Deserialize, Debug)]
 struct PluginManifest {
     plugin: PluginSection,
@@ -69,21 +61,12 @@ struct PluginManifest {
 struct PluginSection {
     id: String,
     version: String,
-    entry: String, // e.g. "libmofa_fm.so" or "libmofa_fm.dylib"
+    entry: String, 
 }
 
-// ── PluginHandle ──────────────────────────────────────────────────────────────
-
 impl PluginHandle {
-    /// Load a plugin from its directory.
-    ///
-    /// Expects `plugin_dir/plugin.toml` and `plugin_dir/<entry>`.
-    ///
-    /// # Safety
-    /// Loading a shared library is inherently unsafe.  The plugin ABI must
-    /// match (C ABI, stable symbol names).
+
     pub fn load(plugin_dir: &Path) -> Result<Self, PluginLoadError> {
-        // 1. Parse manifest
         let manifest_path = plugin_dir.join("plugin.toml");
         let raw = std::fs::read_to_string(&manifest_path).map_err(|e| {
             PluginLoadError::Manifest {
@@ -99,15 +82,12 @@ impl PluginHandle {
 
         let lib_path = plugin_dir.join(&manifest.plugin.entry);
 
-        // 2. Load the shared library
-        // SAFETY: plugin ABI contract must be upheld by the caller.
+        
         let lib = unsafe { Library::new(&lib_path)? };
 
-        // 3. Resolve the mandatory constructor symbol
-        // SAFETY: same constraint as above.
         let create_raw: Symbol<unsafe extern "C" fn() -> *mut ()> = unsafe {
             lib.get(b"mofa_app_create\0").map_err(|e| {
-                let _ = e; // rethrow with context
+                let _ = e;
                 PluginLoadError::MissingSymbol {
                     symbol: "mofa_app_create".into(),
                     path: lib_path.clone(),
@@ -115,9 +95,7 @@ impl PluginHandle {
             })?
         };
 
-        // Extend the lifetime to 'static — safe because we keep `_lib` alive.
-        // SAFETY: `lib` is stored in the same struct, so symbols are valid as
-        //         long as `PluginHandle` is alive.
+        
         let create_raw: unsafe extern "C" fn() -> *mut () =
             unsafe { std::mem::transmute(create_raw.into_raw()) };
 
@@ -132,9 +110,6 @@ impl PluginHandle {
     }
 }
 
-// ── Plugin registry ───────────────────────────────────────────────────────────
-
-/// Thread-safe map of `plugin_id → PluginHandle`.
 #[derive(Debug, Default)]
 pub struct PluginRegistry {
     inner: Arc<Mutex<HashMap<String, PluginHandle>>>,
@@ -145,7 +120,6 @@ impl PluginRegistry {
         Self::default()
     }
 
-    /// Insert or replace a plugin.
     pub fn register(&self, handle: PluginHandle) {
         let id = handle.info.id.clone();
         let mut guard = self.inner.lock().expect("registry lock poisoned");
@@ -158,8 +132,6 @@ impl PluginRegistry {
         }
     }
 
-    /// Remove a plugin by id, returning the old handle (which unloads the lib
-    /// when dropped).
     pub fn unregister(&self, id: &str) -> Option<PluginHandle> {
         self.inner
             .lock()

--- a/plugin_loader.rs
+++ b/plugin_loader.rs
@@ -1,0 +1,178 @@
+// mofa-plugin-loader/src/plugin_loader.rs
+//
+// Runtime hot-reload for MofaApp plugins.
+// Enabled only when MOFA_HOT_RELOAD=1 is set (off by default).
+
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+};
+
+use libloading::{Library, Symbol};
+
+/// Metadata exposed by every plugin `.so` / `.dylib`.
+#[derive(Clone, Debug)]
+pub struct PluginInfo {
+    pub id: String,
+    pub version: String,
+}
+
+/// A loaded plugin.  Keeps the `Library` alive so symbols stay valid.
+pub struct PluginHandle {
+    _lib: Library,
+    pub info: PluginInfo,
+    /// C-ABI constructor: `extern "C" fn() -> *mut dyn MofaApp`
+    ///
+    /// Callers cast the raw pointer to the concrete app type they expect.
+    pub create_raw: unsafe extern "C" fn() -> *mut (),
+}
+
+impl std::fmt::Debug for PluginHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PluginHandle")
+            .field("info", &self.info)
+            .finish()
+    }
+}
+
+/// Errors that can arise while loading a plugin.
+#[derive(Debug, thiserror::Error)]
+pub enum PluginLoadError {
+    #[error("libloading error: {0}")]
+    Lib(#[from] libloading::Error),
+
+    #[error("manifest read error for {path}: {source}")]
+    Manifest {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[error("manifest parse error for {path}: {source}")]
+    ManifestParse {
+        path: PathBuf,
+        source: toml::de::Error,
+    },
+
+    #[error("missing symbol `{symbol}` in {path}")]
+    MissingSymbol { symbol: String, path: PathBuf },
+}
+
+// ── plugin.toml schema ────────────────────────────────────────────────────────
+
+#[derive(serde::Deserialize, Debug)]
+struct PluginManifest {
+    plugin: PluginSection,
+}
+
+#[derive(serde::Deserialize, Debug)]
+struct PluginSection {
+    id: String,
+    version: String,
+    entry: String, // e.g. "libmofa_fm.so" or "libmofa_fm.dylib"
+}
+
+// ── PluginHandle ──────────────────────────────────────────────────────────────
+
+impl PluginHandle {
+    /// Load a plugin from its directory.
+    ///
+    /// Expects `plugin_dir/plugin.toml` and `plugin_dir/<entry>`.
+    ///
+    /// # Safety
+    /// Loading a shared library is inherently unsafe.  The plugin ABI must
+    /// match (C ABI, stable symbol names).
+    pub fn load(plugin_dir: &Path) -> Result<Self, PluginLoadError> {
+        // 1. Parse manifest
+        let manifest_path = plugin_dir.join("plugin.toml");
+        let raw = std::fs::read_to_string(&manifest_path).map_err(|e| {
+            PluginLoadError::Manifest {
+                path: manifest_path.clone(),
+                source: e,
+            }
+        })?;
+        let manifest: PluginManifest =
+            toml::from_str(&raw).map_err(|e| PluginLoadError::ManifestParse {
+                path: manifest_path,
+                source: e,
+            })?;
+
+        let lib_path = plugin_dir.join(&manifest.plugin.entry);
+
+        // 2. Load the shared library
+        // SAFETY: plugin ABI contract must be upheld by the caller.
+        let lib = unsafe { Library::new(&lib_path)? };
+
+        // 3. Resolve the mandatory constructor symbol
+        // SAFETY: same constraint as above.
+        let create_raw: Symbol<unsafe extern "C" fn() -> *mut ()> = unsafe {
+            lib.get(b"mofa_app_create\0").map_err(|e| {
+                let _ = e; // rethrow with context
+                PluginLoadError::MissingSymbol {
+                    symbol: "mofa_app_create".into(),
+                    path: lib_path.clone(),
+                }
+            })?
+        };
+
+        // Extend the lifetime to 'static — safe because we keep `_lib` alive.
+        // SAFETY: `lib` is stored in the same struct, so symbols are valid as
+        //         long as `PluginHandle` is alive.
+        let create_raw: unsafe extern "C" fn() -> *mut () =
+            unsafe { std::mem::transmute(create_raw.into_raw()) };
+
+        Ok(PluginHandle {
+            _lib: lib,
+            info: PluginInfo {
+                id: manifest.plugin.id,
+                version: manifest.plugin.version,
+            },
+            create_raw,
+        })
+    }
+}
+
+// ── Plugin registry ───────────────────────────────────────────────────────────
+
+/// Thread-safe map of `plugin_id → PluginHandle`.
+#[derive(Debug, Default)]
+pub struct PluginRegistry {
+    inner: Arc<Mutex<HashMap<String, PluginHandle>>>,
+}
+
+impl PluginRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert or replace a plugin.
+    pub fn register(&self, handle: PluginHandle) {
+        let id = handle.info.id.clone();
+        let mut guard = self.inner.lock().expect("registry lock poisoned");
+        if let Some(old) = guard.insert(id.clone(), handle) {
+            tracing::info!(
+                plugin_id = %id,
+                old_version = %old.info.version,
+                "unregistered old plugin version"
+            );
+        }
+    }
+
+    /// Remove a plugin by id, returning the old handle (which unloads the lib
+    /// when dropped).
+    pub fn unregister(&self, id: &str) -> Option<PluginHandle> {
+        self.inner
+            .lock()
+            .expect("registry lock poisoned")
+            .remove(id)
+    }
+
+    pub fn get_ids(&self) -> Vec<String> {
+        self.inner
+            .lock()
+            .expect("registry lock poisoned")
+            .keys()
+            .cloned()
+            .collect()
+    }
+}

--- a/watcher.rs
+++ b/watcher.rs
@@ -1,8 +1,3 @@
-// mofa-plugin-loader/src/watcher.rs
-//
-// File-system watcher that detects `.so` / `.dylib` changes and sends
-// HotReloadEvents on a channel.
-
 use std::{
     path::{Path, PathBuf},
     sync::mpsc::{self, Receiver, Sender},
@@ -13,19 +8,12 @@ use notify::{
     Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher,
 };
 
-/// Events the shell reacts to.
 #[derive(Debug)]
 pub enum HotReloadEvent {
     Updated(PathBuf),
     Removed(PathBuf),
 }
 
-/// Spawn a background thread watching `plugin_dir` for shared-library changes.
-///
-/// Returns a `Receiver` the shell polls / selects on.
-///
-/// The watcher is kept alive by the returned `WatcherGuard`; drop it to stop
-/// watching.
 pub struct WatcherGuard {
     _watcher: RecommendedWatcher,
 }
@@ -73,7 +61,7 @@ pub fn watch_plugin_dir(
                         }
                     }
                 }
-                Ok(_) => {} // other events ignored
+                Ok(_) => {}
                 Err(e) => {
                     tracing::warn!(error = %e, "hot-reload watcher error");
                 }
@@ -92,7 +80,6 @@ pub fn watch_plugin_dir(
     Ok((WatcherGuard { _watcher: watcher }, rx))
 }
 
-/// Returns `true` for `.so` (Linux) and `.dylib` (macOS) files.
 fn is_shared_lib(path: &Path) -> bool {
     match path.extension().and_then(|e| e.to_str()) {
         Some("so") | Some("dylib") => true,

--- a/watcher.rs
+++ b/watcher.rs
@@ -1,0 +1,101 @@
+// mofa-plugin-loader/src/watcher.rs
+//
+// File-system watcher that detects `.so` / `.dylib` changes and sends
+// HotReloadEvents on a channel.
+
+use std::{
+    path::{Path, PathBuf},
+    sync::mpsc::{self, Receiver, Sender},
+    time::Duration,
+};
+
+use notify::{
+    Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher,
+};
+
+/// Events the shell reacts to.
+#[derive(Debug)]
+pub enum HotReloadEvent {
+    Updated(PathBuf),
+    Removed(PathBuf),
+}
+
+/// Spawn a background thread watching `plugin_dir` for shared-library changes.
+///
+/// Returns a `Receiver` the shell polls / selects on.
+///
+/// The watcher is kept alive by the returned `WatcherGuard`; drop it to stop
+/// watching.
+pub struct WatcherGuard {
+    _watcher: RecommendedWatcher,
+}
+
+pub fn watch_plugin_dir(
+    plugin_dir: &Path,
+) -> Result<(WatcherGuard, Receiver<HotReloadEvent>), notify::Error> {
+    let (tx, rx): (Sender<HotReloadEvent>, Receiver<HotReloadEvent>) =
+        mpsc::channel();
+
+    let tx_clone = tx.clone();
+
+    let mut watcher = RecommendedWatcher::new(
+        move |res: notify::Result<Event>| {
+            match res {
+                Ok(Event {
+                    kind: EventKind::Modify(_) | EventKind::Create(_),
+                    paths,
+                    ..
+                }) => {
+                    for path in paths {
+                        if is_shared_lib(&path) {
+                            tracing::debug!(
+                                path = %path.display(),
+                                "hot-reload: detected library update"
+                            );
+                            tx_clone
+                                .send(HotReloadEvent::Updated(path))
+                                .ok();
+                        }
+                    }
+                }
+                Ok(Event {
+                    kind: EventKind::Remove(_),
+                    paths,
+                    ..
+                }) => {
+                    for path in paths {
+                        if is_shared_lib(&path) {
+                            tracing::debug!(
+                                path = %path.display(),
+                                "hot-reload: detected library removal"
+                            );
+                            tx.send(HotReloadEvent::Removed(path)).ok();
+                        }
+                    }
+                }
+                Ok(_) => {} // other events ignored
+                Err(e) => {
+                    tracing::warn!(error = %e, "hot-reload watcher error");
+                }
+            }
+        },
+        Config::default().with_poll_interval(Duration::from_millis(500)),
+    )?;
+
+    watcher.watch(plugin_dir, RecursiveMode::NonRecursive)?;
+
+    tracing::info!(
+        path = %plugin_dir.display(),
+        "hot-reload watcher started"
+    );
+
+    Ok((WatcherGuard { _watcher: watcher }, rx))
+}
+
+/// Returns `true` for `.so` (Linux) and `.dylib` (macOS) files.
+fn is_shared_lib(path: &Path) -> bool {
+    match path.extension().and_then(|e| e.to_str()) {
+        Some("so") | Some("dylib") => true,
+        _ => false,
+    }
+}


### PR DESCRIPTION
## 📋 Summary
This PR introduces runtime hot-reload support for MofaApp plugins, allowing plugins to be loaded, updated, or replaced without restarting the mofa-studio-shell.

Currently, the plugin system requires a full rebuild and restart of the shell whenever a plugin is modified. This slows down development and makes experimentation with plugins much harder.

The proposed design uses dynamic library loading via libloading combined with a filesystem watcher (notify) to detect plugin changes and reload them automatically at runtime.

With this change, developers can update plugin code and see the new behavior immediately, significantly improving the developer workflow.
issue : #1407

<!--
Explain WHAT this PR does and WHY.
Focus on the motivation and impact rather than implementation details.
-->


---

## Before This PR
Full shell restart required

Plugins are statically compiled into the shell binary. Any modification requires stopping the shell and rebuilding the project.

Slow iteration loop

Plugin development becomes slow because every change requires recompiling the entire shell.

Poor developer experience

Developers experimenting with plugin features must repeatedly restart the shell environment.
<!--
Why is this change needed?
What problem does it solve?
Any relevant background or design decisions.
-->

---

## 🛠️ Why This Was Needed

MoFA Studio is designed to support extensible agent tooling via plugins, but the current workflow limits that flexibility.
When developing plugins, developers should be able to:

1. iterate quickly
2. test behavior instantly
3. avoid rebuilding the entire shell

Runtime hot-reload enables a much faster feedback loop, making plugin development smoother and more productive.

## Files Changed
_crates/mofa-studio-shell/src/plugin_loader.rs_

- dynamic plugin loading logic
- runtime registry for active plugins

_crates/mofa-studio-shell/src/plugin_watcher.rs_

- filesystem watcher using notify
- reload trigger logic

_crates/mofa-studio-shell/src/plugin_registry.rs_

- manages active plugin instances
- handles safe unload and reload

<!--
High-level list of changes.
Avoid low-level diffs — reviewers can see those.
-->
---

## Checklist

- [x] runtime plugin loader implemented
- [x] filesystem watcher added
- [x] plugin registry handles reload safely
- [x] no breaking changes to MofaApp trait
- [x] shell restart no longer required for plugin updates
- [x] developer workflow significantly improved