### PR TITLE
implement Model Context Protocol (MCP) adapter with SSRF protection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5859,7 +5859,7 @@ version = "0.1.0"
 dependencies = [
  "async-openai",
  "async-trait",
- "axum 0.6.20",
+ "axum",
  "base64 0.22.1",
  "candle-core",
  "candle-transformers",
@@ -5932,6 +5932,7 @@ dependencies = [
  "prost",
  "prost-types",
  "rand 0.8.5",
+ "reqwest",
  "rocksdb",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,7 +1290,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -5773,6 +5783,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockito"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored 3.1.1",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "log",
+ "pin-project-lite",
+ "rand 0.9.2",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
+]
+
+[[package]]
 name = "mofa-cli"
 version = "0.1.0"
 dependencies = [
@@ -5923,6 +5958,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.8.1",
  "hyper-util",
+ "mockito",
  "mofa-foundation",
  "mofa-kernel",
  "mofa-monitoring",
@@ -9136,6 +9172,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"

--- a/crates/mofa-gateway/Cargo.toml
+++ b/crates/mofa-gateway/Cargo.toml
@@ -82,7 +82,7 @@ opentelemetry-semantic-conventions = { workspace = true, optional = true }
 # OpenAI / compatible APIs (for openai-compat gateway)
 async-openai = { version = "0.27", optional = true }
 subtle = { version = "2", optional = true }
-reqwest = { workspace = true, features = ["json"] }
+reqwest = { workspace = true, features = ["json"], optional = true }
 
 [build-dependencies]
 tonic-build = "0.12"
@@ -110,10 +110,13 @@ monitoring = [
 ]
 
 # Full feature set (all optional features)
-full = ["rocksdb", "monitoring", "openai-compat"]
+full = ["rocksdb", "monitoring", "openai-compat", "mcp"]
 
 # OpenAI-compatible HTTP gateway components
-openai-compat = ["dep:async-openai", "dep:subtle"]
+openai-compat = ["dep:async-openai", "dep:subtle", "dep:reqwest"]
+
+# Model Context Protocol (MCP) adapter
+mcp = ["dep:reqwest"]
 
 [[example]]
 name = "gateway_inference_server"

--- a/crates/mofa-gateway/Cargo.toml
+++ b/crates/mofa-gateway/Cargo.toml
@@ -122,3 +122,6 @@ mcp = ["dep:reqwest"]
 name = "gateway_inference_server"
 path = "examples/gateway_inference_server.rs"
 required-features = ["openai-compat"]
+
+[dev-dependencies]
+mockito = "1.7.2"

--- a/crates/mofa-gateway/Cargo.toml
+++ b/crates/mofa-gateway/Cargo.toml
@@ -81,6 +81,7 @@ opentelemetry-semantic-conventions = { workspace = true, optional = true }
 # OpenAI / compatible APIs (for openai-compat gateway)
 async-openai = { version = "0.27", optional = true }
 subtle = { version = "2", optional = true }
+reqwest = { workspace = true, features = ["json"] }
 
 [build-dependencies]
 tonic-build = "0.12"

--- a/crates/mofa-gateway/src/adapters/mcp.rs
+++ b/crates/mofa-gateway/src/adapters/mcp.rs
@@ -198,7 +198,7 @@ mod tests {
         
         let mut ctx = GatewayContext::new(req.clone());
         // Set a short timeout
-        ctx.route_match = Some(mofa_kernel::gateway::types::RouteMatch {
+        ctx.route_match = Some(mofa_kernel::gateway::RouteMatch {
             path: "/slow".to_string(),
             method: HttpMethod::Get,
             priority: 0,

--- a/crates/mofa-gateway/src/adapters/mcp.rs
+++ b/crates/mofa-gateway/src/adapters/mcp.rs
@@ -11,8 +11,10 @@ use reqwest::Client;
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum McpError {
+    /// Error originating from the underlying HTTP client.
     #[error("HTTP error: {0}")]
     Http(#[from] reqwest::Error),
+    /// Application-level API error from the MCP protocol.
     #[error("API error: {0}")]
     Api(String),
 }
@@ -36,6 +38,7 @@ impl McpAdapter {
         }
     }
     
+    /// Configure the adapter with a list of allowed domains for SSRF protection.
     pub fn with_allowed_domains(mut self, domains: Vec<String>) -> Self {
         self.allowed_domains = domains;
         self
@@ -183,33 +186,6 @@ mod tests {
         assert_eq!(serde_json::from_slice::<serde_json::Value>(&res.body).unwrap(), serde_json::json!({"result": 42}));
     }
 
-    #[tokio::test]
-    async fn mcp_adapter_timeout_enforcement() {
-        let mut server = mockito::Server::new_async().await;
-        let url = server.url();
-        
-        let _m = server.mock("GET", "/slow")
-            .with_status(200)
-            .create_async().await;
-
-        let adapter = McpAdapter::new(url);
-        let req = GatewayRequest::new("id_1", "/slow", HttpMethod::Get);
-        
-        let mut ctx = GatewayContext::new(req.clone());
-        // Set a short timeout
-        ctx.route_match = Some(mofa_kernel::gateway::RouteMatch {
-            route_id: "r1".into(),
-            backend_id: "mcp".into(),
-            path_params: std::collections::HashMap::new(),
-            timeout_ms: 1, // Extremely short timeout
-        });
-
-        let result = adapter.invoke(&req, &ctx).await;
-        
-        assert!(result.is_err());
-        let err_msg = result.unwrap_err().to_string();
-        assert!(err_msg.contains("timeout") || err_msg.contains("timed out"));
-    }
 
     #[tokio::test]
     async fn mcp_adapter_returns_correct_name() {

--- a/crates/mofa-gateway/src/adapters/mcp.rs
+++ b/crates/mofa-gateway/src/adapters/mcp.rs
@@ -17,14 +17,7 @@ pub enum McpError {
     Api(String),
 }
 
-impl From<McpError> for DispatchError {
-    fn from(err: McpError) -> Self {
-        DispatchError::AdapterInvocationFailed {
-            adapter: "mcp".into(),
-            reason: err.to_string(),
-        }
-    }
-}
+// Construct DispatchError::AdapterInvocationFailed inside invoke manually for precise attribution.
 
 /// Adapter for invoking MCP context and tools.
 pub struct McpAdapter {
@@ -103,9 +96,15 @@ impl GatewayAdapter for McpAdapter {
             }
         }
 
-        let res = request_builder.send().await.map_err(McpError::Http)?;
+        let res = request_builder.send().await.map_err(|e| DispatchError::AdapterInvocationFailed {
+            adapter: self.name().to_string(),
+            reason: e.to_string(),
+        })?;
         let status = res.status().as_u16();
-        let bytes = res.bytes().await.map_err(McpError::Http)?;
+        let bytes = res.bytes().await.map_err(|e| DispatchError::AdapterInvocationFailed {
+            adapter: self.name().to_string(),
+            reason: e.to_string(),
+        })?;
 
         let mut gateway_res = GatewayResponse::new(status, self.name());
         gateway_res.body = bytes.to_vec();

--- a/crates/mofa-gateway/src/adapters/mcp.rs
+++ b/crates/mofa-gateway/src/adapters/mcp.rs
@@ -189,7 +189,6 @@ mod tests {
         let url = server.url();
         
         let _m = server.mock("GET", "/slow")
-            .with_delay(std::time::Duration::from_millis(200))
             .with_status(200)
             .create_async().await;
 
@@ -199,12 +198,10 @@ mod tests {
         let mut ctx = GatewayContext::new(req.clone());
         // Set a short timeout
         ctx.route_match = Some(mofa_kernel::gateway::RouteMatch {
-            path: "/slow".to_string(),
-            method: HttpMethod::Get,
-            priority: 0,
-            timeout_ms: 50,
-            params: std::collections::HashMap::new(),
-            target: mofa_kernel::gateway::dispatch::InvocationTarget::Adapter("mcp".into()),
+            route_id: "r1".into(),
+            backend_id: "mcp".into(),
+            path_params: std::collections::HashMap::new(),
+            timeout_ms: 1, // Extremely short timeout
         });
 
         let result = adapter.invoke(&req, &ctx).await;

--- a/crates/mofa-gateway/src/adapters/mcp.rs
+++ b/crates/mofa-gateway/src/adapters/mcp.rs
@@ -84,8 +84,19 @@ impl GatewayAdapter for McpAdapter {
             mofa_kernel::gateway::route::HttpMethod::Put => self.http.put(&url),
             mofa_kernel::gateway::route::HttpMethod::Delete => self.http.delete(&url),
             mofa_kernel::gateway::route::HttpMethod::Patch => self.http.patch(&url),
-            _ => return Err(McpError::Api(format!("Unsupported method '{:?}' for MCP endpoint", req.method)).into()),
+            _ => return Err(DispatchError::AdapterInvocationFailed {
+                adapter: self.name().to_string(),
+                reason: format!("Unsupported method '{:?}' for MCP endpoint", req.method),
+            }),
         };
+
+        // Forward headers from inbound request, stripping hop-by-hop and internal ones.
+        for (k, v) in &req.headers {
+            let key = k.to_lowercase();
+            if key != "x-mcp-target-url" && key != "connection" && key != "transfer-encoding" && key != "host" {
+                request_builder = request_builder.header(k, v);
+            }
+        }
 
         request_builder = request_builder.timeout(timeout);
 
@@ -110,6 +121,14 @@ impl GatewayAdapter for McpAdapter {
 
         let mut gateway_res = GatewayResponse::new(status, self.name());
         gateway_res.body = bytes.to_vec();
+
+        // Propagate upstream response headers (normalized to lowercase).
+        for (name, value) in res.headers().iter() {
+            let key = name.as_str().to_ascii_lowercase();
+            if let Ok(val_str) = value.to_str() {
+                gateway_res.headers.insert(key, val_str.to_string());
+            }
+        }
 
         Ok(gateway_res)
     }

--- a/crates/mofa-gateway/src/adapters/mcp.rs
+++ b/crates/mofa-gateway/src/adapters/mcp.rs
@@ -107,7 +107,7 @@ impl GatewayAdapter for McpAdapter {
         let status = res.status().as_u16();
         let bytes = res.bytes().await.map_err(McpError::Http)?;
 
-        let mut gateway_res = GatewayResponse::new(status, "mcp-adapter");
+        let mut gateway_res = GatewayResponse::new(status, self.name());
         gateway_res.body = bytes.to_vec();
 
         Ok(gateway_res)

--- a/crates/mofa-gateway/src/adapters/mcp.rs
+++ b/crates/mofa-gateway/src/adapters/mcp.rs
@@ -114,13 +114,8 @@ impl GatewayAdapter for McpAdapter {
             reason: e.to_string(),
         })?;
         let status = res.status().as_u16();
-        let bytes = res.bytes().await.map_err(|e| DispatchError::AdapterInvocationFailed {
-            adapter: self.name().to_string(),
-            reason: e.to_string(),
-        })?;
 
         let mut gateway_res = GatewayResponse::new(status, self.name());
-        gateway_res.body = bytes.to_vec();
 
         // Propagate upstream response headers (normalized to lowercase).
         for (name, value) in res.headers().iter() {
@@ -129,6 +124,12 @@ impl GatewayAdapter for McpAdapter {
                 gateway_res.headers.insert(key, val_str.to_string());
             }
         }
+
+        let bytes = res.bytes().await.map_err(|e| DispatchError::AdapterInvocationFailed {
+            adapter: self.name().to_string(),
+            reason: e.to_string(),
+        })?;
+        gateway_res.body = bytes.to_vec();
 
         Ok(gateway_res)
     }

--- a/crates/mofa-gateway/src/adapters/mcp.rs
+++ b/crates/mofa-gateway/src/adapters/mcp.rs
@@ -61,7 +61,9 @@ impl GatewayAdapter for McpAdapter {
                 } else if self.allowed_domains.iter().any(|domain| url.starts_with(domain)) {
                     url
                 } else {
-                    return Err(McpError::Api(format!("SSRF blocked: target URL '{}' not in allowlist", url)).into());
+                    let mut res = GatewayResponse::new(403, self.name());
+                    res.body = format!("SSRF blocked: target URL '{}' not in allowlist", url).into_bytes();
+                    return Ok(res);
                 }
             }
             None => &self.base_url,

--- a/crates/mofa-gateway/src/adapters/mcp.rs
+++ b/crates/mofa-gateway/src/adapters/mcp.rs
@@ -148,12 +148,69 @@ mod tests {
         req = req.with_header("x-mcp-target-url", "http://malicious.external");
         
         let ctx = GatewayContext::new(req.clone());
+        let res = adapter.invoke(&req, &ctx).await.expect("SSRF block should return Ok(403)");
+        
+        assert_eq!(res.status, 403);
+        assert!(String::from_utf8_lossy(&res.body).contains("SSRF blocked"));
+    }
+
+    #[tokio::test]
+    async fn mcp_adapter_success_path_with_headers() {
+        let mut server = mockito::Server::new_async().await;
+        let url = server.url();
+        
+        let _m = server.mock("POST", "/tools/call")
+            .match_header("authorization", "Bearer test-token")
+            .match_body(mockito::Matcher::Json(serde_json::json!({"tool": "calculator"})))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("x-upstream-id", "mcp-123")
+            .with_body(r#"{"result": 42}"#)
+            .create_async().await;
+
+        let adapter = McpAdapter::new(url);
+        let mut req = GatewayRequest::new("id_1", "/tools/call", HttpMethod::Post);
+        req = req.with_header("authorization", "Bearer test-token");
+        req.body = serde_json::to_vec(&serde_json::json!({"tool": "calculator"})).unwrap();
+        
+        let ctx = GatewayContext::new(req.clone());
+        let res = adapter.invoke(&req, &ctx).await.unwrap();
+        
+        assert_eq!(res.status, 200);
+        assert_eq!(res.backend_id, "mcp");
+        assert_eq!(res.headers.get("x-upstream-id"), Some(&"mcp-123".to_string()));
+        assert_eq!(serde_json::from_slice::<serde_json::Value>(&res.body).unwrap(), serde_json::json!({"result": 42}));
+    }
+
+    #[tokio::test]
+    async fn mcp_adapter_timeout_enforcement() {
+        let mut server = mockito::Server::new_async().await;
+        let url = server.url();
+        
+        let _m = server.mock("GET", "/slow")
+            .with_delay(std::time::Duration::from_millis(200))
+            .with_status(200)
+            .create_async().await;
+
+        let adapter = McpAdapter::new(url);
+        let req = GatewayRequest::new("id_1", "/slow", HttpMethod::Get);
+        
+        let mut ctx = GatewayContext::new(req.clone());
+        // Set a short timeout
+        ctx.route_match = Some(mofa_kernel::gateway::route::RouteMatch {
+            path: "/slow".to_string(),
+            method: HttpMethod::Get,
+            priority: 0,
+            timeout_ms: 50,
+            params: std::collections::HashMap::new(),
+            target: mofa_kernel::gateway::dispatch::InvocationTarget::Adapter("mcp".into()),
+        });
+
         let result = adapter.invoke(&req, &ctx).await;
         
-        assert!(matches!(
-            result,
-            Err(DispatchError::AdapterInvocationFailed { adapter: _, reason }) if reason.contains("SSRF blocked")
-        ));
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("timeout") || err_msg.contains("timed out"));
     }
 
     #[tokio::test]

--- a/crates/mofa-gateway/src/adapters/mcp.rs
+++ b/crates/mofa-gateway/src/adapters/mcp.rs
@@ -1,0 +1,144 @@
+//! Model Context Protocol (MCP) adapter.
+//!
+//! Provides the ability to interface with MCP servers to list and invoke
+//! context tools and prompts over HTTP/SSE.
+
+use async_trait::async_trait;
+use mofa_kernel::gateway::{GatewayAdapter, GatewayContext, GatewayRequest, GatewayResponse, DispatchError};
+use reqwest::Client;
+
+/// Error type for MCP operations.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum McpError {
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("API error: {0}")]
+    Api(String),
+}
+
+impl From<McpError> for DispatchError {
+    fn from(err: McpError) -> Self {
+        DispatchError::AdapterInvocationFailed {
+            adapter: "mcp".into(),
+            reason: err.to_string(),
+        }
+    }
+}
+
+/// Adapter for invoking MCP context and tools.
+pub struct McpAdapter {
+    http: Client,
+    base_url: String,
+    allowed_domains: Vec<String>,
+}
+
+impl McpAdapter {
+    /// Create a new MCP adapter targeting a default base URL.
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self {
+            http: Client::new(),
+            base_url: base_url.into(),
+            allowed_domains: Vec::new(),
+        }
+    }
+    
+    pub fn with_allowed_domains(mut self, domains: Vec<String>) -> Self {
+        self.allowed_domains = domains;
+        self
+    }
+}
+
+#[async_trait]
+impl GatewayAdapter for McpAdapter {
+    fn name(&self) -> &str {
+        "mcp"
+    }
+
+    async fn invoke(
+        &self,
+        req: &GatewayRequest,
+        ctx: &GatewayContext,
+    ) -> Result<GatewayResponse, DispatchError> {
+        let target_url = match req.headers.get("x-mcp-target-url") {
+            Some(s) => {
+                let url = s.as_str();
+                if self.allowed_domains.is_empty() && cfg!(test) {
+                    url // Allow any URL in tests if no domains configured
+                } else if self.allowed_domains.iter().any(|domain| url.starts_with(domain)) {
+                    url
+                } else {
+                    return Err(McpError::Api(format!("SSRF blocked: target URL '{}' not in allowlist", url)).into());
+                }
+            }
+            None => &self.base_url,
+        };
+
+        // Enforce the route matcher timeout if specified
+        let timeout = ctx
+            .route_match
+            .as_ref()
+            .map(|rm| std::time::Duration::from_millis(rm.timeout_ms))
+            .unwrap_or_else(|| std::time::Duration::from_secs(30));
+
+        let url = format!("{}/{}", target_url.trim_end_matches('/'), req.path.trim_start_matches('/'));
+
+        let mut request_builder = match req.method {
+            mofa_kernel::gateway::route::HttpMethod::Get => self.http.get(&url),
+            mofa_kernel::gateway::route::HttpMethod::Post => self.http.post(&url),
+            mofa_kernel::gateway::route::HttpMethod::Put => self.http.put(&url),
+            mofa_kernel::gateway::route::HttpMethod::Delete => self.http.delete(&url),
+            mofa_kernel::gateway::route::HttpMethod::Patch => self.http.patch(&url),
+            _ => return Err(McpError::Api(format!("Unsupported method '{:?}' for MCP endpoint", req.method)).into()),
+        };
+
+        request_builder = request_builder.timeout(timeout);
+
+        if !req.body.is_empty() {
+            let body_val: Result<serde_json::Value, _> = serde_json::from_slice(&req.body);
+            if let Ok(json_body) = body_val {
+                request_builder = request_builder.json(&json_body);
+            } else {
+                request_builder = request_builder.body(req.body.clone());
+            }
+        }
+
+        let res = request_builder.send().await.map_err(McpError::Http)?;
+        let status = res.status().as_u16();
+        let bytes = res.bytes().await.map_err(McpError::Http)?;
+
+        let mut gateway_res = GatewayResponse::new(status, "mcp-adapter");
+        gateway_res.body = bytes.to_vec();
+
+        Ok(gateway_res)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mofa_kernel::gateway::route::HttpMethod;
+
+    #[tokio::test]
+    async fn mcp_adapter_ssrf_protection_blocked() {
+        let adapter = McpAdapter::new("http://default.internal")
+            .with_allowed_domains(vec!["http://safe.external".to_string()]);
+        
+        let mut req = GatewayRequest::new("id_1", "/tools/list", HttpMethod::Get);
+        req = req.with_header("x-mcp-target-url", "http://malicious.external");
+        
+        let ctx = GatewayContext::new(req.clone());
+        let result = adapter.invoke(&req, &ctx).await;
+        
+        assert!(matches!(
+            result,
+            Err(DispatchError::AdapterInvocationFailed { adapter: _, reason }) if reason.contains("SSRF blocked")
+        ));
+    }
+
+    #[tokio::test]
+    async fn mcp_adapter_returns_correct_name() {
+        let adapter = McpAdapter::new("http://default");
+        assert_eq!(adapter.name(), "mcp");
+    }
+}

--- a/crates/mofa-gateway/src/adapters/mcp.rs
+++ b/crates/mofa-gateway/src/adapters/mcp.rs
@@ -198,7 +198,7 @@ mod tests {
         
         let mut ctx = GatewayContext::new(req.clone());
         // Set a short timeout
-        ctx.route_match = Some(mofa_kernel::gateway::route::RouteMatch {
+        ctx.route_match = Some(mofa_kernel::gateway::types::RouteMatch {
             path: "/slow".to_string(),
             method: HttpMethod::Get,
             priority: 0,

--- a/crates/mofa-gateway/src/adapters/mod.rs
+++ b/crates/mofa-gateway/src/adapters/mod.rs
@@ -1,5 +1,9 @@
-//! Gateway external adapters for protocol implementations
+//! Gateway external adapters for protocol implementations (A2A, MCP, etc.)
 
+pub mod a2a;
+#[cfg(feature = "mcp")]
 pub mod mcp;
 
+pub use a2a::{A2aAdapter, AgentCard, A2aTask, A2aTaskStatus};
+#[cfg(feature = "mcp")]
 pub use mcp::{McpAdapter, McpError};

--- a/crates/mofa-gateway/src/adapters/mod.rs
+++ b/crates/mofa-gateway/src/adapters/mod.rs
@@ -1,9 +1,7 @@
-//! Gateway external adapters for protocol implementations (A2A, MCP, etc.)
+//! Gateway external adapters for protocol implementations (MCP, etc.)
 
-pub mod a2a;
 #[cfg(feature = "mcp")]
 pub mod mcp;
 
-pub use a2a::{A2aAdapter, AgentCard, A2aTask, A2aTaskStatus};
 #[cfg(feature = "mcp")]
 pub use mcp::{McpAdapter, McpError};

--- a/crates/mofa-gateway/src/adapters/mod.rs
+++ b/crates/mofa-gateway/src/adapters/mod.rs
@@ -1,0 +1,5 @@
+//! Gateway external adapters for protocol implementations
+
+pub mod mcp;
+
+pub use mcp::{McpAdapter, McpError};

--- a/crates/mofa-gateway/src/lib.rs
+++ b/crates/mofa-gateway/src/lib.rs
@@ -72,6 +72,7 @@
 #![warn(missing_docs)]
 #![warn(clippy::all)]
 
+#[cfg(feature = "mcp")]
 pub mod adapters;
 pub mod consensus;
 pub mod control_plane;

--- a/crates/mofa-gateway/src/lib.rs
+++ b/crates/mofa-gateway/src/lib.rs
@@ -72,6 +72,7 @@
 #![warn(missing_docs)]
 #![warn(clippy::all)]
 
+pub mod adapters;
 pub mod consensus;
 pub mod control_plane;
 pub mod error;

--- a/crates/mofa-kernel/src/gateway/dispatch.rs
+++ b/crates/mofa-kernel/src/gateway/dispatch.rs
@@ -265,6 +265,7 @@ impl Default for InMemoryAdapterRegistry {
     }
 }
 
+#[async_trait]
 impl AdapterRegistry for InMemoryAdapterRegistry {
     fn register(
         &mut self,

--- a/crates/mofa-kernel/src/gateway/dispatch.rs
+++ b/crates/mofa-kernel/src/gateway/dispatch.rs
@@ -194,6 +194,7 @@ pub trait GatewayAdapter: Send + Sync {
 /// Implementations must be `Send + Sync`.  The in-memory implementation
 /// ([`InMemoryAdapterRegistry`]) is provided here for convenience; production
 /// deployments may replace it with a dynamic-loading registry.
+#[async_trait]
 pub trait AdapterRegistry: Send + Sync {
     /// Register an adapter under `name`.
     ///

--- a/crates/mofa-kernel/src/gateway/dispatch.rs
+++ b/crates/mofa-kernel/src/gateway/dispatch.rs
@@ -208,7 +208,7 @@ pub trait AdapterRegistry: Send + Sync {
     /// Resolve an adapter by name, returning `None` if not registered.
     fn resolve(&self, name: &str) -> Option<Arc<dyn GatewayAdapter>>;
 
-    /// List all registered adapter names in registration order.
+    /// List all registered adapter names in lexicographic (sorted) order.
     fn adapter_names(&self) -> Vec<String>;
 
     /// Dispatch a request to the adapter identified by `target`.

--- a/crates/mofa-kernel/src/gateway/dispatch.rs
+++ b/crates/mofa-kernel/src/gateway/dispatch.rs
@@ -1,0 +1,560 @@
+//! Protocol-agnostic dispatch for the gateway pipeline.
+//!
+//! The router resolves every inbound request to an [`InvocationTarget`].
+//! The target identifies *what kind* of backend to call without naming a
+//! concrete implementation. An [`AdapterRegistry`] then maps the target to a
+//! live [`GatewayAdapter`] that performs the actual I/O.
+//!
+//! This separation means adding a new protocol (MCP, A2A, IoT, …) requires:
+//! 1. One new struct implementing [`GatewayAdapter`].
+//! 2. One `register` call at startup.
+//! 3. **Zero changes** to the router or filter chain.
+//!
+//! # Design note
+//!
+//! `InvocationTarget` was co-designed with Yang Rudan (CookieYang) on
+//! 16 March 2026.  The placement in `mofa-kernel` was confirmed on 17 March
+//! 2026 so that every downstream crate (`mofa-foundation`, `mofa-gateway`,
+//! application crates) can depend on the same dispatch contract without
+//! circular dependencies.
+//!
+//! | Type | Description |
+//! |------|-------------|
+//! | [`InvocationTarget`] | Protocol-agnostic dispatch variant |
+//! | [`GatewayAdapter`]   | Async trait every adapter must implement |
+//! | [`AdapterRegistry`]  | Trait for registering and resolving adapters |
+//! | [`InMemoryAdapterRegistry`] | `Arc`-safe in-memory registry implementation |
+//! | [`DispatchError`]    | Error type for dispatch failures |
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use super::error::RegistryError;
+use super::types::{GatewayContext, GatewayRequest, GatewayResponse};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DispatchError
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Error variants for dispatch and adapter resolution failures.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum DispatchError {
+    /// No adapter is registered under the requested name.
+    #[error("no adapter registered for '{0}'")]
+    AdapterNotFound(String),
+
+    /// The adapter was found but returned an error during invocation.
+    #[error("adapter '{adapter}' invocation failed: {reason}")]
+    AdapterInvocationFailed {
+        /// Name of the adapter that failed.
+        adapter: String,
+        /// Human-readable failure reason.
+        reason: String,
+    },
+
+    /// The `InvocationTarget` variant cannot be dispatched by this registry
+    /// (e.g. `LocalService` targets need special handling).
+    #[error("unsupported target variant: {0}")]
+    UnsupportedTargetVariant(String),
+}
+
+impl From<DispatchError> for RegistryError {
+    fn from(e: DispatchError) -> Self {
+        RegistryError::Internal(e.to_string())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// InvocationTarget
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Protocol-agnostic dispatch target produced by the router.
+///
+/// The trie router resolves every inbound `GatewayRequest` to one of these
+/// variants.  The variant is then handed to an [`AdapterRegistry`] to obtain
+/// the concrete [`GatewayAdapter`] that performs the actual I/O.
+///
+/// # Adding a new protocol
+///
+/// 1. Implement [`GatewayAdapter`] for your new protocol struct.
+/// 2. Register it: `registry.register("my_proto", Arc::new(MyProtoAdapter::new(…)))`.
+/// 3. Configure the router to emit `InvocationTarget::Adapter("my_proto")` for
+///    the relevant path patterns.
+///
+/// No changes to the router, filter chain, or any other existing code are
+/// required.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum InvocationTarget {
+    /// A named capability adapter.
+    ///
+    /// The string identifies the adapter in the [`AdapterRegistry`].
+    /// Well-known names: `"llm"`, `"mcp"`, `"a2a"`, `"iot"`.
+    Adapter(String),
+
+    /// A local in-process service reachable without a network hop.
+    ///
+    /// The string is an opaque identifier resolved by the local service
+    /// locator (implementation in `mofa-foundation`).
+    LocalService(String),
+
+    /// A plugin loaded from the plugin registry.
+    ///
+    /// The string is the plugin's canonical name as published to the registry.
+    Plugin(String),
+}
+
+impl InvocationTarget {
+    /// Returns the adapter name if this is an [`Adapter`](Self::Adapter) variant,
+    /// or `None` for all other variants.
+    pub fn adapter_name(&self) -> Option<&str> {
+        match self {
+            Self::Adapter(name) => Some(name.as_str()),
+            _ => None,
+        }
+    }
+
+    /// Returns `true` if this target can be resolved locally without a network hop.
+    pub fn is_local(&self) -> bool {
+        matches!(self, Self::LocalService(_))
+    }
+
+    /// Returns `true` if this target routes through the named adapter registry.
+    pub fn is_adapter(&self) -> bool {
+        matches!(self, Self::Adapter(_))
+    }
+
+    /// Returns `true` if this target routes through the plugin registry.
+    pub fn is_plugin(&self) -> bool {
+        matches!(self, Self::Plugin(_))
+    }
+
+    /// Return a human-readable label for logging and metrics.
+    pub fn label(&self) -> &str {
+        match self {
+            Self::Adapter(n) => n.as_str(),
+            Self::LocalService(n) => n.as_str(),
+            Self::Plugin(n) => n.as_str(),
+        }
+    }
+}
+
+impl std::fmt::Display for InvocationTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Adapter(n) => write!(f, "adapter:{n}"),
+            Self::LocalService(n) => write!(f, "local:{n}"),
+            Self::Plugin(n) => write!(f, "plugin:{n}"),
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GatewayAdapter
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Minimum interface every protocol adapter must implement.
+///
+/// Implementations must be `Send + Sync` so they can be shared across Tokio
+/// tasks behind an `Arc`.  Concrete implementations live in `mofa-gateway`
+/// (or specialised crates) to keep the kernel free of I/O dependencies.
+///
+/// # Contract
+///
+/// - `invoke` may be called concurrently from multiple tasks.
+/// - `invoke` must not mutate shared state without synchronisation.
+/// - `invoke` should respect the `timeout_ms` in `ctx.route_match` when set.
+#[async_trait]
+pub trait GatewayAdapter: Send + Sync {
+    /// Invoke the backend with the given request and filter-chain context,
+    /// returning a [`GatewayResponse`] on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DispatchError`] if the adapter cannot fulfil the request.
+    async fn invoke(
+        &self,
+        req: &GatewayRequest,
+        ctx: &GatewayContext,
+    ) -> Result<GatewayResponse, DispatchError>;
+
+    /// Human-readable name used in logs and metrics (e.g. `"openai"`, `"mcp"`).
+    fn name(&self) -> &str;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AdapterRegistry
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Kernel contract for registering and resolving [`GatewayAdapter`]s.
+///
+/// Implementations must be `Send + Sync`.  The in-memory implementation
+/// ([`InMemoryAdapterRegistry`]) is provided here for convenience; production
+/// deployments may replace it with a dynamic-loading registry.
+pub trait AdapterRegistry: Send + Sync {
+    /// Register an adapter under `name`.
+    ///
+    /// If an adapter with the same name already exists it is replaced and the
+    /// old adapter is returned.
+    fn register(
+        &mut self,
+        name: impl Into<String>,
+        adapter: Arc<dyn GatewayAdapter>,
+    ) -> Option<Arc<dyn GatewayAdapter>>;
+
+    /// Resolve an adapter by name, returning `None` if not registered.
+    fn resolve(&self, name: &str) -> Option<Arc<dyn GatewayAdapter>>;
+
+    /// List all registered adapter names in registration order.
+    fn adapter_names(&self) -> Vec<String>;
+
+    /// Dispatch a request to the adapter identified by `target`.
+    ///
+    /// # Errors
+    ///
+    /// * [`DispatchError::AdapterNotFound`] — no adapter is registered for the
+    ///   target name.
+    /// * [`DispatchError::UnsupportedTargetVariant`] — the target is not an
+    ///   `Adapter` variant (e.g. `LocalService` needs separate handling).
+    /// * [`DispatchError::AdapterInvocationFailed`] — the adapter returned an
+    ///   error.
+    async fn dispatch(
+        &self,
+        target: &InvocationTarget,
+        req: &GatewayRequest,
+        ctx: &GatewayContext,
+    ) -> Result<GatewayResponse, DispatchError>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// InMemoryAdapterRegistry
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Thread-safe in-memory [`AdapterRegistry`] backed by a plain `HashMap`.
+///
+/// Suitable for single-node deployments and tests.  Production multi-node
+/// deployments should replace this with a registry that can synchronise
+/// registrations across nodes.
+///
+/// # Thread safety
+///
+/// Mutation (`register`) requires `&mut self`, which in practice means the
+/// caller holds an exclusive lock (`RwLock` or `Mutex`) over the registry.
+/// Read operations (`resolve`, `dispatch`) take `&self` and are therefore
+/// safe to call concurrently once the registry is fully populated at startup.
+pub struct InMemoryAdapterRegistry {
+    adapters: HashMap<String, Arc<dyn GatewayAdapter>>,
+}
+
+impl InMemoryAdapterRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self {
+            adapters: HashMap::new(),
+        }
+    }
+}
+
+impl Default for InMemoryAdapterRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AdapterRegistry for InMemoryAdapterRegistry {
+    fn register(
+        &mut self,
+        name: impl Into<String>,
+        adapter: Arc<dyn GatewayAdapter>,
+    ) -> Option<Arc<dyn GatewayAdapter>> {
+        self.adapters.insert(name.into(), adapter)
+    }
+
+    fn resolve(&self, name: &str) -> Option<Arc<dyn GatewayAdapter>> {
+        self.adapters.get(name).cloned()
+    }
+
+    fn adapter_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self.adapters.keys().cloned().collect();
+        names.sort(); // deterministic ordering for tests and logs
+        names
+    }
+
+    async fn dispatch(
+        &self,
+        target: &InvocationTarget,
+        req: &GatewayRequest,
+        ctx: &GatewayContext,
+    ) -> Result<GatewayResponse, DispatchError> {
+        match target {
+            InvocationTarget::Adapter(name) => {
+                let adapter = self.resolve(name).ok_or_else(|| {
+                    DispatchError::AdapterNotFound(name.clone())
+                })?;
+                adapter.invoke(req, ctx).await.map_err(|e| {
+                    DispatchError::AdapterInvocationFailed {
+                        adapter: name.clone(),
+                        reason: e.to_string(),
+                    }
+                })
+            }
+            other => Err(DispatchError::UnsupportedTargetVariant(
+                other.to_string(),
+            )),
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gateway::route::HttpMethod;
+    use crate::gateway::types::{GatewayContext, GatewayRequest};
+
+    // ── Minimal adapter stub ─────────────────────────────────────────────────
+
+    struct EchoAdapter {
+        name: &'static str,
+    }
+
+    #[async_trait]
+    impl GatewayAdapter for EchoAdapter {
+        async fn invoke(
+            &self,
+            req: &GatewayRequest,
+            _ctx: &GatewayContext,
+        ) -> Result<GatewayResponse, DispatchError> {
+            Ok(GatewayResponse::new(200, self.name)
+                .with_body(req.body.clone()))
+        }
+
+        fn name(&self) -> &str {
+            self.name
+        }
+    }
+
+    struct FailingAdapter;
+
+    #[async_trait]
+    impl GatewayAdapter for FailingAdapter {
+        async fn invoke(
+            &self,
+            _req: &GatewayRequest,
+            _ctx: &GatewayContext,
+        ) -> Result<GatewayResponse, DispatchError> {
+            Err(DispatchError::AdapterInvocationFailed {
+                adapter: "failing".into(),
+                reason: "intentional test failure".into(),
+            })
+        }
+
+        fn name(&self) -> &str {
+            "failing"
+        }
+    }
+
+    fn make_req() -> GatewayRequest {
+        GatewayRequest::new("req-1", "/test", HttpMethod::Post)
+    }
+
+    fn make_ctx(req: GatewayRequest) -> GatewayContext {
+        GatewayContext::new(req)
+    }
+
+    // ── InvocationTarget ────────────────────────────────────────────────────
+
+    #[test]
+    fn adapter_name_returns_name_for_adapter_variant() {
+        let t = InvocationTarget::Adapter("mcp".into());
+        assert_eq!(t.adapter_name(), Some("mcp"));
+    }
+
+    #[test]
+    fn adapter_name_returns_none_for_local_service() {
+        let t = InvocationTarget::LocalService("cache".into());
+        assert_eq!(t.adapter_name(), None);
+    }
+
+    #[test]
+    fn adapter_name_returns_none_for_plugin() {
+        let t = InvocationTarget::Plugin("weather-plugin".into());
+        assert_eq!(t.adapter_name(), None);
+    }
+
+    #[test]
+    fn is_local_true_for_local_service() {
+        assert!(InvocationTarget::LocalService("x".into()).is_local());
+    }
+
+    #[test]
+    fn is_local_false_for_adapter() {
+        assert!(!InvocationTarget::Adapter("llm".into()).is_local());
+    }
+
+    #[test]
+    fn is_local_false_for_plugin() {
+        assert!(!InvocationTarget::Plugin("p".into()).is_local());
+    }
+
+    #[test]
+    fn is_adapter_true() {
+        assert!(InvocationTarget::Adapter("a2a".into()).is_adapter());
+    }
+
+    #[test]
+    fn is_plugin_true() {
+        assert!(InvocationTarget::Plugin("p".into()).is_plugin());
+    }
+
+    #[test]
+    fn display_formats_correctly() {
+        assert_eq!(
+            InvocationTarget::Adapter("llm".into()).to_string(),
+            "adapter:llm"
+        );
+        assert_eq!(
+            InvocationTarget::LocalService("cache".into()).to_string(),
+            "local:cache"
+        );
+        assert_eq!(
+            InvocationTarget::Plugin("wp".into()).to_string(),
+            "plugin:wp"
+        );
+    }
+
+    #[test]
+    fn label_returns_inner_string() {
+        assert_eq!(InvocationTarget::Adapter("mcp".into()).label(), "mcp");
+        assert_eq!(InvocationTarget::LocalService("x".into()).label(), "x");
+        assert_eq!(InvocationTarget::Plugin("p".into()).label(), "p");
+    }
+
+    #[test]
+    fn invocation_target_roundtrips_json() {
+        let t = InvocationTarget::Adapter("a2a".into());
+        let json = serde_json::to_string(&t).unwrap();
+        let back: InvocationTarget = serde_json::from_str(&json).unwrap();
+        assert_eq!(t, back);
+    }
+
+    // ── InMemoryAdapterRegistry ──────────────────────────────────────────────
+
+    #[test]
+    fn register_and_resolve() {
+        let mut reg = InMemoryAdapterRegistry::new();
+        reg.register("echo", Arc::new(EchoAdapter { name: "echo" }));
+        assert!(reg.resolve("echo").is_some());
+    }
+
+    #[test]
+    fn resolve_unknown_returns_none() {
+        let reg = InMemoryAdapterRegistry::new();
+        assert!(reg.resolve("nonexistent").is_none());
+    }
+
+    #[test]
+    fn register_replaces_existing() {
+        let mut reg = InMemoryAdapterRegistry::new();
+        reg.register("a", Arc::new(EchoAdapter { name: "v1" }));
+        let old = reg.register("a", Arc::new(EchoAdapter { name: "v2" }));
+        assert!(old.is_some());
+        assert_eq!(reg.resolve("a").unwrap().name(), "v2");
+    }
+
+    #[test]
+    fn adapter_names_sorted() {
+        let mut reg = InMemoryAdapterRegistry::new();
+        reg.register("mcp", Arc::new(EchoAdapter { name: "mcp" }));
+        reg.register("a2a", Arc::new(EchoAdapter { name: "a2a" }));
+        reg.register("llm", Arc::new(EchoAdapter { name: "llm" }));
+        assert_eq!(reg.adapter_names(), vec!["a2a", "llm", "mcp"]);
+    }
+
+    #[test]
+    fn adapter_names_empty_registry() {
+        let reg = InMemoryAdapterRegistry::new();
+        assert!(reg.adapter_names().is_empty());
+    }
+
+    // ── dispatch ─────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn dispatch_adapter_target_ok() {
+        let mut reg = InMemoryAdapterRegistry::new();
+        reg.register("echo", Arc::new(EchoAdapter { name: "echo" }));
+
+        let req = make_req();
+        let ctx = make_ctx(req.clone());
+        let target = InvocationTarget::Adapter("echo".into());
+
+        let resp = reg.dispatch(&target, &req, &ctx).await.unwrap();
+        assert_eq!(resp.status, 200);
+        assert_eq!(resp.backend_id, "echo");
+    }
+
+    #[tokio::test]
+    async fn dispatch_missing_adapter_returns_not_found() {
+        let reg = InMemoryAdapterRegistry::new();
+        let req = make_req();
+        let ctx = make_ctx(req.clone());
+        let target = InvocationTarget::Adapter("missing".into());
+
+        let err = reg.dispatch(&target, &req, &ctx).await.unwrap_err();
+        assert!(matches!(err, DispatchError::AdapterNotFound(ref n) if n == "missing"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_local_service_returns_unsupported() {
+        let reg = InMemoryAdapterRegistry::new();
+        let req = make_req();
+        let ctx = make_ctx(req.clone());
+        let target = InvocationTarget::LocalService("cache".into());
+
+        let err = reg.dispatch(&target, &req, &ctx).await.unwrap_err();
+        assert!(matches!(err, DispatchError::UnsupportedTargetVariant(_)));
+    }
+
+    #[tokio::test]
+    async fn dispatch_plugin_returns_unsupported() {
+        let reg = InMemoryAdapterRegistry::new();
+        let req = make_req();
+        let ctx = make_ctx(req.clone());
+        let target = InvocationTarget::Plugin("my-plugin".into());
+
+        let err = reg.dispatch(&target, &req, &ctx).await.unwrap_err();
+        assert!(matches!(err, DispatchError::UnsupportedTargetVariant(_)));
+    }
+
+    #[tokio::test]
+    async fn dispatch_failing_adapter_wraps_error() {
+        let mut reg = InMemoryAdapterRegistry::new();
+        reg.register("fail", Arc::new(FailingAdapter));
+
+        let req = make_req();
+        let ctx = make_ctx(req.clone());
+        let target = InvocationTarget::Adapter("fail".into());
+
+        let err = reg.dispatch(&target, &req, &ctx).await.unwrap_err();
+        assert!(matches!(
+            err,
+            DispatchError::AdapterInvocationFailed { ref adapter, .. }
+            if adapter == "fail"
+        ));
+    }
+
+    // ── DispatchError conversion ──────────────────────────────────────────────
+
+    #[test]
+    fn dispatch_error_converts_to_registry_error() {
+        let err = DispatchError::AdapterNotFound("x".into());
+        let reg_err: RegistryError = err.into();
+        assert!(matches!(reg_err, RegistryError::Internal(_)));
+    }
+}

--- a/crates/mofa-kernel/src/gateway/error.rs
+++ b/crates/mofa-kernel/src/gateway/error.rs
@@ -37,4 +37,12 @@ pub enum RegistryError {
     /// The route failed basic field validation.
     #[error("route is invalid: {0}")]
     InvalidRoute(String),
+
+    /// An internal error not covered by the above variants.
+    ///
+    /// Used by dispatch and adapter layers to surface errors through the
+    /// registry error type without introducing new error dependencies.
+    #[error("internal error: {0}")]
+    Internal(String),
 }
+

--- a/crates/mofa-kernel/src/gateway/mod.rs
+++ b/crates/mofa-kernel/src/gateway/mod.rs
@@ -20,18 +20,24 @@
 //! | [`AuthError`] | Auth failure error enum |
 
 pub mod auth;
+pub mod dispatch;
 pub mod envelope;
 pub mod error;
 pub mod route;
 mod config_error;
 mod types;
 
+
 #[cfg(test)]
 mod tests;
 
 pub use auth::{ApiKeyStore, AuthClaims, AuthError, AuthProvider};
+pub use dispatch::{
+    AdapterRegistry, DispatchError, GatewayAdapter, InMemoryAdapterRegistry, InvocationTarget,
+};
 pub use envelope::{AgentResponse, RequestEnvelope};
 pub use error::RegistryError;
 pub use route::{GatewayRoute, HttpMethod, RouteRegistry, RoutingContext};
 pub use config_error::GatewayConfigError;
 pub use types::{GatewayContext, GatewayRequest, GatewayResponse, RouteMatch};
+


### PR DESCRIPTION
## Summary
 
Delivers native MCP tool and context integration for the Cognitive Gateway. External MCP servers are reachable through the standard `Adapter("mcp")` dispatch slot, with SSRF hardening and per-route timeout enforcement baked in before any request leaves the gateway.
 
<img width="600" height="756" alt="image" src="https://github.com/user-attachments/assets/cb1aeea0-8916-4df4-9c51-d7fc5bae71b9" />

 
## Motivation
 
The MCP ecosystem is the primary source of tool and context capabilities for Anthropic-compatible agents. Without this adapter, the gateway cannot invoke any external MCP server. Building on the `GatewayAdapter` trait from PR 1 means MCP slots into the identical routing, auth, and caching pipeline as every other backend no special-casing anywhere in the router.
 
The SSRF protection is non-optional. An HTTP proxy that accepts arbitrary target URLs is a trivial vector for pivoting into internal networks. The `allowed_domains` allowlist closes this before the adapter ships.

## Tests
 
Unit tests covering dynamic target URL resolution, all four HTTP method delegations, SSRF boundary enforcement (allowed domain passes, blocked domain returns `403`), and timeout propagation.