### PR TITLE
feat(swarm): add swarm cli run command with DAG execution

### DIFF
--- a/crates/mofa-cli/src/cli.rs
+++ b/crates/mofa-cli/src/cli.rs
@@ -162,6 +162,28 @@ pub enum Commands {
         #[command(subcommand)]
         action: RagCommands,
     },
+
+    /// Swarm orchestration commands
+    Swarm {
+        #[command(subcommand)]
+        action: SwarmCommands,
+    },
+}
+
+/// Swarm orchestration subcommands
+#[derive(Subcommand)]
+pub enum SwarmCommands {
+    /// Run a swarm workflow from a YAML config file
+    ///
+    /// Example: mofa swarm run examples/swarm_demo.yaml
+    Run {
+        /// Path to the swarm YAML config file
+        file: PathBuf,
+
+        /// Print a JSON summary of the run to stdout after completion
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 /// Generate subcommands
@@ -747,5 +769,18 @@ mod tests {
     fn test_rag_query_parses() {
         let parsed = Cli::try_parse_from(["mofa", "rag", "query", "what is mofa", "--top-k", "3"]);
         assert!(parsed.is_ok(), "rag query command should parse");
+    }
+
+    #[test]
+    fn test_swarm_run_parses() {
+        let parsed = Cli::try_parse_from(["mofa", "swarm", "run", "examples/swarm_demo.yaml"]);
+        assert!(parsed.is_ok(), "swarm run <file> should parse");
+    }
+
+    #[test]
+    fn test_swarm_run_with_json_flag_parses() {
+        let parsed =
+            Cli::try_parse_from(["mofa", "swarm", "run", "examples/swarm_demo.yaml", "--json"]);
+        assert!(parsed.is_ok(), "swarm run --json should parse");
     }
 }

--- a/crates/mofa-cli/src/cli.rs
+++ b/crates/mofa-cli/src/cli.rs
@@ -184,6 +184,12 @@ pub enum SwarmCommands {
         #[arg(long)]
         json: bool,
     },
+
+    /// Validate a swarm workflow YAML file
+    Validate {
+        /// Path to the swarm YAML config file
+        file: PathBuf,
+    },
 }
 
 /// Generate subcommands
@@ -782,5 +788,11 @@ mod tests {
         let parsed =
             Cli::try_parse_from(["mofa", "swarm", "run", "examples/swarm_demo.yaml", "--json"]);
         assert!(parsed.is_ok(), "swarm run --json should parse");
+    }
+
+    #[test]
+    fn test_swarm_validate_parses() {
+        let parsed = Cli::try_parse_from(["mofa", "swarm", "validate", "examples/swarm_demo.yaml"]);
+        assert!(parsed.is_ok(), "swarm validate <file> should parse");
     }
 }

--- a/crates/mofa-cli/src/commands/mod.rs
+++ b/crates/mofa-cli/src/commands/mod.rs
@@ -12,4 +12,5 @@ pub mod plugin;
 pub mod rag;
 pub mod run;
 pub mod session;
+pub mod swarm;
 pub mod tool;

--- a/crates/mofa-cli/src/commands/swarm.rs
+++ b/crates/mofa-cli/src/commands/swarm.rs
@@ -7,7 +7,7 @@ use crate::CliError;
 use colored::Colorize;
 use mofa_foundation::swarm::{
     AgentSpec, SchedulerSummary, SubtaskDAG, SubtaskExecutorFn, SwarmConfig, SwarmScheduler,
-    SwarmSubtask, TaskExecutionContext,
+    SwarmSubtask, TaskAnalyzer, TaskExecutionContext,
 };
 use mofa_sdk::llm::{LLMAgentBuilder, OpenAIConfig, OpenAIProvider};
 use serde::Deserialize;
