### PR TITLE
(Feat)testing contract harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Run tests
         run: cargo test --workspace --all-features
 
+      - name: Run contract and regression suites
+        run: cargo test -p mofa-testing --test contract_gateway_tests --test contract_local_inference_tests --test fixture_loader_tests
+
       - name: Build examples
         run: cargo build --examples
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5859,7 +5859,7 @@ version = "0.1.0"
 dependencies = [
  "async-openai",
  "async-trait",
- "axum 0.6.20",
+ "axum",
  "base64 0.22.1",
  "candle-core",
  "candle-transformers",
@@ -6151,11 +6151,17 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
  "chrono",
  "mofa-foundation",
+ "mofa-gateway",
  "mofa-kernel",
+ "mofa-local-llm",
+ "mofa-runtime",
  "serde",
  "serde_json",
+ "serde_yaml",
+ "tempfile",
  "tokio",
 ]
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -9,9 +9,15 @@ description = "Testing utilities for the MoFA agent framework"
 [dependencies]
 mofa-kernel = { path = "../crates/mofa-kernel" }
 mofa-foundation = { path = "../crates/mofa-foundation" }
+mofa-runtime = { path = "../crates/mofa-runtime" }
+mofa-gateway = { path = "../crates/mofa-gateway" }
+mofa-local-llm = { path = "../crates/mofa-local-llm" }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 chrono = { workspace = true }
+axum = { workspace = true }
+tempfile = { workspace = true }

--- a/tests/fixtures/contracts/gateway/data_precedence.json
+++ b/tests/fixtures/contracts/gateway/data_precedence.json
@@ -1,0 +1,20 @@
+{
+  "case_name": "gateway-data-precedence",
+  "kind": "contract",
+  "target": "gateway-chat",
+  "agent_present": true,
+  "agent_state": "Ready",
+  "request": {
+    "message": "ignore me",
+    "data": { "query": "json wins" }
+  },
+  "agent_response": {
+    "json": { "result": "ok" }
+  },
+  "expected": {
+    "status": 200,
+    "output_json": { "result": "ok" },
+    "expected_input_json": { "query": "json wins" },
+    "session_generated": true
+  }
+}

--- a/tests/fixtures/contracts/gateway/generated_session.json
+++ b/tests/fixtures/contracts/gateway/generated_session.json
@@ -1,0 +1,18 @@
+{
+  "case_name": "gateway-generated-session",
+  "kind": "contract",
+  "target": "gateway-chat",
+  "agent_present": true,
+  "agent_state": "Ready",
+  "request": {
+    "message": "make a session"
+  },
+  "agent_response": {
+    "text": "generated"
+  },
+  "expected": {
+    "status": 200,
+    "output_text": "generated",
+    "session_generated": true
+  }
+}

--- a/tests/fixtures/contracts/gateway/invalid_state.yaml
+++ b/tests/fixtures/contracts/gateway/invalid_state.yaml
@@ -1,0 +1,10 @@
+case_name: gateway-invalid-state
+kind: contract
+target: gateway-chat
+agent_present: true
+agent_state: Created
+request:
+  message: not ready
+expected:
+  status: 500
+  error_contains: cannot process messages

--- a/tests/fixtures/contracts/gateway/message_only.yaml
+++ b/tests/fixtures/contracts/gateway/message_only.yaml
@@ -1,0 +1,13 @@
+case_name: gateway-message-only
+kind: contract
+target: gateway-chat
+agent_present: true
+agent_state: Ready
+request:
+  message: hello gateway
+agent_response:
+  text: gateway-ok
+expected:
+  status: 200
+  output_text: gateway-ok
+  expected_input_text: hello gateway

--- a/tests/fixtures/contracts/gateway/missing_agent.json
+++ b/tests/fixtures/contracts/gateway/missing_agent.json
@@ -1,0 +1,13 @@
+{
+  "case_name": "gateway-missing-agent",
+  "kind": "contract",
+  "target": "gateway-chat",
+  "agent_present": false,
+  "request": {
+    "message": "where are you"
+  },
+  "expected": {
+    "status": 404,
+    "error_contains": "Agent not found"
+  }
+}

