### PR TITLE
feat: add Cohere embedding provider via LLMProvider trait

### DIFF
--- a/crates/mofa-foundation/Cargo.toml
+++ b/crates/mofa-foundation/Cargo.toml
@@ -31,6 +31,8 @@ persistence-all = [
 kokoro = ["mofa-plugins/kokoro"]
 # Enable MCP (Model Context Protocol) client support
 mcp = ["dep:rmcp"]
+# Enable Cohere embedding provider
+cohere = []
 # Enable Qdrant vector database support
 qdrant = ["dep:qdrant-client", "dep:sha2"]
 # Enable accurate token counting with tiktoken

--- a/crates/mofa-foundation/README.md
+++ b/crates/mofa-foundation/README.md
@@ -11,13 +11,16 @@ mofa-foundation = "0.1"
 
 ## Features
 
-- LLM integration (OpenAI provider)
+- LLM integration (OpenAI, Ollama, Cohere\* providers)
+- RAG pipeline with pluggable embedding backends
 - Agent abstractions and implementations
 - Persistence layer (PostgreSQL, MySQL, SQLite support)
 - Actor-based execution using Ractor
 - ReAct agent pattern implementation
 - Rich agent context and session management
 - Memory and reasoner components
+
+\* Cohere support requires the `cohere` feature flag: `mofa-foundation = { version = "0.1", features = ["cohere"] }`
 
 ## Documentation
 

--- a/crates/mofa-foundation/src/llm/cohere.rs
+++ b/crates/mofa-foundation/src/llm/cohere.rs
@@ -1,0 +1,646 @@
+//! Cohere Provider Implementation
+//!
+//! Provides Cohere API integration as an [`LLMProvider`], currently focused on
+//! the [Embed API v2](https://docs.cohere.com/reference/embed).
+//!
+//! Supported embedding models: `embed-english-v3.0`, `embed-multilingual-v3.0`,
+//! `embed-v4.0`.
+//!
+//! **Note:** Cohere also offers chat/generation models (Command R, Command R+)
+//! and a Rerank API.  This provider currently implements **embedding only**.
+//! Chat support can be added in a future iteration.
+//!
+//! # Examples
+//!
+//! ```rust,ignore
+//! use mofa_foundation::llm::cohere::{CohereProvider, CohereConfig};
+//!
+//! // Basic usage for embeddings
+//! let provider = CohereProvider::new("co-xxxx");
+//!
+//! // With custom model and input type
+//! let provider = CohereProvider::with_config(
+//!     CohereConfig::new("co-xxxx")
+//!         .with_model("embed-v4.0")
+//!         .with_input_type(CohereInputType::SearchQuery)
+//! );
+//! ```
+
+use super::provider::{LLMProvider, ModelCapabilities, ModelInfo};
+use super::types::*;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/// Cohere `input_type` parameter — tells the API how to optimise the
+/// embedding for the intended use-case.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[non_exhaustive]
+pub enum CohereInputType {
+    /// Use when embedding documents for storage / indexing.
+    #[default]
+    SearchDocument,
+    /// Use when embedding a user query for retrieval.
+    SearchQuery,
+    /// General-purpose classification input.
+    Classification,
+    /// General-purpose clustering input.
+    Clustering,
+}
+
+impl CohereInputType {
+    /// The string recognized by the Cohere Embed API.
+    pub fn as_api_str(&self) -> &'static str {
+        match self {
+            Self::SearchDocument => "search_document",
+            Self::SearchQuery => "search_query",
+            Self::Classification => "classification",
+            Self::Clustering => "clustering",
+        }
+    }
+}
+
+impl std::fmt::Display for CohereInputType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_api_str())
+    }
+}
+
+/// Truncation strategy for inputs exceeding the model's token limit
+/// (512 tokens for embed-v3.0 models).
+///
+/// When `None`, the Cohere API returns an error if any input exceeds the
+/// limit.  Set to `"END"` or `"START"` to auto-truncate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum CohereTruncate {
+    /// Drop tokens from the end of the input.
+    #[serde(rename = "END")]
+    End,
+    /// Drop tokens from the start of the input.
+    #[serde(rename = "START")]
+    Start,
+}
+
+impl CohereTruncate {
+    /// The string recognized by the Cohere API.
+    pub fn as_api_str(&self) -> &'static str {
+        match self {
+            Self::End => "END",
+            Self::Start => "START",
+        }
+    }
+}
+
+/// Configuration for the Cohere provider.
+#[derive(Debug, Clone)]
+pub struct CohereConfig {
+    /// Cohere API key (**required**).
+    pub api_key: String,
+    /// Default embedding model.
+    pub default_model: String,
+    /// How the input texts will be used (controls optimisation on the
+    /// Cohere side).
+    pub input_type: CohereInputType,
+    /// Base URL of the Cohere API.
+    pub base_url: String,
+    /// Maximum texts per single API call.  Cohere caps this at 96.
+    pub batch_size: usize,
+    /// Truncation strategy for inputs exceeding 512 tokens.
+    /// When `None`, the API returns an error on over-length input.
+    /// Recommended: `Some(CohereTruncate::End)` for most RAG use-cases.
+    pub truncate: Option<CohereTruncate>,
+    /// Request timeout in seconds.
+    pub timeout_secs: u64,
+}
+
+impl Default for CohereConfig {
+    fn default() -> Self {
+        Self {
+            api_key: String::new(),
+            default_model: "embed-english-v3.0".to_string(),
+            input_type: CohereInputType::default(),
+            base_url: "https://api.cohere.com".to_string(),
+            batch_size: 96,
+            truncate: Some(CohereTruncate::End),
+            timeout_secs: 30,
+        }
+    }
+}
+
+impl CohereConfig {
+    /// Create a new config with the given API key.
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self {
+            api_key: api_key.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Create a config from environment variables.
+    ///
+    /// Reads `COHERE_API_KEY`, `COHERE_MODEL`, `COHERE_BASE_URL`.
+    pub fn from_env() -> Self {
+        Self {
+            api_key: std::env::var("COHERE_API_KEY").unwrap_or_default(),
+            default_model: std::env::var("COHERE_MODEL")
+                .unwrap_or_else(|_| "embed-english-v3.0".to_string()),
+            base_url: std::env::var("COHERE_BASE_URL")
+                .unwrap_or_else(|_| "https://api.cohere.com".to_string()),
+            ..Default::default()
+        }
+    }
+
+    /// Override the model name.
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.default_model = model.into();
+        self
+    }
+
+    /// Override the input type.
+    pub fn with_input_type(mut self, input_type: CohereInputType) -> Self {
+        self.input_type = input_type;
+        self
+    }
+
+    /// Override the base URL (useful for proxies / on-prem deployments).
+    pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
+        self.base_url = url.into();
+        self
+    }
+
+    /// Override the batch size (clamped to 1..=96).
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = batch_size.clamp(1, 96);
+        self
+    }
+
+    /// Override the per-request timeout (seconds).
+    pub fn with_timeout(mut self, secs: u64) -> Self {
+        self.timeout_secs = secs;
+        self
+    }
+
+    /// Override the truncation strategy.
+    ///
+    /// Pass `None` to disable truncation (the API will error on
+    /// inputs exceeding 512 tokens).
+    pub fn with_truncate(mut self, truncate: Option<CohereTruncate>) -> Self {
+        self.truncate = truncate;
+        self
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cohere API request / response shapes (private)
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct CohereEmbedRequest<'a> {
+    model: &'a str,
+    texts: &'a [String],
+    input_type: &'a str,
+    embedding_types: &'a [&'a str],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    truncate: Option<&'a str>,
+}
+
+#[derive(Deserialize)]
+struct CohereEmbedResponse {
+    embeddings: CohereEmbeddings,
+}
+
+#[derive(Deserialize)]
+struct CohereEmbeddings {
+    float: Vec<Vec<f32>>,
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+/// Cohere [`LLMProvider`] implementation — currently provides **embedding**
+/// support.  Chat/generation (Command R) can be added in a future iteration.
+///
+/// Calls the Cohere Embed API v2 (`POST {base_url}/v2/embed`) via
+/// `reqwest` and translates to/from MoFA's standard
+/// [`EmbeddingRequest`]/[`EmbeddingResponse`] types.
+pub struct CohereProvider {
+    config: CohereConfig,
+    http: reqwest::Client,
+}
+
+impl CohereProvider {
+    /// Create a provider with the given API key and default settings.
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self::with_config(CohereConfig::new(api_key))
+    }
+
+    /// Create a provider reading `COHERE_API_KEY` / `COHERE_MODEL` /
+    /// `COHERE_BASE_URL` from the environment.
+    pub fn from_env() -> Self {
+        Self::with_config(CohereConfig::from_env())
+    }
+
+    /// Create a provider from an explicit [`CohereConfig`].
+    pub fn with_config(config: CohereConfig) -> Self {
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(config.timeout_secs))
+            .build()
+            .expect("failed to build reqwest client");
+        Self { config, http }
+    }
+
+    /// Access the underlying config.
+    pub fn config(&self) -> &CohereConfig {
+        &self.config
+    }
+
+    /// Calls the Cohere Embed API for a single batch of texts and
+    /// returns the raw `Vec<Vec<f32>>`.
+    async fn call_embed_api(&self, texts: &[String]) -> LLMResult<Vec<Vec<f32>>> {
+        let url = format!("{}/v2/embed", self.config.base_url.trim_end_matches('/'));
+        let input_type_str = self.config.input_type.as_api_str();
+
+        let body = CohereEmbedRequest {
+            model: &self.config.default_model,
+            texts,
+            input_type: input_type_str,
+            embedding_types: &["float"],
+            truncate: self.config.truncate.map(|t| t.as_api_str()),
+        };
+
+        let response = self
+            .http
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.config.api_key))
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| {
+                if e.is_timeout() {
+                    LLMError::Timeout(format!(
+                        "Cohere embedding request timed out after {}s",
+                        self.config.timeout_secs
+                    ))
+                } else {
+                    LLMError::NetworkError(e.to_string())
+                }
+            })?;
+
+        let status = response.status();
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            return Err(LLMError::RateLimited(
+                "Cohere API rate limited — retry after backoff".to_string(),
+            ));
+        }
+        if !status.is_success() {
+            let body_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "<unreadable body>".to_string());
+            return Err(LLMError::ApiError {
+                code: Some(status.as_u16().to_string()),
+                message: body_text,
+            });
+        }
+
+        let embed_response: CohereEmbedResponse = response
+            .json()
+            .await
+            .map_err(|e| LLMError::Other(format!("failed to parse Cohere embed response: {e}")))?;
+
+        Ok(embed_response.embeddings.float)
+    }
+}
+
+#[async_trait]
+impl LLMProvider for CohereProvider {
+    fn name(&self) -> &str {
+        "cohere"
+    }
+
+    fn default_model(&self) -> &str {
+        &self.config.default_model
+    }
+
+    fn supported_models(&self) -> Vec<&str> {
+        vec![
+            "embed-english-v3.0",
+            "embed-multilingual-v3.0",
+            "embed-english-light-v3.0",
+            "embed-multilingual-light-v3.0",
+            "embed-v4.0",
+        ]
+    }
+
+    fn supports_streaming(&self) -> bool {
+        false
+    }
+
+    fn supports_tools(&self) -> bool {
+        false
+    }
+
+    fn supports_vision(&self) -> bool {
+        false
+    }
+
+    fn supports_embedding(&self) -> bool {
+        true
+    }
+
+    // -- Chat is not yet implemented (Cohere does support chat via Command R) --
+
+    async fn chat(&self, _request: ChatCompletionRequest) -> LLMResult<ChatCompletionResponse> {
+        Err(LLMError::ProviderNotSupported(
+            "Cohere chat is not yet implemented; this provider currently supports embedding only"
+                .to_string(),
+        ))
+    }
+
+    // -- Embedding --
+
+    async fn embedding(&self, request: EmbeddingRequest) -> LLMResult<EmbeddingResponse> {
+        let texts: Vec<String> = match request.input {
+            EmbeddingInput::Single(s) => vec![s],
+            EmbeddingInput::Multiple(v) => v,
+        };
+
+        if texts.is_empty() {
+            return Ok(EmbeddingResponse {
+                object: "list".to_string(),
+                model: request.model.clone(),
+                data: vec![],
+                usage: EmbeddingUsage {
+                    prompt_tokens: 0,
+                    total_tokens: 0,
+                },
+            });
+        }
+
+        // Sub-batch at the Cohere max of 96 texts per call
+        let batch_size = self.config.batch_size.clamp(1, 96);
+        let mut all_vectors: Vec<Vec<f32>> = Vec::with_capacity(texts.len());
+
+        for chunk in texts.chunks(batch_size) {
+            let chunk_vec: Vec<String> = chunk.to_vec();
+            let vectors = self.call_embed_api(&chunk_vec).await?;
+            if vectors.len() != chunk.len() {
+                return Err(LLMError::Other(format!(
+                    "Cohere embedding count mismatch: expected {}, got {}",
+                    chunk.len(),
+                    vectors.len()
+                )));
+            }
+            all_vectors.extend(vectors);
+        }
+
+        // Convert to EmbeddingData
+        let data: Vec<EmbeddingData> = all_vectors
+            .into_iter()
+            .enumerate()
+            .map(|(i, embedding)| EmbeddingData {
+                object: "embedding".to_string(),
+                index: u32::try_from(i).unwrap_or(u32::MAX),
+                embedding,
+            })
+            .collect();
+
+        // Cohere does not expose token counts in the v2 embed response,
+        // so we report zeros.  The EmbeddingUsage fields are non-optional
+        // in MoFA's type system but this is consistent with how some
+        // providers behave when counts are unavailable.
+        Ok(EmbeddingResponse {
+            object: "list".to_string(),
+            model: request.model,
+            data,
+            usage: EmbeddingUsage {
+                prompt_tokens: 0,
+                total_tokens: 0,
+            },
+        })
+    }
+
+    async fn health_check(&self) -> LLMResult<bool> {
+        // A lightweight check: embed a single token.  If the API key is
+        // valid and the service is up this will succeed.
+        let texts = vec!["health".to_string()];
+        match self.call_embed_api(&texts).await {
+            Ok(_) => Ok(true),
+            Err(_) => Ok(false),
+        }
+    }
+
+    async fn get_model_info(&self, model: &str) -> LLMResult<ModelInfo> {
+        let info = match model {
+            "embed-english-v3.0" => ModelInfo {
+                id: model.to_string(),
+                name: "Cohere Embed English v3.0".to_string(),
+                description: Some("English-only embedding model, 1024 dimensions".to_string()),
+                context_window: Some(512),
+                max_output_tokens: None,
+                training_cutoff: None,
+                capabilities: ModelCapabilities {
+                    streaming: false,
+                    tools: false,
+                    vision: false,
+                    json_mode: false,
+                    json_schema: false,
+                },
+            },
+            "embed-multilingual-v3.0" => ModelInfo {
+                id: model.to_string(),
+                name: "Cohere Embed Multilingual v3.0".to_string(),
+                description: Some(
+                    "Multilingual embedding model, 1024 dimensions, 100+ languages".to_string(),
+                ),
+                context_window: Some(512),
+                max_output_tokens: None,
+                training_cutoff: None,
+                capabilities: ModelCapabilities {
+                    streaming: false,
+                    tools: false,
+                    vision: false,
+                    json_mode: false,
+                    json_schema: false,
+                },
+            },
+            "embed-v4.0" => ModelInfo {
+                id: model.to_string(),
+                name: "Cohere Embed v4.0".to_string(),
+                description: Some(
+                    "Latest Cohere embedding model with improved retrieval quality".to_string(),
+                ),
+                context_window: Some(512),
+                max_output_tokens: None,
+                training_cutoff: None,
+                capabilities: ModelCapabilities {
+                    streaming: false,
+                    tools: false,
+                    vision: false,
+                    json_mode: false,
+                    json_schema: false,
+                },
+            },
+            _ => {
+                return Err(LLMError::ProviderNotSupported(format!(
+                    "unknown Cohere model '{model}'"
+                )));
+            }
+        };
+        Ok(info)
+    }
+}
+
+impl std::fmt::Debug for CohereProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CohereProvider")
+            .field("config", &self.config)
+            .finish()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ----- Config -----
+
+    #[test]
+    fn default_config() {
+        let config = CohereConfig::default();
+        assert_eq!(config.default_model, "embed-english-v3.0");
+        assert_eq!(config.input_type, CohereInputType::SearchDocument);
+        assert_eq!(config.base_url, "https://api.cohere.com");
+        assert_eq!(config.batch_size, 96);
+        assert!(config.api_key.is_empty());
+    }
+
+    #[test]
+    fn config_builder_chain() {
+        let config = CohereConfig::new("test-key")
+            .with_model("embed-v4.0")
+            .with_input_type(CohereInputType::SearchQuery)
+            .with_base_url("https://custom.endpoint.com")
+            .with_batch_size(50)
+            .with_timeout(90);
+
+        assert_eq!(config.api_key, "test-key");
+        assert_eq!(config.default_model, "embed-v4.0");
+        assert_eq!(config.input_type, CohereInputType::SearchQuery);
+        assert_eq!(config.base_url, "https://custom.endpoint.com");
+        assert_eq!(config.batch_size, 50);
+        assert_eq!(config.timeout_secs, 90);
+    }
+
+    #[test]
+    fn batch_size_clamped() {
+        assert_eq!(CohereConfig::default().with_batch_size(0).batch_size, 1);
+        assert_eq!(CohereConfig::default().with_batch_size(200).batch_size, 96);
+    }
+
+    #[test]
+    fn input_type_display() {
+        assert_eq!(
+            CohereInputType::SearchDocument.to_string(),
+            "search_document"
+        );
+        assert_eq!(CohereInputType::SearchQuery.to_string(), "search_query");
+        assert_eq!(
+            CohereInputType::Classification.to_string(),
+            "classification"
+        );
+        assert_eq!(CohereInputType::Clustering.to_string(), "clustering");
+    }
+
+    // ----- Provider trait methods -----
+
+    #[test]
+    fn provider_metadata() {
+        let provider = CohereProvider::new("key");
+        assert_eq!(provider.name(), "cohere");
+        assert_eq!(provider.default_model(), "embed-english-v3.0");
+        assert!(provider.supports_embedding());
+        assert!(!provider.supports_streaming());
+        assert!(!provider.supports_tools());
+        assert!(!provider.supports_vision());
+    }
+
+    #[tokio::test]
+    async fn chat_returns_not_supported() {
+        let provider = CohereProvider::new("key");
+        let request = ChatCompletionRequest::new("embed-english-v3.0");
+        let result = provider.chat(request).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn embedding_empty_input() {
+        let provider = CohereProvider::new("key");
+        let request = EmbeddingRequest {
+            model: "embed-english-v3.0".to_string(),
+            input: EmbeddingInput::Multiple(vec![]),
+            encoding_format: None,
+            dimensions: None,
+            user: None,
+        };
+        let result = provider.embedding(request).await.unwrap();
+        assert!(result.data.is_empty());
+    }
+
+    // ----- Truncate -----
+
+    #[test]
+    fn truncate_default_is_end() {
+        let config = CohereConfig::default();
+        assert_eq!(config.truncate, Some(CohereTruncate::End));
+    }
+
+    #[test]
+    fn truncate_api_str() {
+        assert_eq!(CohereTruncate::End.as_api_str(), "END");
+        assert_eq!(CohereTruncate::Start.as_api_str(), "START");
+    }
+
+    #[test]
+    fn truncate_can_be_disabled() {
+        let config = CohereConfig::new("key").with_truncate(None);
+        assert!(config.truncate.is_none());
+    }
+
+    // ----- Model info -----
+
+    #[tokio::test]
+    async fn get_model_info_known_model() {
+        let provider = CohereProvider::new("key");
+        let info = provider.get_model_info("embed-english-v3.0").await.unwrap();
+        assert_eq!(info.id, "embed-english-v3.0");
+        assert!(!info.capabilities.streaming);
+    }
+
+    #[tokio::test]
+    async fn get_model_info_unknown_model_errors() {
+        let provider = CohereProvider::new("key");
+        let result = provider.get_model_info("nonexistent-model").await;
+        assert!(result.is_err());
+    }
+
+    // ----- from_env -----
+
+    #[test]
+    fn from_env_uses_defaults_when_vars_unset() {
+        // Don't set any env vars — should fall back to defaults
+        let config = CohereConfig::from_env();
+        assert_eq!(config.default_model, "embed-english-v3.0");
+        assert_eq!(config.base_url, "https://api.cohere.com");
+    }
+}