@@ -50,9 +50,10 @@ pub async fn run_swarm(file: &Path, json_output: bool) -> Result<(), CliError> {
 
     let config = run_file.config;
     // 2. Load DAG 
-    let mut dag = run_file.dag.ok_or_else(|| {
-        CliError::Other("Swarm YAML must include a `dag` section".to_string())
-    })?;
+    let mut dag = match run_file.dag {
+        Some(dag) => dag,
+        None => build_dag_from_task(&config).await?,
+    };
     if dag.name.is_empty() {
         dag.name = config.name.clone();
     }
@@ -93,6 +94,47 @@ pub async fn run_swarm(file: &Path, json_output: bool) -> Result<(), CliError> {
 }
 
 //  Helpers 
+
+async fn build_dag_from_task(config: &SwarmConfig) -> Result<SubtaskDAG, CliError> {
+    // Prefer the live analyzer when provider config is available.
+    let use_live_analyzer = std::env::var("OPENAI_API_KEY").is_ok();
+    let mut dag = if use_live_analyzer {
+        build_dag_with_live_analyzer(config).await?
+    } else {
+        // Keep a deterministic local fallback so the CLI path stays usable in tests.
+        TaskAnalyzer::analyze_offline(&config.task)
+    };
+
+    // Normalise the generated DAG name to the swarm config name for display.
+    dag.name = config.name.clone();
+
+    Ok(dag)
+}
+
+async fn build_dag_with_live_analyzer(config: &SwarmConfig) -> Result<SubtaskDAG, CliError> {
+    let api_key = std::env::var("OPENAI_API_KEY").map_err(|_| {
+        CliError::Other("Task analyzer requires OPENAI_API_KEY in the environment".to_string())
+    })?;
+
+    let mut provider_config = OpenAIConfig::new(api_key);
+    if let Ok(base_url) = std::env::var("OPENAI_BASE_URL") {
+        provider_config = provider_config.with_base_url(base_url);
+    }
+    if let Ok(model) = std::env::var("OPENAI_MODEL") {
+        provider_config = provider_config.with_model(model);
+    } else if let Some(model) = config.agents.iter().find_map(|agent| agent.model.as_deref()) {
+        // Reuse the first configured agent model when no global model override is present.
+        provider_config = provider_config.with_model(model);
+    }
+
+    let analyzer = TaskAnalyzer::new(Arc::new(OpenAIProvider::with_config(provider_config)));
+    let mut dag = analyzer
+        .analyze(&config.task)
+        .await
+        .map_err(|e| CliError::Other(format!("Task analysis failed: {e}")))?;
+    dag.name = config.name.clone();
+    Ok(dag)
+}
 
 /// Print a colourful banner before execution begins.
 fn print_swarm_header(config: &SwarmConfig, task_count: usize, executor: SwarmExecutorKind) {
@@ -401,17 +443,22 @@ dag:
     }
 
     #[tokio::test]
-    async fn test_run_swarm_missing_dag_returns_error() {
-        let yaml = r#"
-name: generic-swarm
-task: "Do something interesting"
-executor: llm
-"#;
-        let mut tmp = NamedTempFile::new().unwrap();
-        tmp.write_all(yaml.as_bytes()).unwrap();
+    async fn test_build_dag_from_task_generates_offline_when_dag_is_missing() {
+        let config = SwarmConfig {
+            id: "test".into(),
+            name: "generated".into(),
+            description: String::new(),
+            task: "Research the topic and write a report".into(),
+            agents: vec![],
+            pattern: Default::default(),
+            sla: Default::default(),
+            hitl: Default::default(),
+            metadata: Default::default(),
+        };
 
-        let result = run_swarm(tmp.path(), false).await;
-        assert!(result.is_err());
+        let dag = build_dag_from_task(&config).await.unwrap();
+        assert_eq!(dag.name, "generated");
+        assert!(dag.task_count() >= 1);
     }
 
     #[tokio::test]

--- a/crates/mofa-cli/src/commands/swarm.rs
+++ b/crates/mofa-cli/src/commands/swarm.rs
@@ -1,0 +1,486 @@
+//! `mofa swarm run` command implementation
+//!
+//! Reads a YAML swarm config plus DAG, executes it through the scheduler,
+//! and prints streaming colored progress logs.
+
+use crate::CliError;
+use colored::Colorize;
+use mofa_foundation::swarm::{
+    AgentSpec, SchedulerSummary, SubtaskDAG, SubtaskExecutorFn, SwarmConfig, SwarmScheduler,
+    SwarmSubtask, TaskExecutionContext,
+};
+use mofa_sdk::llm::{LLMAgentBuilder, OpenAIConfig, OpenAIProvider};
+use serde::Deserialize;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Instant;
+
+#[derive(Debug, Deserialize)]
+struct SwarmRunFile {
+    #[serde(flatten)]
+    config: SwarmConfig,
+    executor: SwarmExecutorKind,
+    dag: Option<SubtaskDAG>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum SwarmExecutorKind {
+    Llm,
+}
+
+/// Execute `mofa swarm run <file>`
+pub async fn run_swarm(file: &Path, json_output: bool) -> Result<(), CliError> {
+    // 1. Read & Parse YAML 
+    let yaml = std::fs::read_to_string(file).map_err(|e| {
+        CliError::Other(format!(
+            "Failed to read swarm config '{}': {}",
+            file.display(),
+            e
+        ))
+    })?;
+
+    let run_file: SwarmRunFile = serde_yaml::from_str(&yaml).map_err(|e| {
+        CliError::Other(format!(
+            "Failed to parse swarm YAML '{}': {}",
+            file.display(),
+            e
+        ))
+    })?;
+
+    let config = run_file.config;
+    // 2. Load DAG 
+    let mut dag = run_file.dag.ok_or_else(|| {
+        CliError::Other("Swarm YAML must include a `dag` section".to_string())
+    })?;
+    if dag.name.is_empty() {
+        dag.name = config.name.clone();
+    }
+
+    print_swarm_header(&config, dag.task_count(), run_file.executor);
+
+    // 3. Build executor 
+    let executor = build_llm_executor(&config, &config.agents)?;
+
+    // 4. Run with the appropriate scheduler 
+    let scheduler = config.pattern.clone().into_scheduler();
+    let wall_start = Instant::now();
+
+    let summary = scheduler
+        .execute(&mut dag, executor)
+        .await
+        .map_err(|e| CliError::Other(format!("Swarm execution failed: {e}")))?;
+
+    let wall_ms = wall_start.elapsed().as_millis();
+
+    // 5. Print result 
+    print_summary(&summary, wall_ms);
+
+    if json_output {
+        let json = serde_json::to_string_pretty(&summary)
+            .map_err(|e| CliError::Other(format!("JSON serialisation failed: {e}")))?;
+        println!("\n{}", json);
+    }
+
+    if summary.failed > 0 {
+        return Err(CliError::Other(format!(
+            "{} task(s) failed during swarm execution",
+            summary.failed
+        )));
+    }
+
+    Ok(())
+}
+
+//  Helpers 
+
+/// Print a colourful banner before execution begins.
+fn print_swarm_header(config: &SwarmConfig, task_count: usize, executor: SwarmExecutorKind) {
+    println!();
+    println!("{} {}", "◈ MoFA Swarm".bold().cyan(), config.name.bold());
+    if !config.description.is_empty() {
+        println!("  {}", config.description.dimmed());
+    }
+    println!(
+        "  {} {}",
+        "Pattern:".dimmed(),
+        format!("{}", config.pattern).yellow()
+    );
+    println!(
+        "  {} {} agent(s)",
+        "Agents:".dimmed(),
+        config.agents.len().to_string().yellow()
+    );
+    println!(
+        "  {} {} task(s)",
+        "DAG:".dimmed(),
+        task_count.to_string().yellow()
+    );
+    println!(
+        "  {} {}",
+        "Executor:".dimmed(),
+        match executor {
+            SwarmExecutorKind::Llm => "LLM".green(),
+        }
+    );
+    println!("  {} {}", "Task:".dimmed(), config.task.italic());
+    println!();
+}
+
+fn build_llm_executor(
+    config: &SwarmConfig,
+    agents: &[AgentSpec],
+) -> Result<SubtaskExecutorFn, CliError> {
+    let api_key = std::env::var("OPENAI_API_KEY").map_err(|_| {
+        CliError::Other("LLM executor requires OPENAI_API_KEY in the environment".to_string())
+    })?;
+    let base_url = std::env::var("OPENAI_BASE_URL").ok();
+    let default_model = std::env::var("OPENAI_MODEL").ok();
+
+    let agents = agents.to_vec();
+    let swarm_task = config.task.clone();
+    let swarm_name = config.name.clone();
+
+    Ok(Arc::new(move |_idx, task, context| {
+        // Clone captured config because the executor is invoked per task.
+        let api_key = api_key.clone();
+        let base_url = base_url.clone();
+        let default_model = default_model.clone();
+        let agents = agents.clone();
+        let swarm_task = swarm_task.clone();
+        let swarm_name = swarm_name.clone();
+
+        Box::pin(async move {
+            let selected_agent = select_agent_for_task(&task, &agents);
+            let agent_spec = selected_agent
+                .as_ref()
+                .and_then(|id| agents.iter().find(|agent| agent.id == *id));
+
+            let mut config = OpenAIConfig::new(api_key);
+            if let Some(url) = base_url {
+                config = config.with_base_url(url);
+            }
+
+            if let Some(model) = agent_spec.and_then(|agent| agent.model.as_deref()) {
+                config = config.with_model(model);
+            } else if let Some(model) = default_model {
+                config = config.with_model(model);
+            }
+
+            let provider = OpenAIProvider::with_config(config);
+            let mut builder = LLMAgentBuilder::new().with_provider(Arc::new(provider));
+
+            if let Some(agent_id) = selected_agent.clone() {
+                builder = builder.with_id(agent_id);
+            }
+
+            let system_prompt = build_system_prompt(&swarm_name, &swarm_task, agent_spec);
+            builder = builder.with_system_prompt(system_prompt);
+
+            let agent = builder.build();
+            // The task prompt carries direct dependency outputs from the scheduler.
+            let prompt = build_task_prompt(&task, &context);
+
+            let output = agent
+                .ask(prompt)
+                .await
+                .map_err(|e| mofa_kernel::agent::types::error::GlobalError::Other(e.to_string()))?;
+
+            Ok(output)
+        })
+    }))
+}
+
+fn select_agent_for_task(task: &SwarmSubtask, agents: &[AgentSpec]) -> Option<String> {
+    if let Some(agent) = &task.assigned_agent {
+        return Some(agent.clone());
+    }
+
+    if agents.is_empty() {
+        return None;
+    }
+
+    if task.required_capabilities.is_empty() {
+        return Some(agents[0].id.clone());
+    }
+
+    // Prefer the agent that matches the most required capabilities.
+    let mut best: Option<(&AgentSpec, usize)> = None;
+    for agent in agents {
+        let matches = task
+            .required_capabilities
+            .iter()
+            .filter(|cap| agent.capabilities.iter().any(|c| c == *cap))
+            .count();
+        if matches == 0 {
+            continue;
+        }
+        match best {
+            Some((_, best_score)) if matches <= best_score => {}
+            _ => best = Some((agent, matches)),
+        }
+    }
+
+    best.map(|(agent, _)| agent.id.clone())
+}
+
+fn build_system_prompt(
+    swarm_name: &str,
+    swarm_task: &str,
+    agent_spec: Option<&AgentSpec>,
+) -> String {
+    let mut prompt = String::new();
+    prompt.push_str("You are a swarm subtask agent.\n");
+    prompt.push_str(&format!("Swarm: {swarm_name}\n"));
+    prompt.push_str(&format!("Overall task: {swarm_task}\n"));
+
+    if let Some(agent) = agent_spec {
+        if !agent.capabilities.is_empty() {
+            prompt.push_str(&format!(
+                "Capabilities: {}\n",
+                agent.capabilities.join(", ")
+            ));
+        }
+        if let Some(model) = &agent.model {
+            prompt.push_str(&format!("Model: {model}\n"));
+        }
+    }
+
+    prompt.push_str("Return a concise, actionable result for the subtask.");
+    prompt
+}
+
+fn build_task_prompt(task: &SwarmSubtask, context: &TaskExecutionContext) -> String {
+    let mut prompt = String::new();
+    prompt.push_str("Subtask description:\n");
+    prompt.push_str(&task.description);
+    if !task.required_capabilities.is_empty() {
+        prompt.push_str("\n\nRequired capabilities:\n");
+        prompt.push_str(&task.required_capabilities.join(", "));
+    }
+    if !context.dependencies.is_empty() {
+        // Only direct dependency outputs are injected here; global run state stays out of prompt assembly.
+        prompt.push_str("\n\nUpstream task outputs:\n");
+        for dependency in &context.dependencies {
+            prompt.push_str("- ");
+            prompt.push_str(&dependency.task_id);
+            prompt.push_str(": ");
+            prompt.push_str(
+                dependency
+                    .output
+                    .as_deref()
+                    .unwrap_or("(completed with no output)"),
+            );
+            prompt.push('\n');
+        }
+    }
+    prompt
+}
+
+/// Print a colourful summary table after the run.
+fn print_summary(summary: &SchedulerSummary, wall_ms: u128) {
+    println!();
+    let status_str = if summary.failed == 0 {
+        "SUCCESS".green().bold()
+    } else {
+        "PARTIAL FAILURE".red().bold()
+    };
+
+    println!("  {} {}", "◈ Swarm complete:".bold(), status_str);
+    println!("  ─────────────────────────────");
+    println!(
+        "  {}   {}/{}",
+        "Tasks:".dimmed(),
+        summary.succeeded.to_string().green(),
+        summary.total_tasks.to_string().bold()
+    );
+    if summary.failed > 0 {
+        println!(
+            "  {}  {}",
+            "Failed:".dimmed(),
+            summary.failed.to_string().red()
+        );
+    }
+    if summary.skipped > 0 {
+        println!(
+            "  {}  {}",
+            "Skipped:".dimmed(),
+            summary.skipped.to_string().yellow()
+        );
+    }
+    println!(
+        "  {} {}ms",
+        "Wall time:".dimmed(),
+        wall_ms.to_string().cyan()
+    );
+
+    // Print each task result
+    println!();
+    for result in &summary.results {
+        let icon = if result.outcome.is_success() {
+            "✓".green()
+        } else {
+            "✗".red()
+        };
+        let ms = result.wall_time.as_millis();
+        let outcome = match &result.outcome {
+            mofa_foundation::swarm::TaskOutcome::Success(output) => {
+                format!("  {}", truncate(output, 80).dimmed())
+            }
+            mofa_foundation::swarm::TaskOutcome::Failure(err) => {
+                format!("  {}", truncate(err, 80).red())
+            }
+            mofa_foundation::swarm::TaskOutcome::Skipped(reason) => {
+                format!("  {}", truncate(reason, 80).yellow())
+            }
+        };
+        println!(
+            "    {} {} ({}ms){}",
+            icon,
+            result.task_id.bold(),
+            ms.to_string().dimmed(),
+            outcome
+        );
+    }
+    println!();
+}
+
+fn truncate(value: &str, max: usize) -> String {
+    let mut out = String::new();
+    let mut count = 0usize;
+    for ch in value.chars() {
+        if count >= max {
+            out.push('…');
+            return out;
+        }
+        out.push(ch);
+        count += 1;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mofa_foundation::swarm::TaskDependencyContext;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[tokio::test]
+    async fn test_run_swarm_requires_llm_credentials() {
+        let yaml = r#"
+name: test-swarm
+description: "A simple test swarm"
+task: "Run a test workflow"
+pattern: sequential
+executor: llm
+agents:
+  - id: step-a
+    capabilities: [search]
+    model: llama-3.1-8b-instant
+  - id: step-b
+    capabilities: [analyze]
+    model: llama-3.1-8b-instant
+dag:
+  tasks:
+    - id: step-a
+      description: "Search for information"
+      capabilities: [search]
+    - id: step-b
+      description: "Analyze the findings"
+      capabilities: [analyze]
+  dependencies:
+    - from: step-a
+      to: step-b
+"#;
+        let mut tmp = NamedTempFile::new().unwrap();
+        tmp.write_all(yaml.as_bytes()).unwrap();
+
+        let result = run_swarm(tmp.path(), false).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_run_swarm_missing_dag_returns_error() {
+        let yaml = r#"
+name: generic-swarm
+task: "Do something interesting"
+executor: llm
+"#;
+        let mut tmp = NamedTempFile::new().unwrap();
+        tmp.write_all(yaml.as_bytes()).unwrap();
+
+        let result = run_swarm(tmp.path(), false).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_run_swarm_bad_file_returns_error() {
+        let result = run_swarm(Path::new("/nonexistent/path.yaml"), false).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_run_swarm_invalid_yaml_returns_error() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        tmp.write_all(b"not: valid: yaml: :::").unwrap();
+        let result = run_swarm(tmp.path(), false).await;
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_swarm_run_file_parses_llm_executor_and_dag() {
+        let yaml = r#"
+name: llm-swarm
+task: "Research a topic"
+pattern: parallel
+executor: llm
+agents:
+  - id: researcher
+    capabilities: [web_search]
+    model: llama-3.1-8b-instant
+dag:
+  tasks:
+    - id: search
+      description: "Search for sources"
+      capabilities: [web_search]
+"#;
+
+        let run_file: SwarmRunFile = serde_yaml::from_str(yaml).unwrap();
+        assert!(matches!(run_file.executor, SwarmExecutorKind::Llm));
+        let dag = run_file.dag.expect("dag should parse");
+        assert_eq!(dag.task_count(), 1);
+        let search = dag.find_by_id("search").expect("task should exist");
+        assert_eq!(dag.get_task(search).unwrap().id, "search");
+        assert_eq!(
+            dag.get_task(search).unwrap().required_capabilities,
+            vec!["web_search"]
+        );
+    }
+
+    #[test]
+    fn test_build_task_prompt_includes_dependency_outputs() {
+        let task = SwarmSubtask::new("summarize", "Write the final summary")
+            .with_capabilities(vec!["summarize".into(), "write".into()]);
+        let context = TaskExecutionContext {
+            dependencies: vec![
+                TaskDependencyContext {
+                    task_id: "analyze".into(),
+                    output: Some("Ranked breakthroughs: A, B, C".into()),
+                },
+                TaskDependencyContext {
+                    task_id: "collect_stats".into(),
+                    output: Some("Stats collected for all candidates".into()),
+                },
+            ],
+        };
+
+        let prompt = build_task_prompt(&task, &context);
+
+        assert!(prompt.contains("Subtask description:\nWrite the final summary"));
+        assert!(prompt.contains("Required capabilities:\nsummarize, write"));
+        assert!(prompt.contains("Upstream task outputs:"));
+        assert!(prompt.contains("- analyze: Ranked breakthroughs: A, B, C"));
+        assert!(prompt.contains("- collect_stats: Stats collected for all candidates"));
+    }
+}

--- a/crates/mofa-cli/src/commands/swarm.rs
+++ b/crates/mofa-cli/src/commands/swarm.rs
@@ -29,9 +29,7 @@ enum SwarmExecutorKind {
     Llm,
 }
 
-/// Execute `mofa swarm run <file>`
-pub async fn run_swarm(file: &Path, json_output: bool) -> Result<(), CliError> {
-    // 1. Read & Parse YAML 
+async fn load_swarm_run_file(file: &Path) -> Result<SwarmRunFile, CliError> {
     let yaml = std::fs::read_to_string(file).map_err(|e| {
         CliError::Other(format!(
             "Failed to read swarm config '{}': {}",
@@ -40,13 +38,19 @@ pub async fn run_swarm(file: &Path, json_output: bool) -> Result<(), CliError> {
         ))
     })?;
 
-    let run_file: SwarmRunFile = serde_yaml::from_str(&yaml).map_err(|e| {
+    serde_yaml::from_str(&yaml).map_err(|e| {
         CliError::Other(format!(
             "Failed to parse swarm YAML '{}': {}",
             file.display(),
             e
         ))
-    })?;
+    })
+}
+
+/// Execute `mofa swarm run <file>`
+pub async fn run_swarm(file: &Path, json_output: bool) -> Result<(), CliError> {
+    // 1. Read & Parse YAML
+    let run_file = load_swarm_run_file(file).await?;
 
     let config = run_file.config;
     // 2. Load DAG 
@@ -89,6 +93,44 @@ pub async fn run_swarm(file: &Path, json_output: bool) -> Result<(), CliError> {
             summary.failed
         )));
     }
+
+    Ok(())
+}
+
+/// Validate `mofa swarm validate <file>`
+pub async fn validate_swarm(file: &Path) -> Result<(), CliError> {
+    let run_file = load_swarm_run_file(file).await?;
+    let config = run_file.config;
+
+    let (dag, dag_source) = match run_file.dag {
+        Some(mut dag) => {
+            if dag.name.is_empty() {
+                dag.name = config.name.clone();
+            }
+            (dag, "yaml")
+        }
+        None => (build_dag_from_task(&config).await?, "generated"),
+    };
+
+    println!("{} {}", "✓ Valid swarm workflow:".green().bold(), config.name);
+    println!("  {} {}", "Pattern:".dimmed(), format!("{}", config.pattern).yellow());
+    println!(
+        "  {} {}",
+        "Executor:".dimmed(),
+        match run_file.executor {
+            SwarmExecutorKind::Llm => "LLM".green(),
+        }
+    );
+    println!(
+        "  {} {}",
+        "DAG source:".dimmed(),
+        dag_source.yellow()
+    );
+    println!(
+        "  {} {} task(s)",
+        "Tasks:".dimmed(),
+        dag.task_count().to_string().yellow()
+    );
 
     Ok(())
 }
@@ -440,6 +482,30 @@ dag:
 
         let result = run_swarm(tmp.path(), false).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_validate_swarm_with_explicit_dag_succeeds() {
+        let yaml = r#"
+name: validate-swarm
+task: "Research a topic"
+pattern: parallel
+executor: llm
+agents:
+  - id: researcher
+    capabilities: [web_search]
+    model: llama-3.1-8b-instant
+dag:
+  tasks:
+    - id: search
+      description: "Search for sources"
+      capabilities: [web_search]
+"#;
+        let mut tmp = NamedTempFile::new().unwrap();
+        tmp.write_all(yaml.as_bytes()).unwrap();
+
+        let result = validate_swarm(tmp.path()).await;
+        assert!(result.is_ok(), "swarm validate should succeed: {:?}", result.err());
     }
 
     #[tokio::test]

--- a/crates/mofa-cli/src/main.rs
+++ b/crates/mofa-cli/src/main.rs
@@ -393,6 +393,9 @@ async fn run_command(cli: Cli) -> CliResult<()> {
             cli::SwarmCommands::Run { file, json } => {
                 commands::swarm::run_swarm(&file, json).await?;
             }
+            cli::SwarmCommands::Validate { file } => {
+                commands::swarm::validate_swarm(&file).await?;
+            }
         },
 
         None => {

--- a/crates/mofa-cli/src/main.rs
+++ b/crates/mofa-cli/src/main.rs
@@ -106,7 +106,9 @@ async fn run_command(cli: Cli) -> CliResult<()> {
         }) => {
             commands::new::run(&name, &template, output.as_deref())
                 .into_report()
-                .attach_with(|| format!("scaffolding project '{name}' with template '{template}'"))?;
+                .attach_with(|| {
+                    format!("scaffolding project '{name}' with template '{template}'")
+                })?;
         }
 
         Some(Commands::Init { path }) => {
@@ -387,6 +389,12 @@ async fn run_command(cli: Cli) -> CliResult<()> {
             }
         },
 
+        Some(Commands::Swarm { action }) => match action {
+            cli::SwarmCommands::Run { file, json } => {
+                commands::swarm::run_swarm(&file, json).await?;
+            }
+        },
+
         None => {
             // Should have been handled by TUI check above
             // If we get here, show help
@@ -404,7 +412,7 @@ async fn run_command(cli: Cli) -> CliResult<()> {
 fn normalize_legacy_output_flags(args: &mut [String]) {
     const TOP_LEVEL_COMMANDS: &[&str] = &[
         "new", "init", "build", "run", "dataflow", "generate", "info", "db", "agent", "config",
-        "plugin", "session", "tool", "doctor", "rag",
+        "plugin", "session", "tool", "doctor", "rag", "swarm",
     ];
 
     let top_command_index = args

--- a/crates/mofa-foundation/src/swarm/dag.rs
+++ b/crates/mofa-foundation/src/swarm/dag.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Utc};
 use petgraph::Direction;
 use petgraph::graph::{DiGraph, NodeIndex};
 use petgraph::visit::EdgeRef;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::HashMap;
 use uuid::Uuid;
 
@@ -78,12 +78,19 @@ pub enum SubtaskStatus {
 pub struct SwarmSubtask {
     pub id: String,
     pub description: String,
+    #[serde(default, alias = "capabilities")]
     pub required_capabilities: Vec<String>,
+    #[serde(default)]
     pub status: SubtaskStatus,
+    #[serde(default)]
     pub assigned_agent: Option<String>,
+    #[serde(default)]
     pub output: Option<String>,
+    #[serde(default = "default_subtask_complexity")]
     pub complexity: f64,
+    #[serde(default)]
     pub started_at: Option<DateTime<Utc>>,
+    #[serde(default)]
     pub completed_at: Option<DateTime<Utc>>,
     /// Risk classification for this subtask (defaults to [`RiskLevel::Low`]).
     #[serde(default)]
@@ -100,6 +107,10 @@ pub struct SwarmSubtask {
     /// `None` means the duration is unknown.
     #[serde(default)]
     pub estimated_duration_secs: Option<u64>,
+}
+
+fn default_subtask_complexity() -> f64 {
+    0.5
 }
 
 impl SwarmSubtask {
@@ -181,13 +192,39 @@ impl Default for DependencyEdge {
 
 // SubtaskDAG
 /// Directed Acyclic Graph representing a decomposed task
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct SubtaskDAG {
     pub id: String,
     pub name: String,
     graph: DiGraph<SwarmSubtask, DependencyEdge>,
-    #[serde(skip)]
     id_to_index: HashMap<String, NodeIndex>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SerializableSubtaskDAG {
+    #[serde(default = "default_dag_id")]
+    id: String,
+    #[serde(default)]
+    name: String,
+    tasks: Vec<SwarmSubtask>,
+    #[serde(default)]
+    dependencies: Vec<SerializableDependency>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SerializableDependency {
+    from: String,
+    to: String,
+    #[serde(default = "default_dependency_kind")]
+    kind: DependencyKind,
+}
+
+fn default_dag_id() -> String {
+    Uuid::now_v7().to_string()
+}
+
+fn default_dependency_kind() -> DependencyKind {
+    DependencyKind::Sequential
 }
 
 impl SubtaskDAG {
@@ -415,7 +452,6 @@ impl SubtaskDAG {
             .count()
     }
 
-
     // ── Risk & HITL helpers ───────────────────────────────────────────────
 
     /// Return the IDs of all subtasks whose `hitl_required` flag is `true`.
@@ -470,9 +506,7 @@ impl SubtaskDAG {
                 .map(|e| (e.source(), *longest.get(&e.source()).unwrap_or(&0)))
                 .max_by_key(|&(_, v)| v);
 
-            let (pred, pred_val) = best_pred
-                .map(|(n, v)| (Some(n), v))
-                .unwrap_or((None, 0));
+            let (pred, pred_val) = best_pred.map(|(n, v)| (Some(n), v)).unwrap_or((None, 0));
 
             longest.insert(idx, pred_val + duration);
             predecessor.insert(idx, pred);
@@ -537,6 +571,96 @@ impl SubtaskDAG {
             self.mark_skipped(idx);
         }
         to_skip.len()
+    }
+}
+
+impl From<&SubtaskDAG> for SerializableSubtaskDAG {
+    fn from(dag: &SubtaskDAG) -> Self {
+        // Serialize tasks in topological order to keep YAML output stable and readable.
+        let tasks = dag
+            .topological_order()
+            .unwrap_or_else(|_| dag.graph.node_indices().collect())
+            .into_iter()
+            .filter_map(|idx| dag.get_task(idx).cloned())
+            .collect();
+
+        // Edges are stored separately so the YAML shape stays independent of petgraph internals.
+        let dependencies = dag
+            .graph
+            .edge_references()
+            .map(|edge| SerializableDependency {
+                from: dag.graph[edge.source()].id.clone(),
+                to: dag.graph[edge.target()].id.clone(),
+                kind: edge.weight().kind.clone(),
+            })
+            .collect();
+
+        Self {
+            id: dag.id.clone(),
+            name: dag.name.clone(),
+            tasks,
+            dependencies,
+        }
+    }
+}
+
+impl TryFrom<SerializableSubtaskDAG> for SubtaskDAG {
+    type Error = String;
+
+    fn try_from(value: SerializableSubtaskDAG) -> Result<Self, Self::Error> {
+        // Rebuild the runtime graph from the YAML-facing task/dependency representation.
+        let mut dag = Self {
+            id: if value.id.is_empty() {
+                default_dag_id()
+            } else {
+                value.id
+            },
+            name: value.name,
+            graph: DiGraph::new(),
+            id_to_index: HashMap::new(),
+        };
+
+        for task in value.tasks {
+            let task_id = task.id.clone();
+            if dag.id_to_index.contains_key(&task_id) {
+                return Err(format!("Duplicate task id in DAG: {task_id}"));
+            }
+            dag.add_task(task);
+        }
+
+        // Dependencies are validated against task IDs as the graph is reconstructed.
+        for dep in value.dependencies {
+            let from = dag
+                .find_by_id(&dep.from)
+                .ok_or_else(|| format!("Dependency references unknown task id: {}", dep.from))?;
+            let to = dag
+                .find_by_id(&dep.to)
+                .ok_or_else(|| format!("Dependency references unknown task id: {}", dep.to))?;
+            dag.add_dependency_with_kind(from, to, dep.kind)
+                .map_err(|e| e.to_string())?;
+        }
+
+        Ok(dag)
+    }
+}
+
+impl Serialize for SubtaskDAG {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // Always serialize through the stable YAML-friendly representation.
+        SerializableSubtaskDAG::from(self).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for SubtaskDAG {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let repr = SerializableSubtaskDAG::deserialize(deserializer)?;
+        Self::try_from(repr).map_err(serde::de::Error::custom)
     }
 }
 
@@ -745,7 +869,8 @@ mod tests {
         let d = dag.add_task(SwarmSubtask::new("d", "Independent"));
 
         dag.add_dependency(a, b).unwrap(); // Sequential (hard)
-        dag.add_dependency_with_kind(a, c, DependencyKind::Soft).unwrap();
+        dag.add_dependency_with_kind(a, c, DependencyKind::Soft)
+            .unwrap();
 
         dag.mark_failed(a, "error");
         let skipped = dag.cascade_skip(a);
@@ -793,12 +918,20 @@ mod tests {
         // a fails — b should become ready (not stuck forever)
         dag.mark_failed(a, "connection timeout");
         let ready = dag.ready_tasks();
-        assert_eq!(ready, vec![b], "b must become ready when its dependency fails");
+        assert_eq!(
+            ready,
+            vec![b],
+            "b must become ready when its dependency fails"
+        );
 
         // b also fails — c should become ready
         dag.mark_failed(b, "no input data");
         let ready = dag.ready_tasks();
-        assert_eq!(ready, vec![c], "c must become ready when its dependency fails");
+        assert_eq!(
+            ready,
+            vec![c],
+            "c must become ready when its dependency fails"
+        );
 
         dag.mark_skipped(c);
         assert!(dag.is_complete());
@@ -823,7 +956,11 @@ mod tests {
 
         // d depends on both b (Completed) and c (Failed) — should be ready
         let ready = dag.ready_tasks();
-        assert_eq!(ready, vec![d], "d must become ready when all deps are terminal");
+        assert_eq!(
+            ready,
+            vec![d],
+            "d must become ready when all deps are terminal"
+        );
     }
 
     #[test]
@@ -885,6 +1022,49 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_subtask_dag_deserializes_from_yaml_task_dependency_shape() {
+        let yaml = r#"
+name: direct-dag
+tasks:
+  - id: search
+    description: Search for sources
+    capabilities: [web_search]
+  - id: summarize
+    description: Summarize results
+    capabilities: [summarize]
+dependencies:
+  - from: search
+    to: summarize
+"#;
+
+        let dag: SubtaskDAG = serde_yaml::from_str(yaml).unwrap();
+
+        assert_eq!(dag.name, "direct-dag");
+        assert_eq!(dag.task_count(), 2);
+        let search = dag.find_by_id("search").unwrap();
+        let summarize = dag.find_by_id("summarize").unwrap();
+        assert_eq!(
+            dag.get_task(search).unwrap().required_capabilities,
+            vec!["web_search"]
+        );
+        assert_eq!(dag.dependencies_of(summarize), vec![search]);
+    }
+
+    #[test]
+    fn test_subtask_dag_rejects_duplicate_task_ids_on_deserialize() {
+        let yaml = r#"
+tasks:
+  - id: dup
+    description: First
+  - id: dup
+    description: Second
+"#;
+
+        let err = serde_yaml::from_str::<SubtaskDAG>(yaml).unwrap_err();
+        assert!(err.to_string().contains("Duplicate task id"));
+    }
+
     // ── RiskLevel tests ───────────────────────────────────────────────────
 
     #[test]
@@ -944,7 +1124,9 @@ mod tests {
         dag.add_task(SwarmSubtask::new("low", "low-risk").with_risk_level(RiskLevel::Low));
         dag.add_task(SwarmSubtask::new("med", "medium-risk").with_risk_level(RiskLevel::Medium));
         dag.add_task(SwarmSubtask::new("high", "high-risk").with_risk_level(RiskLevel::High));
-        dag.add_task(SwarmSubtask::new("crit", "critical-risk").with_risk_level(RiskLevel::Critical));
+        dag.add_task(
+            SwarmSubtask::new("crit", "critical-risk").with_risk_level(RiskLevel::Critical),
+        );
 
         let mut hitl = dag.hitl_required_tasks();
         hitl.sort();
@@ -954,15 +1136,9 @@ mod tests {
     #[test]
     fn test_critical_path_linear_chain() {
         let mut dag = SubtaskDAG::new("cp-chain");
-        let a = dag.add_task(
-            SwarmSubtask::new("a", "Fetch").with_estimated_duration(10),
-        );
-        let b = dag.add_task(
-            SwarmSubtask::new("b", "Process").with_estimated_duration(20),
-        );
-        let c = dag.add_task(
-            SwarmSubtask::new("c", "Report").with_estimated_duration(30),
-        );
+        let a = dag.add_task(SwarmSubtask::new("a", "Fetch").with_estimated_duration(10));
+        let b = dag.add_task(SwarmSubtask::new("b", "Process").with_estimated_duration(20));
+        let c = dag.add_task(SwarmSubtask::new("c", "Report").with_estimated_duration(30));
         dag.add_dependency(a, b).unwrap();
         dag.add_dependency(b, c).unwrap();
 
@@ -991,8 +1167,14 @@ mod tests {
 
         let path = dag.critical_path().unwrap();
         // Critical path: start → long → merge (total = 5 + 50 + 5 = 60)
-        assert!(path.contains(&"long".to_string()), "critical path must go through 'long': {path:?}");
-        assert!(!path.contains(&"short".to_string()), "critical path must NOT go through 'short': {path:?}");
+        assert!(
+            path.contains(&"long".to_string()),
+            "critical path must go through 'long': {path:?}"
+        );
+        assert!(
+            !path.contains(&"short".to_string()),
+            "critical path must NOT go through 'short': {path:?}"
+        );
         assert_eq!(dag.critical_path_duration_secs().unwrap(), 60);
     }
 

--- a/crates/mofa-foundation/src/swarm/mod.rs
+++ b/crates/mofa-foundation/src/swarm/mod.rs
@@ -14,6 +14,7 @@ pub use patterns::CoordinationPattern;
 pub mod scheduler;
 pub use scheduler::{
     FailurePolicy, ParallelScheduler, SchedulerSummary, SequentialScheduler, SubtaskExecutorFn,
-    SwarmScheduler, SwarmSchedulerConfig, TaskExecutionResult, TaskOutcome,
+    SwarmScheduler, SwarmSchedulerConfig, TaskDependencyContext, TaskExecutionContext,
+    TaskExecutionResult, TaskOutcome,
 };
 pub use telemetry::{audit_batch_to_debug, audit_to_debug};

--- a/crates/mofa-foundation/src/swarm/scheduler.rs
+++ b/crates/mofa-foundation/src/swarm/scheduler.rs
@@ -16,9 +16,27 @@ use mofa_kernel::agent::types::error::{GlobalError, GlobalResult};
 
 use crate::swarm::{CoordinationPattern, SubtaskDAG, SwarmSubtask};
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskDependencyContext {
+    pub task_id: String,
+    pub output: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TaskExecutionContext {
+    pub dependencies: Vec<TaskDependencyContext>,
+}
+
 /// task executor used by schedulers
-pub type SubtaskExecutorFn =
-    Arc<dyn Fn(NodeIndex, SwarmSubtask) -> BoxFuture<'static, GlobalResult<String>> + Send + Sync>;
+pub type SubtaskExecutorFn = Arc<
+    dyn Fn(
+            NodeIndex,
+            SwarmSubtask,
+            TaskExecutionContext,
+        ) -> BoxFuture<'static, GlobalResult<String>>
+        + Send
+        + Sync,
+>;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TaskOutcome {
@@ -163,6 +181,21 @@ impl SequentialScheduler {
     pub fn with_config(config: SwarmSchedulerConfig) -> Self {
         Self { config }
     }
+
+    fn build_execution_context(dag: &SubtaskDAG, idx: NodeIndex) -> TaskExecutionContext {
+        let dependencies = dag
+            .dependencies_of(idx)
+            .into_iter()
+            .filter_map(|dep_idx| {
+                dag.get_task(dep_idx).map(|task| TaskDependencyContext {
+                    task_id: task.id.clone(),
+                    output: task.output.clone(),
+                })
+            })
+            .collect();
+
+        TaskExecutionContext { dependencies }
+    }
 }
 
 impl Default for SequentialScheduler {
@@ -226,9 +259,10 @@ impl SwarmScheduler for SequentialScheduler {
             let start = Instant::now();
             info!(task_id = %task_id, task_desc = %task_snapshot.description, "Executing node");
 
+            let exec_context = Self::build_execution_context(dag, idx);
             let outcome = timeout(
                 self.config.task_timeout,
-                executor(idx, task_snapshot.clone()),
+                executor(idx, task_snapshot.clone(), exec_context),
             )
             .await;
             let elapsed = start.elapsed();
@@ -370,6 +404,8 @@ impl SwarmScheduler for ParallelScheduler {
                 let sem = semaphore.clone();
                 let timeout_dur = self.config.task_timeout;
 
+                let exec_context = SequentialScheduler::build_execution_context(dag, idx);
+
                 let fut = async move {
                     let _permit = if let Some(s) = sem {
                         Some(s.acquire_owned().await.expect("semaphore closed"))
@@ -378,7 +414,8 @@ impl SwarmScheduler for ParallelScheduler {
                     };
 
                     let start = Instant::now();
-                    match timeout(timeout_dur, exec(idx, task_snapshot.clone())).await {
+                    match timeout(timeout_dur, exec(idx, task_snapshot.clone(), exec_context)).await
+                    {
                         Ok(Ok(output)) => TaskExecutionResult::success(
                             &task_snapshot,
                             idx,
@@ -486,7 +523,7 @@ mod tests {
         let exec_order = Arc::new(tokio::sync::Mutex::new(Vec::new()));
         let exec_order_clone = exec_order.clone();
 
-        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task, _context| {
             let order = exec_order_clone.clone();
             let task_id = task.id.clone();
             Box::pin(async move {
@@ -515,7 +552,7 @@ mod tests {
         dag.add_dependency(idx_a, idx_b).unwrap();
         dag.add_dependency(idx_a, idx_c).unwrap();
 
-        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task, _context| {
             Box::pin(async move {
                 if task.id == "A" {
                     Err(GlobalError::runtime("A failed"))
@@ -557,7 +594,7 @@ mod tests {
 
         dag.add_dependency(idx_a, idx_b).unwrap();
 
-        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task, _context| {
             Box::pin(async move {
                 if task.id == "A" {
                     Err(GlobalError::runtime("A failed"))
@@ -585,7 +622,7 @@ mod tests {
         let mut dag = SubtaskDAG::new("test");
         let _idx_a = dag.add_task(SwarmSubtask::new("A", "Task A"));
 
-        let executor: SubtaskExecutorFn = Arc::new(move |_idx, _task| {
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, _task, _context| {
             Box::pin(async move {
                 sleep(Duration::from_millis(100)).await;
                 Ok("done".into())
@@ -621,7 +658,7 @@ mod tests {
         let execution_log = Arc::new(tokio::sync::Mutex::new(Vec::new()));
         let execution_log_clone = execution_log.clone();
 
-        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task, _context| {
             let log = execution_log_clone.clone();
             let task_id = task.id.clone();
             Box::pin(async move {
@@ -658,7 +695,7 @@ mod tests {
         let active_clone = active_tasks.clone();
         let peak_clone = peak_tasks.clone();
 
-        let executor: SubtaskExecutorFn = Arc::new(move |_idx, _task| {
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, _task, _context| {
             let active = active_clone.clone();
             let peak = peak_clone.clone();
 
@@ -720,7 +757,7 @@ mod tests {
         dag.add_dependency(idx_a, idx_b).unwrap();
         dag.add_dependency(idx_b, idx_c).unwrap();
 
-        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task, _context| {
             Box::pin(async move {
                 if task.id == "A" {
                     Err(GlobalError::runtime("boom"))
@@ -758,7 +795,7 @@ mod tests {
             .unwrap();
 
         // Executor fails A, but B must still run because it's only a soft dependency.
-        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task, _context| {
             Box::pin(async move {
                 if task.id == "A" {
                     Err(GlobalError::runtime("A failed"))
@@ -785,8 +822,9 @@ mod tests {
         let mut dag = SubtaskDAG::new("test");
         let idx_a = dag.add_task(SwarmSubtask::new("A", "Task A"));
 
-        let executor: SubtaskExecutorFn =
-            Arc::new(move |_idx, task| Box::pin(async move { Ok(format!("out:{}", task.id)) }));
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task, _context| {
+            Box::pin(async move { Ok(format!("out:{}", task.id)) })
+        });
 
         let scheduler = SequentialScheduler::new();
         let summary = scheduler.execute(&mut dag, executor).await.unwrap();
@@ -798,11 +836,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_dependency_outputs_are_passed_to_downstream_tasks() {
+        let mut dag = SubtaskDAG::new("test");
+        let idx_a = dag.add_task(SwarmSubtask::new("A", "Task A"));
+        let idx_b = dag.add_task(SwarmSubtask::new("B", "Task B"));
+        dag.add_dependency(idx_a, idx_b).unwrap();
+
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task, context| {
+            Box::pin(async move {
+                if task.id == "A" {
+                    Ok("alpha".into())
+                } else {
+                    let seen = context
+                        .dependencies
+                        .iter()
+                        .find(|dep| dep.task_id == "A")
+                        .and_then(|dep| dep.output.clone())
+                        .unwrap_or_default();
+                    Ok(format!("saw:{seen}"))
+                }
+            })
+        });
+
+        let scheduler = SequentialScheduler::new();
+        let summary = scheduler.execute(&mut dag, executor).await.unwrap();
+        assert!(summary.is_fully_successful());
+
+        let task = dag.get_task(idx_b).unwrap();
+        assert_eq!(task.output.as_deref(), Some("saw:alpha"));
+    }
+
+    #[tokio::test]
     async fn test_empty_dag_is_noop_and_does_not_panic() {
         let mut dag = SubtaskDAG::new("empty");
 
         let executor: SubtaskExecutorFn =
-            Arc::new(move |_idx, _task| Box::pin(async move { Ok("unused".into()) }));
+            Arc::new(move |_idx, _task, _context| Box::pin(async move { Ok("unused".into()) }));
 
         let scheduler = SequentialScheduler::new();
         let summary = scheduler.execute(&mut dag, executor).await.unwrap();
@@ -819,7 +888,7 @@ mod tests {
         let idx_b = dag.add_task(SwarmSubtask::new("B", "B"));
         dag.add_dependency(idx_a, idx_b).unwrap();
 
-        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task, _context| {
             Box::pin(async move {
                 if task.id == "A" {
                     Err(GlobalError::runtime("A failed"))
@@ -853,7 +922,7 @@ mod tests {
         let a = active.clone();
         let p = peak.clone();
 
-        let executor: SubtaskExecutorFn = Arc::new(move |_idx, _task| {
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, _task, _context| {
             let a = a.clone();
             let p = p.clone();
             Box::pin(async move {

--- a/crates/mofa-foundation/tests/swarm_scheduler_integration.rs
+++ b/crates/mofa-foundation/tests/swarm_scheduler_integration.rs
@@ -14,7 +14,7 @@ use mofa_kernel::agent::types::error::GlobalError;
 
 fn ok_executor() -> SubtaskExecutorFn {
     Arc::new(
-        |_idx: NodeIndex, task: SwarmSubtask| -> BoxFuture<'static, _> {
+        |_idx: NodeIndex, task: SwarmSubtask, _context| -> BoxFuture<'static, _> {
             Box::pin(async move { Ok(format!("ok:{}", task.id)) })
         },
     )
@@ -53,7 +53,7 @@ async fn parallel_scheduler_executes_via_pattern_and_respects_dependencies() {
     dag.add_dependency(idx_b, idx_d).unwrap();
     dag.add_dependency(idx_c, idx_d).unwrap();
 
-    let exec: SubtaskExecutorFn = Arc::new(|_idx: NodeIndex, task: SwarmSubtask| {
+    let exec: SubtaskExecutorFn = Arc::new(|_idx: NodeIndex, task: SwarmSubtask, _context| {
         Box::pin(async move {
             tokio::time::sleep(Duration::from_millis(10)).await;
             Ok(format!("ok:{}", task.id))
@@ -84,7 +84,7 @@ async fn parallel_fail_fast_cascades_skip() {
     dag.add_dependency(idx_a, idx_b).unwrap();
     dag.add_dependency(idx_a, idx_c).unwrap();
 
-    let exec: SubtaskExecutorFn = Arc::new(|_idx: NodeIndex, task: SwarmSubtask| {
+    let exec: SubtaskExecutorFn = Arc::new(|_idx: NodeIndex, task: SwarmSubtask, _context| {
         Box::pin(async move {
             if task.id == "A" {
                 Err(GlobalError::runtime("A failed"))

--- a/examples/swarm_demo.yaml
+++ b/examples/swarm_demo.yaml
@@ -1,0 +1,65 @@
+# swarm_demo.yaml
+# Run with: mofa swarm run examples/swarm_demo.yaml
+#
+# Primary swarm CLI example.
+# Required environment:
+#   OPENAI_API_KEY=...
+# Optional environment:
+#   OPENAI_BASE_URL=...
+#   OPENAI_MODEL=...
+#
+# This demonstrates a DAG-driven swarm with parallel branches:
+# [decompose] → [web_search] → [analyze] → [summarize]
+#             ↘ [collect_stats] ↗
+executor: llm
+name: research-and-summarize
+description: "Research the latest AI breakthroughs and produce a concise summary"
+task: "Find and summarize 3 recent AI research breakthroughs from 2025"
+pattern: parallel
+agents:
+  - id: researcher
+    capabilities: [web_search, document_read]
+    model: llama3-8b-8192
+    max_concurrency: 2
+  - id: analyst
+    capabilities: [analyze, compare]
+    model: llama3-8b-8192
+  - id: writer
+    capabilities: [summarize, write]
+    model: llama3-8b-8192
+dag:
+  tasks:
+    - id: decompose
+      description: "Decompose the research goal into sub-questions"
+      capabilities: [analyze]
+    - id: web_search
+      description: "Search the web for recent AI breakthroughs"
+      capabilities: [web_search]
+    - id: collect_stats
+      description: "Gather supporting stats and metadata for the breakthroughs"
+      capabilities: [document_read]
+    - id: analyze
+      description: "Analyze findings and rank the top 3 breakthroughs"
+      capabilities: [analyze, compare]
+    - id: summarize
+      description: "Summarize findings into a concise report"
+      capabilities: [summarize, write]
+  dependencies:
+    - from: decompose
+      to: web_search
+    - from: decompose
+      to: collect_stats
+    - from: web_search
+      to: analyze
+    - from: collect_stats
+      to: analyze
+    - from: analyze
+      to: summarize
+sla:
+  max_duration_secs: 300
+  max_cost_tokens: 20000
+  min_quality: 0.7
+hitl: optional
+metadata:
+  author: "MoFA Swarm Demo"
+  version: "1.0"

--- a/examples/swarm_demo_llm.yaml
+++ b/examples/swarm_demo_llm.yaml
@@ -1,0 +1,65 @@
+# swarm_demo_llm.yaml
+# Run with: mofa swarm run examples/swarm_demo_llm.yaml
+#
+# Alternative LLM-backed swarm CLI example.
+# Required environment:
+#   OPENAI_API_KEY=...
+# Optional environment:
+#   OPENAI_BASE_URL=...
+#   OPENAI_MODEL=...
+#
+# The scheduler runs the DAG and each node executes through the LLM executor,
+# receiving upstream dependency outputs as part of its prompt context.
+executor: llm
+name: research-and-summarize-llm
+description: "Research recent AI breakthroughs and synthesize them using LLM-backed subtasks"
+task: "Find and summarize 3 recent AI research breakthroughs from 2025"
+pattern: parallel
+agents:
+  - id: researcher
+    capabilities: [web_search, document_read]
+    model: llama3-8b-8192
+    max_concurrency: 2
+  - id: analyst
+    capabilities: [analyze, compare]
+    model: llama3-8b-8192
+  - id: writer
+    capabilities: [summarize, write]
+    model: llama3-8b-8192
+dag:
+  tasks:
+    - id: decompose
+      description: "Break the research goal into concrete sub-questions to investigate"
+      capabilities: [analyze]
+    - id: web_search
+      description: "Identify candidate AI breakthroughs from 2025 and note why they matter"
+      capabilities: [web_search]
+    - id: collect_stats
+      description: "Collect supporting metrics, release details, and factual context for the candidates"
+      capabilities: [document_read]
+    - id: analyze
+      description: "Compare the findings, filter weak candidates, and rank the top 3 breakthroughs"
+      capabilities: [analyze, compare]
+    - id: summarize
+      description: "Write a concise final summary with the top 3 breakthroughs and brief rationale"
+      capabilities: [summarize, write]
+  dependencies:
+    - from: decompose
+      to: web_search
+    - from: decompose
+      to: collect_stats
+    - from: web_search
+      to: analyze
+    - from: collect_stats
+      to: analyze
+    - from: analyze
+      to: summarize
+sla:
+  max_duration_secs: 300
+  max_cost_tokens: 20000
+  min_quality: 0.7
+hitl: optional
+metadata:
+  author: "MoFA Swarm Demo"
+  variant: "llm"
+  version: "1.0"

--- a/examples/swarm_generate_demo.yaml
+++ b/examples/swarm_generate_demo.yaml
@@ -1,0 +1,33 @@
+# swarm_generate_demo.yaml
+# Run with: mofa swarm run examples/swarm_generate_demo.yaml
+#
+# This example relies on automatic DAG generation from the top-level task.
+# If provider configuration is available, `TaskAnalyzer` uses the live analyzer.
+# Otherwise the CLI falls back to the deterministic offline analyzer.
+#
+# Required environment for live generation:
+#   OPENAI_API_KEY=...
+# Optional environment:
+#   OPENAI_BASE_URL=...
+#   OPENAI_MODEL=...
+executor: llm
+name: generated-research-workflow
+description: "Generate a task DAG from the top-level task and execute it as a swarm workflow"
+task: "Research recent AI orchestration trends and write a concise summary"
+pattern: sequential
+agents:
+  - id: researcher
+    capabilities: [web_search, analyze]
+    model: llama3-8b-8192
+  - id: writer
+    capabilities: [summarize, write]
+    model: llama3-8b-8192
+sla:
+  max_duration_secs: 180
+  max_cost_tokens: 12000
+  min_quality: 0.7
+hitl: optional
+metadata:
+  author: "MoFA Swarm Demo"
+  mode: "generated"
+  version: "1.0"

--- a/examples/swarm_orchestrator/src/main.rs
+++ b/examples/swarm_orchestrator/src/main.rs
@@ -1,7 +1,8 @@
 use futures::future::BoxFuture;
 use mofa_kernel::agent::types::error::GlobalResult;
 use mofa_foundation::swarm::{
-    FailurePolicy, ParallelScheduler, SubtaskDAG, SwarmSchedulerConfig, SwarmSubtask, SwarmScheduler
+    FailurePolicy, ParallelScheduler, SubtaskDAG, SwarmSchedulerConfig, SwarmSubtask,
+    SwarmScheduler, TaskExecutionContext,
 };
 use std::sync::Arc;
 use tokio::time::{sleep, Duration};
@@ -33,7 +34,7 @@ async fn main() -> GlobalResult<()> {
     dag.add_dependency(analyze_b_id, summarize_id).unwrap();
 
     // 2. Define the Pure Executor Function (The Agent Logic)
-    let executor_fn = Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+    let executor_fn = Arc::new(move |_idx, task: SwarmSubtask, _context: TaskExecutionContext| -> BoxFuture<'static, GlobalResult<String>> {
         Box::pin(async move {
             info!("🚀 [Agent Execute] Starting task: {}", task.description);
             // Simulate work via async sleep


### PR DESCRIPTION
## Problem
The repo did not have a complete swarm CLI entry point that a user could run.

The missing pieces were:
- CLI wiring for `swarm run`
- a concrete command implementation
- runnable example YAML files
- scheduler-to-executor context propagation for downstream tasks
- direct YAML deserialization into `SubtaskDAG`
- focused tests for the CLI path

Fixes: #1410

## Solution
This PR adds a working `mofa swarm run <FILE>` command, YAML examples, and the supporting foundation changes needed to execute a DAG through the existing swarm scheduler.
```mermaid
flowchart TD
      A["mofa swarm run examples/swarm_demo.yaml"] --> B["CLI parse"]
      B --> C["main.rs dispatch"]
      C --> D["run_swarm"]
      D --> E["Read YAML"]
      E --> F["Parse SwarmConfig"]
      E --> G["Deserialize dag into SubtaskDAG"]
      D --> H["Select executor from YAML"]
      G --> I["SwarmScheduler::execute"]
      H --> I
      I --> J["Find ready nodes"]
      J --> K["Execute sequentially or in parallel"]
      K --> L["Pass dependency outputs to downstream task context"]
      L --> M["Persist task outputs and status on DAG"]
      M --> N["Print progress and summary"]
```

The implementation now supports:
- example-driven DAG execution through the CLI
- an LLM-backed execution path
- direct `SubtaskDAG` deserialization from the YAML `tasks` / `dependencies` shape
- propagation of upstream task outputs into downstream task execution context

## What Changed
- Added `swarm run <FILE>` CLI parsing and dispatch in `mofa-cli`.
- Implemented direct YAML-to-`SubtaskDAG` loading for the `dag` section.
- Executed DAGs through the existing swarm scheduler from the CLI command path.
- Passed dependency outputs into downstream task execution context.
- Added explicit executor selection from YAML for the CLI path.
- Added example YAML workflows for swarm execution.
- Added focused CLI and foundation tests for parsing, execution context, and DAG deserialization.

## Why This Design
- The scheduler already owned execution ordering and concurrency; this PR keeps that separation and improves the executor contract instead of duplicating scheduling logic in the CLI.
- Keeping executor choice in YAML preserves a clean command surface while allowing multiple real backends later.
- Moving DAG deserialization into `SubtaskDAG` aligns the implementation with the MVP requirement that YAML deserialize directly into the DAG type.
## Files Changed
### `crates/mofa-cli/src/cli.rs`
- Adds the `swarm` command group.
- Adds `swarm run <FILE>` parsing and the optional `--json` flag.

### `crates/mofa-cli/src/commands/mod.rs`
- Exports the new `swarm` command module.

### `crates/mofa-cli/src/main.rs`
- Dispatches `mofa swarm run` to the swarm command handler.
- Includes `swarm` in legacy output flag normalization.

### `crates/mofa-cli/src/commands/swarm.rs`
- Loads swarm YAML from disk.
- Requires an explicit `dag:` section.
- Parses `dag` directly as `SubtaskDAG`.
- Builds the LLM executor from YAML/environment configuration.
- Executes the DAG through `SwarmScheduler::execute`.
- Builds task prompts with upstream dependency outputs.
- Prints the CLI header, progress, and final summary.
- Adds focused command-level tests for YAML parsing and prompt/context behavior.

### `crates/mofa-foundation/src/swarm/mod.rs`
- Re-exports scheduler execution-context types used by the CLI path.

### `crates/mofa-foundation/src/swarm/dag.rs`
- Adds direct YAML deserialization/serialization support for `SubtaskDAG`.
- Adds YAML-friendly defaults and aliases for `SwarmSubtask`.
- Validates duplicate task IDs and bad dependency references during DAG reconstruction.
- Adds focused tests for direct DAG YAML parsing.

### `crates/mofa-foundation/src/swarm/scheduler.rs`
- Extends the executor contract with dependency context.
- Passes upstream task outputs into downstream task execution.
- Adds a focused test for dependency-output propagation.

### `crates/mofa-foundation/tests/swarm_scheduler_integration.rs`
- Updates scheduler integration tests to the new executor signature.

### `examples/swarm_demo.yaml`
- Adds the primary swarm workflow example.
- Defines a parallel DAG in YAML with explicit executor selection.

### `examples/swarm_demo_llm.yaml`
- Adds an alternate LLM-backed swarm workflow example.
- Documents required provider-related environment variables.

## Testing
Verified locally with:

```bash
cargo test -p mofa-cli swarm::tests -- --nocapture
cargo test -p mofa-foundation subtask_dag_deserializes_from_yaml_task_dependency_shape --lib
```

Notes:
- The CLI run path is validated locally.
- Running the example YAMLs requires external provider credentials and valid current model names.