--- a/tests/fixtures/contracts/gateway/preserved_session.yaml
+++ b/tests/fixtures/contracts/gateway/preserved_session.yaml
@@ -1,0 +1,14 @@
+case_name: gateway-preserved-session
+kind: contract
+target: gateway-chat
+agent_present: true
+agent_state: Running
+request:
+  message: keep session
+  session_id: session-123
+agent_response:
+  text: session-kept
+expected:
+  status: 200
+  output_text: session-kept
+  session_id: session-123

--- a/tests/fixtures/contracts/local_inference/infer_before_load.yaml
+++ b/tests/fixtures/contracts/local_inference/infer_before_load.yaml
@@ -1,0 +1,7 @@
+case_name: local-inference-before-load
+kind: contract
+target: local-inference
+model_name: contract-model
+backend: cpu
+input: hello world
+expected_error_contains: model is not loaded

--- a/tests/fixtures/contracts/local_inference/missing_model_path.json
+++ b/tests/fixtures/contracts/local_inference/missing_model_path.json
@@ -1,0 +1,9 @@
+{
+  "case_name": "local-inference-missing-model",
+  "kind": "contract",
+  "target": "local-inference",
+  "model_name": "missing-model",
+  "model_path": "/definitely/missing/model.gguf",
+  "backend": "cpu",
+  "expected_error_contains": "model file not found"
+}

--- a/tests/fixtures/contracts/local_inference/successful_load.yaml
+++ b/tests/fixtures/contracts/local_inference/successful_load.yaml
@@ -1,0 +1,16 @@
+case_name: local-inference-success
+kind: contract
+target: local-inference
+model_name: contract-model
+backend: cpu
+create_temp_model: true
+input: hello there general
+expected_output_contains:
+  - "[cpu backend]"
+  - "model=contract-model"
+  - "input_tokens=3"
+expected_metadata_fields:
+  - backend
+  - model_id
+  - model_path
+deterministic: true

--- a/tests/fixtures/scenarios/basic.json
+++ b/tests/fixtures/scenarios/basic.json
@@ -1,0 +1,15 @@
+{
+  "case_name": "basic-json-scenario",
+  "kind": "contract",
+  "target": "testing-scenario",
+  "suite_name": "fixture-json-suite",
+  "llm": {
+    "model_name": "fixture-model-json",
+    "responses": [
+      { "prompt_substring": "ping", "response": "pong" }
+    ]
+  },
+  "expectations": {
+    "infer_total": 1
+  }
+}

--- a/tests/fixtures/scenarios/basic.yaml
+++ b/tests/fixtures/scenarios/basic.yaml
@@ -1,0 +1,11 @@
+case_name: basic-yaml-scenario
+kind: contract
+target: testing-scenario
+suite_name: fixture-yaml-suite
+llm:
+  model_name: fixture-model
+  responses:
+    - prompt_substring: hello
+      response: hi
+expectations:
+  infer_total: 1

--- a/tests/fixtures/scenarios/malformed.yaml
+++ b/tests/fixtures/scenarios/malformed.yaml
@@ -1,0 +1,6 @@
+suite_name: malformed
+llm:
+  responses:
+    - prompt_substring: broken
+      response: ok
+    - not-valid

--- a/tests/src/fixtures.rs
+++ b/tests/src/fixtures.rs
@@ -1,0 +1,50 @@
+//! Helpers for loading deterministic fixture files from `tests/fixtures`.
+
+use anyhow::{Context, Result, bail};
+use serde::de::DeserializeOwned;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Return the absolute path to the fixture root directory.
+pub fn fixtures_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("fixtures")
+}
+
+/// Return the absolute path to a fixture relative to the fixture root.
+pub fn fixture_path(relative_path: impl AsRef<Path>) -> PathBuf {
+    fixtures_root().join(relative_path)
+}
+
+/// Load a fixture from `tests/fixtures`, parsing JSON, YAML, or YML by extension.
+pub fn load_fixture<T>(relative_path: impl AsRef<Path>) -> Result<T>
+where
+    T: DeserializeOwned,
+{
+    let path = fixture_path(relative_path);
+    load_fixture_from_path(path)
+}
+
+fn load_fixture_from_path<T>(path: PathBuf) -> Result<T>
+where
+    T: DeserializeOwned,
+{
+    let raw = fs::read_to_string(&path)
+        .with_context(|| format!("failed to read fixture '{}'", path.display()))?;
+    let extension = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_ascii_lowercase())
+        .unwrap_or_default();
+
+    match extension.as_str() {
+        "json" => serde_json::from_str(&raw)
+            .with_context(|| format!("failed to parse JSON fixture '{}'", path.display())),
+        "yaml" | "yml" => serde_yaml::from_str(&raw)
+            .with_context(|| format!("failed to parse YAML fixture '{}'", path.display())),
+        other => bail!(
+            "unsupported fixture extension '{}' for '{}'",
+            other,
+            path.display()
+        ),
+    }
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -8,6 +8,7 @@
 //! integration tests only when a behavior cannot be described cleanly as a
 //! reusable fixture.
 