--- a/crates/mofa-foundation/src/llm/mod.rs
+++ b/crates/mofa-foundation/src/llm/mod.rs
@@ -320,14 +320,17 @@ pub mod ollama;
 pub mod openai;
 pub mod pipeline;
 
+#[cfg(feature = "cohere")]
+pub mod cohere;
+
 // Framework components
 pub mod agent_loop;
 pub mod context;
+pub mod stream_adapter;
+pub mod stream_bridge;
 pub mod task_orchestrator;
 pub mod token_budget;
 pub mod vision;
-pub mod stream_adapter;
-pub mod stream_bridge;
 // Audio processing
 pub mod transcription;
 

--- a/crates/mofa-foundation/src/rag/embedding_adapter.rs
+++ b/crates/mofa-foundation/src/rag/embedding_adapter.rs
@@ -26,6 +26,10 @@ pub enum RagEmbeddingProvider {
     OpenAi,
     /// Local Ollama embedding API (default: `nomic-embed-text`).
     Ollama,
+    /// Cohere Embed API (default: `embed-english-v3.0`).
+    /// Requires the `cohere` feature flag.
+    #[cfg(feature = "cohere")]
+    Cohere,
 }
 
 impl std::fmt::Display for RagEmbeddingProvider {
@@ -33,6 +37,8 @@ impl std::fmt::Display for RagEmbeddingProvider {
         match self {
             RagEmbeddingProvider::OpenAi => write!(f, "openai"),
             RagEmbeddingProvider::Ollama => write!(f, "ollama"),
+            #[cfg(feature = "cohere")]
+            RagEmbeddingProvider::Cohere => write!(f, "cohere"),
         }
     }
 }
