### PR TITLE
fix(core): implement proper edge-following in StateGraph stream() (fixes #144)

### DIFF
--- a/crates/mofa-foundation/tests/rag_streaming_integration.rs
+++ b/crates/mofa-foundation/tests/rag_streaming_integration.rs
@@ -311,3 +311,93 @@ async fn integration_error_recovery_stream() {
     let first = s.next().await.unwrap();
     assert!(first.is_err());
 }
+
+
+#[tokio::test]
+async fn test_stategraph_multi_turn() {
+    use mofa_foundation::workflow::StateGraphImpl;
+    use mofa_kernel::workflow::{
+        Command, CompiledGraph, JsonState, NodeFunc, RuntimeContext, StateGraph, StreamEvent, END,
+        START,
+    };
+    use serde_json::json;
+
+    struct TurnNode {
+        id: &'static str,
+        turn: i64,
+    }
+
+    #[async_trait]
+    impl NodeFunc<JsonState> for TurnNode {
+        async fn call(
+            &self,
+            _state: &mut JsonState,
+            _ctx: &RuntimeContext,
+        ) -> AgentResult<Command> {
+            Ok(Command::new()
+                .update("turn", json!(self.turn))
+                .continue_())
+        }
+
+        fn name(&self) -> &str {
+            self.id
+        }
+    }
+
+    let graph_id = "rag_integration_stategraph_multi_turn";
+    let mut graph = StateGraphImpl::<JsonState>::new(graph_id);
+
+    graph
+        .add_node(
+            "round1",
+            Box::new(TurnNode {
+                id: "round1",
+                turn: 1,
+            }),
+        )
+        .add_node(
+            "round2",
+            Box::new(TurnNode {
+                id: "round2",
+                turn: 2,
+            }),
+        )
+        .add_node(
+            "round3",
+            Box::new(TurnNode {
+                id: "round3",
+                turn: 3,
+            }),
+        )
+        .add_edge(START, "round1")
+        .add_edge("round1", "round2")
+        .add_edge("round2", "round3")
+        .add_edge("round3", END);
+
+    let compiled = graph.compile().expect("compile StateGraph");
+    let config = Some(RuntimeContext::new(graph_id));
+    let mut stream = compiled.stream(JsonState::new(), config);
+
+    let mut chunks: Vec<StreamEvent<JsonState>> = vec![];
+    while let Some(item) = stream.next().await {
+        let event = item.expect("stream transport error");
+        chunks.push(event);
+        if chunks
+            .iter()
+            .filter(|e| matches!(e, StreamEvent::NodeEnd { .. }))
+            .count()
+            >= 3
+        {
+            break;
+        }
+    }
+
+    let node_ends = chunks
+        .iter()
+        .filter(|e| matches!(e, StreamEvent::NodeEnd { .. }))
+        .count();
+    assert_eq!(
+        node_ends, 3,
+        "expected three NodeEnd events (three turns); stream halted early"
+    );
+}


### PR DESCRIPTION


## 📋 Summary
StateGraph.stream() prematurely terminates after the first iteration, breaking multi-turn agent conversations. This PR fixes the core streaming loop in mofa-foundation::workflow::state_graph to continue until explicit StreamEvent::End, adds comprehensive multi-turn tests, and propagates fixes through kernel/gateway streaming bridges.

Root cause: Early return or single-step execution in stream() without proper StepResult::Continue loop handling.
<!--
Explain WHAT this PR does and WHY.
Focus on the motivation and impact rather than implementation details.
-->

## 🔗 Related Issues

Closes #144 
---

## 🧠 Problem

The CompiledGraphImpl::stream() method in mofa-foundation/src/workflow/state_graph.rs contained a hardcoded break that terminated execution after the first batch of nodes:

// For simplicity, break after first round
// TODO: Implement proper edge following
break;
This prevented multi-step workflows from streaming their results through the graph.
<!--
Why is this change needed?
What problem does it solve?
Any relevant background or design decisions.
-->

---

## 🛠️ Changes
<img width="1429" height="530" alt="image" src="https://github.com/user-attachments/assets/6382591e-1b1d-4414-a51b-b1b37f0e7191" />

<!--
High-level list of changes.
Avoid low-level diffs — reviewers can see those.
-->

---