+pub mod adversarial;
 pub mod assertions;
 pub mod backend;
 pub mod bus;

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -2,20 +2,28 @@
 //!
 //! Provides mock implementations, failure injection, and deterministic time
 //! control for testing MoFA agents.
+//!
+//! Contract fixtures live under `tests/fixtures/`. Prefer them when you need
+//! deterministic, portable regression coverage across crates. Reach for ad hoc
+//! integration tests only when a behavior cannot be described cleanly as a
+//! reusable fixture.
 
-pub mod adversarial;
 pub mod assertions;
 pub mod backend;
 pub mod bus;
 pub mod clock;
+pub mod fixtures;
+pub mod regression;
 pub mod report;
 pub mod tools;
 
 pub use backend::MockLLMBackend;
 pub use bus::MockAgentBus;
 pub use clock::{Clock, MockClock, SystemClock};
+pub use fixtures::{fixture_path, fixtures_root, load_fixture};
+pub use regression::{assert_contains_all, assert_error_contains, assert_exact_match};
 pub use report::{
-    JsonFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,
-    TextFormatter,
+    JsonFormatter, JunitFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder,
+    TestStatus, TextFormatter,
 };
 pub use tools::MockTool;

--- a/tests/src/regression.rs
+++ b/tests/src/regression.rs
@@ -1,0 +1,35 @@
+//! Small regression-oriented assertions used by fixture-driven contract tests.
+
+/// Assert that two strings are exactly equal.
+pub fn assert_exact_match(actual: impl AsRef<str>, expected: impl AsRef<str>) {
+    assert_eq!(
+        actual.as_ref(),
+        expected.as_ref(),
+        "exact regression mismatch"
+    );
+}
+
+/// Assert that an error string contains the expected substring.
+pub fn assert_error_contains(error: impl AsRef<str>, expected_substring: impl AsRef<str>) {
+    let error = error.as_ref();
+    let expected_substring = expected_substring.as_ref();
+    assert!(
+        error.contains(expected_substring),
+        "expected error to contain '{}', got '{}'",
+        expected_substring,
+        error
+    );
+}
+
+/// Assert that a string contains each expected substring.
+pub fn assert_contains_all(actual: impl AsRef<str>, expected_substrings: &[String]) {
+    let actual = actual.as_ref();
+    for expected in expected_substrings {
+        assert!(
+            actual.contains(expected),
+            "expected '{}' to contain '{}'",
+            actual,
+            expected
+        );
+    }
+}

--- a/tests/src/report/format.rs
+++ b/tests/src/report/format.rs
@@ -102,3 +102,69 @@ impl ReportFormatter for TextFormatter {
         buf
     }
 }