@@ -44,9 +50,17 @@ impl std::str::FromStr for RagEmbeddingProvider {
         match s.to_ascii_lowercase().as_str() {
             "openai" | "open_ai" => Ok(Self::OpenAi),
             "ollama" => Ok(Self::Ollama),
+            #[cfg(feature = "cohere")]
+            "cohere" => Ok(Self::Cohere),
             other => Err(format!(
-                "unknown embedding provider '{}'; expected 'openai' or 'ollama'",
-                other
+                "unknown embedding provider '{}'; expected 'openai', 'ollama'\
+                 {}",
+                other,
+                if cfg!(feature = "cohere") {
+                    ", or 'cohere'"
+                } else {
+                    ""
+                },
             )),
         }
     }
@@ -107,6 +121,19 @@ impl RagEmbeddingConfig {
         }
     }
 
+    /// Create a config for Cohere with defaults.
+    ///
+    /// Requires the `cohere` feature flag.
+    #[cfg(feature = "cohere")]
+    pub fn cohere() -> Self {
+        Self {
+            provider: RagEmbeddingProvider::Cohere,
+            model: Some("embed-english-v3.0".to_string()),
+            batch_size: 96, // Cohere API limit
+            ..Default::default()
+        }
+    }
+
     /// Override the model name.
     pub fn with_model(mut self, model: impl Into<String>) -> Self {
         self.model = Some(model.into());
@@ -136,6 +163,8 @@ impl RagEmbeddingConfig {
         self.model.as_deref().unwrap_or(match self.provider {
             RagEmbeddingProvider::OpenAi => "text-embedding-3-small",
             RagEmbeddingProvider::Ollama => "nomic-embed-text",
+            #[cfg(feature = "cohere")]
+            RagEmbeddingProvider::Cohere => "embed-english-v3.0",
         })
     }
 }
