### PR TITLE
feat(testing): add HITL testing harness and example

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -60,6 +60,7 @@ members = [
     "rag_retrieval_demo",
     "rag_indexing_demo",
     "adversarial_testing_demo",
+    "hitl_testing",
     "llm_fallback_chain",
     "resume_from_checkpoint",
     "claw_demo",

--- a/examples/hitl_testing/Cargo.toml
+++ b/examples/hitl_testing/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "hitl_testing"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+mofa-testing = { path = "../../tests" }
+mofa-kernel = { path = "../../crates/mofa-kernel" }
+tokio = { workspace = true }
+serde_json = { workspace = true }

--- a/examples/hitl_testing/src/main.rs
+++ b/examples/hitl_testing/src/main.rs
@@ -136,9 +136,53 @@ async fn run_timeout_flow() {
     println!();
 }
 
+async fn run_deferred_flow() {
+    let harness = HitlTestHarness::new();
+    // A deferred decision records reviewer intent but keeps the review pending
+    harness.reviewer().push_decision(ScriptedDecision::Defer {
+        reason: "waiting for product sign-off".to_string(),
+    });
+
+    let review_id = harness
+        .request_workflow_review(
+            "hitl-exec-defer",
+            "launch_gate",
+            sample_context("Launch feature flag to 100%"),
+        )
+        .await
+        .expect("create deferred review");
+
+    let decision = harness
+        .resolve_with_script(&review_id)
+        .await
+        .expect("apply deferred decision");
+    let wait_result = harness
+        .wait_for_review(&review_id, Duration::from_millis(50))
+        .await;
+    let pending_reviews = harness
+        .list_pending_reviews(None)
+        .await
+        .expect("list pending reviews");
+    let review = harness
+        .get_review(&review_id)
+        .await
+        .expect("load deferred review")
+        .expect("review exists");
+
+    println!("== Deferred Flow ==");
+    println!("review_id: {}", review_id);
+    println!("decision: {:?}", decision);
+    println!("wait_result: {:?}", wait_result);
+    println!("status: {:?}", review.status);
+    println!("pending_reviews: {}", pending_reviews.len());
+    println!("deferred_response: {:?}", review.response);
+    println!();
+}
+
 #[tokio::main]
 async fn main() {
     run_approved_flow().await;
     run_rejected_tool_flow().await;
     run_timeout_flow().await;
+    run_deferred_flow().await;
 }

--- a/examples/hitl_testing/src/main.rs
+++ b/examples/hitl_testing/src/main.rs
@@ -1,0 +1,144 @@
+use mofa_kernel::hitl::{ExecutionStep, ExecutionTrace, ReviewContext, ReviewStatus};
+use mofa_testing::{HitlTestHarness, ScriptedDecision};
+use serde_json::json;
+use std::collections::HashMap;
+use std::time::Duration;
+
+fn sample_context(task: &str) -> ReviewContext {
+    // Build a review context so the example exercises the
+    // same kernel HITL types used by production review requests.
+    let trace = ExecutionTrace {
+        steps: vec![ExecutionStep {
+            step_id: "review-gate".to_string(),
+            step_type: "workflow".to_string(),
+            timestamp_ms: 0,
+            input: Some(json!({ "task": task })),
+            output: None,
+            metadata: HashMap::new(),
+        }],
+        duration_ms: 180,
+    };
+
+    ReviewContext::new(trace, json!({ "request": task }))
+}
+
+async fn run_approved_flow() {
+    let harness = HitlTestHarness::new();
+    // Queue the reviewer decision before creating the review so the flow stays deterministic.
+    harness.reviewer().push_decision(ScriptedDecision::Approve {
+        comment: Some("approved for production".to_string()),
+    });
+
+    let review_id = harness
+        .request_workflow_review(
+            "hitl-exec-approve",
+            "deploy_production",
+            sample_context("Deploy to production"),
+        )
+        .await
+        .expect("create workflow review");
+
+    let decision = harness
+        .resolve_with_script(&review_id)
+        .await
+        .expect("resolve workflow review");
+    let response = harness
+        .wait_for_review(&review_id, Duration::from_millis(50))
+        .await
+        .expect("wait for workflow review");
+    let review = harness
+        .get_review(&review_id)
+        .await
+        .expect("load workflow review")
+        .expect("review exists");
+
+    println!("== Approval Flow ==");
+    println!("review_id: {}", review_id);
+    println!("decision: {:?}", decision);
+    println!("response: {:?}", response);
+    println!("status: {:?}", review.status);
+    println!("resolved_by: {:?}", review.resolved_by);
+    println!("node_id: {:?}", review.node_id);
+    println!();
+}
+
+async fn run_rejected_tool_flow() {
+    let harness = HitlTestHarness::new();
+    // Tool-call reviews attach tool metadata to the stored review request.
+    harness.reviewer().push_decision(ScriptedDecision::Reject {
+        reason: "manual verification required".to_string(),
+        comment: Some("run staging validation first".to_string()),
+    });
+
+    let review_id = harness
+        .request_tool_call_review(
+            "hitl-exec-reject",
+            "deployment_api",
+            json!({ "environment": "prod", "version": "2026.03.17" }),
+            sample_context("Call deployment_api for production rollout"),
+        )
+        .await
+        .expect("create tool review");
+
+    harness
+        .resolve_with_script(&review_id)
+        .await
+        .expect("resolve tool review");
+    let review = harness
+        .get_review(&review_id)
+        .await
+        .expect("load tool review")
+        .expect("review exists");
+
+    println!("== Rejection Flow ==");
+    println!("review_id: {}", review_id);
+    println!("status: {:?}", review.status);
+    println!("tool_name: {:?}", review.metadata.custom.get("tool_name"));
+    println!("tool_args: {:?}", review.metadata.custom.get("tool_args"));
+    println!("tags: {:?}", review.metadata.tags);
+    println!();
+}
+
+async fn run_timeout_flow() {
+    let harness = HitlTestHarness::new();
+    // A timeout decision intentionally leaves the review unresolved so callers
+    // can verify blocked execution paths.
+    harness.reviewer().push_decision(ScriptedDecision::Timeout);
+
+    let review_id = harness
+        .request_workflow_review(
+            "hitl-exec-timeout",
+            "destructive_action",
+            sample_context("Delete production index"),
+        )
+        .await
+        .expect("create timeout review");
+
+    let decision = harness
+        .resolve_with_script(&review_id)
+        .await
+        .expect("apply timeout decision");
+    let wait_result = harness
+        .wait_for_review(&review_id, Duration::from_millis(50))
+        .await;
+    let review = harness
+        .get_review(&review_id)
+        .await
+        .expect("load timeout review")
+        .expect("review exists");
+
+    println!("== Timeout Flow ==");
+    println!("review_id: {}", review_id);
+    println!("decision: {:?}", decision);
+    println!("wait_result: {:?}", wait_result);
+    println!("status: {:?}", review.status);
+    println!("pending: {}", matches!(review.status, ReviewStatus::Pending));
+    println!();
+}
+
+#[tokio::main]
+async fn main() {
+    run_approved_flow().await;
+    run_rejected_tool_flow().await;
+    run_timeout_flow().await;
+}

--- a/tests/src/hitl.rs
+++ b/tests/src/hitl.rs
@@ -278,6 +278,13 @@ impl HitlTestHarness {
             .map_err(FoundationHitlError::Store)
     }
 
+    pub async fn list_pending_reviews(
+        &self,
+        limit: Option<u64>,
+    ) -> Result<Vec<ReviewRequest>, FoundationHitlError> {
+        self.manager.list_pending(None, limit).await
+    }
+
     pub async fn review_status(
         &self,
         review_id: &ReviewRequestId,

--- a/tests/src/hitl.rs
+++ b/tests/src/hitl.rs
@@ -1,0 +1,294 @@
+//! HITL testing harness built on top of the real MoFA review manager.
+//!
+//! This module provides a scripted reviewer for deterministic approval-flow
+//! tests without re-implementing review orchestration logic.
+
+use mofa_foundation::hitl::{
+    FoundationHitlError, InMemoryReviewStore, ReviewManager, ReviewManagerConfig, ReviewNotifier,
+    ReviewPolicyEngine, ReviewStore, ToolReviewHandler, WorkflowReviewHandler,
+};
+use mofa_kernel::hitl::{
+    ReviewContext, ReviewRequest, ReviewRequestId, ReviewResponse, ReviewStatus,
+};
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::time::sleep;
+
+/// Deterministic scripted decision returned by a simulated reviewer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScriptedDecision {
+    Approve { comment: Option<String> },
+    Reject {
+        reason: String,
+        comment: Option<String>,
+    },
+    RequestChanges {
+        changes: String,
+        comment: Option<String>,
+    },
+    Defer { reason: String },
+    Timeout,
+}
+
+impl ScriptedDecision {
+    fn to_review_response(&self) -> Option<ReviewResponse> {
+        match self {
+            Self::Approve { comment } => Some(ReviewResponse::Approved {
+                comment: comment.clone(),
+            }),
+            Self::Reject { reason, comment } => Some(ReviewResponse::Rejected {
+                reason: reason.clone(),
+                comment: comment.clone(),
+            }),
+            Self::RequestChanges { changes, comment } => Some(ReviewResponse::ChangesRequested {
+                changes: changes.clone(),
+                comment: comment.clone(),
+            }),
+            Self::Defer { reason } => Some(ReviewResponse::Deferred {
+                reason: reason.clone(),
+            }),
+            Self::Timeout => None,
+        }
+    }
+}
+
+/// Queue-backed simulated reviewer for deterministic HITL tests.
+#[derive(Debug, Clone)]
+pub struct ScriptedReviewer {
+    decisions: Arc<Mutex<VecDeque<ScriptedDecision>>>,
+    default_decision: Arc<Mutex<ScriptedDecision>>,
+    reviewer_id: Arc<str>,
+}
+
+impl Default for ScriptedReviewer {
+    fn default() -> Self {
+        Self::new("hitl-test-reviewer")
+    }
+}
+
+impl ScriptedReviewer {
+    pub fn new(reviewer_id: impl Into<String>) -> Self {
+        Self {
+            decisions: Arc::new(Mutex::new(VecDeque::new())),
+            default_decision: Arc::new(Mutex::new(ScriptedDecision::Approve { comment: None })),
+            reviewer_id: reviewer_id.into().into(),
+        }
+    }
+
+    pub fn with_default_decision(mut self, decision: ScriptedDecision) -> Self {
+        self.default_decision = Arc::new(Mutex::new(decision));
+        self
+    }
+
+    pub fn set_default_decision(&self, decision: ScriptedDecision) {
+        *self
+            .default_decision
+            .lock()
+            .expect("scripted reviewer default decision lock poisoned") = decision;
+    }
+
+    pub fn push_decision(&self, decision: ScriptedDecision) {
+        self.decisions
+            .lock()
+            .expect("scripted reviewer queue lock poisoned")
+            .push_back(decision);
+    }
+
+    pub fn pending_decisions(&self) -> usize {
+        self.decisions
+            .lock()
+            .expect("scripted reviewer queue lock poisoned")
+            .len()
+    }
+
+    fn next_decision(&self) -> ScriptedDecision {
+        self.decisions
+            .lock()
+            .expect("scripted reviewer queue lock poisoned")
+            .pop_front()
+            .unwrap_or_else(|| {
+                self.default_decision
+                    .lock()
+                    .expect("scripted reviewer default decision lock poisoned")
+                    .clone()
+            })
+    }
+
+    pub fn reviewer_id(&self) -> &str {
+        &self.reviewer_id
+    }
+}
+
+/// Test harness for deterministic HITL review scenarios.
+pub struct HitlTestHarness {
+    store: Arc<InMemoryReviewStore>,
+    manager: Arc<ReviewManager>,
+    workflow_handler: WorkflowReviewHandler,
+    tool_handler: ToolReviewHandler,
+    reviewer: ScriptedReviewer,
+}
+
+impl Default for HitlTestHarness {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HitlTestHarness {
+    /// Build a harness with in-memory review storage and no external side effects.
+    pub fn new() -> Self {
+        Self::with_config(ReviewManagerConfig {
+            default_expiration: Duration::from_secs(30),
+            expiration_check_interval: Duration::from_secs(1),
+            enable_rate_limiting: false,
+        })
+    }
+
+    pub fn with_config(config: ReviewManagerConfig) -> Self {
+        let store = Arc::new(InMemoryReviewStore::new());
+        let manager = Arc::new(ReviewManager::new(
+            store.clone() as Arc<dyn ReviewStore>,
+            Arc::new(ReviewNotifier::default()),
+            Arc::new(ReviewPolicyEngine::default()),
+            None,
+            config,
+        ));
+        let workflow_handler = WorkflowReviewHandler::new(manager.clone());
+        let tool_handler = ToolReviewHandler::new(manager.clone());
+
+        Self {
+            store,
+            manager,
+            workflow_handler,
+            tool_handler,
+            reviewer: ScriptedReviewer::default(),
+        }
+    }
+
+    pub fn reviewer(&self) -> &ScriptedReviewer {
+        &self.reviewer
+    }
+
+    pub async fn request_workflow_review(
+        &self,
+        execution_id: &str,
+        node_id: &str,
+        context: ReviewContext,
+    ) -> Result<ReviewRequestId, FoundationHitlError> {
+        self.workflow_handler
+            .request_node_review(execution_id, node_id, context)
+            .await
+    }
+
+    pub async fn request_tool_call_review(
+        &self,
+        execution_id: &str,
+        tool_name: &str,
+        tool_args: serde_json::Value,
+        context: ReviewContext,
+    ) -> Result<ReviewRequestId, FoundationHitlError> {
+        self.tool_handler
+            .request_tool_call_review(execution_id, tool_name, tool_args, context)
+            .await
+    }
+
+    pub async fn request_tool_output_review(
+        &self,
+        execution_id: &str,
+        tool_name: &str,
+        tool_output: serde_json::Value,
+        context: ReviewContext,
+    ) -> Result<ReviewRequestId, FoundationHitlError> {
+        self.tool_handler
+            .request_tool_output_review(execution_id, tool_name, tool_output, context)
+            .await
+    }
+
+    /// Apply the next scripted reviewer decision to an existing review.
+    pub async fn resolve_with_script(
+        &self,
+        review_id: &ReviewRequestId,
+    ) -> Result<ScriptedDecision, FoundationHitlError> {
+        let decision = self.reviewer.next_decision();
+
+        if let Some(response) = decision.to_review_response() {
+            self.manager
+                .resolve_review(
+                    review_id,
+                    response,
+                    self.reviewer.reviewer_id().to_string(),
+                )
+                .await?;
+        }
+
+        Ok(decision)
+    }
+
+    pub async fn wait_for_review(
+        &self,
+        review_id: &ReviewRequestId,
+        timeout: Duration,
+    ) -> Result<ReviewResponse, FoundationHitlError> {
+        let start = std::time::Instant::now();
+        let check_interval = Duration::from_millis(25);
+
+        loop {
+            if start.elapsed() > timeout {
+                return Err(FoundationHitlError::InvalidConfig(format!(
+                    "Review {} timed out",
+                    review_id.as_str()
+                )));
+            }
+
+            if let Some(review) = self.manager.get_review(review_id).await? {
+                if review.is_expired() {
+                    return Err(FoundationHitlError::InvalidConfig(format!(
+                        "Review {} expired",
+                        review_id.as_str()
+                    )));
+                }
+
+                if let Some(response) = review.response {
+                    match response {
+                        ReviewResponse::Deferred { .. } => {}
+                        terminal => return Ok(terminal),
+                    }
+                }
+            }
+
+            sleep(check_interval).await;
+        }
+    }
+
+    pub async fn get_review(
+        &self,
+        review_id: &ReviewRequestId,
+    ) -> Result<Option<ReviewRequest>, FoundationHitlError> {
+        self.manager.get_review(review_id).await
+    }
+
+    pub async fn reviews_for_execution(
+        &self,
+        execution_id: &str,
+    ) -> Result<Vec<ReviewRequest>, FoundationHitlError> {
+        self.store
+            .list_by_execution(execution_id)
+            .await
+            .map_err(FoundationHitlError::Store)
+    }
+
+    pub async fn review_status(
+        &self,
+        review_id: &ReviewRequestId,
+    ) -> Result<Option<ReviewStatus>, FoundationHitlError> {
+        Ok(self.get_review(review_id).await?.map(|review| review.status))
+    }
+
+    pub async fn is_approved(
+        &self,
+        review_id: &ReviewRequestId,
+    ) -> Result<bool, FoundationHitlError> {
+        self.workflow_handler.is_approved(review_id).await
+    }
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -8,12 +8,14 @@ pub mod assertions;
 pub mod backend;
 pub mod bus;
 pub mod clock;
+pub mod hitl;
 pub mod report;
 pub mod tools;
 
 pub use backend::MockLLMBackend;
 pub use bus::MockAgentBus;
 pub use clock::{Clock, MockClock, SystemClock};
+pub use hitl::{HitlTestHarness, ScriptedDecision, ScriptedReviewer};
 pub use report::{
     JsonFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,
     TextFormatter,

--- a/tests/tests/hitl_harness_tests.rs
+++ b/tests/tests/hitl_harness_tests.rs
@@ -237,3 +237,27 @@ async fn tool_output_review_preserves_output_metadata() {
         Some(&json!({"result": "ok", "release_id": "rel-42"}))
     );
 }
+
+#[tokio::test]
+async fn list_pending_reviews_returns_only_unresolved_reviews() {
+    let harness = HitlTestHarness::new();
+    harness.reviewer().push_decision(ScriptedDecision::Approve {
+        comment: Some("approved".to_string()),
+    });
+
+    let resolved = harness
+        .request_workflow_review("exec-pending", "node-resolved", sample_context())
+        .await
+        .unwrap();
+    let pending = harness
+        .request_workflow_review("exec-pending", "node-pending", sample_context())
+        .await
+        .unwrap();
+
+    harness.resolve_with_script(&resolved).await.unwrap();
+
+    let pending_reviews = harness.list_pending_reviews(None).await.unwrap();
+    assert_eq!(pending_reviews.len(), 1);
+    assert_eq!(pending_reviews[0].id, pending);
+    assert_eq!(pending_reviews[0].status, ReviewStatus::Pending);
+}

--- a/tests/tests/hitl_harness_tests.rs
+++ b/tests/tests/hitl_harness_tests.rs
@@ -1,0 +1,239 @@
+use mofa_kernel::hitl::{ExecutionStep, ExecutionTrace, ReviewContext, ReviewResponse, ReviewStatus};
+use mofa_testing::{HitlTestHarness, ScriptedDecision};
+use serde_json::json;
+use std::collections::HashMap;
+use std::time::Duration;
+
+fn sample_context() -> ReviewContext {
+    // Keep the context small in tests, but include a real execution trace so we
+    // validate the harness against actual HITL request shapes.
+    let trace = ExecutionTrace {
+        steps: vec![ExecutionStep {
+            step_id: "deploy".to_string(),
+            step_type: "workflow".to_string(),
+            timestamp_ms: 0,
+            input: Some(json!({"task": "deploy"})),
+            output: None,
+            metadata: HashMap::new(),
+        }],
+        duration_ms: 120,
+    };
+
+    ReviewContext::new(trace, json!({"request": "deploy to production"}))
+}
+
+#[tokio::test]
+async fn workflow_review_can_be_approved_with_scripted_decision() {
+    let harness = HitlTestHarness::new();
+    // Script the next reviewer action up front so the test does not depend on timing.
+    harness.reviewer().push_decision(ScriptedDecision::Approve {
+        comment: Some("approved for rollout".to_string()),
+    });
+
+    let review_id = harness
+        .request_workflow_review("exec-1", "deploy_node", sample_context())
+        .await
+        .unwrap();
+
+    let applied = harness.resolve_with_script(&review_id).await.unwrap();
+    assert_eq!(
+        applied,
+        ScriptedDecision::Approve {
+            comment: Some("approved for rollout".to_string()),
+        }
+    );
+
+    let response = harness
+        .wait_for_review(&review_id, Duration::from_millis(50))
+        .await
+        .unwrap();
+    assert!(matches!(
+        response,
+        ReviewResponse::Approved { comment }
+            if comment.as_deref() == Some("approved for rollout")
+    ));
+
+    let review = harness.get_review(&review_id).await.unwrap().unwrap();
+    assert_eq!(review.status, ReviewStatus::Approved);
+    assert_eq!(review.node_id.as_deref(), Some("deploy_node"));
+    assert_eq!(review.resolved_by.as_deref(), Some("hitl-test-reviewer"));
+    assert!(harness.is_approved(&review_id).await.unwrap());
+}
+
+#[tokio::test]
+async fn tool_call_review_can_be_rejected_and_preserve_metadata() {
+    let harness = HitlTestHarness::new();
+    // Rejections are useful because they verify both resolution status and
+    // preservation of tool-specific metadata on the stored review.
+    harness.reviewer().push_decision(ScriptedDecision::Reject {
+        reason: "production deployment requires manual sign-off".to_string(),
+        comment: Some("run staging first".to_string()),
+    });
+
+    let review_id = harness
+        .request_tool_call_review(
+            "exec-2",
+            "deployment_api",
+            json!({"environment": "prod"}),
+            sample_context(),
+        )
+        .await
+        .unwrap();
+
+    harness.resolve_with_script(&review_id).await.unwrap();
+
+    let review = harness.get_review(&review_id).await.unwrap().unwrap();
+    assert_eq!(review.status, ReviewStatus::Rejected);
+    assert!(review.metadata.tags.iter().any(|tag| tag == "tool_execution"));
+    assert_eq!(
+        review.metadata.custom.get("tool_name"),
+        Some(&json!("deployment_api"))
+    );
+    assert_eq!(
+        review.metadata.custom.get("tool_args"),
+        Some(&json!({"environment": "prod"}))
+    );
+}
+
+#[tokio::test]
+async fn scripted_decisions_are_applied_in_order() {
+    let harness = HitlTestHarness::new();
+    harness.reviewer().push_decision(ScriptedDecision::Reject {
+        reason: "first attempt denied".to_string(),
+        comment: None,
+    });
+    harness.reviewer().push_decision(ScriptedDecision::Approve {
+        comment: Some("second attempt accepted".to_string()),
+    });
+
+    let first = harness
+        .request_workflow_review("exec-seq", "node-a", sample_context())
+        .await
+        .unwrap();
+    let second = harness
+        .request_workflow_review("exec-seq", "node-b", sample_context())
+        .await
+        .unwrap();
+
+    let first_decision = harness.resolve_with_script(&first).await.unwrap();
+    let second_decision = harness.resolve_with_script(&second).await.unwrap();
+
+    assert!(matches!(first_decision, ScriptedDecision::Reject { .. }));
+    assert!(matches!(second_decision, ScriptedDecision::Approve { .. }));
+    assert_eq!(
+        harness.review_status(&first).await.unwrap(),
+        Some(ReviewStatus::Rejected)
+    );
+    assert_eq!(
+        harness.review_status(&second).await.unwrap(),
+        Some(ReviewStatus::Approved)
+    );
+    assert_eq!(harness.reviewer().pending_decisions(), 0);
+}
+
+#[tokio::test]
+async fn timeout_decision_leaves_review_pending() {
+    let harness = HitlTestHarness::new();
+    // Timeout is modeled as "no reviewer response", so the review should remain pending.
+    harness.reviewer().push_decision(ScriptedDecision::Timeout);
+
+    let review_id = harness
+        .request_workflow_review("exec-timeout", "node-timeout", sample_context())
+        .await
+        .unwrap();
+
+    let applied = harness.resolve_with_script(&review_id).await.unwrap();
+    assert_eq!(applied, ScriptedDecision::Timeout);
+
+    let err = harness
+        .wait_for_review(&review_id, Duration::from_millis(50))
+        .await
+        .unwrap_err();
+    let message = err.to_string();
+    assert!(message.contains("timed out"));
+
+    let review = harness.get_review(&review_id).await.unwrap().unwrap();
+    assert_eq!(review.status, ReviewStatus::Pending);
+    assert!(review.response.is_none());
+}
+
+#[tokio::test]
+async fn deferred_decision_stays_pending_and_does_not_finish_wait() {
+    let harness = HitlTestHarness::new();
+    harness.reviewer().push_decision(ScriptedDecision::Defer {
+        reason: "needs product review".to_string(),
+    });
+
+    let review_id = harness
+        .request_workflow_review("exec-defer", "node-defer", sample_context())
+        .await
+        .unwrap();
+
+    let applied = harness.resolve_with_script(&review_id).await.unwrap();
+    assert!(matches!(applied, ScriptedDecision::Defer { .. }));
+
+    let err = harness
+        .wait_for_review(&review_id, Duration::from_millis(50))
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("timed out"));
+
+    let review = harness.get_review(&review_id).await.unwrap().unwrap();
+    assert_eq!(review.status, ReviewStatus::Pending);
+    assert!(matches!(review.response, Some(ReviewResponse::Deferred { .. })));
+}
+
+#[tokio::test]
+async fn reviewer_default_decision_is_configurable_through_harness() {
+    let harness = HitlTestHarness::new();
+    harness
+        .reviewer()
+        .set_default_decision(ScriptedDecision::Reject {
+            reason: "default deny".to_string(),
+            comment: None,
+        });
+
+    let review_id = harness
+        .request_workflow_review("exec-default", "node-default", sample_context())
+        .await
+        .unwrap();
+
+    let applied = harness.resolve_with_script(&review_id).await.unwrap();
+    assert!(matches!(applied, ScriptedDecision::Reject { .. }));
+    assert_eq!(
+        harness.review_status(&review_id).await.unwrap(),
+        Some(ReviewStatus::Rejected)
+    );
+}
+
+#[tokio::test]
+async fn tool_output_review_preserves_output_metadata() {
+    let harness = HitlTestHarness::new();
+    harness.reviewer().push_decision(ScriptedDecision::Approve {
+        comment: Some("output accepted".to_string()),
+    });
+
+    let review_id = harness
+        .request_tool_output_review(
+            "exec-tool-output",
+            "deployment_api",
+            json!({"result": "ok", "release_id": "rel-42"}),
+            sample_context(),
+        )
+        .await
+        .unwrap();
+
+    harness.resolve_with_script(&review_id).await.unwrap();
+
+    let review = harness.get_review(&review_id).await.unwrap().unwrap();
+    assert_eq!(review.status, ReviewStatus::Approved);
+    assert!(review.metadata.tags.iter().any(|tag| tag == "tool_output"));
+    assert_eq!(
+        review.metadata.custom.get("tool_name"),
+        Some(&json!("deployment_api"))
+    );
+    assert_eq!(
+        review.metadata.custom.get("tool_output"),
+        Some(&json!({"result": "ok", "release_id": "rel-42"}))
+    );
+}


### PR DESCRIPTION
## Summary

Add a HITL testing harness to `mofa-testing` so approval workflows can be exercised deterministically using the real `mofa-foundation` review manager and review handlers.

This PR adds scripted reviewer behavior, focused harness tests, deferred-review handling in the harness wait path, and a runnable example for manual validation.

Fixes: #1434

## Harness Flow
<img width="590" height="1086" alt="image" src="https://github.com/user-attachments/assets/255d168c-ed2c-4fc9-9673-e005e95f50af" />
---

## Changes

- added `tests/src/hitl.rs` with:
  - `HitlTestHarness`
  - `ScriptedReviewer`
  - `ScriptedDecision`
- wrapped the real `ReviewManager`, `WorkflowReviewHandler`, and `ToolReviewHandler` instead of creating a parallel fake HITL system
- added deterministic scripted reviewer outcomes:
  - approve
  - reject
  - request changes
  - defer
  - timeout
- made the scripted reviewer default decision configurable through the harness
- made `wait_for_review` treat deferred responses as non-terminal so deferred reviews remain pending from the harness perspective
- exported the new HITL testing API from `tests/src/lib.rs`
- added automated tests covering:
  - workflow approval flow
  - tool-call rejection with metadata preservation
  - tool-output review metadata preservation
  - sequential scripted decisions
  - configurable default reviewer fallback
  - deferred reviews staying pending
  - timeout leaving the review pending
- added a runnable example under `examples/hitl_testing`

---

## Files Changed

### `tests/src/hitl.rs`

Adds the HITL testing harness itself:

- `ScriptedDecision` to model deterministic reviewer outcomes
- `ScriptedReviewer` to queue reviewer decisions in a predictable order
- configurable default fallback behavior when no queued decision exists
- `HitlTestHarness` to request, resolve, wait on, and inspect reviews

It is built on the real `mofa-foundation` HITL stack rather than a parallel fake implementation. The harness wait path also treats deferred responses as non-terminal so deferred reviews still behave like pending reviews in tests.

### `tests/src/lib.rs`

Re-exports the new HITL testing module and public harness types so they are available directly through `mofa-testing`.

### `tests/tests/hitl_harness_tests.rs`

Adds focused automated coverage for:

- workflow review approval
- tool-call review rejection
- tool-output review approval with metadata preservation
- tool metadata preservation
- ordered application of scripted reviewer decisions
- configurable default reviewer decisions
- deferred review behavior
- timeout behavior that leaves a review unresolved and pending

### `examples/hitl_testing/Cargo.toml`

Adds the example crate definition and the dependencies required to run the HITL testing example from the examples workspace.

### `examples/hitl_testing/src/main.rs`

Adds a runnable example for three review paths:

- approval
- rejection
- timeout

The example prints review IDs, decisions, statuses, reviewer metadata, and tool metadata for manual validation.

### `examples/Cargo.toml`

Registers the new `hitl_testing` example crate in the examples workspace.

## Testing

1. Ran the `mofa-testing` test suite:

   `cargo test -p mofa-testing`

2. Ran the manual example:

   `CARGO_TARGET_DIR= ... /mofa/target cargo run --manifest-path 
   .../mofa/examples/Cargo.toml -p hitl_testing`

3. Verified approval, rejection, and timeout behavior from the example output

## Example output:

```text
== Approval Flow ==
review_id: ...
decision: Approve { comment: Some("approved for production") }
response: Approved { comment: Some("approved for production") }
status: Approved

== Rejection Flow ==
review_id: ...
status: Rejected
tool_name: Some(String("deployment_api"))
tool_args: Some(Object {"environment": String("prod"), "version": String("2026.03.17")})
tags: ["tool_execution"]

== Timeout Flow ==
review_id: ...
decision: Timeout
wait_result: Err(InvalidConfig("Review ... timed out"))
status: Pending
pending: true
```