+
+/// Renders a report as a JUnit XML document for CI systems.
+pub struct JunitFormatter;
+
+impl ReportFormatter for JunitFormatter {
+    fn format(&self, report: &TestReport) -> String {
+        let mut xml = String::new();
+        xml.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        xml.push_str(&format!(
+            "<testsuite name=\"{}\" tests=\"{}\" failures=\"{}\" skipped=\"{}\" time=\"{:.3}\" timestamp=\"{}\">\n",
+            escape_xml(&report.suite_name),
+            report.total(),
+            report.failed(),
+            report.skipped(),
+            report.total_duration.as_secs_f64(),
+            report.timestamp
+        ));
+
+        for result in &report.results {
+            xml.push_str(&format!(
+                "  <testcase name=\"{}\" classname=\"{}\" time=\"{:.3}\">",
+                escape_xml(&result.name),
+                escape_xml(&report.suite_name),
+                result.duration.as_secs_f64()
+            ));
+
+            match result.status {
+                TestStatus::Passed => {}
+                TestStatus::Failed => {
+                    let message = result.error.as_deref().unwrap_or("test failed");
+                    xml.push_str(&format!(
+                        "<failure message=\"{}\">{}</failure>",
+                        escape_xml(message),
+                        escape_xml(message)
+                    ));
+                }
+                TestStatus::Skipped => {
+                    let message = result.error.as_deref().unwrap_or("test skipped");
+                    xml.push_str(&format!("<skipped message=\"{}\" />", escape_xml(message)));
+                }
+            }
+
+            if !result.metadata.is_empty() {
+                xml.push_str("<system-out>");
+                for (key, value) in &result.metadata {
+                    xml.push_str(&escape_xml(&format!("{key}={value}\n")));
+                }
+                xml.push_str("</system-out>");
+            }
+
+            xml.push_str("</testcase>\n");
+        }
+
+        xml.push_str("</testsuite>\n");
+        xml
+    }
+}
+
+fn escape_xml(input: &str) -> String {
+    input
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}

--- a/tests/src/report/mod.rs
+++ b/tests/src/report/mod.rs
@@ -5,5 +5,5 @@ mod format;
 mod types;
 
 pub use builder::TestReportBuilder;
-pub use format::{JsonFormatter, ReportFormatter, TextFormatter};
+pub use format::{JsonFormatter, JunitFormatter, ReportFormatter, TextFormatter};
 pub use types::{TestCaseResult, TestReport, TestStatus};

