### PR TITLE
feat(swarm): Add Gateway Capability Integration for Swarm Execution

### DIFF
--- a/crates/mofa-cli/src/cli.rs
+++ b/crates/mofa-cli/src/cli.rs
@@ -162,6 +162,12 @@ pub enum Commands {
         #[command(subcommand)]
         action: RagCommands,
     },
+
+    /// Swarm orchestration commands
+    Swarm {
+        #[command(subcommand)]
+        action: SwarmCommands,
+    },
 }
 
 /// Generate subcommands
@@ -217,6 +223,20 @@ pub enum DatabaseType {
     Mysql,
     /// SQLite database
     Sqlite,
+}
+
+/// Swarm orchestration subcommands
+#[derive(Subcommand)]
+pub enum SwarmCommands {
+    /// Execute a swarm workflow from a YAML file
+    Run {
+        /// Swarm YAML file path
+        file: PathBuf,
+
+        /// Emit a machine-readable JSON summary
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 impl std::fmt::Display for DatabaseType {

--- a/crates/mofa-cli/src/commands/mod.rs
+++ b/crates/mofa-cli/src/commands/mod.rs
@@ -12,4 +12,5 @@ pub mod plugin;
 pub mod rag;
 pub mod run;
 pub mod session;
+pub mod swarm;
 pub mod tool;

--- a/crates/mofa-cli/src/commands/swarm.rs
+++ b/crates/mofa-cli/src/commands/swarm.rs
@@ -1,0 +1,276 @@
+use crate::error::{CliError, CliResult, IntoCliReport as _};
+use error_stack::ResultExt as _;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    CapabilityExecutionPolicy, CoordinationPattern, DependencyKind, SubtaskDAG, SubtaskExecutorFn,
+    SwarmScheduler, SwarmSubtask,
+};
+use mofa_foundation::{GatewayCapabilityRegistry, built_in_capability_registry_from_env};
+use mofa_kernel::agent::types::error::GlobalResult;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+#[derive(Debug, Clone, Deserialize)]
+struct SwarmRunConfig {
+    name: String,
+    task: String,
+    #[serde(default)]
+    pattern: CoordinationPattern,
+    dag: SwarmDagFile,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct SwarmDagFile {
+    tasks: Vec<SwarmTaskFile>,
+    #[serde(default)]
+    dependencies: Vec<SwarmDependencyFile>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct SwarmTaskFile {
+    id: String,
+    description: String,
+    #[serde(default, alias = "required_capabilities")]
+    capabilities: Vec<String>,
+    #[serde(default)]
+    capability_params: HashMap<String, Value>,
+    #[serde(default)]
+    capability_policy: CapabilityExecutionPolicy,
+    #[serde(default)]
+    deps: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct SwarmDependencyFile {
+    from: String,
+    to: String,
+    #[serde(default)]
+    kind: Option<DependencyKind>,
+}
+
+#[derive(Debug, Serialize)]
+struct SwarmRunSummary {
+    name: String,
+    task: String,
+    pattern: CoordinationPattern,
+    total_tasks: usize,
+    succeeded: usize,
+    failed: usize,
+    skipped: usize,
+    outputs: Vec<String>,
+}
+
+pub async fn run(file: &Path, json: bool) -> CliResult<()> {
+    let raw = std::fs::read_to_string(file)
+        .map_err(CliError::from)
+        .into_report()
+        .attach_with(|| format!("reading swarm config '{}'", file.display()))?;
+
+    let config: SwarmRunConfig = serde_yaml::from_str(&raw)
+        .map_err(CliError::from)
+        .into_report()
+        .attach_with(|| format!("parsing swarm YAML '{}'", file.display()))?;
+
+    let registry = built_in_capability_registry_from_env();
+    let summary = run_config_with_registry(config, registry)
+        .await
+        .attach_with(|| format!("executing swarm '{}'", file.display()))?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&summary)
+                .map_err(CliError::from)
+                .into_report()
+                .attach("serializing swarm summary to JSON")?
+        );
+    } else {
+        println!("Swarm: {}", summary.name);
+        println!("Task: {}", summary.task);
+        println!("Pattern: {:?}", summary.pattern);
+        println!(
+            "Tasks: total={} succeeded={} failed={} skipped={}",
+            summary.total_tasks, summary.succeeded, summary.failed, summary.skipped
+        );
+        for output in &summary.outputs {
+            println!("output: {output}");
+        }
+    }
+
+    Ok(())
+}
+
+async fn run_config_with_registry(
+    config: SwarmRunConfig,
+    registry: Arc<GatewayCapabilityRegistry>,
+) -> CliResult<SwarmRunSummary> {
+    let SwarmRunConfig {
+        name,
+        task,
+        pattern,
+        dag,
+    } = config;
+
+    let mut dag = build_dag(&name, dag)
+        .map_err(|e| CliError::Other(e.to_string()))
+        .into_report()
+        .attach("building SubtaskDAG from YAML")?;
+
+    let executor: SubtaskExecutorFn = Arc::new(move |_idx, task: SwarmSubtask| {
+        let registry = Arc::clone(&registry);
+        Box::pin(async move { execute_task(task, registry).await })
+            as BoxFuture<'static, GlobalResult<String>>
+    });
+
+    let scheduler = pattern.clone().into_scheduler();
+    let summary = scheduler
+        .execute(&mut dag, executor)
+        .await
+        .map_err(|e| CliError::Other(e.to_string()))
+        .into_report()
+        .attach("running swarm scheduler")?;
+
+    Ok(SwarmRunSummary {
+        name,
+        task,
+        pattern,
+        total_tasks: summary.total_tasks,
+        succeeded: summary.succeeded,
+        failed: summary.failed,
+        skipped: summary.skipped,
+        outputs: summary
+            .successful_outputs()
+            .into_iter()
+            .map(ToOwned::to_owned)
+            .collect(),
+    })
+}
+
+async fn execute_task(
+    task: SwarmSubtask,
+    registry: Arc<GatewayCapabilityRegistry>,
+) -> GlobalResult<String> {
+    match registry
+        .invoke_task(&task, format!("swarm-{}", task.id))
+        .await?
+    {
+        Some(response) => Ok(response.output),
+        None => Ok(format!("local: {}", task.description)),
+    }
+}
+
+fn build_dag(name: &str, dag_file: SwarmDagFile) -> GlobalResult<SubtaskDAG> {
+    let tasks = dag_file
+        .tasks
+        .iter()
+        .map(|task| {
+            SwarmSubtask::new(task.id.clone(), task.description.clone())
+            .with_capabilities(task.capabilities.clone())
+            .with_capability_params(task.capability_params.clone())
+            .with_capability_policy(task.capability_policy)
+        })
+        .collect();
+    let dependencies = dag_file
+        .tasks
+        .iter()
+        .flat_map(|task| {
+            task.deps.iter().map(|dep_id| {
+                (
+                    dep_id.clone(),
+                    task.id.clone(),
+                    DependencyKind::Sequential,
+                )
+            })
+        })
+        .chain(dag_file.dependencies.iter().map(|dependency| {
+            (
+                dependency.from.clone(),
+                dependency.to.clone(),
+                dependency.kind.clone().unwrap_or(DependencyKind::Sequential),
+            )
+        }))
+        .collect();
+
+    SubtaskDAG::from_subtasks(name, tasks, dependencies)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use mofa_foundation::{CapabilityRequest, CapabilityResponse, GatewayCapability};
+
+    struct EchoCapability;
+
+    #[async_trait]
+    impl GatewayCapability for EchoCapability {
+        fn name(&self) -> &str {
+            "web_search"
+        }
+
+        async fn invoke(&self, input: CapabilityRequest) -> GlobalResult<CapabilityResponse> {
+            Ok(CapabilityResponse {
+                output: format!(
+                    "capability:{}:{}",
+                    input.input,
+                    input.params["query"]
+                ),
+                metadata: HashMap::new(),
+                latency_ms: 1,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn run_uses_capability_registry_and_task_params() {
+        let config: SwarmRunConfig = serde_yaml::from_str(
+            r#"
+name: gateway-demo
+task: "Search for AI news"
+pattern: sequential
+dag:
+  tasks:
+    - id: search
+      description: "latest AI news"
+      capabilities: [web_search]
+      capability_policy: require_capability
+      capability_params:
+        query: "2025 ai news"
+"#,
+        )
+        .unwrap();
+
+        let registry = Arc::new(GatewayCapabilityRegistry::new());
+        registry.register(Arc::new(EchoCapability));
+
+        let summary = run_config_with_registry(config, registry).await.unwrap();
+        assert_eq!(summary.succeeded, 1);
+        assert_eq!(
+            summary.outputs,
+            vec!["capability:latest AI news:\"2025 ai news\"".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn run_falls_back_to_local_when_policy_allows_it() {
+        let config: SwarmRunConfig = serde_yaml::from_str(
+            r#"
+name: local-demo
+task: "Write summary"
+pattern: sequential
+dag:
+  tasks:
+    - id: write
+      description: "Write a summary"
+"#,
+        )
+        .unwrap();
+
+        let registry = Arc::new(GatewayCapabilityRegistry::new());
+        let summary = run_config_with_registry(config, registry).await.unwrap();
+        assert_eq!(summary.outputs, vec!["local: Write a summary".to_string()]);
+    }
+}

--- a/crates/mofa-cli/src/main.rs
+++ b/crates/mofa-cli/src/main.rs
@@ -387,6 +387,12 @@ async fn run_command(cli: Cli) -> CliResult<()> {
             }
         },
 
+        Some(Commands::Swarm { action }) => match action {
+            cli::SwarmCommands::Run { file, json } => {
+                commands::swarm::run(&file, json).await?;
+            }
+        },
+
         None => {
             // Should have been handled by TUI check above
             // If we get here, show help
@@ -404,7 +410,7 @@ async fn run_command(cli: Cli) -> CliResult<()> {
 fn normalize_legacy_output_flags(args: &mut [String]) {
     const TOP_LEVEL_COMMANDS: &[&str] = &[
         "new", "init", "build", "run", "dataflow", "generate", "info", "db", "agent", "config",
-        "plugin", "session", "tool", "doctor", "rag",
+        "plugin", "session", "tool", "doctor", "rag", "swarm",
     ];
 
     let top_command_index = args

--- a/crates/mofa-foundation/src/gateway/capability.rs
+++ b/crates/mofa-foundation/src/gateway/capability.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use mofa_kernel::agent::types::error::GlobalResult;
 
-use crate::swarm::SwarmSubtask;
+use crate::swarm::{CapabilityExecutionPolicy, SwarmSubtask};
 
 /// Request payload passed to a gateway-backed capability.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -107,13 +107,30 @@ impl GatewayCapabilityRegistry {
         task: &SwarmSubtask,
         trace_id: impl Into<String>,
     ) -> GlobalResult<Option<CapabilityResponse>> {
+        if matches!(task.capability_policy, CapabilityExecutionPolicy::LocalOnly) {
+            return Ok(None);
+        }
+
         let Some(capability) = self.resolve_for_task(task) else {
+            if matches!(
+                task.capability_policy,
+                CapabilityExecutionPolicy::RequireCapability
+            ) && !task.required_capabilities.is_empty()
+            {
+                return Err(mofa_kernel::agent::types::error::GlobalError::Other(
+                    format!(
+                        "required capability not available for task '{}': {}",
+                        task.id,
+                        task.required_capabilities.join(", ")
+                    ),
+                ));
+            }
             return Ok(None);
         };
 
         let request = CapabilityRequest {
             input: task.description.clone(),
-            params: HashMap::new(),
+            params: task.capability_params.clone(),
             trace_id: trace_id.into(),
         };
 
@@ -209,5 +226,20 @@ mod tests {
             .expect("missing capability should not be an error");
 
         assert!(response.is_none());
+    }
+
+    #[tokio::test]
+    async fn invoke_task_errors_when_policy_requires_capability() {
+        let registry = GatewayCapabilityRegistry::new();
+        let task = SwarmSubtask::new("task-1", "read sensor")
+            .with_capabilities(vec!["read_sensor".to_string()])
+            .with_capability_policy(CapabilityExecutionPolicy::RequireCapability);
+
+        let error = registry
+            .invoke_task(&task, "trace-required")
+            .await
+            .expect_err("missing required capability should fail");
+
+        assert!(error.to_string().contains("required capability not available"));
     }
 }

--- a/crates/mofa-foundation/src/gateway/capability.rs
+++ b/crates/mofa-foundation/src/gateway/capability.rs
@@ -1,0 +1,213 @@
+use async_trait::async_trait;
+use dashmap::DashMap;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use mofa_kernel::agent::types::error::GlobalResult;
+
+use crate::swarm::SwarmSubtask;
+
+/// Request payload passed to a gateway-backed capability.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CapabilityRequest {
+    /// Primary task input, typically the subtask description.
+    pub input: String,
+    /// Structured arguments for the capability implementation.
+    #[serde(default)]
+    pub params: HashMap<String, Value>,
+    /// Trace identifier propagated from the caller.
+    pub trace_id: String,
+}
+
+/// Response payload returned from a gateway-backed capability.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CapabilityResponse {
+    /// Primary textual output that becomes the task result.
+    pub output: String,
+    /// Structured metadata returned by the capability implementation.
+    #[serde(default)]
+    pub metadata: HashMap<String, Value>,
+    /// End-to-end capability invocation latency in milliseconds.
+    pub latency_ms: u64,
+}
+
+/// Capability interface for external tools, devices, and APIs.
+#[async_trait]
+pub trait GatewayCapability: Send + Sync {
+    /// Stable capability name used for registry lookup.
+    fn name(&self) -> &str;
+
+    /// Execute the capability with a structured request.
+    async fn invoke(&self, input: CapabilityRequest) -> GlobalResult<CapabilityResponse>;
+}
+
+/// Shared registry of gateway-backed capabilities.
+#[derive(Default)]
+pub struct GatewayCapabilityRegistry {
+    capabilities: DashMap<String, Arc<dyn GatewayCapability>>,
+}
+
+impl GatewayCapabilityRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register or replace a capability under its stable name.
+    pub fn register(&self, capability: Arc<dyn GatewayCapability>) {
+        self.capabilities
+            .insert(capability.name().to_string(), capability);
+    }
+
+    /// Remove a capability by name.
+    pub fn unregister(&self, name: &str) -> Option<Arc<dyn GatewayCapability>> {
+        self.capabilities.remove(name).map(|(_, capability)| capability)
+    }
+
+    /// Look up a capability by exact name.
+    pub fn get(&self, name: &str) -> Option<Arc<dyn GatewayCapability>> {
+        self.capabilities.get(name).map(|entry| Arc::clone(entry.value()))
+    }
+
+    /// Returns `true` when a capability exists for the given name.
+    pub fn contains(&self, name: &str) -> bool {
+        self.capabilities.contains_key(name)
+    }
+
+    /// Return all registered capability names in sorted order.
+    pub fn names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self
+            .capabilities
+            .iter()
+            .map(|entry| entry.key().clone())
+            .collect();
+        names.sort();
+        names
+    }
+
+    /// Resolve the first registered capability required by a subtask.
+    ///
+    /// This scans all declared required capabilities in order rather than
+    /// assuming the first tag is always available.
+    pub fn resolve_for_task(&self, task: &SwarmSubtask) -> Option<Arc<dyn GatewayCapability>> {
+        task.required_capabilities
+            .iter()
+            .find_map(|capability_name| self.get(capability_name))
+    }
+
+    /// Invoke the first registered capability required by a subtask.
+    ///
+    /// Returns `Ok(None)` when none of the task's required capabilities are
+    /// registered in the gateway registry so callers can decide whether to
+    /// fail or fall back to another execution path.
+    pub async fn invoke_task(
+        &self,
+        task: &SwarmSubtask,
+        trace_id: impl Into<String>,
+    ) -> GlobalResult<Option<CapabilityResponse>> {
+        let Some(capability) = self.resolve_for_task(task) else {
+            return Ok(None);
+        };
+
+        let request = CapabilityRequest {
+            input: task.description.clone(),
+            params: HashMap::new(),
+            trace_id: trace_id.into(),
+        };
+
+        capability.invoke(request).await.map(Some)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mofa_kernel::agent::types::error::GlobalError;
+
+    struct MockCapability {
+        name: &'static str,
+        output: &'static str,
+    }
+
+    #[async_trait]
+    impl GatewayCapability for MockCapability {
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        async fn invoke(&self, input: CapabilityRequest) -> GlobalResult<CapabilityResponse> {
+            if input.input.is_empty() {
+                return Err(GlobalError::Other("missing input".to_string()));
+            }
+
+            Ok(CapabilityResponse {
+                output: format!("{}: {}", self.output, input.input),
+                metadata: HashMap::from([(
+                    "trace_id".to_string(),
+                    Value::String(input.trace_id),
+                )]),
+                latency_ms: 12,
+            })
+        }
+    }
+
+    #[test]
+    fn register_and_lookup_capability() {
+        let registry = GatewayCapabilityRegistry::new();
+        registry.register(Arc::new(MockCapability {
+            name: "web_search",
+            output: "ok",
+        }));
+
+        assert!(registry.contains("web_search"));
+        assert_eq!(registry.names(), vec!["web_search".to_string()]);
+        assert!(registry.get("web_search").is_some());
+    }
+
+    #[tokio::test]
+    async fn invoke_task_uses_first_matching_registered_capability() {
+        let registry = GatewayCapabilityRegistry::new();
+        registry.register(Arc::new(MockCapability {
+            name: "http_fetch",
+            output: "fetched",
+        }));
+
+        let task = SwarmSubtask::new("task-1", "fetch status page").with_capabilities(vec![
+            "missing".to_string(),
+            "http_fetch".to_string(),
+        ]);
+
+        let response = registry
+            .invoke_task(&task, "trace-123")
+            .await
+            .expect("capability invocation should succeed")
+            .expect("matching capability should be found");
+
+        assert_eq!(response.output, "fetched: fetch status page");
+        assert_eq!(
+            response.metadata.get("trace_id"),
+            Some(&Value::String("trace-123".to_string()))
+        );
+    }
+
+    #[tokio::test]
+    async fn invoke_task_returns_none_when_no_capability_matches() {
+        let registry = GatewayCapabilityRegistry::new();
+        registry.register(Arc::new(MockCapability {
+            name: "web_search",
+            output: "ok",
+        }));
+
+        let task =
+            SwarmSubtask::new("task-1", "draft report").with_capabilities(vec!["llm".to_string()]);
+
+        let response = registry
+            .invoke_task(&task, "trace-456")
+            .await
+            .expect("missing capability should not be an error");
+
+        assert!(response.is_none());
+    }
+}

--- a/crates/mofa-foundation/src/gateway/http_capabilities.rs
+++ b/crates/mofa-foundation/src/gateway/http_capabilities.rs
@@ -152,7 +152,12 @@ impl GatewayCapability for DuckDuckGoSearchCapability {
     }
 
     async fn invoke(&self, input: CapabilityRequest) -> GlobalResult<CapabilityResponse> {
-        let query = input.input.trim();
+        let query = input
+            .params
+            .get("query")
+            .and_then(Value::as_str)
+            .unwrap_or(input.input.as_str())
+            .trim();
         if query.is_empty() {
             return Err(GlobalError::Other("web search query must not be empty".to_string()));
         }

--- a/crates/mofa-foundation/src/gateway/http_capabilities.rs
+++ b/crates/mofa-foundation/src/gateway/http_capabilities.rs
@@ -1,0 +1,386 @@
+use async_trait::async_trait;
+use reqwest::Client;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::time::Instant;
+
+use mofa_kernel::agent::types::error::{GlobalError, GlobalResult};
+
+use crate::gateway::{CapabilityRequest, CapabilityResponse, GatewayCapability};
+
+/// Generic HTTP GET capability that fetches a configured endpoint.
+pub struct HttpFetchCapability {
+    client: Client,
+    name: String,
+    url_param: String,
+}
+
+/// POST-backed notification capability for webhooks such as Slack.
+pub struct WebhookNotificationCapability {
+    client: Client,
+    name: String,
+    webhook_url: String,
+}
+
+impl WebhookNotificationCapability {
+    /// Create a new notification capability using the provided webhook URL.
+    pub fn new(webhook_url: impl Into<String>) -> Self {
+        Self {
+            client: Client::new(),
+            name: "send_notification".to_string(),
+            webhook_url: webhook_url.into(),
+        }
+    }
+
+    /// Override the registry-visible capability name.
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
+    }
+}
+
+/// HTTP GET capability for sensor or IoT endpoints.
+pub struct ReadSensorCapability {
+    client: Client,
+    name: String,
+    endpoint_url: String,
+}
+
+impl ReadSensorCapability {
+    /// Create a new sensor capability using the provided endpoint URL.
+    pub fn new(endpoint_url: impl Into<String>) -> Self {
+        Self {
+            client: Client::new(),
+            name: "read_sensor".to_string(),
+            endpoint_url: endpoint_url.into(),
+        }
+    }
+
+    /// Override the registry-visible capability name.
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
+    }
+}
+
+impl HttpFetchCapability {
+    /// Create a new HTTP fetch capability that reads the target URL from params.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            client: Client::new(),
+            name: name.into(),
+            url_param: "url".to_string(),
+        }
+    }
+
+    /// Override the request parameter used to carry the target URL.
+    pub fn with_url_param(mut self, url_param: impl Into<String>) -> Self {
+        self.url_param = url_param.into();
+        self
+    }
+}
+
+#[async_trait]
+impl GatewayCapability for HttpFetchCapability {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    async fn invoke(&self, input: CapabilityRequest) -> GlobalResult<CapabilityResponse> {
+        let target_url = input
+            .params
+            .get(&self.url_param)
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                GlobalError::Other(format!("missing '{}' param for {}", self.url_param, self.name))
+            })?;
+
+        let start = Instant::now();
+        let response = self
+            .client
+            .get(target_url)
+            .send()
+            .await
+            .map_err(|e| GlobalError::Other(format!("http fetch request failed: {e}")))?;
+
+        let status = response.status().as_u16();
+        let body = response
+            .text()
+            .await
+            .map_err(|e| GlobalError::Other(format!("http fetch body read failed: {e}")))?;
+
+        Ok(CapabilityResponse {
+            output: body,
+            metadata: HashMap::from([
+                ("status".to_string(), Value::from(status)),
+                ("url".to_string(), Value::String(target_url.to_string())),
+                ("trace_id".to_string(), Value::String(input.trace_id)),
+            ]),
+            latency_ms: start.elapsed().as_millis() as u64,
+        })
+    }
+}
+
+/// DuckDuckGo-backed web search capability.
+pub struct DuckDuckGoSearchCapability {
+    client: Client,
+    name: String,
+    base_url: String,
+}
+
+impl DuckDuckGoSearchCapability {
+    /// Create a new web search capability using the provided base URL.
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self {
+            client: Client::new(),
+            name: "web_search".to_string(),
+            base_url: base_url.into(),
+        }
+    }
+
+    /// Override the registry-visible capability name.
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
+    }
+}
+
+#[async_trait]
+impl GatewayCapability for DuckDuckGoSearchCapability {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    async fn invoke(&self, input: CapabilityRequest) -> GlobalResult<CapabilityResponse> {
+        let query = input.input.trim();
+        if query.is_empty() {
+            return Err(GlobalError::Other("web search query must not be empty".to_string()));
+        }
+
+        let start = Instant::now();
+        let response = self
+            .client
+            .get(&self.base_url)
+            .query(&[("q", query), ("format", "json"), ("no_html", "1")])
+            .send()
+            .await
+            .map_err(|e| GlobalError::Other(format!("web search request failed: {e}")))?;
+
+        let status = response.status().as_u16();
+        let payload: Value = response
+            .json()
+            .await
+            .map_err(|e| GlobalError::Other(format!("web search JSON parse failed: {e}")))?;
+
+        let output = payload
+            .get("AbstractText")
+            .and_then(Value::as_str)
+            .filter(|text| !text.trim().is_empty())
+            .map(ToOwned::to_owned)
+            .or_else(|| {
+                payload
+                    .get("Heading")
+                    .and_then(Value::as_str)
+                    .filter(|text| !text.trim().is_empty())
+                    .map(ToOwned::to_owned)
+            })
+            .unwrap_or_else(|| payload.to_string());
+
+        Ok(CapabilityResponse {
+            output,
+            metadata: HashMap::from([
+                ("status".to_string(), Value::from(status)),
+                ("query".to_string(), Value::String(query.to_string())),
+                ("trace_id".to_string(), Value::String(input.trace_id)),
+            ]),
+            latency_ms: start.elapsed().as_millis() as u64,
+        })
+    }
+}
+
+#[async_trait]
+impl GatewayCapability for WebhookNotificationCapability {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    async fn invoke(&self, input: CapabilityRequest) -> GlobalResult<CapabilityResponse> {
+        let start = Instant::now();
+        let response = self
+            .client
+            .post(&self.webhook_url)
+            .json(&serde_json::json!({
+                "text": input.input,
+                "params": input.params,
+                "trace_id": input.trace_id,
+            }))
+            .send()
+            .await
+            .map_err(|e| GlobalError::Other(format!("notification request failed: {e}")))?;
+
+        let status = response.status().as_u16();
+        let body = response
+            .text()
+            .await
+            .map_err(|e| GlobalError::Other(format!("notification body read failed: {e}")))?;
+
+        Ok(CapabilityResponse {
+            output: body,
+            metadata: HashMap::from([
+                ("status".to_string(), Value::from(status)),
+                ("webhook_url".to_string(), Value::String(self.webhook_url.clone())),
+            ]),
+            latency_ms: start.elapsed().as_millis() as u64,
+        })
+    }
+}
+
+#[async_trait]
+impl GatewayCapability for ReadSensorCapability {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    async fn invoke(&self, input: CapabilityRequest) -> GlobalResult<CapabilityResponse> {
+        let start = Instant::now();
+        let response = self
+            .client
+            .get(&self.endpoint_url)
+            .query(&[("trace_id", input.trace_id.clone())])
+            .send()
+            .await
+            .map_err(|e| GlobalError::Other(format!("sensor read request failed: {e}")))?;
+
+        let status = response.status().as_u16();
+        let body = response
+            .text()
+            .await
+            .map_err(|e| GlobalError::Other(format!("sensor body read failed: {e}")))?;
+
+        Ok(CapabilityResponse {
+            output: body,
+            metadata: HashMap::from([
+                ("status".to_string(), Value::from(status)),
+                ("endpoint_url".to_string(), Value::String(self.endpoint_url.clone())),
+            ]),
+            latency_ms: start.elapsed().as_millis() as u64,
+        })
+    }
+}
+
+#[cfg(all(test, feature = "http-api"))]
+mod tests {
+    use super::*;
+    use axum::{Json, Router, routing::get};
+    use tokio::net::TcpListener;
+
+    async fn spawn_test_server(app: Router) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{}", addr)
+    }
+
+    #[tokio::test]
+    async fn http_fetch_capability_returns_body_and_metadata() {
+        let base_url = spawn_test_server(Router::new().route(
+            "/payload",
+            get(|| async { "sensor=24.5C" }),
+        ))
+        .await;
+
+        let capability = HttpFetchCapability::new("http_fetch");
+        let response = capability
+            .invoke(CapabilityRequest {
+                input: "ignored".to_string(),
+                params: HashMap::from([(
+                    "url".to_string(),
+                    Value::String(format!("{base_url}/payload")),
+                )]),
+                trace_id: "trace-http".to_string(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(response.output, "sensor=24.5C");
+        assert_eq!(
+            response.metadata.get("status"),
+            Some(&Value::from(200_u16))
+        );
+    }
+
+    #[tokio::test]
+    async fn duckduckgo_capability_prefers_abstract_text() {
+        let base_url = spawn_test_server(Router::new().route(
+            "/",
+            get(|| async {
+                Json(serde_json::json!({
+                    "AbstractText": "MoFA summary result",
+                    "Heading": "Ignored heading"
+                }))
+            }),
+        ))
+        .await;
+
+        let capability = DuckDuckGoSearchCapability::new(base_url);
+        let response = capability
+            .invoke(CapabilityRequest {
+                input: "mofa".to_string(),
+                params: HashMap::new(),
+                trace_id: "trace-search".to_string(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(response.output, "MoFA summary result");
+        assert_eq!(
+            response.metadata.get("query"),
+            Some(&Value::String("mofa".to_string()))
+        );
+    }
+
+    #[tokio::test]
+    async fn webhook_notification_posts_json_payload() {
+        let base_url = spawn_test_server(Router::new().route(
+            "/notify",
+            axum::routing::post(|Json(payload): Json<Value>| async move { Json(payload) }),
+        ))
+        .await;
+
+        let capability = WebhookNotificationCapability::new(format!("{base_url}/notify"));
+        let response = capability
+            .invoke(CapabilityRequest {
+                input: "Ship it".to_string(),
+                params: HashMap::from([("channel".to_string(), Value::String("alerts".to_string()))]),
+                trace_id: "trace-notify".to_string(),
+            })
+            .await
+            .unwrap();
+
+        let echoed: Value = serde_json::from_str(&response.output).unwrap();
+        assert_eq!(echoed.get("text"), Some(&Value::String("Ship it".to_string())));
+    }
+
+    #[tokio::test]
+    async fn read_sensor_fetches_endpoint_text() {
+        let base_url = spawn_test_server(Router::new().route(
+            "/sensor",
+            get(|| async { "temperature=21.2" }),
+        ))
+        .await;
+
+        let capability = ReadSensorCapability::new(format!("{base_url}/sensor"));
+        let response = capability
+            .invoke(CapabilityRequest {
+                input: "ignored".to_string(),
+                params: HashMap::new(),
+                trace_id: "trace-sensor".to_string(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(response.output, "temperature=21.2");
+    }
+}

--- a/crates/mofa-foundation/src/gateway/mod.rs
+++ b/crates/mofa-foundation/src/gateway/mod.rs
@@ -4,6 +4,19 @@
 //! traits. Kernel traits live in `mofa-kernel::gateway`; implementations live
 //! here so the kernel stays free of runtime dependencies.
 
+pub mod capability;
+pub mod http_capabilities;
+pub mod registry_builder;
 pub mod rate_limiter;
 
+pub use capability::{
+    CapabilityRequest, CapabilityResponse, GatewayCapability, GatewayCapabilityRegistry,
+};
+pub use http_capabilities::{
+    DuckDuckGoSearchCapability, HttpFetchCapability, ReadSensorCapability,
+    WebhookNotificationCapability,
+};
+pub use registry_builder::{
+    GatewayCapabilityRegistryConfig, built_in_capability_registry_from_env,
+};
 pub use rate_limiter::TokenBucketRateLimiter;

--- a/crates/mofa-foundation/src/gateway/registry_builder.rs
+++ b/crates/mofa-foundation/src/gateway/registry_builder.rs
@@ -5,6 +5,8 @@ use crate::gateway::{
     ReadSensorCapability, WebhookNotificationCapability,
 };
 
+const DEFAULT_DUCKDUCKGO_URL: &str = "https://api.duckduckgo.com/";
+
 /// Environment/config-backed settings for registering built-in capabilities.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GatewayCapabilityRegistryConfig {
@@ -21,7 +23,7 @@ pub struct GatewayCapabilityRegistryConfig {
 impl Default for GatewayCapabilityRegistryConfig {
     fn default() -> Self {
         Self {
-            web_search_url: Some("https://api.duckduckgo.com/".to_string()),
+            web_search_url: Some(DEFAULT_DUCKDUCKGO_URL.to_string()),
             enable_http_fetch: true,
             notification_webhook_url: None,
             sensor_url: None,
@@ -35,7 +37,7 @@ impl GatewayCapabilityRegistryConfig {
         Self {
             web_search_url: std::env::var("GATEWAY_WEB_SEARCH_URL")
                 .ok()
-                .or_else(|| Some("https://api.duckduckgo.com/".to_string())),
+                .or_else(|| Some(DEFAULT_DUCKDUCKGO_URL.to_string())),
             enable_http_fetch: std::env::var("GATEWAY_HTTP_FETCH_ENABLED")
                 .ok()
                 .map(|value| !matches!(value.trim().to_ascii_lowercase().as_str(), "0" | "false" | "no"))

--- a/crates/mofa-foundation/src/gateway/registry_builder.rs
+++ b/crates/mofa-foundation/src/gateway/registry_builder.rs
@@ -1,0 +1,109 @@
+use std::sync::Arc;
+
+use crate::gateway::{
+    DuckDuckGoSearchCapability, GatewayCapabilityRegistry, HttpFetchCapability,
+    ReadSensorCapability, WebhookNotificationCapability,
+};
+
+/// Environment/config-backed settings for registering built-in capabilities.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GatewayCapabilityRegistryConfig {
+    /// Base URL for DuckDuckGo-compatible search.
+    pub web_search_url: Option<String>,
+    /// Whether generic HTTP fetch should be registered.
+    pub enable_http_fetch: bool,
+    /// Webhook target for notification delivery.
+    pub notification_webhook_url: Option<String>,
+    /// Sensor endpoint for simple HTTP-based device reads.
+    pub sensor_url: Option<String>,
+}
+
+impl Default for GatewayCapabilityRegistryConfig {
+    fn default() -> Self {
+        Self {
+            web_search_url: Some("https://api.duckduckgo.com/".to_string()),
+            enable_http_fetch: true,
+            notification_webhook_url: None,
+            sensor_url: None,
+        }
+    }
+}
+
+impl GatewayCapabilityRegistryConfig {
+    /// Load built-in capability settings from environment variables.
+    pub fn from_env() -> Self {
+        Self {
+            web_search_url: std::env::var("GATEWAY_WEB_SEARCH_URL")
+                .ok()
+                .or_else(|| Some("https://api.duckduckgo.com/".to_string())),
+            enable_http_fetch: std::env::var("GATEWAY_HTTP_FETCH_ENABLED")
+                .ok()
+                .map(|value| !matches!(value.trim().to_ascii_lowercase().as_str(), "0" | "false" | "no"))
+                .unwrap_or(true),
+            notification_webhook_url: std::env::var("GATEWAY_NOTIFICATION_WEBHOOK").ok(),
+            sensor_url: std::env::var("GATEWAY_SENSOR_URL").ok(),
+        }
+    }
+
+    /// Build a capability registry from this config.
+    pub fn build_registry(&self) -> Arc<GatewayCapabilityRegistry> {
+        let registry = Arc::new(GatewayCapabilityRegistry::new());
+
+        if let Some(web_search_url) = &self.web_search_url {
+            registry.register(Arc::new(DuckDuckGoSearchCapability::new(
+                web_search_url.clone(),
+            )));
+        }
+
+        if self.enable_http_fetch {
+            registry.register(Arc::new(HttpFetchCapability::new("http_fetch")));
+        }
+
+        if let Some(webhook_url) = &self.notification_webhook_url {
+            registry.register(Arc::new(WebhookNotificationCapability::new(
+                webhook_url.clone(),
+            )));
+        }
+
+        if let Some(sensor_url) = &self.sensor_url {
+            registry.register(Arc::new(ReadSensorCapability::new(sensor_url.clone())));
+        }
+
+        registry
+    }
+}
+
+/// Convenience helper for the common case of loading built-ins from env vars.
+pub fn built_in_capability_registry_from_env() -> Arc<GatewayCapabilityRegistry> {
+    GatewayCapabilityRegistryConfig::from_env().build_registry()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_registers_web_search_and_http_fetch() {
+        let registry = GatewayCapabilityRegistryConfig::default().build_registry();
+        assert!(registry.contains("web_search"));
+        assert!(registry.contains("http_fetch"));
+        assert!(!registry.contains("send_notification"));
+        assert!(!registry.contains("read_sensor"));
+    }
+
+    #[test]
+    fn custom_config_registers_optional_capabilities() {
+        let registry = GatewayCapabilityRegistryConfig {
+            web_search_url: None,
+            enable_http_fetch: false,
+            notification_webhook_url: Some("https://example.test/webhook".to_string()),
+            sensor_url: Some("https://example.test/sensor".to_string()),
+        }
+        .build_registry();
+
+        assert!(!registry.contains("web_search"));
+        assert!(!registry.contains("http_fetch"));
+        assert!(registry.contains("send_notification"));
+        assert!(registry.contains("read_sensor"));
+    }
+}

--- a/crates/mofa-foundation/src/lib.rs
+++ b/crates/mofa-foundation/src/lib.rs
@@ -88,7 +88,13 @@ pub use metrics::{
 
 // Gateway implementations (rate limiter, routing strategies)
 pub mod gateway;
-pub use gateway::TokenBucketRateLimiter;
+pub use gateway::{
+    GatewayCapabilityRegistryConfig,
+    CapabilityRequest, CapabilityResponse, GatewayCapability, GatewayCapabilityRegistry,
+    DuckDuckGoSearchCapability, HttpFetchCapability, ReadSensorCapability,
+    TokenBucketRateLimiter, WebhookNotificationCapability,
+    built_in_capability_registry_from_env,
+};
 
 // Re-export config types
 pub use config::{AgentInfo, AgentYamlConfig, LLMYamlConfig, RuntimeConfig, ToolConfig};

--- a/crates/mofa-foundation/src/swarm/dag.rs
+++ b/crates/mofa-foundation/src/swarm/dag.rs
@@ -5,6 +5,7 @@ use petgraph::Direction;
 use petgraph::graph::{DiGraph, NodeIndex};
 use petgraph::visit::EdgeRef;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::collections::HashMap;
 use uuid::Uuid;
 
@@ -73,12 +74,30 @@ pub enum SubtaskStatus {
     Skipped,
 }
 
+/// How a subtask should resolve its declared capabilities at execution time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum CapabilityExecutionPolicy {
+    /// Use a matching registered capability when available, otherwise fall back.
+    #[default]
+    PreferCapability,
+    /// Require a matching registered capability and fail when none is available.
+    RequireCapability,
+    /// Ignore registered capabilities and always use the local executor path.
+    LocalOnly,
+}
+
 /// A single subtask node in the DAG
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SwarmSubtask {
     pub id: String,
     pub description: String,
+    #[serde(default, alias = "capabilities")]
     pub required_capabilities: Vec<String>,
+    #[serde(default)]
+    pub capability_params: HashMap<String, Value>,
+    #[serde(default)]
+    pub capability_policy: CapabilityExecutionPolicy,
     pub status: SubtaskStatus,
     pub assigned_agent: Option<String>,
     pub output: Option<String>,
@@ -109,6 +128,8 @@ impl SwarmSubtask {
             id: id.into(),
             description: description.into(),
             required_capabilities: Vec::new(),
+            capability_params: HashMap::new(),
+            capability_policy: CapabilityExecutionPolicy::default(),
             status: SubtaskStatus::Pending,
             assigned_agent: None,
             output: None,
@@ -124,6 +145,18 @@ impl SwarmSubtask {
     /// Set required capabilities for this subtask
     pub fn with_capabilities(mut self, caps: Vec<String>) -> Self {
         self.required_capabilities = caps;
+        self
+    }
+
+    /// Set structured capability parameters for this subtask.
+    pub fn with_capability_params(mut self, params: HashMap<String, Value>) -> Self {
+        self.capability_params = params;
+        self
+    }
+
+    /// Set the capability execution policy for this subtask.
+    pub fn with_capability_policy(mut self, policy: CapabilityExecutionPolicy) -> Self {
+        self.capability_policy = policy;
         self
     }
 
@@ -191,6 +224,37 @@ pub struct SubtaskDAG {
 }
 
 impl SubtaskDAG {
+    /// Build a DAG from validated subtasks and dependency records.
+    pub fn from_subtasks(
+        name: impl Into<String>,
+        tasks: Vec<SwarmSubtask>,
+        dependencies: Vec<(String, String, DependencyKind)>,
+    ) -> GlobalResult<Self> {
+        let mut dag = Self::new(name);
+
+        for task in tasks {
+            let id = task.id.trim();
+            if id.is_empty() {
+                return Err(GlobalError::Other(
+                    "Subtask 'id' must not be empty".to_string(),
+                ));
+            }
+            if dag.find_by_id(id).is_some() {
+                return Err(GlobalError::Other(format!(
+                    "Duplicate subtask id '{}' all ids must be unique",
+                    task.id
+                )));
+            }
+            dag.add_task(task);
+        }
+
+        for (from_id, to_id, kind) in dependencies {
+            dag.add_dependency_by_id(&from_id, &to_id, kind)?;
+        }
+
+        Ok(dag)
+    }
+
     /// Create a new empty DAG
     pub fn new(name: impl Into<String>) -> Self {
         Self {
@@ -233,6 +297,22 @@ impl SubtaskDAG {
         }
 
         Ok(())
+    }
+
+    /// Add a dependency edge by subtask id.
+    pub fn add_dependency_by_id(
+        &mut self,
+        from_id: &str,
+        to_id: &str,
+        kind: DependencyKind,
+    ) -> GlobalResult<()> {
+        let from = self.find_by_id(from_id).ok_or_else(|| {
+            GlobalError::Other(format!("dependency references unknown task id '{}'", from_id))
+        })?;
+        let to = self.find_by_id(to_id).ok_or_else(|| {
+            GlobalError::Other(format!("dependency references unknown task id '{}'", to_id))
+        })?;
+        self.add_dependency_with_kind(from, to, kind)
     }
 
     /// Return tasks that are pending and have all hard dependencies satisfied
@@ -405,6 +485,22 @@ impl SubtaskDAG {
         if let Some(task) = self.graph.node_weight_mut(idx) {
             task.assigned_agent = Some(agent_id.into());
         }
+    }
+
+    /// Rebuild the internal task-id index after deserialization.
+    pub fn rebuild_index(&mut self) -> GlobalResult<()> {
+        let mut rebuilt = HashMap::new();
+        for idx in self.graph.node_indices() {
+            let task = &self.graph[idx];
+            if rebuilt.insert(task.id.clone(), idx).is_some() {
+                return Err(GlobalError::Other(format!(
+                    "Duplicate subtask id '{}' found while rebuilding DAG index",
+                    task.id
+                )));
+            }
+        }
+        self.id_to_index = rebuilt;
+        Ok(())
     }
 
     /// Number of tasks in the Failed state
@@ -923,6 +1019,11 @@ mod tests {
         assert_eq!(t.risk_level, RiskLevel::Low);
         assert!(!t.hitl_required);
         assert!(t.estimated_duration_secs.is_none());
+        assert!(t.capability_params.is_empty());
+        assert_eq!(
+            t.capability_policy,
+            CapabilityExecutionPolicy::PreferCapability
+        );
     }
 
     #[test]
@@ -949,6 +1050,17 @@ mod tests {
         let mut hitl = dag.hitl_required_tasks();
         hitl.sort();
         assert_eq!(hitl, vec!["crit", "high"]);
+    }
+
+    #[test]
+    fn test_rebuild_index_restores_lookup_state() {
+        let mut dag = SubtaskDAG::new("rebuild");
+        let idx = dag.add_task(SwarmSubtask::new("task-1", "Task"));
+        dag.id_to_index.clear();
+        assert_eq!(dag.find_by_id("task-1"), None);
+
+        dag.rebuild_index().unwrap();
+        assert_eq!(dag.find_by_id("task-1"), Some(idx));
     }
 
     #[test]

--- a/crates/mofa-foundation/src/swarm/mod.rs
+++ b/crates/mofa-foundation/src/swarm/mod.rs
@@ -9,7 +9,10 @@ pub use config::{
     AgentSpec, AuditEvent, AuditEventKind, HITLMode, SLAConfig, SwarmConfig, SwarmMetrics,
     SwarmResult, SwarmStatus,
 };
-pub use dag::{DependencyEdge, DependencyKind, RiskLevel, SubtaskDAG, SubtaskStatus, SwarmSubtask};
+pub use dag::{
+    CapabilityExecutionPolicy, DependencyEdge, DependencyKind, RiskLevel, SubtaskDAG,
+    SubtaskStatus, SwarmSubtask,
+};
 pub use patterns::CoordinationPattern;
 pub mod scheduler;
 pub use scheduler::{

--- a/crates/mofa-foundation/tests/swarm_gateway_capability_tests.rs
+++ b/crates/mofa-foundation/tests/swarm_gateway_capability_tests.rs
@@ -1,0 +1,93 @@
+use async_trait::async_trait;
+use futures::future::BoxFuture;
+use std::sync::Arc;
+
+use mofa_foundation::{
+    CapabilityRequest, CapabilityResponse, GatewayCapability, GatewayCapabilityRegistry,
+};
+use mofa_foundation::swarm::{
+    CoordinationPattern, SubtaskDAG, SubtaskExecutorFn, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::{GlobalError, GlobalResult};
+
+struct EchoCapability;
+
+#[async_trait]
+impl GatewayCapability for EchoCapability {
+    fn name(&self) -> &str {
+        "web_search"
+    }
+
+    async fn invoke(&self, input: CapabilityRequest) -> GlobalResult<CapabilityResponse> {
+        Ok(CapabilityResponse {
+            output: format!("capability: {}", input.input),
+            metadata: Default::default(),
+            latency_ms: 1,
+        })
+    }
+}
+
+#[tokio::test]
+async fn swarm_executor_can_resolve_and_invoke_registered_capability() {
+    let registry = Arc::new(GatewayCapabilityRegistry::new());
+    registry.register(Arc::new(EchoCapability));
+
+    let mut dag = SubtaskDAG::new("gateway-capability");
+    dag.add_task(
+        SwarmSubtask::new("search", "latest AI news").with_capabilities(vec!["web_search".into()]),
+    );
+
+    let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+        let registry = Arc::clone(&registry);
+        Box::pin(async move {
+            let response = registry
+                .invoke_task(&task, format!("trace-{}", task.id))
+                .await?
+                .ok_or_else(|| {
+                    GlobalError::Other(format!(
+                        "no registered capability for task '{}'",
+                        task.id
+                    ))
+                })?;
+            Ok(response.output)
+        }) as BoxFuture<'static, GlobalResult<String>>
+    });
+
+    let scheduler = CoordinationPattern::Sequential.into_scheduler();
+    let summary = scheduler.execute(&mut dag, executor).await.unwrap();
+
+    assert!(summary.is_fully_successful());
+    assert_eq!(summary.successful_outputs(), vec!["capability: latest AI news"]);
+}
+
+#[tokio::test]
+async fn swarm_executor_surfaces_missing_required_capability() {
+    let registry = Arc::new(GatewayCapabilityRegistry::new());
+
+    let mut dag = SubtaskDAG::new("gateway-capability-missing");
+    dag.add_task(
+        SwarmSubtask::new("search", "latest AI news").with_capabilities(vec!["web_search".into()]),
+    );
+
+    let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+        let registry = Arc::clone(&registry);
+        Box::pin(async move {
+            let response = registry
+                .invoke_task(&task, format!("trace-{}", task.id))
+                .await?
+                .ok_or_else(|| {
+                    GlobalError::Other(format!(
+                        "no registered capability for task '{}'",
+                        task.id
+                    ))
+                })?;
+            Ok(response.output)
+        }) as BoxFuture<'static, GlobalResult<String>>
+    });
+
+    let scheduler = CoordinationPattern::Sequential.into_scheduler();
+    let summary = scheduler.execute(&mut dag, executor).await.unwrap();
+
+    assert_eq!(summary.failed, 1);
+    assert_eq!(summary.succeeded, 0);
+}

--- a/crates/mofa-gateway/src/handlers/capability.rs
+++ b/crates/mofa-gateway/src/handlers/capability.rs
@@ -1,0 +1,147 @@
+//! Gateway capability endpoints.
+//!
+//! POST /capability/invoke - invoke a registered capability
+//! GET  /capability/list   - list registered capability names
+
+use axum::{
+    Json, Router,
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::{get, post},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use mofa_foundation::{CapabilityRequest, CapabilityResponse};
+
+use crate::state::AppState;
+
+/// Build the capability API router.
+pub fn capability_router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/capability/invoke", post(invoke_capability))
+        .route("/capability/list", get(list_capabilities))
+}
+
+/// JSON payload for `POST /capability/invoke`.
+#[derive(Debug, Deserialize)]
+pub struct InvokeCapabilityRequest {
+    /// Registered capability name to invoke.
+    pub capability: String,
+    /// Primary textual input for the capability.
+    pub input: String,
+    /// Arbitrary structured arguments forwarded to the capability.
+    #[serde(default)]
+    pub params: HashMap<String, Value>,
+    /// Optional caller-supplied trace identifier.
+    pub trace_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct CapabilityListResponse {
+    capabilities: Vec<String>,
+    trace_id: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorResponse {
+    error: String,
+    trace_id: String,
+}
+
+fn trace_id() -> String {
+    Uuid::new_v4().to_string()
+}
+
+fn registry_or_503(
+    state: &AppState,
+) -> Result<Arc<mofa_foundation::GatewayCapabilityRegistry>, (StatusCode, Json<ErrorResponse>)> {
+    match &state.capability_registry {
+        Some(registry) => Ok(Arc::clone(registry)),
+        None => Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorResponse {
+                error: "capability registry not configured".to_string(),
+                trace_id: trace_id(),
+            }),
+        )),
+    }
+}
+
+/// List the names of all registered capabilities.
+pub async fn list_capabilities(State(state): State<Arc<AppState>>) -> Response {
+    let registry = match registry_or_503(&state) {
+        Ok(registry) => registry,
+        Err(resp) => return resp.into_response(),
+    };
+
+    (
+        StatusCode::OK,
+        Json(CapabilityListResponse {
+            capabilities: registry.names(),
+            trace_id: trace_id(),
+        }),
+    )
+        .into_response()
+}
+
+/// Invoke a registered capability with the provided request payload.
+pub async fn invoke_capability(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<InvokeCapabilityRequest>,
+) -> Response {
+    let registry = match registry_or_503(&state) {
+        Ok(registry) => registry,
+        Err(resp) => return resp.into_response(),
+    };
+
+    let capability_name = req.capability.trim();
+    if capability_name.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: "capability must not be empty".to_string(),
+                trace_id: trace_id(),
+            }),
+        )
+            .into_response();
+    }
+
+    let capability = match registry.get(capability_name) {
+        Some(capability) => capability,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!("unknown capability '{capability_name}'"),
+                    trace_id: trace_id(),
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    let capability_trace_id = req.trace_id.unwrap_or_else(trace_id);
+    match capability
+        .invoke(CapabilityRequest {
+            input: req.input,
+            params: req.params,
+            trace_id: capability_trace_id.clone(),
+        })
+        .await
+    {
+        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Err(error) => (
+            StatusCode::BAD_GATEWAY,
+            Json(ErrorResponse {
+                error: error.to_string(),
+                trace_id: capability_trace_id,
+            }),
+        )
+            .into_response(),
+    }
+}

--- a/crates/mofa-gateway/src/handlers/mod.rs
+++ b/crates/mofa-gateway/src/handlers/mod.rs
@@ -1,11 +1,13 @@
 //! Request handlers for the control-plane API
 
 pub mod agents;
+pub mod capability;
 pub mod chat;
 pub mod health;
 pub mod openai;
 
 pub use agents::agents_router;
+pub use capability::capability_router;
 pub use chat::chat_router;
 pub use health::health_router;
 pub use openai::openai_router;

--- a/crates/mofa-gateway/src/server.rs
+++ b/crates/mofa-gateway/src/server.rs
@@ -9,10 +9,11 @@ use tower_http::cors::{Any, CorsLayer};
 use tower_http::trace::TraceLayer;
 use tracing::info;
 
-use crate::handlers::{agents_router, chat_router, health_router, openai_router};
+use crate::handlers::{agents_router, capability_router, chat_router, health_router, openai_router};
 use crate::inference_bridge::InferenceBridge;
 use crate::middleware::RateLimiter;
 use crate::state::AppState;
+use mofa_foundation::GatewayCapabilityRegistry;
 use mofa_runtime::agent::registry::AgentRegistry;
 
 /// Control-plane server configuration
@@ -90,6 +91,8 @@ pub struct GatewayServer {
     registry: Arc<AgentRegistry>,
     /// Optional orchestrator config for inference bridge
     orchestrator_config: Option<OrchestratorConfig>,
+    /// Optional capability registry for HTTP capability access
+    capability_registry: Option<Arc<GatewayCapabilityRegistry>>,
 }
 
 impl GatewayServer {
@@ -99,6 +102,7 @@ impl GatewayServer {
             config,
             registry,
             orchestrator_config: None,
+            capability_registry: None,
         }
     }
 
@@ -112,7 +116,17 @@ impl GatewayServer {
             config,
             registry,
             orchestrator_config: Some(orchestrator_config),
+            capability_registry: None,
         }
+    }
+
+    /// Attach a capability registry to expose capability endpoints.
+    pub fn with_capability_registry(
+        mut self,
+        capability_registry: Arc<GatewayCapabilityRegistry>,
+    ) -> Self {
+        self.capability_registry = Some(capability_registry);
+        self
     }
 
     /// Build the axum `Router` without starting the server.
@@ -126,7 +140,11 @@ impl GatewayServer {
         ));
 
         // Create state
-        let state = Arc::new(AppState::new(self.registry.clone(), rate_limiter.clone()));
+        let mut app_state = AppState::new(self.registry.clone(), rate_limiter.clone());
+        if let Some(capability_registry) = &self.capability_registry {
+            app_state = app_state.with_capability_registry(Arc::clone(capability_registry));
+        }
+        let state = Arc::new(app_state);
 
         // Spawn background GC task for rate-limiter entries
         let gc_limiter = rate_limiter.clone();
@@ -141,15 +159,14 @@ impl GatewayServer {
         let mut router = Router::new()
             .merge(health_router())
             .merge(agents_router())
+            .merge(capability_router())
             .merge(chat_router())
             .with_state(state);
 
         // Add OpenAI router if inference bridge is configured
         if let Some(ref orch_config) = self.orchestrator_config {
             let bridge = Arc::new(InferenceBridge::new(orch_config.clone()));
-            router = router
-                .merge(openai_router())
-                .layer(axum::Extension(bridge));
+            router = router.merge(openai_router()).layer(axum::Extension(bridge));
         }
 
         if self.config.enable_tracing {

--- a/crates/mofa-gateway/src/state.rs
+++ b/crates/mofa-gateway/src/state.rs
@@ -3,6 +3,7 @@
 use crate::inference_bridge::InferenceBridge;
 use crate::middleware::RateLimiter;
 use mofa_foundation::inference::OrchestratorConfig;
+use mofa_foundation::GatewayCapabilityRegistry;
 use mofa_runtime::agent::registry::AgentRegistry;
 use std::sync::Arc;
 
@@ -15,6 +16,8 @@ pub struct AppState {
     pub rate_limiter: Arc<RateLimiter>,
     /// Inference bridge - connects to InferenceOrchestrator (optional)
     pub inference_bridge: Option<Arc<InferenceBridge>>,
+    /// Shared gateway capability registry (optional)
+    pub capability_registry: Option<Arc<GatewayCapabilityRegistry>>,
 }
 
 impl AppState {
@@ -24,6 +27,7 @@ impl AppState {
             registry,
             rate_limiter,
             inference_bridge: None,
+            capability_registry: None,
         }
     }
 
@@ -38,6 +42,13 @@ impl AppState {
             registry,
             rate_limiter,
             inference_bridge: Some(Arc::new(bridge)),
+            capability_registry: None,
         }
+    }
+
+    /// Attach a capability registry to an existing app state.
+    pub fn with_capability_registry(mut self, capability_registry: Arc<GatewayCapabilityRegistry>) -> Self {
+        self.capability_registry = Some(capability_registry);
+        self
     }
 }

--- a/crates/mofa-gateway/tests/capability_api.rs
+++ b/crates/mofa-gateway/tests/capability_api.rs
@@ -1,0 +1,137 @@
+use async_trait::async_trait;
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use http_body_util::BodyExt;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+use mofa_foundation::{
+    CapabilityRequest, CapabilityResponse, GatewayCapability, GatewayCapabilityRegistry,
+};
+use mofa_gateway::{GatewayServer, ServerConfig};
+use mofa_kernel::agent::types::error::GlobalResult;
+use mofa_runtime::agent::registry::AgentRegistry;
+
+struct EchoCapability;
+
+#[async_trait]
+impl GatewayCapability for EchoCapability {
+    fn name(&self) -> &str {
+        "web_search"
+    }
+
+    async fn invoke(&self, input: CapabilityRequest) -> GlobalResult<CapabilityResponse> {
+        Ok(CapabilityResponse {
+            output: format!("echo: {}", input.input),
+            metadata: HashMap::from([(
+                "trace_id".to_string(),
+                Value::String(input.trace_id),
+            )]),
+            latency_ms: 3,
+        })
+    }
+}
+
+fn build_app() -> axum::Router {
+    let registry = Arc::new(AgentRegistry::new());
+    let capability_registry = Arc::new(GatewayCapabilityRegistry::new());
+    capability_registry.register(Arc::new(EchoCapability));
+
+    GatewayServer::new(ServerConfig::default(), registry)
+        .with_capability_registry(capability_registry)
+        .build_router()
+}
+
+async fn read_json(resp: axum::response::Response) -> Value {
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+#[tokio::test]
+async fn list_capabilities_returns_registered_names() {
+    let app = build_app();
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/capability/list")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let payload = read_json(resp).await;
+    assert_eq!(
+        payload.get("capabilities").and_then(|v| v.as_array()).unwrap(),
+        &vec![Value::String("web_search".to_string())]
+    );
+}
+
+#[tokio::test]
+async fn invoke_capability_returns_capability_response() {
+    let app = build_app();
+
+    let body = serde_json::json!({
+        "capability": "web_search",
+        "input": "latest AI news",
+        "params": {},
+        "trace_id": "trace-capability"
+    });
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/capability/invoke")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let payload = read_json(resp).await;
+    assert_eq!(
+        payload.get("output").and_then(|v| v.as_str()),
+        Some("echo: latest AI news")
+    );
+    assert_eq!(
+        payload.get("metadata").and_then(|v| v.get("trace_id")),
+        Some(&Value::String("trace-capability".to_string()))
+    );
+}
+
+#[tokio::test]
+async fn invoke_unknown_capability_returns_404() {
+    let app = build_app();
+
+    let body = serde_json::json!({
+        "capability": "missing",
+        "input": "latest AI news",
+        "params": {}
+    });
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/capability/invoke")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let payload = read_json(resp).await;
+    assert!(payload.get("error").is_some());
+}

--- a/crates/mofa-gateway/tests/capability_api.rs
+++ b/crates/mofa-gateway/tests/capability_api.rs
@@ -39,6 +39,8 @@ impl GatewayCapability for EchoCapability {
 fn build_app() -> axum::Router {
     let registry = Arc::new(AgentRegistry::new());
     let capability_registry = Arc::new(GatewayCapabilityRegistry::new());
+    // Register a deterministic in-memory capability so the HTTP layer can be
+    // tested without external network dependencies.
     capability_registry.register(Arc::new(EchoCapability));
 
     GatewayServer::new(ServerConfig::default(), registry)
@@ -55,6 +57,8 @@ async fn read_json(resp: axum::response::Response) -> Value {
 async fn list_capabilities_returns_registered_names() {
     let app = build_app();
 
+    // The list endpoint should surface the names currently registered in the
+    // shared capability registry.
     let resp = app
         .oneshot(
             Request::builder()
@@ -78,6 +82,8 @@ async fn list_capabilities_returns_registered_names() {
 async fn invoke_capability_returns_capability_response() {
     let app = build_app();
 
+    // Exercise the full request path: JSON body -> registry lookup ->
+    // capability invoke -> serialized response.
     let body = serde_json::json!({
         "capability": "web_search",
         "input": "latest AI news",
@@ -113,6 +119,8 @@ async fn invoke_capability_returns_capability_response() {
 async fn invoke_unknown_capability_returns_404() {
     let app = build_app();
 
+    // Unknown capability names should fail at lookup time rather than falling
+    // through to an empty or local execution path.
     let body = serde_json::json!({
         "capability": "missing",
         "input": "latest AI news",

--- a/examples/gateway_demo.yaml
+++ b/examples/gateway_demo.yaml
@@ -1,0 +1,18 @@
+name: gateway-real-demo
+task: "Search for AI news and notify team"
+pattern: sequential
+dag:
+  tasks:
+    - id: search
+      description: "latest AI news"
+      capabilities: [web_search]
+      capability_policy: require_capability
+      capability_params:
+        query: "latest AI news 2025"
+    - id: notify
+      description: "Send summary to team webhook"
+      capabilities: [send_notification]
+      capability_policy: prefer_capability
+      capability_params:
+        channel: "team-updates"
+      deps: [search]


### PR DESCRIPTION
## Summary
This PR implements Gateway integration for swarm execution as a capability layer.

The core design is:
- `mofa-foundation` owns capability traits, request/response types, registry, and built-in HTTP-backed capabilities
- swarm execution resolves task capabilities through that registry
- `mofa-cli` exposes `mofa swarm run <FILE>` and wires capability execution into the runtime path
- `mofa-gateway` optionally exposes the capability registry over HTTP with invoke/list endpoints

This is intentionally separate from the existing `mofa-gateway` control-plane routing role.
Fixes: #1412
## Flowcharts

### Gateway Capability Execution Flow
```mermaid
flowchart TD
      A[Task with required_capabilities] --> B[GatewayCapabilityRegistry]
      B --> C{Matching capability found?}
      C -->|yes| D[Invoke GatewayCapability]
      C -->|no + require_capability| E[Fail task]
      C -->|no + prefer_capability| F[Local execution path]
      C -->|local_only| F
      D --> G[CapabilityResponse.output]
      G --> H[Task result]
      F --> H
```

### HTTP Capability API Flow
```mermaid
flowchart TD
    A[HTTP client or external agent] --> B[POST /capability/invoke]
    B --> C[Lookup capability in registry]
    C -->|found| D[Invoke capability]
    C -->|missing| E[404 error]
    D --> F[CapabilityResponse JSON]
```

## What Changed
- Added a capability abstraction and shared registry in `mofa-foundation`.
- Added built-in HTTP-backed capabilities for web search, HTTP fetch, notifications, and sensor reads.
- Added capability-aware swarm execution with `capability_policy` and `capability_params`.
- Added `mofa swarm run <FILE>` as a tracked CLI entrypoint for executing capability-backed swarm workflows.
- Added capability invoke/list HTTP endpoints in `mofa-gateway`.
- Added a runnable example workflow in `examples/gateway_demo.yaml`.

## Files Changed
### `crates/mofa-foundation`
- `src/gateway/capability.rs`: adds `GatewayCapability`, request/response types, registry lookup, and task-level capability invocation.
- `src/gateway/http_capabilities.rs`: adds real HTTP-backed capability implementations for web search, HTTP fetch, notifications, and sensor reads.
- `src/gateway/registry_builder.rs`: adds env-driven capability registry construction for built-in capabilities.
- `src/gateway/mod.rs`: exports the new capability and registry builder modules.
- `src/lib.rs`: re-exports the gateway capability APIs for downstream crates.
- `src/swarm/dag.rs`: adds capability policy/params on subtasks and the shared DAG construction helper used by the CLI path.
- `src/swarm/mod.rs`: re-exports the new swarm capability-policy types.
- `tests/swarm_gateway_capability_tests.rs`: tests scheduler-path capability resolution and missing-capability failure behavior.

### `crates/mofa-cli`
- `src/cli.rs`: adds the `swarm` command group and `run` subcommand.
- `src/main.rs`: wires `mofa swarm run` into the CLI dispatch path.
- `src/commands/mod.rs`: exports the swarm command module.
- `src/commands/swarm.rs`: loads YAML, builds the DAG, builds the capability registry, executes the scheduler, and returns task outputs.

### `crates/mofa-gateway`
- `src/handlers/capability.rs`: adds `GET /capability/list` and `POST /capability/invoke` handlers.
- `src/handlers/mod.rs`: registers the capability handler module.
- `src/state.rs`: extends app state with the optional capability registry.
- `src/server.rs`: mounts the capability routes into the gateway server.
- `tests/capability_api.rs`: tests the capability list and invoke HTTP endpoints.

### Examples
- `examples/gateway_demo.yaml`: adds a runnable swarm example using `web_search` and `send_notification` capability tags.

## Testing
Executed successfully:
```bash
cargo check -p mofa-foundation -p mofa-gateway
cargo check -p mofa-foundation -p mofa-cli
cargo test -p mofa-foundation gateway::capability -- --nocapture
cargo test -p mofa-foundation --test swarm_gateway_capability_tests -- --nocapture
cargo test -p mofa-gateway --test capability_api -- --nocapture
```
## How To Try

  ```bash
  GATEWAY_WEB_SEARCH_URL=https://api.duckduckgo.com/ cargo run -p mofa-cli -- swarm run examples/gateway_demo.yaml --json
```

  This runs the example workflow through the real capability path:

  - search resolves web_search from the registry and performs an HTTP request
  - notify follows prefer_capability policy and executes locally unless a matching send_notification capability is registered
 
<img width="1232" height="513" alt="Screenshot from 2026-03-22 10-51-44" src="https://github.com/user-attachments/assets/a2769d04-475e-423d-887b-c976031e653b" />

