### PR TITLE
feat(testing): Agent Testing Platform: Structured Run Artifacts, Runner Harness, Session Snapshots, Examples

### DIFF
--- a/crates/mofa-foundation/src/agent/context/prompt.rs
+++ b/crates/mofa-foundation/src/agent/context/prompt.rs
@@ -142,6 +142,17 @@ impl PromptContext {
         self
     }
 
+    /// Replace the agent identity.
+    pub fn set_identity(&mut self, identity: AgentIdentity) {
+        self.agent_name = identity.name.clone();
+        self.identity = identity;
+    }
+
+    /// Replace the bootstrap file list.
+    pub fn set_bootstrap_files(&mut self, files: Vec<String>) {
+        self.bootstrap_files = files;
+    }
+
     /// Set skills that should always be loaded
     pub fn with_always_load(mut self, skills: Vec<String>) -> Self {
         self.always_load = skills;

--- a/crates/mofa-foundation/src/agent/executor.rs
+++ b/crates/mofa-foundation/src/agent/executor.rs
@@ -595,7 +595,9 @@ impl MoFAAgent for AgentExecutor {
         self.base.initialize(ctx).await?;
 
         // Additional executor-specific initialization
-        self.base.transition_to(AgentState::Ready)?;
+        if self.base.state() != AgentState::Ready {
+            self.base.transition_to(AgentState::Ready)?;
+        }
 
         Ok(())
     }

--- a/crates/mofa-foundation/src/agent/executor.rs
+++ b/crates/mofa-foundation/src/agent/executor.rs
@@ -548,6 +548,15 @@ impl AgentExecutor {
         &self.config
     }
 
+    /// Update the prompt context (system prompt builder).
+    pub async fn update_prompt_context<F>(&self, updater: F)
+    where
+        F: FnOnce(&mut PromptContext),
+    {
+        let mut ctx = self.context.write().await;
+        updater(&mut ctx);
+    }
+
     /// Get mutable reference to base agent
     pub fn base_mut(&mut self) -> &mut BaseAgent {
         &mut self.base
@@ -643,7 +652,10 @@ mod tests {
             "mock"
         }
 
-        async fn chat(&self, _request: ChatCompletionRequest) -> AgentResult<ChatCompletionResponse> {
+        async fn chat(
+            &self,
+            _request: ChatCompletionRequest,
+        ) -> AgentResult<ChatCompletionResponse> {
             Ok(ChatCompletionResponse {
                 content: Some("ok".to_string()),
                 tool_calls: Some(Vec::<ToolCall>::new()),

--- a/crates/mofa-runtime/src/runner.rs
+++ b/crates/mofa-runtime/src/runner.rs
@@ -349,6 +349,11 @@ impl<T: MoFAAgent> AgentRunner<T> {
         &self.context
     }
 
+    /// Update session ID in the execution context.
+    pub fn set_session_id(&mut self, session_id: Option<String>) {
+        self.context.session_id = session_id;
+    }
+
     /// 获取运行器状态
     /// Get runner state
     pub async fn state(&self) -> RunnerState {

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,9 @@
 [workspace]
 resolver = "3"
 members = [
+    "agent_runner_basic",
+    "agent_runner_custom_session",
+    "agent_runner_tools",
     "cli_production_smoke",
     "cli_agent_logs_demo",
     "cli_plugin_lifecycle",

--- a/examples/agent_runner_basic/Cargo.toml
+++ b/examples/agent_runner_basic/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "agent_runner_basic"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+mofa-testing = { path = "../../tests" }
+tokio.workspace = true

--- a/examples/agent_runner_basic/src/main.rs
+++ b/examples/agent_runner_basic/src/main.rs
@@ -1,0 +1,29 @@
+use anyhow::Result;
+use mofa_testing::AgentTestRunner;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let mut runner = AgentTestRunner::new().await?;
+    runner.mock_llm().add_response("Hello from the runner").await;
+
+    let result = runner.run_text("hi").await?;
+    println!("Output: {}", result.output_text().unwrap_or_default());
+    println!(
+        "Session: {}",
+        result
+            .metadata
+            .session_id
+            .as_deref()
+            .unwrap_or("<none>")
+    );
+    println!("Workspace: {}", result.metadata.workspace_root.display());
+    println!(
+        "Runner stats: total={} success={} failed={}",
+        result.metadata.runner_stats_after.total_executions,
+        result.metadata.runner_stats_after.successful_executions,
+        result.metadata.runner_stats_after.failed_executions
+    );
+
+    runner.shutdown().await?;
+    Ok(())
+}

--- a/examples/agent_runner_custom_session/Cargo.toml
+++ b/examples/agent_runner_custom_session/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "agent_runner_custom_session"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+mofa-testing = { path = "../../tests" }
+mofa-foundation = { path = "../../crates/mofa-foundation" }
+tokio.workspace = true

--- a/examples/agent_runner_custom_session/src/main.rs
+++ b/examples/agent_runner_custom_session/src/main.rs
@@ -1,0 +1,42 @@
+use anyhow::Result;
+use mofa_foundation::agent::context::prompt::AgentIdentity;
+use mofa_testing::AgentTestRunner;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let mut runner = AgentTestRunner::new().await?;
+
+    runner.write_bootstrap_file("CUSTOM.md", "Custom bootstrap content.")?;
+    runner
+        .configure_prompt(
+            Some(AgentIdentity {
+                name: "RunnerDemo".to_string(),
+                description: "Custom identity for example runs".to_string(),
+                icon: None,
+            }),
+            Some(vec!["CUSTOM.md".to_string()]),
+        )
+        .await;
+
+    runner
+        .mock_llm()
+        .add_response("Custom session response")
+        .await;
+
+    let result = runner
+        .run_text_with_session("demo-session", "hello session")
+        .await?;
+
+    println!(
+        "Session id: {}",
+        result
+            .metadata
+            .session_id
+            .as_deref()
+            .unwrap_or("<none>")
+    );
+    println!("Output: {}", result.output_text().unwrap_or_default());
+
+    runner.shutdown().await?;
+    Ok(())
+}

--- a/examples/agent_runner_tools/Cargo.toml
+++ b/examples/agent_runner_tools/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "agent_runner_tools"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+mofa-testing = { path = "../../tests" }
+serde_json.workspace = true
+tokio.workspace = true

--- a/examples/agent_runner_tools/src/main.rs
+++ b/examples/agent_runner_tools/src/main.rs
@@ -1,0 +1,47 @@
+use anyhow::Result;
+use mofa_testing::{AgentTestRunner, MockTool};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let mut runner = AgentTestRunner::new().await?;
+
+    let tool = MockTool::new(
+        "echo_tool",
+        "Echo the provided input",
+        json!({
+            "type": "object",
+            "properties": {
+                "input": { "type": "string" }
+            },
+            "required": ["input"]
+        }),
+    );
+
+    runner.register_mock_tool(tool).await?;
+
+    runner
+        .mock_llm()
+        .add_tool_call_response("echo_tool", json!({ "input": "ping" }), None)
+        .await;
+    runner
+        .mock_llm()
+        .add_response("Tool response completed")
+        .await;
+
+    let result = runner.run_text("use the tool").await?;
+    println!("Output: {}", result.output_text().unwrap_or_default());
+
+    for record in &result.metadata.tool_calls {
+        println!(
+            "Tool call: name={} input={} output={} duration_ms={:?}",
+            record.tool_name,
+            record.input,
+            record.output.as_ref().unwrap_or(&serde_json::Value::Null),
+            record.duration_ms
+        );
+    }
+
+    runner.shutdown().await?;
+    Ok(())
+}

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -9,9 +9,12 @@ description = "Testing utilities for the MoFA agent framework"
 [dependencies]
 mofa-kernel = { path = "../crates/mofa-kernel" }
 mofa-foundation = { path = "../crates/mofa-foundation" }
+mofa-runtime = { path = "../crates/mofa-runtime" }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
+thiserror = { workspace = true }
+uuid = { workspace = true }

--- a/tests/src/agent_runner.rs
+++ b/tests/src/agent_runner.rs
@@ -5,12 +5,14 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use mofa_foundation::agent::context::prompt::AgentIdentity;
 use mofa_foundation::agent::executor::{AgentExecutor, AgentExecutorConfig};
 use mofa_kernel::agent::context::AgentContext;
 use mofa_kernel::agent::core::MoFAAgent;
 use mofa_kernel::agent::error::{AgentError, AgentResult};
 use mofa_foundation::agent::components::tool::as_tool;
 use mofa_foundation::agent::session::{JsonlSessionStorage, Session, SessionStorage};
+use crate::tools::MockTool;
 use mofa_kernel::agent::types::{AgentInput, AgentOutput, ChatCompletionRequest};
 use mofa_kernel::agent::types::{ChatCompletionResponse, ToolCall};
 use mofa_kernel::agent::AgentCapabilities;
@@ -52,6 +54,9 @@ pub struct AgentRunMetadata {
     pub agent_state_after: AgentState,
     pub started_at: DateTime<Utc>,
     pub session_snapshot: Option<Session>,
+    pub tool_calls: Vec<ToolCallRecord>,
+    pub llm_last_request: Option<ChatCompletionRequest>,
+    pub llm_last_response: Option<ChatCompletionResponse>,
 }
 
 /// Result of a single agent run.
@@ -62,6 +67,15 @@ pub struct AgentRunResult {
     pub error: Option<AgentError>,
     pub duration: Duration,
     pub metadata: AgentRunMetadata,
+}
+
+/// Captures a tool call with its input and output.
+#[derive(Debug, Clone)]
+pub struct ToolCallRecord {
+    pub tool_name: String,
+    pub input: serde_json::Value,
+    pub output: Option<serde_json::Value>,
+    pub success: bool,
 }
 
 impl AgentRunResult {
@@ -81,6 +95,7 @@ pub struct MockAgentLLMProvider {
     responses: RwLock<VecDeque<MockLlmResponse>>,
     default_response: RwLock<String>,
     last_request: RwLock<Option<ChatCompletionRequest>>,
+    last_response: RwLock<Option<ChatCompletionResponse>>,
 }
 
 #[derive(Debug, Clone)]
@@ -100,6 +115,7 @@ impl MockAgentLLMProvider {
             responses: RwLock::new(VecDeque::new()),
             default_response: RwLock::new("This is a mock response.".to_string()),
             last_request: RwLock::new(None),
+            last_response: RwLock::new(None),
         }
     }
 
@@ -145,6 +161,10 @@ impl MockAgentLLMProvider {
     pub async fn last_request(&self) -> Option<ChatCompletionRequest> {
         self.last_request.read().await.clone()
     }
+
+    pub async fn last_response(&self) -> Option<ChatCompletionResponse> {
+        self.last_response.read().await.clone()
+    }
 }
 
 #[async_trait]
@@ -167,7 +187,7 @@ impl mofa_kernel::agent::types::LLMProvider for MockAgentLLMProvider {
             }
         };
 
-        match response {
+        let response = match response {
             MockLlmResponse::Text(content) => Ok(ChatCompletionResponse {
                 content: Some(content),
                 tool_calls: Some(Vec::<ToolCall>::new()),
@@ -179,7 +199,10 @@ impl mofa_kernel::agent::types::LLMProvider for MockAgentLLMProvider {
                 usage: None,
             }),
             MockLlmResponse::Error(message) => Err(AgentError::ExecutionFailed(message)),
-        }
+        }?;
+
+        *self.last_response.write().await = Some(response.clone());
+        Ok(response)
     }
 }
 
@@ -197,6 +220,13 @@ impl SessionAwareExecutor {
         tool: Arc<dyn mofa_kernel::agent::components::tool::DynTool>,
     ) -> AgentResult<()> {
         self.executor.register_tool(tool).await
+    }
+
+    async fn update_prompt_context<F>(&self, updater: F)
+    where
+        F: FnOnce(&mut mofa_foundation::agent::context::prompt::PromptContext),
+    {
+        self.executor.update_prompt_context(updater).await;
     }
 }
 
@@ -276,6 +306,7 @@ pub struct AgentTestRunner {
     execution_id: String,
     llm: Arc<MockAgentLLMProvider>,
     runner: AgentRunner<SessionAwareExecutor>,
+    mock_tools: Vec<MockTool>,
 }
 
 impl AgentTestRunner {
@@ -301,6 +332,7 @@ impl AgentTestRunner {
             execution_id,
             llm,
             runner,
+            mock_tools: Vec::new(),
         })
     }
 
@@ -348,8 +380,43 @@ impl AgentTestRunner {
             .map_err(AgentRunnerError::from)
     }
 
+    pub async fn register_mock_tool(&mut self, tool: MockTool) -> Result<(), AgentRunnerError> {
+        self.register_simple_tool(tool.clone()).await?;
+        self.mock_tools.push(tool);
+        Ok(())
+    }
+
+    pub async fn configure_prompt(
+        &self,
+        identity: Option<AgentIdentity>,
+        bootstrap_files: Option<Vec<String>>,
+    ) {
+        self.runner
+            .agent()
+            .update_prompt_context(|ctx| {
+                if let Some(identity) = identity {
+                    ctx.set_identity(identity);
+                }
+                if let Some(files) = bootstrap_files {
+                    ctx.set_bootstrap_files(files);
+                }
+            })
+            .await;
+    }
+
     pub async fn run_text(&mut self, input: &str) -> Result<AgentRunResult, AgentRunnerError> {
         self.run_input(AgentInput::text(input)).await
+    }
+
+    pub async fn run_texts(
+        &mut self,
+        inputs: &[&str],
+    ) -> Result<Vec<AgentRunResult>, AgentRunnerError> {
+        let mut results = Vec::with_capacity(inputs.len());
+        for input in inputs {
+            results.push(self.run_text(input).await?);
+        }
+        Ok(results)
     }
 
     pub async fn run_input(
@@ -367,6 +434,9 @@ impl AgentTestRunner {
         let runner_stats_after = self.runner.stats().await;
         let agent_state_after = self.runner.agent_state();
         let session_snapshot = self.load_session_snapshot().await;
+        let tool_calls = self.collect_tool_calls().await;
+        let llm_last_request = self.llm.last_request().await;
+        let llm_last_response = self.llm.last_response().await;
 
         let (output, error) = match result {
             Ok(output) => (Some(output), None),
@@ -387,6 +457,9 @@ impl AgentTestRunner {
             agent_state_after,
             started_at,
             session_snapshot,
+            tool_calls,
+            llm_last_request,
+            llm_last_response,
         };
 
         Ok(AgentRunResult {
@@ -406,5 +479,27 @@ impl AgentTestRunner {
         let session_id = self.runner.context().session_id.as_deref()?;
         let storage = JsonlSessionStorage::new(self.workspace.path()).await.ok()?;
         storage.load(session_id).await.ok()?
+    }
+
+    async fn collect_tool_calls(&self) -> Vec<ToolCallRecord> {
+        let mut records = Vec::new();
+        for tool in &self.mock_tools {
+            let calls = tool.history().await;
+            let results = tool.results().await;
+            for (idx, call) in calls.into_iter().enumerate() {
+                let result = results.get(idx).cloned();
+                let (output, success) = match result {
+                    Some(result) => (Some(result.output.clone()), result.success),
+                    None => (None, false),
+                };
+                records.push(ToolCallRecord {
+                    tool_name: tool.name().to_string(),
+                    input: call.arguments,
+                    output,
+                    success,
+                });
+            }
+        }
+        records
     }
 }

--- a/tests/src/agent_runner.rs
+++ b/tests/src/agent_runner.rs
@@ -9,9 +9,12 @@ use mofa_foundation::agent::executor::{AgentExecutor, AgentExecutorConfig};
 use mofa_kernel::agent::context::AgentContext;
 use mofa_kernel::agent::core::MoFAAgent;
 use mofa_kernel::agent::error::{AgentError, AgentResult};
+use mofa_foundation::agent::components::tool::as_tool;
+use mofa_foundation::agent::session::{JsonlSessionStorage, Session, SessionStorage};
 use mofa_kernel::agent::types::{AgentInput, AgentOutput, ChatCompletionRequest};
 use mofa_kernel::agent::types::{ChatCompletionResponse, ToolCall};
 use mofa_kernel::agent::AgentCapabilities;
+use mofa_kernel::agent::AgentState;
 use mofa_runtime::runner::{AgentRunner, RunnerState, RunnerStats};
 use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
@@ -34,19 +37,26 @@ pub enum AgentRunnerError {
 
 /// Metadata captured for each run.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct AgentRunMetadata {
     pub agent_id: String,
     pub agent_name: String,
     pub execution_id: String,
     pub session_id: Option<String>,
     pub workspace_root: PathBuf,
-    pub runner_state: RunnerState,
-    pub runner_stats: RunnerStats,
+    pub runner_state_before: RunnerState,
+    pub runner_state_after: RunnerState,
+    pub runner_stats_before: RunnerStats,
+    pub runner_stats_after: RunnerStats,
+    pub agent_state_before: AgentState,
+    pub agent_state_after: AgentState,
     pub started_at: DateTime<Utc>,
+    pub session_snapshot: Option<Session>,
 }
 
 /// Result of a single agent run.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct AgentRunResult {
     pub output: Option<AgentOutput>,
     pub error: Option<AgentError>,
@@ -68,8 +78,19 @@ impl AgentRunResult {
 #[derive(Debug)]
 pub struct MockAgentLLMProvider {
     name: String,
-    responses: RwLock<VecDeque<String>>,
+    responses: RwLock<VecDeque<MockLlmResponse>>,
     default_response: RwLock<String>,
+    last_request: RwLock<Option<ChatCompletionRequest>>,
+}
+
+#[derive(Debug, Clone)]
+enum MockLlmResponse {
+    Text(String),
+    ToolCall {
+        content: Option<String>,
+        tool_calls: Vec<ToolCall>,
+    },
+    Error(String),
 }
 
 impl MockAgentLLMProvider {
@@ -78,11 +99,39 @@ impl MockAgentLLMProvider {
             name: name.into(),
             responses: RwLock::new(VecDeque::new()),
             default_response: RwLock::new("This is a mock response.".to_string()),
+            last_request: RwLock::new(None),
         }
     }
 
     pub async fn add_response(&self, response: impl Into<String>) {
-        self.responses.write().await.push_back(response.into());
+        self.responses
+            .write()
+            .await
+            .push_back(MockLlmResponse::Text(response.into()));
+    }
+
+    pub async fn add_tool_call_response(
+        &self,
+        tool_name: &str,
+        arguments: serde_json::Value,
+        content: Option<String>,
+    ) {
+        let tool_call = ToolCall {
+            id: Uuid::now_v7().to_string(),
+            name: tool_name.to_string(),
+            arguments,
+        };
+        self.responses.write().await.push_back(MockLlmResponse::ToolCall {
+            content,
+            tool_calls: vec![tool_call],
+        });
+    }
+
+    pub async fn add_error_response(&self, message: impl Into<String>) {
+        self.responses
+            .write()
+            .await
+            .push_back(MockLlmResponse::Error(message.into()));
     }
 
     pub async fn set_default_response(&self, response: impl Into<String>) {
@@ -91,6 +140,10 @@ impl MockAgentLLMProvider {
 
     pub async fn pending_responses(&self) -> usize {
         self.responses.read().await.len()
+    }
+
+    pub async fn last_request(&self) -> Option<ChatCompletionRequest> {
+        self.last_request.read().await.clone()
     }
 }
 
@@ -102,22 +155,31 @@ impl mofa_kernel::agent::types::LLMProvider for MockAgentLLMProvider {
 
     async fn chat(
         &self,
-        _request: ChatCompletionRequest,
+        request: ChatCompletionRequest,
     ) -> AgentResult<ChatCompletionResponse> {
+        *self.last_request.write().await = Some(request);
         let response = {
             let mut responses = self.responses.write().await;
             if let Some(next) = responses.pop_front() {
                 next
             } else {
-                self.default_response.read().await.clone()
+                MockLlmResponse::Text(self.default_response.read().await.clone())
             }
         };
 
-        Ok(ChatCompletionResponse {
-            content: Some(response),
-            tool_calls: Some(Vec::<ToolCall>::new()),
-            usage: None,
-        })
+        match response {
+            MockLlmResponse::Text(content) => Ok(ChatCompletionResponse {
+                content: Some(content),
+                tool_calls: Some(Vec::<ToolCall>::new()),
+                usage: None,
+            }),
+            MockLlmResponse::ToolCall { content, tool_calls } => Ok(ChatCompletionResponse {
+                content,
+                tool_calls: Some(tool_calls),
+                usage: None,
+            }),
+            MockLlmResponse::Error(message) => Err(AgentError::ExecutionFailed(message)),
+        }
     }
 }
 
@@ -128,6 +190,13 @@ struct SessionAwareExecutor {
 impl SessionAwareExecutor {
     fn new(executor: AgentExecutor) -> Self {
         Self { executor }
+    }
+
+    async fn register_tool(
+        &self,
+        tool: Arc<dyn mofa_kernel::agent::components::tool::DynTool>,
+    ) -> AgentResult<()> {
+        self.executor.register_tool(tool).await
     }
 }
 
@@ -182,6 +251,15 @@ impl TempWorkspace {
 
     fn path(&self) -> &Path {
         &self.root
+    }
+
+    fn write_file(&self, relative_path: &Path, content: &str) -> Result<PathBuf, AgentRunnerError> {
+        let path = self.root.join(relative_path);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&path, content)?;
+        Ok(path)
     }
 }
 
@@ -242,6 +320,34 @@ impl AgentTestRunner {
         Arc::clone(&self.llm)
     }
 
+    pub fn write_bootstrap_file(
+        &self,
+        filename: &str,
+        content: &str,
+    ) -> Result<PathBuf, AgentRunnerError> {
+        self.workspace.write_file(Path::new(filename), content)
+    }
+
+    pub fn write_workspace_file(
+        &self,
+        relative_path: impl AsRef<Path>,
+        content: &str,
+    ) -> Result<PathBuf, AgentRunnerError> {
+        self.workspace.write_file(relative_path.as_ref(), content)
+    }
+
+    pub async fn register_simple_tool<T>(&self, tool: T) -> Result<(), AgentRunnerError>
+    where
+        T: mofa_foundation::agent::components::tool::SimpleTool + Send + Sync + 'static,
+    {
+        let tool_ref = as_tool(tool);
+        self.runner
+            .agent()
+            .register_tool(tool_ref)
+            .await
+            .map_err(AgentRunnerError::from)
+    }
+
     pub async fn run_text(&mut self, input: &str) -> Result<AgentRunResult, AgentRunnerError> {
         self.run_input(AgentInput::text(input)).await
     }
@@ -251,9 +357,16 @@ impl AgentTestRunner {
         input: AgentInput,
     ) -> Result<AgentRunResult, AgentRunnerError> {
         let started_at = Utc::now();
+        let runner_state_before = self.runner.state().await;
+        let runner_stats_before = self.runner.stats().await;
+        let agent_state_before = self.runner.agent_state();
         let timer = Instant::now();
         let result = self.runner.execute(input).await;
         let duration = timer.elapsed();
+        let runner_state_after = self.runner.state().await;
+        let runner_stats_after = self.runner.stats().await;
+        let agent_state_after = self.runner.agent_state();
+        let session_snapshot = self.load_session_snapshot().await;
 
         let (output, error) = match result {
             Ok(output) => (Some(output), None),
@@ -266,9 +379,14 @@ impl AgentTestRunner {
             execution_id: self.runner.context().execution_id.clone(),
             session_id: self.runner.context().session_id.clone(),
             workspace_root: self.workspace.path().to_path_buf(),
-            runner_state: self.runner.state().await,
-            runner_stats: self.runner.stats().await,
+            runner_state_before,
+            runner_state_after,
+            runner_stats_before,
+            runner_stats_after,
+            agent_state_before,
+            agent_state_after,
             started_at,
+            session_snapshot,
         };
 
         Ok(AgentRunResult {
@@ -282,5 +400,11 @@ impl AgentTestRunner {
     pub async fn shutdown(self) -> Result<(), AgentRunnerError> {
         self.runner.shutdown().await?;
         Ok(())
+    }
+
+    async fn load_session_snapshot(&self) -> Option<Session> {
+        let session_id = self.runner.context().session_id.as_deref()?;
+        let storage = JsonlSessionStorage::new(self.workspace.path()).await.ok()?;
+        storage.load(session_id).await.ok()?
     }
 }

--- a/tests/src/agent_runner.rs
+++ b/tests/src/agent_runner.rs
@@ -19,6 +19,8 @@ use mofa_kernel::agent::AgentCapabilities;
 use mofa_kernel::agent::AgentState;
 use mofa_runtime::runner::{AgentRunner, RunnerState, RunnerStats};
 use std::collections::VecDeque;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -57,6 +59,8 @@ pub struct AgentRunMetadata {
     pub tool_calls: Vec<ToolCallRecord>,
     pub llm_last_request: Option<ChatCompletionRequest>,
     pub llm_last_response: Option<ChatCompletionResponse>,
+    pub workspace_snapshot_before: WorkspaceSnapshot,
+    pub workspace_snapshot_after: WorkspaceSnapshot,
 }
 
 /// Result of a single agent run.
@@ -76,6 +80,22 @@ pub struct ToolCallRecord {
     pub input: serde_json::Value,
     pub output: Option<serde_json::Value>,
     pub success: bool,
+    pub duration_ms: Option<u64>,
+    pub timed_out: bool,
+}
+
+/// Snapshot of files in the test workspace.
+#[derive(Debug, Clone)]
+pub struct WorkspaceSnapshot {
+    pub files: Vec<WorkspaceFileSnapshot>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkspaceFileSnapshot {
+    pub relative_path: String,
+    pub size_bytes: u64,
+    pub modified_ms: Option<u64>,
+    pub checksum: u64,
 }
 
 impl AgentRunResult {
@@ -291,12 +311,70 @@ impl TempWorkspace {
         std::fs::write(&path, content)?;
         Ok(path)
     }
+
+    fn snapshot(&self) -> WorkspaceSnapshot {
+        let mut files = Vec::new();
+        collect_workspace_files(&self.root, &self.root, &mut files);
+        files.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
+        WorkspaceSnapshot { files }
+    }
 }
 
 impl Drop for TempWorkspace {
     fn drop(&mut self) {
         let _ = std::fs::remove_dir_all(&self.root);
     }
+}
+
+fn collect_workspace_files(root: &Path, current: &Path, files: &mut Vec<WorkspaceFileSnapshot>) {
+    let entries = match std::fs::read_dir(current) {
+        Ok(entries) => entries,
+        Err(_) => return,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_workspace_files(root, &path, files);
+            continue;
+        }
+
+        let metadata = match entry.metadata() {
+            Ok(metadata) => metadata,
+            Err(_) => continue,
+        };
+
+        let size_bytes = metadata.len();
+        let modified_ms = metadata
+            .modified()
+            .ok()
+            .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|duration| duration.as_millis() as u64);
+
+        let bytes = match std::fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(_) => Vec::new(),
+        };
+        let checksum = hash_bytes(&bytes);
+        let relative_path = path
+            .strip_prefix(root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .to_string();
+
+        files.push(WorkspaceFileSnapshot {
+            relative_path,
+            size_bytes,
+            modified_ms,
+            checksum,
+        });
+    }
+}
+
+fn hash_bytes(bytes: &[u8]) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    bytes.hash(&mut hasher);
+    hasher.finish()
 }
 
 /// Test harness for running real agent execution paths.
@@ -427,6 +505,7 @@ impl AgentTestRunner {
         let runner_state_before = self.runner.state().await;
         let runner_stats_before = self.runner.stats().await;
         let agent_state_before = self.runner.agent_state();
+        let workspace_snapshot_before = self.workspace.snapshot();
         let timer = Instant::now();
         let result = self.runner.execute(input).await;
         let duration = timer.elapsed();
@@ -434,6 +513,7 @@ impl AgentTestRunner {
         let runner_stats_after = self.runner.stats().await;
         let agent_state_after = self.runner.agent_state();
         let session_snapshot = self.load_session_snapshot().await;
+        let workspace_snapshot_after = self.workspace.snapshot();
         let tool_calls = self.collect_tool_calls().await;
         let llm_last_request = self.llm.last_request().await;
         let llm_last_response = self.llm.last_response().await;
@@ -460,6 +540,8 @@ impl AgentTestRunner {
             tool_calls,
             llm_last_request,
             llm_last_response,
+            workspace_snapshot_before,
+            workspace_snapshot_after,
         };
 
         Ok(AgentRunResult {
@@ -488,15 +570,33 @@ impl AgentTestRunner {
             let results = tool.results().await;
             for (idx, call) in calls.into_iter().enumerate() {
                 let result = results.get(idx).cloned();
-                let (output, success) = match result {
-                    Some(result) => (Some(result.output.clone()), result.success),
-                    None => (None, false),
+                let (output, success, duration_ms, timed_out) = match result {
+                    Some(result) => {
+                        let duration_ms = result
+                            .metadata
+                            .get("duration_ms")
+                            .and_then(|value| value.parse::<u64>().ok());
+                        let timed_out = result
+                            .error
+                            .as_ref()
+                            .map(|err| err.contains("timed out"))
+                            .unwrap_or(false);
+                        (
+                            Some(result.output.clone()),
+                            result.success,
+                            duration_ms,
+                            timed_out,
+                        )
+                    }
+                    None => (None, false, None, false),
                 };
                 records.push(ToolCallRecord {
                     tool_name: tool.name().to_string(),
                     input: call.arguments,
                     output,
                     success,
+                    duration_ms,
+                    timed_out,
                 });
             }
         }

--- a/tests/src/agent_runner.rs
+++ b/tests/src/agent_runner.rs
@@ -361,7 +361,7 @@ fn collect_workspace_files(root: &Path, current: &Path, files: &mut Vec<Workspac
             .strip_prefix(root)
             .unwrap_or(&path)
             .to_string_lossy()
-            .to_string();
+            .replace('\\', "/");
 
         files.push(WorkspaceFileSnapshot {
             relative_path,

--- a/tests/src/agent_runner.rs
+++ b/tests/src/agent_runner.rs
@@ -11,6 +11,7 @@ use mofa_kernel::agent::context::AgentContext;
 use mofa_kernel::agent::core::MoFAAgent;
 use mofa_kernel::agent::error::{AgentError, AgentResult};
 use mofa_foundation::agent::components::tool::as_tool;
+use mofa_foundation::agent::components::tool::SimpleTool;
 use mofa_foundation::agent::session::{JsonlSessionStorage, Session, SessionStorage};
 use crate::tools::MockTool;
 use mofa_kernel::agent::types::{AgentInput, AgentOutput, ChatCompletionRequest};
@@ -484,6 +485,19 @@ impl AgentTestRunner {
 
     pub async fn run_text(&mut self, input: &str) -> Result<AgentRunResult, AgentRunnerError> {
         self.run_input(AgentInput::text(input)).await
+    }
+
+    pub async fn run_text_with_session(
+        &mut self,
+        session_id: &str,
+        input: &str,
+    ) -> Result<AgentRunResult, AgentRunnerError> {
+        let original_session = self.runner.context().session_id.clone();
+        self.runner
+            .set_session_id(Some(session_id.to_string()));
+        let result = self.run_text(input).await;
+        self.runner.set_session_id(original_session);
+        result
     }
 
     pub async fn run_texts(

--- a/tests/src/agent_runner.rs
+++ b/tests/src/agent_runner.rs
@@ -1,0 +1,286 @@
+//! Real agent runner harness for integration-style tests.
+//!
+//! Provides a lightweight wrapper around the MoFA runtime `AgentRunner`
+//! with an isolated workspace and deterministic mock LLM.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use mofa_foundation::agent::executor::{AgentExecutor, AgentExecutorConfig};
+use mofa_kernel::agent::context::AgentContext;
+use mofa_kernel::agent::core::MoFAAgent;
+use mofa_kernel::agent::error::{AgentError, AgentResult};
+use mofa_kernel::agent::types::{AgentInput, AgentOutput, ChatCompletionRequest};
+use mofa_kernel::agent::types::{ChatCompletionResponse, ToolCall};
+use mofa_kernel::agent::AgentCapabilities;
+use mofa_runtime::runner::{AgentRunner, RunnerState, RunnerStats};
+use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use thiserror::Error;
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+/// Errors returned by the agent runner harness itself.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum AgentRunnerError {
+    #[error("failed to create test workspace: {0}")]
+    WorkspaceIo(#[from] std::io::Error),
+
+    #[error("agent runner failure: {0}")]
+    Agent(#[from] AgentError),
+}
+
+/// Metadata captured for each run.
+#[derive(Debug, Clone)]
+pub struct AgentRunMetadata {
+    pub agent_id: String,
+    pub agent_name: String,
+    pub execution_id: String,
+    pub session_id: Option<String>,
+    pub workspace_root: PathBuf,
+    pub runner_state: RunnerState,
+    pub runner_stats: RunnerStats,
+    pub started_at: DateTime<Utc>,
+}
+
+/// Result of a single agent run.
+#[derive(Debug)]
+pub struct AgentRunResult {
+    pub output: Option<AgentOutput>,
+    pub error: Option<AgentError>,
+    pub duration: Duration,
+    pub metadata: AgentRunMetadata,
+}
+
+impl AgentRunResult {
+    pub fn is_success(&self) -> bool {
+        self.error.is_none()
+    }
+
+    pub fn output_text(&self) -> Option<String> {
+        self.output.as_ref().map(AgentOutput::to_text)
+    }
+}
+
+/// Simple deterministic LLM provider for tests.
+#[derive(Debug)]
+pub struct MockAgentLLMProvider {
+    name: String,
+    responses: RwLock<VecDeque<String>>,
+    default_response: RwLock<String>,
+}
+
+impl MockAgentLLMProvider {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            responses: RwLock::new(VecDeque::new()),
+            default_response: RwLock::new("This is a mock response.".to_string()),
+        }
+    }
+
+    pub async fn add_response(&self, response: impl Into<String>) {
+        self.responses.write().await.push_back(response.into());
+    }
+
+    pub async fn set_default_response(&self, response: impl Into<String>) {
+        *self.default_response.write().await = response.into();
+    }
+
+    pub async fn pending_responses(&self) -> usize {
+        self.responses.read().await.len()
+    }
+}
+
+#[async_trait]
+impl mofa_kernel::agent::types::LLMProvider for MockAgentLLMProvider {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    async fn chat(
+        &self,
+        _request: ChatCompletionRequest,
+    ) -> AgentResult<ChatCompletionResponse> {
+        let response = {
+            let mut responses = self.responses.write().await;
+            if let Some(next) = responses.pop_front() {
+                next
+            } else {
+                self.default_response.read().await.clone()
+            }
+        };
+
+        Ok(ChatCompletionResponse {
+            content: Some(response),
+            tool_calls: Some(Vec::<ToolCall>::new()),
+            usage: None,
+        })
+    }
+}
+
+struct SessionAwareExecutor {
+    executor: AgentExecutor,
+}
+
+impl SessionAwareExecutor {
+    fn new(executor: AgentExecutor) -> Self {
+        Self { executor }
+    }
+}
+
+#[async_trait]
+impl MoFAAgent for SessionAwareExecutor {
+    fn id(&self) -> &str {
+        self.executor.id()
+    }
+
+    fn name(&self) -> &str {
+        self.executor.name()
+    }
+
+    fn capabilities(&self) -> &AgentCapabilities {
+        self.executor.capabilities()
+    }
+
+    fn state(&self) -> mofa_kernel::agent::AgentState {
+        self.executor.state()
+    }
+
+    async fn initialize(&mut self, ctx: &AgentContext) -> AgentResult<()> {
+        self.executor.initialize(ctx).await
+    }
+
+    async fn execute(
+        &mut self,
+        input: AgentInput,
+        ctx: &AgentContext,
+    ) -> AgentResult<AgentOutput> {
+        let message = input.as_text().unwrap_or("");
+        let session_key = ctx.session_id.as_deref().unwrap_or("default");
+        let response = self.executor.process_message(session_key, message).await?;
+        Ok(AgentOutput::text(response))
+    }
+
+    async fn shutdown(&mut self) -> AgentResult<()> {
+        self.executor.shutdown().await
+    }
+}
+
+struct TempWorkspace {
+    root: PathBuf,
+}
+
+impl TempWorkspace {
+    fn new(prefix: &str) -> Result<Self, AgentRunnerError> {
+        let root = std::env::temp_dir().join(format!("{}-{}", prefix, Uuid::now_v7()));
+        std::fs::create_dir_all(&root)?;
+        Ok(Self { root })
+    }
+
+    fn path(&self) -> &Path {
+        &self.root
+    }
+}
+
+impl Drop for TempWorkspace {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+/// Test harness for running real agent execution paths.
+pub struct AgentTestRunner {
+    workspace: TempWorkspace,
+    session_id: String,
+    execution_id: String,
+    llm: Arc<MockAgentLLMProvider>,
+    runner: AgentRunner<SessionAwareExecutor>,
+}
+
+impl AgentTestRunner {
+    pub async fn new() -> Result<Self, AgentRunnerError> {
+        Self::with_config(AgentExecutorConfig::default()).await
+    }
+
+    pub async fn with_config(config: AgentExecutorConfig) -> Result<Self, AgentRunnerError> {
+        let workspace = TempWorkspace::new("mofa-agent-test")?;
+        let llm = Arc::new(MockAgentLLMProvider::new("mock-llm"));
+        let executor = AgentExecutor::with_config(llm.clone(), workspace.path(), config).await?;
+        let agent = SessionAwareExecutor::new(executor);
+
+        let execution_id = Uuid::now_v7().to_string();
+        let session_id = Uuid::now_v7().to_string();
+        let context = AgentContext::with_session(&execution_id, &session_id);
+
+        let runner = AgentRunner::with_context(agent, context).await?;
+
+        Ok(Self {
+            workspace,
+            session_id,
+            execution_id,
+            llm,
+            runner,
+        })
+    }
+
+    pub fn workspace(&self) -> &Path {
+        self.workspace.path()
+    }
+
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    pub fn execution_id(&self) -> &str {
+        &self.execution_id
+    }
+
+    pub fn mock_llm(&self) -> Arc<MockAgentLLMProvider> {
+        Arc::clone(&self.llm)
+    }
+
+    pub async fn run_text(&mut self, input: &str) -> Result<AgentRunResult, AgentRunnerError> {
+        self.run_input(AgentInput::text(input)).await
+    }
+
+    pub async fn run_input(
+        &mut self,
+        input: AgentInput,
+    ) -> Result<AgentRunResult, AgentRunnerError> {
+        let started_at = Utc::now();
+        let timer = Instant::now();
+        let result = self.runner.execute(input).await;
+        let duration = timer.elapsed();
+
+        let (output, error) = match result {
+            Ok(output) => (Some(output), None),
+            Err(err) => (None, Some(err)),
+        };
+
+        let metadata = AgentRunMetadata {
+            agent_id: self.runner.agent().id().to_string(),
+            agent_name: self.runner.agent().name().to_string(),
+            execution_id: self.runner.context().execution_id.clone(),
+            session_id: self.runner.context().session_id.clone(),
+            workspace_root: self.workspace.path().to_path_buf(),
+            runner_state: self.runner.state().await,
+            runner_stats: self.runner.stats().await,
+            started_at,
+        };
+
+        Ok(AgentRunResult {
+            output,
+            error,
+            duration,
+            metadata,
+        })
+    }
+
+    pub async fn shutdown(self) -> Result<(), AgentRunnerError> {
+        self.runner.shutdown().await?;
+        Ok(())
+    }
+}

--- a/tests/src/assertions.rs
+++ b/tests/src/assertions.rs
@@ -112,3 +112,145 @@ pub fn assert_session_messages(
         );
     }
 }
+
+/// Assert the most recent tool result matches the expected JSON output.
+///
+/// # Example
+/// ```ignore
+/// assert_tool_last_result!(tool, json!("done"));
+/// ```
+#[macro_export]
+macro_rules! assert_tool_last_result {
+    ($tool:expr, $expected:expr) => {{
+        let result = $tool
+            .last_result()
+            .await
+            .expect("Expected tool to have a result, but it was never executed");
+        let expected = $expected;
+        assert_eq!(
+            result.output, expected,
+            "Expected latest tool result {:?}, got {:?}",
+            expected, result.output
+        );
+    }};
+}
+
+/// Assert the agent run produced the expected output text.
+///
+/// # Example
+/// ```ignore
+/// assert_agent_output_text!(result, "hello");
+/// ```
+#[macro_export]
+macro_rules! assert_agent_output_text {
+    ($result:expr, $expected:expr) => {{
+        let expected = $expected;
+        let actual = $result.output_text();
+        assert_eq!(
+            actual.as_deref(),
+            Some(expected),
+            "Expected agent output {:?}, got {:?}",
+            expected,
+            actual
+        );
+    }};
+}
+
+/// Assert the agent run failed with an error containing the given substring.
+///
+/// # Example
+/// ```ignore
+/// assert_run_failed_with!(result, "timeout");
+/// ```
+#[macro_export]
+macro_rules! assert_run_failed_with {
+    ($result:expr, $pattern:expr) => {{
+        let pattern = $pattern;
+        let error = $result
+            .error
+            .as_ref()
+            .expect("Expected run to fail, but it succeeded");
+        let message = error.to_string();
+        assert!(
+            message.contains(pattern),
+            "Expected error containing {:?}, got {:?}",
+            pattern,
+            message
+        );
+    }};
+}
+
+/// Assert the workspace snapshot contains a file with the given relative path.
+///
+/// # Example
+/// ```ignore
+/// assert_workspace_contains_file!(snapshot, "sessions/demo.jsonl");
+/// ```
+#[macro_export]
+macro_rules! assert_workspace_contains_file {
+    ($snapshot:expr, $relative_path:expr) => {{
+        let relative_path = $relative_path;
+        let found = $snapshot
+            .files
+            .iter()
+            .any(|file| file.relative_path == relative_path);
+        assert!(
+            found,
+            "Expected workspace snapshot to contain {:?}, found paths: {:?}",
+            relative_path,
+            $snapshot
+                .files
+                .iter()
+                .map(|file| file.relative_path.as_str())
+                .collect::<Vec<_>>()
+        );
+    }};
+}
+
+/// Assert the run metadata captured a tool call with the given tool name.
+///
+/// # Example
+/// ```ignore
+/// assert_run_recorded_tool_call!(result, "echo_tool");
+/// ```
+#[macro_export]
+macro_rules! assert_run_recorded_tool_call {
+    ($result:expr, $tool_name:expr) => {{
+        let tool_name = $tool_name;
+        let found = $result
+            .metadata
+            .tool_calls
+            .iter()
+            .any(|record| record.tool_name == tool_name);
+        assert!(
+            found,
+            "Expected run metadata to contain tool call {:?}, found tool calls: {:?}",
+            tool_name,
+            $result
+                .metadata
+                .tool_calls
+                .iter()
+                .map(|record| record.tool_name.as_str())
+                .collect::<Vec<_>>()
+        );
+    }};
+}
+
+/// Assert the runner total execution count after a run matches the expected value.
+///
+/// # Example
+/// ```ignore
+/// assert_runner_total_executions!(result, 1);
+/// ```
+#[macro_export]
+macro_rules! assert_runner_total_executions {
+    ($result:expr, $expected:expr) => {{
+        let expected = $expected;
+        let actual = $result.metadata.runner_stats_after.total_executions;
+        assert_eq!(
+            actual, expected,
+            "Expected runner total executions {}, got {}",
+            expected, actual
+        );
+    }};
+}

--- a/tests/src/assertions.rs
+++ b/tests/src/assertions.rs
@@ -84,3 +84,31 @@ macro_rules! assert_bus_message_sent {
         );
     }};
 }
+
+/// Assert a session's messages match the expected (role, content) pairs.
+pub fn assert_session_messages(
+    session: &mofa_foundation::agent::session::Session,
+    expected: &[(&str, &str)],
+) {
+    assert_eq!(
+        session.messages.len(),
+        expected.len(),
+        "Expected {} session messages, got {}",
+        expected.len(),
+        session.messages.len()
+    );
+
+    for (idx, (role, content)) in expected.iter().enumerate() {
+        let msg = &session.messages[idx];
+        assert_eq!(
+            msg.role, *role,
+            "Expected role '{}' at index {}, got '{}'",
+            role, idx, msg.role
+        );
+        assert_eq!(
+            msg.content, *content,
+            "Expected content '{}' at index {}, got '{}'",
+            content, idx, msg.content
+        );
+    }
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -17,7 +17,7 @@ pub use bus::MockAgentBus;
 pub use clock::{Clock, MockClock, SystemClock};
 pub use agent_runner::{
     AgentRunMetadata, AgentRunResult, AgentRunnerError, AgentTestRunner, MockAgentLLMProvider,
-    ToolCallRecord,
+    ToolCallRecord, WorkspaceFileSnapshot, WorkspaceSnapshot,
 };
 pub use report::{
     JsonFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -17,6 +17,7 @@ pub use bus::MockAgentBus;
 pub use clock::{Clock, MockClock, SystemClock};
 pub use agent_runner::{
     AgentRunMetadata, AgentRunResult, AgentRunnerError, AgentTestRunner, MockAgentLLMProvider,
+    ToolCallRecord,
 };
 pub use report::{
     JsonFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -4,6 +4,7 @@
 //! control for testing MoFA agents.
 
 pub mod adversarial;
+pub mod agent_runner;
 pub mod assertions;
 pub mod backend;
 pub mod bus;
@@ -14,6 +15,9 @@ pub mod tools;
 pub use backend::MockLLMBackend;
 pub use bus::MockAgentBus;
 pub use clock::{Clock, MockClock, SystemClock};
+pub use agent_runner::{
+    AgentRunMetadata, AgentRunResult, AgentRunnerError, AgentTestRunner, MockAgentLLMProvider,
+};
 pub use report::{
     JsonFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,
     TextFormatter,

--- a/tests/src/tools.rs
+++ b/tests/src/tools.rs
@@ -20,6 +20,7 @@ pub struct MockTool {
     category: ToolCategory,
     pub stubbed_result: Arc<RwLock<ToolResult>>,
     pub call_history: Arc<RwLock<Vec<ToolInput>>>,
+    pub result_history: Arc<RwLock<Vec<ToolResult>>>,
     failure_queue: Arc<RwLock<VecDeque<String>>>,
     failure_patterns: Arc<RwLock<Vec<(Value, String)>>>,
     result_sequence: Arc<RwLock<VecDeque<ToolResult>>>,
@@ -37,6 +38,7 @@ impl MockTool {
                 "Mock execution default",
             ))),
             call_history: Arc::new(RwLock::new(Vec::new())),
+            result_history: Arc::new(RwLock::new(Vec::new())),
             failure_queue: Arc::new(RwLock::new(VecDeque::new())),
             failure_patterns: Arc::new(RwLock::new(Vec::new())),
             result_sequence: Arc::new(RwLock::new(VecDeque::new())),
@@ -56,6 +58,16 @@ impl MockTool {
     /// Number of times this tool has been executed.
     pub async fn call_count(&self) -> usize {
         self.call_history.read().await.len()
+    }
+
+    /// Retrieve a clone of the full result history.
+    pub async fn results(&self) -> Vec<ToolResult> {
+        self.result_history.read().await.clone()
+    }
+
+    /// Returns the most recent result, or `None` if never executed.
+    pub async fn last_result(&self) -> Option<ToolResult> {
+        self.result_history.read().await.last().cloned()
     }
 
     /// Queue failures for the next N calls.
@@ -115,7 +127,9 @@ impl SimpleTool for MockTool {
         {
             let mut queue = self.failure_queue.write().await;
             if let Some(err) = queue.pop_front() {
-                return ToolResult::failure(err);
+                let result = ToolResult::failure(err);
+                self.result_history.write().await.push(result.clone());
+                return result;
             }
         }
 
@@ -124,7 +138,9 @@ impl SimpleTool for MockTool {
             let patterns = self.failure_patterns.read().await;
             for (pattern, err) in patterns.iter() {
                 if input.arguments == *pattern {
-                    return ToolResult::failure(err);
+                    let result = ToolResult::failure(err);
+                    self.result_history.write().await.push(result.clone());
+                    return result;
                 }
             }
         }
@@ -133,11 +149,14 @@ impl SimpleTool for MockTool {
         {
             let mut seq = self.result_sequence.write().await;
             if let Some(result) = seq.pop_front() {
+                self.result_history.write().await.push(result.clone());
                 return result;
             }
         }
 
-        self.stubbed_result.read().await.clone()
+        let result = self.stubbed_result.read().await.clone();
+        self.result_history.write().await.push(result.clone());
+        result
     }
 
     fn category(&self) -> ToolCategory {

--- a/tests/src/tools.rs
+++ b/tests/src/tools.rs
@@ -122,12 +122,16 @@ impl SimpleTool for MockTool {
 
     async fn execute(&self, input: ToolInput) -> ToolResult {
         self.call_history.write().await.push(input.clone());
+        let start = std::time::Instant::now();
 
         // 1. Drain failure queue
         {
             let mut queue = self.failure_queue.write().await;
             if let Some(err) = queue.pop_front() {
-                let result = ToolResult::failure(err);
+                let mut result = ToolResult::failure(err);
+                result
+                    .metadata
+                    .insert("duration_ms".to_string(), start.elapsed().as_millis().to_string());
                 self.result_history.write().await.push(result.clone());
                 return result;
             }
@@ -138,7 +142,10 @@ impl SimpleTool for MockTool {
             let patterns = self.failure_patterns.read().await;
             for (pattern, err) in patterns.iter() {
                 if input.arguments == *pattern {
-                    let result = ToolResult::failure(err);
+                    let mut result = ToolResult::failure(err);
+                    result
+                        .metadata
+                        .insert("duration_ms".to_string(), start.elapsed().as_millis().to_string());
                     self.result_history.write().await.push(result.clone());
                     return result;
                 }
@@ -149,12 +156,19 @@ impl SimpleTool for MockTool {
         {
             let mut seq = self.result_sequence.write().await;
             if let Some(result) = seq.pop_front() {
+                let mut result = result;
+                result
+                    .metadata
+                    .insert("duration_ms".to_string(), start.elapsed().as_millis().to_string());
                 self.result_history.write().await.push(result.clone());
                 return result;
             }
         }
 
-        let result = self.stubbed_result.read().await.clone();
+        let mut result = self.stubbed_result.read().await.clone();
+        result
+            .metadata
+            .insert("duration_ms".to_string(), start.elapsed().as_millis().to_string());
         self.result_history.write().await.push(result.clone());
         result
     }

--- a/tests/tests/agent_runner_tests.rs
+++ b/tests/tests/agent_runner_tests.rs
@@ -1,0 +1,66 @@
+use mofa_testing::agent_runner::AgentTestRunner;
+
+#[tokio::test]
+async fn agent_runner_executes_and_captures_output() {
+    let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+    runner
+        .mock_llm()
+        .add_response("Mocked response")
+        .await;
+
+    let result = runner
+        .run_text("hello")
+        .await
+        .expect("run should succeed");
+
+    assert!(result.is_success());
+    assert_eq!(result.output_text().as_deref(), Some("Mocked response"));
+    assert_eq!(
+        result.metadata.session_id.as_deref(),
+        Some(runner.session_id())
+    );
+    assert_eq!(result.metadata.execution_id, runner.execution_id());
+
+    runner.shutdown().await.expect("shutdown succeeds");
+}
+
+#[tokio::test]
+async fn agent_runner_creates_isolated_workspaces() {
+    let mut runner_a = AgentTestRunner::new().await.expect("runner A initializes");
+    let mut runner_b = AgentTestRunner::new().await.expect("runner B initializes");
+
+    assert_ne!(runner_a.workspace(), runner_b.workspace());
+
+    runner_a
+        .mock_llm()
+        .add_response("Response A")
+        .await;
+    runner_b
+        .mock_llm()
+        .add_response("Response B")
+        .await;
+
+    let _ = runner_a
+        .run_text("hi")
+        .await
+        .expect("runner A executes");
+    let _ = runner_b
+        .run_text("hi")
+        .await
+        .expect("runner B executes");
+
+    let session_a = runner_a
+        .workspace()
+        .join("sessions")
+        .join(format!("{}.jsonl", runner_a.session_id()));
+    let session_b = runner_b
+        .workspace()
+        .join("sessions")
+        .join(format!("{}.jsonl", runner_b.session_id()));
+
+    assert!(session_a.exists());
+    assert!(session_b.exists());
+
+    runner_a.shutdown().await.expect("shutdown A");
+    runner_b.shutdown().await.expect("shutdown B");
+}

--- a/tests/tests/agent_runner_tests.rs
+++ b/tests/tests/agent_runner_tests.rs
@@ -1,4 +1,5 @@
 use mofa_testing::agent_runner::AgentTestRunner;
+use mofa_testing::assertions::assert_session_messages;
 use mofa_testing::tools::MockTool;
 use serde_json::json;
 
@@ -27,6 +28,25 @@ async fn agent_runner_executes_and_captures_output() {
     assert!(result.metadata.session_snapshot.is_some());
     let snapshot = result.metadata.session_snapshot.as_ref().unwrap();
     assert_eq!(snapshot.len(), 2);
+    assert_session_messages(snapshot, &[("user", "hello"), ("assistant", "Mocked response")]);
+
+    let expected_session_path = format!("sessions/{}.jsonl", runner.session_id());
+    assert!(
+        !result
+            .metadata
+            .workspace_snapshot_before
+            .files
+            .iter()
+            .any(|file| file.relative_path == expected_session_path)
+    );
+    assert!(
+        result
+            .metadata
+            .workspace_snapshot_after
+            .files
+            .iter()
+            .any(|file| file.relative_path == expected_session_path)
+    );
 
     runner.shutdown().await.expect("shutdown succeeds");
 }
@@ -56,6 +76,7 @@ async fn agent_runner_creates_isolated_workspaces() {
         .await
         .expect("runner B executes");
 
+    // Session files should exist in each separate workspace.
     let session_a = runner_a
         .workspace()
         .join("sessions")
@@ -93,6 +114,7 @@ async fn agent_runner_executes_tool_calls() {
         .await
         .expect("tool registered");
 
+    // First response triggers a tool call; second response is the final answer.
     runner
         .mock_llm()
         .add_tool_call_response("echo_tool", json!({ "input": "ping" }), None)
@@ -107,6 +129,7 @@ async fn agent_runner_executes_tool_calls() {
         .await
         .expect("run should succeed");
 
+    // Tool call should be captured in both tool history and run metadata.
     assert_eq!(result.output_text().as_deref(), Some("Final response"));
     assert_eq!(tool.call_count().await, 1);
     let last_call = tool.last_call().await.expect("tool call captured");
@@ -120,6 +143,7 @@ async fn agent_runner_executes_tool_calls() {
         record.output,
         Some(json!("Mock execution default"))
     );
+    assert!(record.duration_ms.is_some());
 
     runner.shutdown().await.expect("shutdown succeeds");
 }
@@ -146,6 +170,7 @@ async fn agent_runner_loads_bootstrap_files() {
         .last_request()
         .await
         .expect("request captured");
+    // Validate the system message includes the bootstrap content.
     let system_message = request
         .messages
         .first()
@@ -160,6 +185,7 @@ async fn agent_runner_loads_bootstrap_files() {
 
 #[tokio::test]
 async fn agent_runner_supports_multi_turn_runs() {
+    // Multi-turn helper should keep the same session and extend history.
     let mut runner = AgentTestRunner::new().await.expect("runner initializes");
     runner.mock_llm().add_response("First reply").await;
     runner.mock_llm().add_response("Second reply").await;
@@ -173,17 +199,28 @@ async fn agent_runner_supports_multi_turn_runs() {
     assert_eq!(results[0].output_text().as_deref(), Some("First reply"));
     assert_eq!(results[1].output_text().as_deref(), Some("Second reply"));
 
+    // Session snapshot should contain two user/assistant pairs.
     let snapshot = results
         .last()
         .and_then(|result| result.metadata.session_snapshot.as_ref())
         .expect("session snapshot captured");
     assert_eq!(snapshot.len(), 4);
+    assert_session_messages(
+        snapshot,
+        &[
+            ("user", "turn one"),
+            ("assistant", "First reply"),
+            ("user", "turn two"),
+            ("assistant", "Second reply"),
+        ],
+    );
 
     runner.shutdown().await.expect("shutdown succeeds");
 }
 
 #[tokio::test]
 async fn agent_runner_customizes_prompt_identity_and_bootstraps() {
+    // Custom identity + bootstrap list should appear in the system prompt.
     let mut runner = AgentTestRunner::new().await.expect("runner initializes");
     runner
         .write_bootstrap_file("CUSTOM.md", "Custom bootstrap content.")
@@ -210,6 +247,7 @@ async fn agent_runner_customizes_prompt_identity_and_bootstraps() {
         .last_request()
         .await
         .expect("request captured");
+    // Validate custom identity and bootstrap content.
     let system_message = request
         .messages
         .first()
@@ -226,6 +264,7 @@ async fn agent_runner_customizes_prompt_identity_and_bootstraps() {
 
 #[tokio::test]
 async fn agent_runner_captures_llm_failure() {
+    // LLM failures should surface in AgentRunResult with failed stats.
     let mut runner = AgentTestRunner::new().await.expect("runner initializes");
     runner
         .mock_llm()

--- a/tests/tests/agent_runner_tests.rs
+++ b/tests/tests/agent_runner_tests.rs
@@ -1,4 +1,6 @@
 use mofa_testing::agent_runner::AgentTestRunner;
+use mofa_testing::tools::MockTool;
+use serde_json::json;
 
 #[tokio::test]
 async fn agent_runner_executes_and_captures_output() {
@@ -20,6 +22,11 @@ async fn agent_runner_executes_and_captures_output() {
         Some(runner.session_id())
     );
     assert_eq!(result.metadata.execution_id, runner.execution_id());
+    assert_eq!(result.metadata.runner_stats_before.total_executions, 0);
+    assert_eq!(result.metadata.runner_stats_after.total_executions, 1);
+    assert!(result.metadata.session_snapshot.is_some());
+    let snapshot = result.metadata.session_snapshot.as_ref().unwrap();
+    assert_eq!(snapshot.len(), 2);
 
     runner.shutdown().await.expect("shutdown succeeds");
 }
@@ -63,4 +70,102 @@ async fn agent_runner_creates_isolated_workspaces() {
 
     runner_a.shutdown().await.expect("shutdown A");
     runner_b.shutdown().await.expect("shutdown B");
+}
+
+#[tokio::test]
+async fn agent_runner_executes_tool_calls() {
+    let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+
+    let tool = MockTool::new(
+        "echo_tool",
+        "Echo the provided input",
+        json!({
+            "type": "object",
+            "properties": {
+                "input": { "type": "string" }
+            },
+            "required": ["input"]
+        }),
+    );
+
+    runner
+        .register_simple_tool(tool.clone())
+        .await
+        .expect("tool registered");
+
+    runner
+        .mock_llm()
+        .add_tool_call_response("echo_tool", json!({ "input": "ping" }), None)
+        .await;
+    runner
+        .mock_llm()
+        .add_response("Final response")
+        .await;
+
+    let result = runner
+        .run_text("use tool")
+        .await
+        .expect("run should succeed");
+
+    assert_eq!(result.output_text().as_deref(), Some("Final response"));
+    assert_eq!(tool.call_count().await, 1);
+    let last_call = tool.last_call().await.expect("tool call captured");
+    assert_eq!(last_call.arguments, json!({ "input": "ping" }));
+
+    runner.shutdown().await.expect("shutdown succeeds");
+}
+
+#[tokio::test]
+async fn agent_runner_loads_bootstrap_files() {
+    let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+    runner
+        .write_bootstrap_file("AGENTS.md", "Bootstrap content for agent test.")
+        .expect("bootstrap file written");
+
+    runner
+        .mock_llm()
+        .add_response("Bootstrapped response")
+        .await;
+
+    let _ = runner
+        .run_text("check prompt")
+        .await
+        .expect("run should succeed");
+
+    let request = runner
+        .mock_llm()
+        .last_request()
+        .await
+        .expect("request captured");
+    let system_message = request
+        .messages
+        .first()
+        .and_then(|msg| msg.content.as_deref())
+        .expect("system message content");
+
+    assert!(system_message.contains("AGENTS.md"));
+    assert!(system_message.contains("Bootstrap content for agent test."));
+
+    runner.shutdown().await.expect("shutdown succeeds");
+}
+
+#[tokio::test]
+async fn agent_runner_captures_llm_failure() {
+    let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+    runner
+        .mock_llm()
+        .add_error_response("mock failure")
+        .await;
+
+    let result = runner
+        .run_text("trigger failure")
+        .await
+        .expect("run should return result");
+
+    assert!(!result.is_success());
+    let error = result.error.expect("error captured");
+    assert!(error.to_string().contains("mock failure"));
+    assert_eq!(result.metadata.runner_stats_after.failed_executions, 1);
+
+    runner.shutdown().await.expect("shutdown succeeds");
 }

--- a/tests/tests/agent_runner_tests.rs
+++ b/tests/tests/agent_runner_tests.rs
@@ -89,7 +89,7 @@ async fn agent_runner_executes_tool_calls() {
     );
 
     runner
-        .register_simple_tool(tool.clone())
+        .register_mock_tool(tool.clone())
         .await
         .expect("tool registered");
 
@@ -111,6 +111,15 @@ async fn agent_runner_executes_tool_calls() {
     assert_eq!(tool.call_count().await, 1);
     let last_call = tool.last_call().await.expect("tool call captured");
     assert_eq!(last_call.arguments, json!({ "input": "ping" }));
+    assert_eq!(result.metadata.tool_calls.len(), 1);
+    let record = &result.metadata.tool_calls[0];
+    assert_eq!(record.tool_name, "echo_tool");
+    assert_eq!(record.input, json!({ "input": "ping" }));
+    assert!(record.success);
+    assert_eq!(
+        record.output,
+        Some(json!("Mock execution default"))
+    );
 
     runner.shutdown().await.expect("shutdown succeeds");
 }
@@ -145,6 +154,72 @@ async fn agent_runner_loads_bootstrap_files() {
 
     assert!(system_message.contains("AGENTS.md"));
     assert!(system_message.contains("Bootstrap content for agent test."));
+
+    runner.shutdown().await.expect("shutdown succeeds");
+}
+
+#[tokio::test]
+async fn agent_runner_supports_multi_turn_runs() {
+    let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+    runner.mock_llm().add_response("First reply").await;
+    runner.mock_llm().add_response("Second reply").await;
+
+    let results = runner
+        .run_texts(&["turn one", "turn two"])
+        .await
+        .expect("multi-turn run succeeds");
+
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0].output_text().as_deref(), Some("First reply"));
+    assert_eq!(results[1].output_text().as_deref(), Some("Second reply"));
+
+    let snapshot = results
+        .last()
+        .and_then(|result| result.metadata.session_snapshot.as_ref())
+        .expect("session snapshot captured");
+    assert_eq!(snapshot.len(), 4);
+
+    runner.shutdown().await.expect("shutdown succeeds");
+}
+
+#[tokio::test]
+async fn agent_runner_customizes_prompt_identity_and_bootstraps() {
+    let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+    runner
+        .write_bootstrap_file("CUSTOM.md", "Custom bootstrap content.")
+        .expect("bootstrap file written");
+    runner
+        .configure_prompt(
+            Some(mofa_foundation::agent::context::prompt::AgentIdentity {
+                name: "TestAgent".to_string(),
+                description: "Custom identity".to_string(),
+                icon: None,
+            }),
+            Some(vec!["CUSTOM.md".to_string()]),
+        )
+        .await;
+
+    runner.mock_llm().add_response("Custom response").await;
+    let _ = runner
+        .run_text("custom prompt")
+        .await
+        .expect("run should succeed");
+
+    let request = runner
+        .mock_llm()
+        .last_request()
+        .await
+        .expect("request captured");
+    let system_message = request
+        .messages
+        .first()
+        .and_then(|msg| msg.content.as_deref())
+        .expect("system message content");
+
+    assert!(system_message.contains("TestAgent"));
+    assert!(system_message.contains("Custom identity"));
+    assert!(system_message.contains("CUSTOM.md"));
+    assert!(system_message.contains("Custom bootstrap content."));
 
     runner.shutdown().await.expect("shutdown succeeds");
 }

--- a/tests/tests/agent_runner_tests.rs
+++ b/tests/tests/agent_runner_tests.rs
@@ -283,3 +283,29 @@ async fn agent_runner_captures_llm_failure() {
 
     runner.shutdown().await.expect("shutdown succeeds");
 }
+
+#[tokio::test]
+async fn agent_runner_allows_custom_session_keys() {
+    let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+    runner
+        .mock_llm()
+        .add_response("Custom session response")
+        .await;
+
+    let result = runner
+        .run_text_with_session("custom-session", "hello session")
+        .await
+        .expect("run should succeed");
+
+    assert_eq!(
+        result.metadata.session_id.as_deref(),
+        Some("custom-session")
+    );
+    let session_path = runner
+        .workspace()
+        .join("sessions")
+        .join("custom-session.jsonl");
+    assert!(session_path.exists());
+
+    runner.shutdown().await.expect("shutdown succeeds");
+}

--- a/tests/tests/assertion_macro_tests.rs
+++ b/tests/tests/assertion_macro_tests.rs
@@ -1,11 +1,11 @@
-//! Tests for assertion macros: assert_tool_called!, assert_tool_called_with!,
-//! assert_infer_called!, assert_bus_message_sent!.
+//! Tests for assertion macros and assertion helpers used by the testing crate.
 
 use mofa_foundation::agent::components::tool::SimpleTool;
 use mofa_foundation::orchestrator::{ModelOrchestrator, ModelProviderConfig, ModelType};
 use mofa_kernel::agent::components::tool::ToolInput;
 use mofa_kernel::bus::CommunicationMode;
 use mofa_kernel::message::AgentMessage;
+use mofa_testing::agent_runner::AgentTestRunner;
 use mofa_testing::backend::MockLLMBackend;
 use mofa_testing::bus::MockAgentBus;
 use mofa_testing::tools::MockTool;
@@ -120,4 +120,90 @@ async fn assert_bus_message_sent_panics_when_no_message_from_sender() {
         .await;
 
     mofa_testing::assert_bus_message_sent!(bus, "agent-2");
+}
+
+// ===================================================================
+// New assertion helpers
+// ===================================================================
+
+#[tokio::test]
+async fn assert_tool_last_result_passes_on_matching_output() {
+    let tool = MockTool::new("search", "Search tool", json!({"type": "object"}));
+    tool.execute(ToolInput::from_json(json!({"query": "rust"})))
+        .await;
+
+    mofa_testing::assert_tool_last_result!(tool, json!("Mock execution default"));
+}
+
+#[tokio::test]
+async fn assert_agent_output_text_passes_on_matching_output() {
+    let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+    runner.mock_llm().add_response("hello from runner").await;
+
+    let result = runner.run_text("hello").await.expect("run succeeds");
+
+    mofa_testing::assert_agent_output_text!(result, "hello from runner");
+    runner.shutdown().await.expect("shutdown succeeds");
+}
+
+#[tokio::test]
+async fn assert_run_failed_with_passes_on_matching_error() {
+    let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+    runner.mock_llm().add_error_response("mock failure").await;
+
+    let result = runner.run_text("hello").await.expect("run completes");
+
+    mofa_testing::assert_run_failed_with!(result, "mock failure");
+    runner.shutdown().await.expect("shutdown succeeds");
+}
+
+#[tokio::test]
+async fn assert_workspace_contains_file_passes_when_snapshot_has_file() {
+    let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+    runner.mock_llm().add_response("workspace ready").await;
+
+    let result = runner.run_text("hello").await.expect("run succeeds");
+    let expected = format!("sessions/{}.jsonl", runner.session_id());
+
+    mofa_testing::assert_workspace_contains_file!(result.metadata.workspace_snapshot_after, expected);
+    runner.shutdown().await.expect("shutdown succeeds");
+}
+
+#[tokio::test]
+async fn assert_run_recorded_tool_call_passes_when_tool_metadata_exists() {
+    let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+    let tool = MockTool::new(
+        "echo_tool",
+        "Echo tool",
+        json!({
+            "type": "object",
+            "properties": { "input": { "type": "string" } },
+            "required": ["input"]
+        }),
+    );
+    runner
+        .register_mock_tool(tool)
+        .await
+        .expect("tool registered");
+    runner
+        .mock_llm()
+        .add_tool_call_response("echo_tool", json!({ "input": "ping" }), None)
+        .await;
+    runner.mock_llm().add_response("done").await;
+
+    let result = runner.run_text("use tool").await.expect("run succeeds");
+
+    mofa_testing::assert_run_recorded_tool_call!(result, "echo_tool");
+    runner.shutdown().await.expect("shutdown succeeds");
+}
+
+#[tokio::test]
+async fn assert_runner_total_executions_passes_on_first_run() {
+    let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+    runner.mock_llm().add_response("counted").await;
+
+    let result = runner.run_text("hello").await.expect("run succeeds");
+
+    mofa_testing::assert_runner_total_executions!(result, 1);
+    runner.shutdown().await.expect("shutdown succeeds");
 }


### PR DESCRIPTION
## Summary

This PR turns the testing utilities into a real agent runner harness built on MoFA’s runtime execution path, adds rich run metadata (tool calls, session snapshots, workspace snapshots), and ships runnable examples that demonstrate the runner in action.

## Context

Idea 6’s biggest gap is agent-level behavioral testing. We already had mocks and infra, but no unified way to run real MoFA execution paths in tests and capture consistent artifacts.

This PR closes that gap by:

- running real `AgentRunner` flows with isolated workspaces
- capturing structured run metadata for assertions and reports
- providing examples that double as manual validation

## Execution Flow

<img width="897" height="1173" alt="image" src="https://github.com/user-attachments/assets/46ee15bc-f446-41f8-93f2-10e815b0b82c" />

## Artifacts Captured

<img width="824" height="660" alt="image" src="https://github.com/user-attachments/assets/8b3ffb73-5877-498a-bad4-eb876dd4e69c" />


## Changed

### `tests/src/agent_runner.rs`

- New `AgentTestRunner` harness that wraps real `AgentRunner` execution.
- Isolated temp workspace + session per runner instance.
- `AgentRunMetadata` captures:
  - runner state/stats before and after
  - agent state before and after
  - session snapshot (JSONL-backed)
  - tool call records (input/output/duration/timeout)
  - last LLM request/response
  - workspace file snapshots before/after
- Adds `run_texts` multi-turn helper to preserve a single session across turns.
- Adds `run_text_with_session` for custom session keys.
- Adds prompt configuration helper for identity + bootstrap list.
- Adds workspace snapshotting with size/mtime/checksum per file.

### `tests/tests/agent_runner_tests.rs`

- Basic run asserts output, metadata, session snapshot, and workspace snapshot.
- Workspace isolation test validates per-runner session files.
- Tool call test validates tool execution, metadata capture, and duration.
- Bootstrap file test asserts prompt content includes workspace files.
- Multi-turn test asserts session history ordering and accumulation.
- Custom prompt identity/bootstrap test validates system prompt customization.
- LLM failure test validates error capture + stats.
- Custom session key test validates session override and file creation.
### `tests/src/tools.rs`

- Records result history alongside call history.
- Captures per-call duration in `metadata` (`duration_ms`).
- Enables tool output assertions without extra plumbing.

### `tests/src/assertions.rs`

- Adds `assert_session_messages` helper for ordered session assertions.
- Keeps multi-turn tests readable with concise checks.

### `tests/src/lib.rs`

- Exports runner harness types for reuse in examples/tests.
- Exposes workspace snapshot models for external assertions.
- Re-exports tool-call record types for downstream consumers.

### `crates/mofa-foundation/src/agent/context/prompt.rs`

- Adds `set_identity` for runtime identity updates.
- Adds `set_bootstrap_files` for runtime bootstrap list updates.

### `crates/mofa-runtime/src/runner.rs`

- Adds `set_session_id` for per-run session overrides.

### `crates/mofa-foundation/src/agent/executor.rs`

- Adds `update_prompt_context` hook for prompt mutation.
- Avoids invalid Ready, Ready transition during init.

### `examples/agent_runner_basic`

- Demonstrates a single real runner execution.

### `examples/agent_runner_tools`

- Exercises tool-call flow end-to-end.
- Prints captured tool metadata (output + duration).
- Highlights tool call record fields in run metadata.

### `examples/agent_runner_custom_session`

- Uses a custom session key.

### `examples/Cargo.toml`

- Registers the new agent-runner examples.

## Testing

1. Ran:
   `mofa/examples && cargo run -p agent_runner_basic`

2. Ran:
   `mofa/examples && cargo run -p agent_runner_tools`

3. Ran:
   `mofa/examples && cargo run -p agent_runner_custom_session`

## Example Output

```text
Output: Hello from the runner
Session: 019d1be1-df6c-78b2-9018-89658b1fb4a3
Workspace: /tmp/mofa-agent-test-019d1be1-df6c-78b2-893bb2d60afa
Runner stats: total=1 success=1 failed=0
```

```text
Output: Tool response completed
Tool call: name=echo_tool input={"input":"ping"} output="Mock execution default" duration_ms=Some(0)
```

```text
Session id: demo-session
Output: Custom session response
```