@@ -222,9 +251,7 @@ impl LlmEmbeddingAdapter {
         let dimensions = self
             .config
             .dimensions
-            .map(|d| {
-                u32::try_from(d).map_err(|_| EmbeddingAdapterError::DimensionOverflow(d))
-            })
+            .map(|d| u32::try_from(d).map_err(|_| EmbeddingAdapterError::DimensionOverflow(d)))
             .transpose()?;
 
         for chunk in texts.chunks(batch_size) {
@@ -290,8 +317,6 @@ impl std::fmt::Debug for LlmEmbeddingAdapter {
             .finish()
     }
 }
-
-
 
 // ---------------------------------------------------------------------------
 // Deterministic chunk IDs
@@ -386,6 +411,30 @@ mod tests {
     fn provider_display() {
         assert_eq!(RagEmbeddingProvider::OpenAi.to_string(), "openai");
         assert_eq!(RagEmbeddingProvider::Ollama.to_string(), "ollama");
+    }
+
+    #[cfg(feature = "cohere")]
+    #[test]
+    fn parse_cohere_provider_from_str() {
+        assert_eq!(
+            "cohere".parse::<RagEmbeddingProvider>().unwrap(),
+            RagEmbeddingProvider::Cohere
+        );
+    }
+
+    #[cfg(feature = "cohere")]
+    #[test]
+    fn cohere_provider_display() {
+        assert_eq!(RagEmbeddingProvider::Cohere.to_string(), "cohere");
+    }
+
+    #[cfg(feature = "cohere")]
+    #[test]
+    fn cohere_config_defaults() {
+        let config = RagEmbeddingConfig::cohere();
+        assert_eq!(config.provider, RagEmbeddingProvider::Cohere);
+        assert_eq!(config.resolved_model(), "embed-english-v3.0");
+        assert_eq!(config.batch_size, 96);
     }
 
     // ----- Config -----

--- a/crates/mofa-foundation/src/rag/mod.rs
+++ b/crates/mofa-foundation/src/rag/mod.rs
@@ -4,13 +4,13 @@
 //! in mofa-kernel, along with utilities for document chunking.
 
 pub mod chunker;
+pub mod default_reranker;
 pub mod embedding_adapter;
-pub mod retrieval;
 pub mod indexing;
 pub mod loaders;
 pub mod pipeline_adapters;
 pub mod recursive_chunker;
-pub mod default_reranker;
+pub mod retrieval;
 pub mod score_reranker;
 pub mod similarity;
 pub mod streaming_generator;
@@ -20,20 +20,18 @@ pub mod vector_store;
 pub mod qdrant_store;
 
 pub use chunker::{ChunkConfig, TextChunker};
+pub use default_reranker::IdentityReranker;
 pub use embedding_adapter::{
-    deterministic_chunk_id, EmbeddingAdapterError, LlmEmbeddingAdapter, RagEmbeddingConfig,
-    RagEmbeddingProvider,
+    EmbeddingAdapterError, LlmEmbeddingAdapter, RagEmbeddingConfig, RagEmbeddingProvider,
+    deterministic_chunk_id,
 };
-pub use retrieval::{
-    query_documents, RagQueryConfig, RetrievalResult, RetrievedChunk,};
 pub use indexing::{
-    index_documents, IndexDocument, IndexMode, IndexResult, RagIndexConfig,
-    RagOrchestrationError,
+    IndexDocument, IndexMode, IndexResult, RagIndexConfig, RagOrchestrationError, index_documents,
 };
 pub use loaders::{DocumentLoader, LoaderError, LoaderResult, MarkdownLoader, TextLoader};
 pub use pipeline_adapters::{InMemoryRetriever, SimpleGenerator};
-pub use recursive_chunker::{RecursiveChunker, RecursiveChunkConfig};
-pub use default_reranker::IdentityReranker;
+pub use recursive_chunker::{RecursiveChunkConfig, RecursiveChunker};
+pub use retrieval::{RagQueryConfig, RetrievalResult, RetrievedChunk, query_documents};
 pub use score_reranker::ScoreReranker;
 pub use similarity::compute_similarity;
 pub use streaming_generator::PassthroughStreamingGenerator;


### PR DESCRIPTION
Implement CohereProvider in mofa-foundation/llm/cohere.rs behind the 'cohere' feature flag, integrating with the existing LLMProvider → LLMClient → LlmEmbeddingAdapter pipeline.

Key additions:
- CohereProvider implementing LLMProvider trait (Embed API v2)
- CohereConfig with builder methods, env-based construction
- CohereInputType enum (search_document, search_query, etc.)
- CohereTruncate enum for 512-token input limit handling
- Cohere variant in RagEmbeddingProvider with default model/batch config
- 16 unit tests covering config, parsing, truncate, model info, errors
- Updated README with Cohere provider documentation

Supports embed-english-v3.0, embed-multilingual-v3.0, and embed-v4.0 models with automatic sub-batching (max 96 texts per request).

Closes #1381

## 📋 Summary

Add Cohere as an embedding provider in mofa-foundation, following the same `LLMProvider → LLMClient → LlmEmbeddingAdapter` architecture used by OpenAI and Ollama. This enables users to use Cohere's embedding models (embed-english-v3.0, embed-multilingual-v3.0, embed-v4.0) as a RAG embedding backend by enabling the `cohere` feature flag.

## 🔗 Related Issues

Closes #1381

---

## 🧠 Context

MoFA's RAG pipeline currently supports OpenAI and Ollama as embedding backends. Cohere offers competitive embedding models with multilingual support and a distinct API (input types, truncation control, 96-text batch limits). Rather than a standalone implementation, this PR integrates Cohere through the existing `LLMProvider` trait so it plugs seamlessly into `LLMClient` and `LlmEmbeddingAdapter` without any changes to the RAG pipeline itself.

The implementation is feature-gated behind `cohere = []` to keep it opt-in and avoid adding any mandatory dependencies (it reuses the existing workspace `reqwest` dependency).

---

## 🛠️ Changes

- **New file** `crates/mofa-foundation/src/llm/cohere.rs` — `CohereProvider` implementing `LLMProvider`, with `CohereConfig`, `CohereInputType`, and `CohereTruncate` types
- **Modified** `crates/mofa-foundation/src/llm/mod.rs` — feature-gated `pub mod cohere` declaration
- **Modified** `crates/mofa-foundation/src/rag/embedding_adapter.rs` — added `Cohere` variant to `RagEmbeddingProvider` enum with `Display`/`FromStr`/`resolved_model()` support and `RagEmbeddingConfig::cohere()` constructor
- **Modified** `crates/mofa-foundation/src/rag/mod.rs` — removed old standalone cohere_embedder module reference
- **Modified** `crates/mofa-foundation/Cargo.toml` — added `cohere = []` feature flag
- **Modified** `crates/mofa-foundation/README.md` — documented Cohere provider and feature flag

---

## 🧪 How you Tested

1. `cargo test -p mofa-foundation --features cohere` — 813 unit tests pass, including 16 new Cohere-specific tests covering config construction, builder methods, `from_env()`, input type/truncate enums, provider metadata, chat error path, empty embedding, model info, and RAG provider parsing/display/config defaults
2. `cargo test --test '*'` — 7 integration tests pass
3. `cargo clippy -p mofa-foundation --features cohere` — 0 warnings from changed code
4. `cargo fmt -- --check` — all changed files formatted correctly
5. Full workspace `cargo build` and `cargo check` pass

---

## 📸 Screenshots / Logs (if applicable)
<img width="795" height="203" alt="Screenshot 2026-03-22 at 2 37 42 AM" src="https://github.com/user-attachments/assets/36e4a575-14a3-42bd-8ae6-80cefdb91779" />
<img width="833" height="351" alt="Screenshot 2026-03-22 at 2 36 07 AM" src="https://github.com/user-attachments/assets/3b0266f4-60ae-4bce-9c92-d3dba2923728" />


---

## ⚠️ Breaking Changes

- [x] No breaking changes

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [x] Public APIs documented
- [x] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---

## 🚀 Deployment Notes (if applicable)

## 🚀 Deployment Notes (if applicable)

To use the Cohere provider, enable the feature flag:

    mofa-foundation = { version = "...", features = ["cohere"] }

Required environment variable: `COHERE_API_KEY` (or pass the key directly via `CohereConfig::new()`).

Optional env vars: `COHERE_MODEL` (default: `embed-english-v3.0`), `COHERE_BASE_URL` (default: `https://api.cohere.com`).

## 🧩 Additional Notes for Reviewers

- The `chat()` method returns `ProviderNotSupported` with "not yet implemented" — Cohere does have chat models (Command R) but that's out of scope for this embedding-focused PR.
- Cohere's Embed API enforces a max of 96 texts per request, so `CohereProvider::embedding()` automatically sub-batches larger inputs.
- The `CohereTruncate` enum (Start/End) controls how Cohere handles inputs exceeding the 512-token limit; defaults to `End`.
- No new dependencies were added — the implementation uses `reqwest` which is already a workspace dependency.