--- a/tests/tests/contract_gateway_tests.rs
+++ b/tests/tests/contract_gateway_tests.rs
@@ -1,0 +1,299 @@
+use async_trait::async_trait;
+use axum::{
+    Json,
+    body::to_bytes,
+    extract::{Path, State},
+    http::{HeaderMap, HeaderName, HeaderValue, StatusCode},
+    response::IntoResponse,
+};
+use mofa_gateway::{
+    handlers::chat::{ChatRequest, chat},
+    middleware::RateLimiter,
+    state::AppState,
+};
+use mofa_runtime::agent::{
+    capabilities::AgentCapabilities,
+    context::AgentContext,
+    core::MoFAAgent,
+    error::AgentResult,
+    registry::AgentRegistry,
+    types::{AgentInput, AgentOutput, AgentState},
+};
+use mofa_testing::{assert_error_contains, load_fixture};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+
+#[derive(Debug, Deserialize)]
+struct GatewayContractFixture {
+    case_name: String,
+    kind: Option<String>,
+    target: Option<String>,
+    #[serde(default = "default_true")]
+    agent_present: bool,
+    agent_state: Option<String>,
+    #[serde(default)]
+    request: GatewayRequestFixture,
+    #[serde(default)]
+    agent_response: GatewayResponseFixture,
+    expected: GatewayExpectedFixture,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GatewayRequestFixture {
+    message: Option<String>,
+    data: Option<Value>,
+    session_id: Option<String>,
+    #[serde(default)]
+    headers: HashMap<String, String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GatewayResponseFixture {
+    text: Option<String>,
+    json: Option<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GatewayExpectedFixture {
+    status: u16,
+    output_text: Option<String>,
+    output_json: Option<Value>,
+    session_id: Option<String>,
+    #[serde(default)]
+    session_generated: bool,
+    expected_input_text: Option<String>,
+    expected_input_json: Option<Value>,
+    error_contains: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Clone)]
+struct ContractAgent {
+    id: String,
+    name: String,
+    state: AgentState,
+    capabilities: AgentCapabilities,
+    response: AgentOutput,
+    last_input: Arc<RwLock<Option<AgentInput>>>,
+}
+
+impl ContractAgent {
+    fn new(id: &str, state: AgentState, response: AgentOutput) -> Self {
+        Self {
+            id: id.to_string(),
+            name: "Contract Agent".to_string(),
+            state,
+            capabilities: AgentCapabilities::builder().with_tag("contract").build(),
+            response,
+            last_input: Arc::new(RwLock::new(None)),
+        }
+    }
+}
+
+#[async_trait]
+impl MoFAAgent for ContractAgent {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn capabilities(&self) -> &AgentCapabilities {
+        &self.capabilities
+    }
+
+    async fn initialize(&mut self, _ctx: &AgentContext) -> AgentResult<()> {
+        self.state = AgentState::Ready;
+        Ok(())
+    }
+
+    async fn execute(
+        &mut self,
+        input: AgentInput,
+        _ctx: &AgentContext,
+    ) -> AgentResult<AgentOutput> {
+        *self.last_input.write().await = Some(input);
+        Ok(self.response.clone())
+    }
+
+    async fn shutdown(&mut self) -> AgentResult<()> {
+        self.state = AgentState::Shutdown;
+        Ok(())
+    }
+
+    fn state(&self) -> AgentState {
+        self.state.clone()
+    }
+}
+
+fn parse_agent_state(raw: Option<&str>) -> AgentState {
+    match raw.unwrap_or("Ready") {
+        "Created" => AgentState::Created,
+        "Ready" => AgentState::Ready,
+        "Running" => AgentState::Running,
+        "Paused" => AgentState::Paused,
+        "Shutdown" => AgentState::Shutdown,
+        other => AgentState::Error(other.to_string()),
+    }
+}
+
+fn fixture_response_body(fixture: &GatewayResponseFixture) -> AgentOutput {
+    if let Some(value) = &fixture.json {
+        AgentOutput::json(value.clone())
+    } else if let Some(text) = &fixture.text {
+        AgentOutput::text(text.clone())
+    } else {
+        AgentOutput::text("ok")
+    }
+}
+
+fn make_headers(headers: &HashMap<String, String>) -> HeaderMap {
+    let mut map = HeaderMap::new();
+    for (key, value) in headers {
+        let name = HeaderName::from_bytes(key.as_bytes()).expect("valid header name");
+        let value = HeaderValue::from_str(value).expect("valid header value");
+        map.insert(name, value);
+    }
+    map
+}
+
+async fn run_gateway_fixture(relative_path: &str) {
+    let fixture: GatewayContractFixture = load_fixture(relative_path).expect("fixture must load");
+    assert_eq!(fixture.kind.as_deref(), Some("contract"));
+    assert_eq!(fixture.target.as_deref(), Some("gateway-chat"));
+
+    let registry = Arc::new(AgentRegistry::new());
+    let rate_limiter = Arc::new(RateLimiter::new(100, Duration::from_secs(60)));
+    let app_state = Arc::new(AppState::new(registry.clone(), rate_limiter));
+
+    let mut registered_agent = None;
+    if fixture.agent_present {
+        let agent = ContractAgent::new(
+            "contract-agent",
+            parse_agent_state(fixture.agent_state.as_deref()),
+            fixture_response_body(&fixture.agent_response),
+        );
+        let agent = Arc::new(RwLock::new(agent));
+        registry
+            .register(agent.clone())
+            .await
+            .expect("register agent");
+        registered_agent = Some(agent);
+    }
+
+    let result = chat(
+        State(app_state),
+        Path("contract-agent".to_string()),
+        make_headers(&fixture.request.headers),
+        Json(ChatRequest {
+            message: fixture.request.message.clone(),
+            data: fixture.request.data.clone(),
+            session_id: fixture.request.session_id.clone(),
+        }),
+    )
+    .await;
+
+    let response = match result {
+        Ok(success) => success.into_response(),
+        Err(err) => err.into_response(),
+    };
+
+    assert_eq!(
+        response.status(),
+        StatusCode::from_u16(fixture.expected.status).expect("valid status"),
+        "fixture '{}' returned unexpected status",
+        fixture.case_name
+    );
+
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("response body");
+    let parsed: Value = serde_json::from_slice(&body).expect("json response");
+
+    if let Some(expected_text) = &fixture.expected.output_text {
+        assert_eq!(parsed["output"], json!({ "Text": expected_text }));
+    }
+
+    if let Some(expected_json) = &fixture.expected.output_json {
+        assert_eq!(parsed["output"], json!({ "Json": expected_json }));
+    }
+
+    if let Some(expected_session_id) = &fixture.expected.session_id {
+        assert_eq!(parsed["session_id"].as_str(), Some(expected_session_id.as_str()));
+    }
+
+    if fixture.expected.session_generated {
+        let session_id = parsed["session_id"].as_str().expect("session_id");
+        assert!(!session_id.trim().is_empty());
+    }
+
+    if let Some(expected_error) = &fixture.expected.error_contains {
+        let error = parsed
+            .get("error")
+            .and_then(Value::as_str)
+            .expect("error response");
+        assert_error_contains(error, expected_error);
+    }
+
+    if let Some(agent) = registered_agent {
+        let last_input_store = {
+            let guard = agent.read().await;
+            guard.last_input.clone()
+        };
+        let last_input = last_input_store.read().await.clone();
+
+        if let Some(expected_text) = &fixture.expected.expected_input_text {
+            assert_eq!(
+                last_input.as_ref().and_then(AgentInput::as_text),
+                Some(expected_text.as_str())
+            );
+        }
+
+        if let Some(expected_json) = &fixture.expected.expected_input_json {
+            let actual_json = last_input
+                .as_ref()
+                .map(AgentInput::to_json)
+                .expect("agent should have received input");
+            assert_eq!(&actual_json, expected_json);
+        }
+    }
+}
+
+#[tokio::test]
+async fn gateway_contract_message_only() {
+    run_gateway_fixture("contracts/gateway/message_only.yaml").await;
+}
+
+#[tokio::test]
+async fn gateway_contract_data_precedence() {
+    run_gateway_fixture("contracts/gateway/data_precedence.json").await;
+}
+
+#[tokio::test]
+async fn gateway_contract_preserves_session_id() {
+    run_gateway_fixture("contracts/gateway/preserved_session.yaml").await;
+}
+
+#[tokio::test]
+async fn gateway_contract_generates_session_id() {
+    run_gateway_fixture("contracts/gateway/generated_session.json").await;
+}
+
+#[tokio::test]
+async fn gateway_contract_invalid_state() {
+    run_gateway_fixture("contracts/gateway/invalid_state.yaml").await;
+}
+
+#[tokio::test]
+async fn gateway_contract_missing_agent() {
+    run_gateway_fixture("contracts/gateway/missing_agent.json").await;
+}

--- a/tests/tests/contract_local_inference_tests.rs
+++ b/tests/tests/contract_local_inference_tests.rs
@@ -1,0 +1,133 @@
+use mofa_foundation::orchestrator::traits::ModelProvider;
+use mofa_local_llm::{ComputeBackend, LinuxInferenceConfig, LinuxLocalProvider};
+use mofa_testing::{assert_contains_all, assert_error_contains, assert_exact_match, load_fixture};
+use serde::Deserialize;
+use tempfile::NamedTempFile;
+
+#[derive(Debug, Deserialize)]
+struct LocalInferenceContractFixture {
+    case_name: String,
+    kind: Option<String>,
+    target: Option<String>,
+    model_name: String,
+    model_path: Option<String>,
+    backend: String,
+    input: Option<String>,
+    #[serde(default)]
+    create_temp_model: bool,
+    expected_error_contains: Option<String>,
+    #[serde(default)]
+    expected_output_contains: Vec<String>,
+    #[serde(default)]
+    expected_metadata_fields: Vec<String>,
+    #[serde(default)]
+    deterministic: bool,
+}
+
+fn parse_backend(raw: &str) -> ComputeBackend {
+    match raw {
+        "cpu" => ComputeBackend::Cpu,
+        "cuda" => ComputeBackend::Cuda,
+        "rocm" => ComputeBackend::Rocm,
+        "vulkan" => ComputeBackend::Vulkan,
+        other => panic!("unsupported backend fixture value: {other}"),
+    }
+}
+
+#[tokio::test]
+async fn local_inference_contract_infer_before_load() {
+    let fixture: LocalInferenceContractFixture =
+        load_fixture("contracts/local_inference/infer_before_load.yaml").expect("fixture");
+    assert_eq!(fixture.kind.as_deref(), Some("contract"));
+    assert_eq!(fixture.target.as_deref(), Some("local-inference"));
+    assert_eq!(fixture.case_name, "local-inference-before-load");
+
+    let provider = LinuxLocalProvider::new(
+        LinuxInferenceConfig::new(&fixture.model_name, fixture.model_path.unwrap_or_default())
+            .with_backend(parse_backend(&fixture.backend)),
+    )
+    .expect("provider creation");
+
+    let err = provider
+        .infer(fixture.input.as_deref().unwrap_or("hello"))
+        .await
+        .expect_err("infer before load must fail");
+    assert_error_contains(
+        err.to_string(),
+        fixture
+            .expected_error_contains
+            .as_deref()
+            .expect("expected error substring"),
+    );
+}
+
+#[tokio::test]
+async fn local_inference_contract_missing_model_path() {
+    let fixture: LocalInferenceContractFixture =
+        load_fixture("contracts/local_inference/missing_model_path.json").expect("fixture");
+    assert_eq!(fixture.case_name, "local-inference-missing-model");
+
+    let mut provider = LinuxLocalProvider::new(
+        LinuxInferenceConfig::new(
+            &fixture.model_name,
+            fixture.model_path.clone().expect("model path"),
+        )
+        .with_backend(parse_backend(&fixture.backend)),
+    )
+    .expect("provider creation");
+
+    let err = provider
+        .load()
+        .await
+        .expect_err("missing model path must fail");
+    assert_error_contains(
+        err.to_string(),
+        fixture
+            .expected_error_contains
+            .as_deref()
+            .expect("expected error substring"),
+    );
+}
+
+#[tokio::test]
+async fn local_inference_contract_successful_load_and_determinism() {
+    let fixture: LocalInferenceContractFixture =
+        load_fixture("contracts/local_inference/successful_load.yaml").expect("fixture");
+    assert_eq!(fixture.case_name, "local-inference-success");
+
+    let temp_model = if fixture.create_temp_model {
+        let file = NamedTempFile::new().expect("temp model file");
+        std::fs::write(file.path(), b"GGUF").expect("write temp model");
+        Some(file)
+    } else {
+        None
+    };
+
+    let model_path = temp_model
+        .as_ref()
+        .map(|file| file.path().to_string_lossy().to_string())
+        .or(fixture.model_path.clone())
+        .expect("model path");
+
+    let mut provider = LinuxLocalProvider::new(
+        LinuxInferenceConfig::new(&fixture.model_name, model_path)
+            .with_backend(parse_backend(&fixture.backend)),
+    )
+    .expect("provider creation");
+
+    provider.load().await.expect("provider should load");
+
+    let input = fixture.input.as_deref().unwrap_or("hello world");
+    let first = provider.infer(input).await.expect("first inference");
+    assert_contains_all(&first, &fixture.expected_output_contains);
+
+    let metadata = provider.get_metadata();
+    for key in &fixture.expected_metadata_fields {
+        assert!(metadata.contains_key(key), "missing metadata key '{key}'");
+    }
+
+    if fixture.deterministic {
+        let second = provider.infer(input).await.expect("second inference");
+        assert_exact_match(&first, &second);
+    }
+}

--- a/tests/tests/fixture_loader_tests.rs
+++ b/tests/tests/fixture_loader_tests.rs
@@ -1,0 +1,41 @@
+use mofa_testing::{fixture_path, load_fixture};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct GenericFixture {
+    case_name: String,
+    kind: String,
+    target: String,
+    suite_name: String,
+}
+
+#[test]
+fn load_scenario_fixture_from_yaml() {
+    let spec: GenericFixture = load_fixture("scenarios/basic.yaml").expect("yaml fixture should load");
+    assert_eq!(spec.case_name, "basic-yaml-scenario");
+    assert_eq!(spec.kind, "contract");
+    assert_eq!(spec.target, "testing-scenario");
+    assert_eq!(spec.suite_name, "fixture-yaml-suite");
+}
+
+#[test]
+fn load_scenario_fixture_from_json() {
+    let spec: GenericFixture = load_fixture("scenarios/basic.json").expect("json fixture should load");
+    assert_eq!(spec.case_name, "basic-json-scenario");
+    assert_eq!(spec.kind, "contract");
+    assert_eq!(spec.target, "testing-scenario");
+    assert_eq!(spec.suite_name, "fixture-json-suite");
+}
+
+#[test]
+fn scenario_spec_from_path_rejects_malformed_fixture() {
+    let err = load_fixture::<GenericFixture>(fixture_path("scenarios/malformed.yaml"))
+        .expect_err("malformed fixture must fail");
+    let message = err.to_string();
+    assert!(
+        message.contains("failed to parse YAML fixture")
+            || message.contains("did not find expected")
+            || message.contains("invalid type"),
+        "unexpected error message: {message}"
+    );
+}

--- a/tests/tests/report_tests.rs
+++ b/tests/tests/report_tests.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use mofa_testing::{
-    JsonFormatter, MockClock, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder,
-    TestStatus, TextFormatter,
+    JsonFormatter, JunitFormatter, MockClock, ReportFormatter, TestCaseResult, TestReport,
+    TestReportBuilder, TestStatus, TextFormatter,
 };
 
 // ---------------------------------------------------------------------------
@@ -271,6 +271,24 @@ fn json_formatter_includes_metadata() {
     let output = JsonFormatter.format(&r);
     let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
     assert_eq!(parsed["results"][0]["metadata"]["key"], "val");
+}
+
+// ===========================================================================
+// JunitFormatter
+// ===========================================================================
+
+#[test]
+fn junit_formatter_emits_testsuite_and_testcases() {
+    let r = mixed_report();
+    let output = JunitFormatter.format(&r);
+    assert!(output.contains("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+    assert!(output.contains("<testsuite name=\"mixed\""));
+    assert!(output.contains("tests=\"5\""));
+    assert!(output.contains("failures=\"2\""));
+    assert!(output.contains("skipped=\"1\""));
+    assert!(output.contains("<testcase name=\"a\""));
+    assert!(output.contains("<failure message=\"boom\">boom</failure>"));
+    assert!(output.contains("<skipped message=\"test skipped\" />"));
 }
 
 // ===========================================================================


### PR DESCRIPTION

<img width="2794" height="4745" alt="pr1441" src="https://github.com/user-attachments/assets/2ad3900e-48b2-4fe5-9d8c-b97d2f2b81a5" />




## Summary

Adds a deterministic contract/regression harness to `mofa-testing` for two production-sensitive surfaces:

- Gateway chat behavior
- Local inference / compute-mesh provider behavior

This builds on the existing scenario-runner/testing utilities and adds fixture-driven coverage, reusable regression helpers, and CI-friendly reporting.

Closes #1354



## Context



This PR strengthens that foundation by:
- making fixture-driven testing easier,
- adding deterministic contract tests for gateway and local inference behavior,
- and improving report output for CI use.

This is primarily testing-framework work, while also improving quality coverage relevant to Gateway and Compute Mesh development.

---

## Changes

- Added fixture-loading helpers for YAML/JSON contract fixtures in `mofa-testing`
- Added lightweight regression assertion helpers for exact-match and stable substring checks
- Extended `ScenarioSpec` with additive metadata fields:
  - `case_name`
  - `kind`
  - `target`
- Added JUnit report formatting for CI-friendly output
- Added gateway contract fixtures/tests covering:
  - message-only requests
  - `data` payload precedence over `message`
  - session preservation
  - generated session IDs
  - invalid agent state handling
  - missing agent handling
- Added local inference contract fixtures/tests covering:
  - infer-before-load failure
  - missing model-path failure
  - successful load with deterministic stub inference
  - metadata assertions
  - deterministic same-input/same-output behavior
- Added a dedicated CI step for the new contract/regression suites
- Made `ChatResponse` deserializable to support contract assertions in tests

---

## How you Tested

1. `cargo test -p mofa-testing --test fixture_loader_tests`
2. `cargo test -p mofa-testing --test contract_gateway_tests`
3. `cargo test -p mofa-testing --test contract_local_inference_tests`
4. `cargo test -p mofa-testing --test report_tests`

Results:
- fixture loader: 3 passed
- gateway contracts: 6 passed
- local inference contracts: 3 passed
- report tests: 25 passed

---

## Breaking Changes

- [x] No breaking changes

This PR adds only additive testing/reporting functionality.

---

## Additional Notes for Reviewers

- Contract fixtures live under `tests/fixtures/`
- The intent is to keep these tests deterministic, portable, and independent of external services
- Assertions intentionally prefer stable behavior checks over brittle exact error matching where possible
