### PR TITLE
 feat(testing): add behavioral diff reporting and runtime examples

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -60,6 +60,7 @@ members = [
     "rag_retrieval_demo",
     "rag_indexing_demo",
     "adversarial_testing_demo",
+    "behavior_diff_example",
     "llm_fallback_chain",
     "resume_from_checkpoint",
     "claw_demo",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -61,6 +61,7 @@ members = [
     "rag_indexing_demo",
     "adversarial_testing_demo",
     "behavior_diff_example",
+    "behavior_diff_runtime_example",
     "llm_fallback_chain",
     "resume_from_checkpoint",
     "claw_demo",

--- a/examples/behavior_diff_example/Cargo.toml
+++ b/examples/behavior_diff_example/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "behavior_diff_example"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+mofa-testing = { path = "../../tests" }
+serde_json = { workspace = true }

--- a/examples/behavior_diff_example/src/main.rs
+++ b/examples/behavior_diff_example/src/main.rs
@@ -1,0 +1,84 @@
+use mofa_testing::behavior_diff::BehaviorDiff;
+use mofa_testing::report::{TestCaseResult, TestReport, TestStatus};
+use std::time::Duration;
+
+fn make_result(
+    name: &str,
+    status: TestStatus,
+    duration_ms: u64,
+    error: Option<&str>,
+    metadata: &[(&str, &str)],
+) -> TestCaseResult {
+    TestCaseResult {
+        name: name.to_string(),
+        status,
+        duration: Duration::from_millis(duration_ms),
+        error: error.map(ToString::to_string),
+        metadata: metadata
+            .iter()
+            .map(|(key, value)| (key.to_string(), value.to_string()))
+            .collect(),
+    }
+}
+
+fn main() {
+    let baseline = TestReport {
+        suite_name: "baseline".to_string(),
+        total_duration: Duration::from_millis(90),
+        timestamp: 0,
+        results: vec![
+            make_result(
+                "answer-question",
+                TestStatus::Passed,
+                20,
+                None,
+                &[
+                    ("output", "Paris"),
+                    ("tool_calls", "knowledge_base"),
+                    ("retry_count", "0"),
+                    ("fallback_triggered", "false"),
+                ],
+            ),
+            make_result("stable-case", TestStatus::Passed, 10, None, &[]),
+        ],
+    };
+
+    let candidate = TestReport {
+        suite_name: "candidate".to_string(),
+        total_duration: Duration::from_millis(125),
+        timestamp: 0,
+        results: vec![
+            make_result(
+                "answer-question",
+                TestStatus::Failed,
+                55,
+                Some("wrong fact"),
+                &[
+                    ("output", "Lyon"),
+                    ("tool_calls", "knowledge_base,search"),
+                    ("retry_count", "2"),
+                    ("fallback_triggered", "true"),
+                ],
+            ),
+            make_result("stable-case", TestStatus::Passed, 10, None, &[]),
+            make_result(
+                "new-case",
+                TestStatus::Passed,
+                12,
+                None,
+                &[("response", "new coverage")],
+            ),
+        ],
+    };
+
+    let diff = BehaviorDiff::between(&baseline, &candidate);
+
+    println!("== Markdown Summary ==");
+    println!("{}", diff.to_markdown());
+
+    println!("== JSON Summary ==");
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&diff.to_json()).expect("behavior diff JSON should serialize")
+    );
+}

--- a/examples/behavior_diff_runtime_example/Cargo.toml
+++ b/examples/behavior_diff_runtime_example/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "behavior_diff_runtime_example"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+mofa-testing = { path = "../../tests" }
+mofa-runtime = { path = "../../crates/mofa-runtime" }
+mofa-kernel = { path = "../../crates/mofa-kernel" }
+tokio = { workspace = true }
+async-trait = { workspace = true }
+serde_json = { workspace = true }

--- a/examples/behavior_diff_runtime_example/src/main.rs
+++ b/examples/behavior_diff_runtime_example/src/main.rs
@@ -1,0 +1,200 @@
+//! Runtime behavioral diff example.
+//!
+//! Runs two real `ExecutionEngine` executions, converts their
+//! `ExecutionResult`s into `mofa-testing` reports, and compares them with
+//! `BehaviorDiff`.
+
+use async_trait::async_trait;
+use mofa_kernel::agent::types::{AgentInput, AgentOutput, AgentState, ToolUsage};
+use mofa_runtime::agent::capabilities::AgentCapabilities;
+use mofa_runtime::agent::context::AgentContext;
+use mofa_runtime::agent::core::MoFAAgent;
+use mofa_runtime::agent::error::AgentResult;
+use mofa_runtime::agent::execution::{ExecutionEngine, ExecutionOptions};
+use mofa_runtime::agent::registry::AgentRegistry;
+use mofa_testing::behavior_diff::{BehaviorDiff, JsonBehaviorDiffFormatter, MarkdownBehaviorDiffFormatter};
+use mofa_testing::{BehaviorDiffFormatter, TestReportBuilder};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+struct ScriptedAgent {
+    id: String,
+    response: String,
+    should_fail: bool,
+    retry_count: usize,
+    fallback_triggered: bool,
+    tool_names: Vec<String>,
+    capabilities: AgentCapabilities,
+    state: AgentState,
+}
+
+impl ScriptedAgent {
+    fn new(
+        id: &str,
+        response: &str,
+        should_fail: bool,
+        retry_count: usize,
+        fallback_triggered: bool,
+        tool_names: &[&str],
+    ) -> Self {
+        Self {
+            id: id.to_string(),
+            response: response.to_string(),
+            should_fail,
+            retry_count,
+            fallback_triggered,
+            tool_names: tool_names.iter().map(|name| name.to_string()).collect(),
+            capabilities: AgentCapabilities::default(),
+            state: AgentState::Created,
+        }
+    }
+}
+
+#[async_trait]
+impl MoFAAgent for ScriptedAgent {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn name(&self) -> &str {
+        &self.id
+    }
+
+    fn capabilities(&self) -> &AgentCapabilities {
+        &self.capabilities
+    }
+
+    fn state(&self) -> AgentState {
+        self.state.clone()
+    }
+
+    async fn initialize(&mut self, _ctx: &AgentContext) -> AgentResult<()> {
+        self.state = AgentState::Ready;
+        Ok(())
+    }
+
+    async fn execute(&mut self, _input: AgentInput, _ctx: &AgentContext) -> AgentResult<AgentOutput> {
+        if self.should_fail {
+            return Err(mofa_runtime::agent::error::AgentError::ExecutionFailed(
+                self.response.clone(),
+            ));
+        }
+
+        // The runtime result only sees normal agent output, so we encode
+        // retry/fallback test data into output metadata and promote it later.
+        let mut output = AgentOutput::text(&self.response);
+        output.tools_used = self
+            .tool_names
+            .iter()
+            .map(|name| {
+                ToolUsage::success(
+                    name.clone(),
+                    serde_json::json!({"source": "example"}),
+                    serde_json::json!({"ok": true}),
+                    10,
+                )
+            })
+            .collect();
+        output.metadata.insert(
+            "scripted_retry_count".into(),
+            serde_json::json!(self.retry_count),
+        );
+        output.metadata.insert(
+            "scripted_fallback".into(),
+            serde_json::json!(self.fallback_triggered),
+        );
+        Ok(output)
+    }
+
+    async fn shutdown(&mut self) -> AgentResult<()> {
+        self.state = AgentState::Shutdown;
+        Ok(())
+    }
+}
+
+async fn run_case(
+    suite_name: &str,
+    case_name: &str,
+    agent: ScriptedAgent,
+) -> mofa_testing::TestReport {
+    // Register the agent into a real runtime registry and execute it through
+    // the standard execution engine path.
+    let registry = Arc::new(AgentRegistry::new());
+    registry
+        .register(Arc::new(RwLock::new(agent)))
+        .await
+        .expect("agent registration should succeed");
+
+    let engine = ExecutionEngine::new(registry);
+    let mut result = engine
+        .execute(case_name, AgentInput::text("compare this run"), ExecutionOptions::default())
+        .await
+        .expect("execution should return a runtime result");
+
+    // Promote the scripted metadata into canonical runtime fields that the
+    // report adapter and behavioral diff already understand.
+    if let Some(output) = result.output.as_ref() {
+        if let Some(retry_count) = output
+            .metadata
+            .get("scripted_retry_count")
+            .and_then(|value| value.as_u64())
+        {
+            result.retries = retry_count as usize;
+        }
+        if let Some(fallback_triggered) = output
+            .metadata
+            .get("scripted_fallback")
+            .and_then(|value| value.as_bool())
+        {
+            result
+                .metadata
+                .insert("fallback".into(), serde_json::json!(fallback_triggered));
+        }
+    }
+
+    TestReportBuilder::new(suite_name)
+        .add_execution_result(case_name, &result)
+        .build()
+}
+
+#[tokio::main]
+async fn main() {
+    // Baseline and candidate run the same case with different output,
+    // tool usage, retry count, and fallback state.
+    let baseline = run_case(
+        "baseline-runtime",
+        "search-answer",
+        ScriptedAgent::new(
+            "search-answer",
+            "Paris",
+            false,
+            0,
+            false,
+            &["knowledge_base"],
+        ),
+    )
+    .await;
+
+    let candidate = run_case(
+        "candidate-runtime",
+        "search-answer",
+        ScriptedAgent::new(
+            "search-answer",
+            "Lyon",
+            false,
+            2,
+            true,
+            &["knowledge_base", "search"],
+        ),
+    )
+    .await;
+
+    // Compare the runtime-derived reports using the testing-layer diff.
+    let diff = BehaviorDiff::between(&baseline, &candidate);
+
+    println!("== Runtime Markdown ==");
+    println!("{}", MarkdownBehaviorDiffFormatter.format(&diff));
+
+    println!("== Runtime JSON ==");
+    println!("{}", JsonBehaviorDiffFormatter.format(&diff));
+}

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -9,6 +9,7 @@ description = "Testing utilities for the MoFA agent framework"
 [dependencies]
 mofa-kernel = { path = "../crates/mofa-kernel" }
 mofa-foundation = { path = "../crates/mofa-foundation" }
+mofa-runtime = { path = "../crates/mofa-runtime" }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 anyhow = { workspace = true }

--- a/tests/src/behavior_diff.rs
+++ b/tests/src/behavior_diff.rs
@@ -336,6 +336,27 @@ impl BehaviorDiff {
             "cases": cases,
         })
     }
+
+    /// Returns true when the diff contains any meaningful change.
+    pub fn has_changes(&self) -> bool {
+        self.summary.added_cases > 0
+            || self.summary.removed_cases > 0
+            || self.summary.status_changes > 0
+            || self.summary.output_changes > 0
+            || self.summary.tool_call_changes > 0
+            || self.summary.retry_changes > 0
+            || self.summary.fallback_changes > 0
+            || self.summary.slower_cases > 0
+            || self.summary.faster_cases > 0
+    }
+
+    /// Returns only cases that were added, removed, or modified.
+    pub fn changed_cases(&self) -> Vec<&CaseBehaviorDiff> {
+        self.cases
+            .iter()
+            .filter(|case| case.change != CaseChangeKind::Unchanged)
+            .collect()
+    }
 }
 
 impl CaseBehaviorDiff {
@@ -447,9 +468,7 @@ fn bool_change(
 }
 
 fn metadata_alias_value<'a>(case: Option<&'a TestCaseResult>, keys: &[&str]) -> Option<&'a str> {
-    let case = case?;
-    keys.iter()
-        .find_map(|key| case.metadata.iter().find(|(k, _)| k == key).map(|(_, v)| v.as_str()))
+    case?.metadata_value_any(keys)
 }
 
 fn parse_boolish(value: &str) -> Option<bool> {

--- a/tests/src/behavior_diff.rs
+++ b/tests/src/behavior_diff.rs
@@ -65,6 +65,17 @@ pub struct ValueChange<T> {
     pub after: T,
 }
 
+/// Converts a [`BehaviorDiff`] into a displayable string.
+pub trait BehaviorDiffFormatter: Send + Sync {
+    fn format(&self, diff: &BehaviorDiff) -> String;
+}
+
+/// Renders a diff as markdown.
+pub struct MarkdownBehaviorDiffFormatter;
+
+/// Renders a diff as pretty JSON.
+pub struct JsonBehaviorDiffFormatter;
+
 impl BehaviorDiff {
     /// Compare a baseline and candidate report by test case name.
     pub fn between(baseline: &TestReport, candidate: &TestReport) -> Self {
@@ -356,6 +367,19 @@ impl BehaviorDiff {
             .iter()
             .filter(|case| case.change != CaseChangeKind::Unchanged)
             .collect()
+    }
+}
+
+impl BehaviorDiffFormatter for MarkdownBehaviorDiffFormatter {
+    fn format(&self, diff: &BehaviorDiff) -> String {
+        diff.to_markdown()
+    }
+}
+
+impl BehaviorDiffFormatter for JsonBehaviorDiffFormatter {
+    fn format(&self, diff: &BehaviorDiff) -> String {
+        serde_json::to_string_pretty(&diff.to_json())
+            .expect("behavior diff serialisation should not fail")
     }
 }
 

--- a/tests/src/behavior_diff.rs
+++ b/tests/src/behavior_diff.rs
@@ -1,0 +1,468 @@
+//! Behavioral diff support for comparing two test reports.
+
+use crate::report::{TestCaseResult, TestReport, TestStatus};
+use std::collections::{BTreeMap, BTreeSet};
+
+const OUTPUT_KEYS: &[&str] = &["output", "final_response", "response"];
+const TOOL_CALL_KEYS: &[&str] = &["tool_calls", "tool_call_sequence", "tools"];
+const RETRY_KEYS: &[&str] = &["retry_count", "retries"];
+const FALLBACK_KEYS: &[&str] = &["fallback_triggered", "fallback_status", "fallback"];
+
+/// Comparison result for two test reports.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BehaviorDiff {
+    pub baseline_suite: String,
+    pub candidate_suite: String,
+    pub summary: BehaviorDiffSummary,
+    pub cases: Vec<CaseBehaviorDiff>,
+}
+
+/// Aggregate change counts for a diff.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct BehaviorDiffSummary {
+    pub added_cases: usize,
+    pub removed_cases: usize,
+    pub status_changes: usize,
+    pub output_changes: usize,
+    pub tool_call_changes: usize,
+    pub retry_changes: usize,
+    pub fallback_changes: usize,
+    pub slower_cases: usize,
+    pub faster_cases: usize,
+    pub unchanged_cases: usize,
+    pub baseline_failed: usize,
+    pub candidate_failed: usize,
+    pub suite_duration_delta_ms: i128,
+}
+
+/// Per-case behavior change record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CaseBehaviorDiff {
+    pub name: String,
+    pub change: CaseChangeKind,
+    pub status_change: Option<ValueChange<TestStatus>>,
+    pub duration_delta_ms: i128,
+    pub error_change: Option<ValueChange<Option<String>>>,
+    pub output_change: Option<ValueChange<String>>,
+    pub tool_calls_change: Option<ValueChange<String>>,
+    pub retry_change: Option<ValueChange<i64>>,
+    pub fallback_change: Option<ValueChange<bool>>,
+}
+
+/// High-level case presence/change classification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CaseChangeKind {
+    Added,
+    Removed,
+    Modified,
+    Unchanged,
+}
+
+/// Generic before/after value change.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValueChange<T> {
+    pub before: T,
+    pub after: T,
+}
+
+impl BehaviorDiff {
+    /// Compare a baseline and candidate report by test case name.
+    pub fn between(baseline: &TestReport, candidate: &TestReport) -> Self {
+        let baseline_cases: BTreeMap<&str, &TestCaseResult> = baseline
+            .results
+            .iter()
+            .map(|case| (case.name.as_str(), case))
+            .collect();
+        let candidate_cases: BTreeMap<&str, &TestCaseResult> = candidate
+            .results
+            .iter()
+            .map(|case| (case.name.as_str(), case))
+            .collect();
+
+        let names: BTreeSet<&str> = baseline_cases
+            .keys()
+            .copied()
+            .chain(candidate_cases.keys().copied())
+            .collect();
+
+        let mut summary = BehaviorDiffSummary {
+            baseline_failed: baseline.failed(),
+            candidate_failed: candidate.failed(),
+            suite_duration_delta_ms:
+                candidate.total_duration.as_millis() as i128 - baseline.total_duration.as_millis() as i128,
+            ..BehaviorDiffSummary::default()
+        };
+        let mut cases = Vec::new();
+
+        for name in names {
+            let diff = match (baseline_cases.get(name), candidate_cases.get(name)) {
+                (None, Some(candidate_case)) => {
+                    summary.added_cases += 1;
+                    CaseBehaviorDiff {
+                        name: name.to_string(),
+                        change: CaseChangeKind::Added,
+                        status_change: Some(ValueChange {
+                            before: TestStatus::Skipped,
+                            after: candidate_case.status.clone(),
+                        }),
+                        duration_delta_ms: candidate_case.duration.as_millis() as i128,
+                        error_change: Some(ValueChange {
+                            before: None,
+                            after: candidate_case.error.clone(),
+                        }),
+                        output_change: metadata_change(None, Some(candidate_case), OUTPUT_KEYS),
+                        tool_calls_change: metadata_change(None, Some(candidate_case), TOOL_CALL_KEYS),
+                        retry_change: numeric_change(None, Some(candidate_case), RETRY_KEYS),
+                        fallback_change: bool_change(None, Some(candidate_case), FALLBACK_KEYS),
+                    }
+                }
+                (Some(baseline_case), None) => {
+                    summary.removed_cases += 1;
+                    CaseBehaviorDiff {
+                        name: name.to_string(),
+                        change: CaseChangeKind::Removed,
+                        status_change: Some(ValueChange {
+                            before: baseline_case.status.clone(),
+                            after: TestStatus::Skipped,
+                        }),
+                        duration_delta_ms: -(baseline_case.duration.as_millis() as i128),
+                        error_change: Some(ValueChange {
+                            before: baseline_case.error.clone(),
+                            after: None,
+                        }),
+                        output_change: metadata_change(Some(baseline_case), None, OUTPUT_KEYS),
+                        tool_calls_change: metadata_change(Some(baseline_case), None, TOOL_CALL_KEYS),
+                        retry_change: numeric_change(Some(baseline_case), None, RETRY_KEYS),
+                        fallback_change: bool_change(Some(baseline_case), None, FALLBACK_KEYS),
+                    }
+                }
+                (Some(baseline_case), Some(candidate_case)) => {
+                    let status_change = if baseline_case.status != candidate_case.status {
+                        summary.status_changes += 1;
+                        Some(ValueChange {
+                            before: baseline_case.status.clone(),
+                            after: candidate_case.status.clone(),
+                        })
+                    } else {
+                        None
+                    };
+
+                    let output_change =
+                        metadata_change(Some(baseline_case), Some(candidate_case), OUTPUT_KEYS);
+                    if output_change.is_some() {
+                        summary.output_changes += 1;
+                    }
+
+                    let tool_calls_change =
+                        metadata_change(Some(baseline_case), Some(candidate_case), TOOL_CALL_KEYS);
+                    if tool_calls_change.is_some() {
+                        summary.tool_call_changes += 1;
+                    }
+
+                    let retry_change =
+                        numeric_change(Some(baseline_case), Some(candidate_case), RETRY_KEYS);
+                    if retry_change.is_some() {
+                        summary.retry_changes += 1;
+                    }
+
+                    let fallback_change =
+                        bool_change(Some(baseline_case), Some(candidate_case), FALLBACK_KEYS);
+                    if fallback_change.is_some() {
+                        summary.fallback_changes += 1;
+                    }
+
+                    let error_change = if baseline_case.error != candidate_case.error {
+                        Some(ValueChange {
+                            before: baseline_case.error.clone(),
+                            after: candidate_case.error.clone(),
+                        })
+                    } else {
+                        None
+                    };
+
+                    let duration_delta_ms = candidate_case.duration.as_millis() as i128
+                        - baseline_case.duration.as_millis() as i128;
+                    if duration_delta_ms > 0 {
+                        summary.slower_cases += 1;
+                    } else if duration_delta_ms < 0 {
+                        summary.faster_cases += 1;
+                    }
+
+                    let modified = status_change.is_some()
+                        || output_change.is_some()
+                        || tool_calls_change.is_some()
+                        || retry_change.is_some()
+                        || fallback_change.is_some()
+                        || error_change.is_some()
+                        || duration_delta_ms != 0;
+                    if !modified {
+                        summary.unchanged_cases += 1;
+                    }
+
+                    CaseBehaviorDiff {
+                        name: name.to_string(),
+                        change: if modified {
+                            CaseChangeKind::Modified
+                        } else {
+                            CaseChangeKind::Unchanged
+                        },
+                        status_change,
+                        duration_delta_ms,
+                        error_change,
+                        output_change,
+                        tool_calls_change,
+                        retry_change,
+                        fallback_change,
+                    }
+                }
+                (None, None) => unreachable!("name set only contains known cases"),
+            };
+
+            cases.push(diff);
+        }
+
+        Self {
+            baseline_suite: baseline.suite_name.clone(),
+            candidate_suite: candidate.suite_name.clone(),
+            summary,
+            cases,
+        }
+    }
+
+    /// Render a readable markdown summary suitable for local review or CI comments.
+    pub fn to_markdown(&self) -> String {
+        let mut out = String::new();
+        out.push_str(&format!(
+            "## Behavioral Diff\n\nBaseline: `{}`\nCandidate: `{}`\n\n",
+            self.baseline_suite, self.candidate_suite
+        ));
+        out.push_str(&format!(
+            "- Cases added: {}\n- Cases removed: {}\n- Status changes: {}\n- Output changes: {}\n- Tool-call changes: {}\n- Retry changes: {}\n- Fallback changes: {}\n- Faster cases: {}\n- Slower cases: {}\n- Baseline failures: {}\n- Candidate failures: {}\n- Suite duration delta: {}ms\n",
+            self.summary.added_cases,
+            self.summary.removed_cases,
+            self.summary.status_changes,
+            self.summary.output_changes,
+            self.summary.tool_call_changes,
+            self.summary.retry_changes,
+            self.summary.fallback_changes,
+            self.summary.faster_cases,
+            self.summary.slower_cases,
+            self.summary.baseline_failed,
+            self.summary.candidate_failed,
+            self.summary.suite_duration_delta_ms,
+        ));
+
+        let interesting: Vec<&CaseBehaviorDiff> = self
+            .cases
+            .iter()
+            .filter(|case| case.change != CaseChangeKind::Unchanged)
+            .collect();
+        if interesting.is_empty() {
+            out.push_str("\nNo behavioral changes detected.\n");
+            return out;
+        }
+
+        out.push_str("\n### Case Changes\n");
+        for case in interesting {
+            out.push_str(&format!("- `{}`: {}\n", case.name, case.describe()));
+        }
+
+        out
+    }
+
+    /// Render the diff as a JSON value suitable for artifacts or CI systems.
+    pub fn to_json(&self) -> serde_json::Value {
+        let cases: Vec<serde_json::Value> = self
+            .cases
+            .iter()
+            .map(|case| {
+                let mut value = serde_json::json!({
+                    "name": case.name,
+                    "change": case.change.as_str(),
+                    "duration_delta_ms": case.duration_delta_ms,
+                });
+                if let Some(change) = &case.status_change {
+                    value["status_change"] = serde_json::json!({
+                        "before": change.before.to_string(),
+                        "after": change.after.to_string(),
+                    });
+                }
+                if let Some(change) = &case.error_change {
+                    value["error_change"] = serde_json::json!({
+                        "before": change.before,
+                        "after": change.after,
+                    });
+                }
+                if let Some(change) = &case.output_change {
+                    value["output_change"] = string_change_json(change);
+                }
+                if let Some(change) = &case.tool_calls_change {
+                    value["tool_calls_change"] = string_change_json(change);
+                }
+                if let Some(change) = &case.retry_change {
+                    value["retry_change"] = serde_json::json!({
+                        "before": change.before,
+                        "after": change.after,
+                    });
+                }
+                if let Some(change) = &case.fallback_change {
+                    value["fallback_change"] = serde_json::json!({
+                        "before": change.before,
+                        "after": change.after,
+                    });
+                }
+                value
+            })
+            .collect();
+
+        serde_json::json!({
+            "baseline_suite": self.baseline_suite,
+            "candidate_suite": self.candidate_suite,
+            "summary": {
+                "added_cases": self.summary.added_cases,
+                "removed_cases": self.summary.removed_cases,
+                "status_changes": self.summary.status_changes,
+                "output_changes": self.summary.output_changes,
+                "tool_call_changes": self.summary.tool_call_changes,
+                "retry_changes": self.summary.retry_changes,
+                "fallback_changes": self.summary.fallback_changes,
+                "slower_cases": self.summary.slower_cases,
+                "faster_cases": self.summary.faster_cases,
+                "unchanged_cases": self.summary.unchanged_cases,
+                "baseline_failed": self.summary.baseline_failed,
+                "candidate_failed": self.summary.candidate_failed,
+                "suite_duration_delta_ms": self.summary.suite_duration_delta_ms,
+            },
+            "cases": cases,
+        })
+    }
+}
+
+impl CaseBehaviorDiff {
+    fn describe(&self) -> String {
+        let mut parts = Vec::new();
+        match self.change {
+            CaseChangeKind::Added => parts.push("added".to_string()),
+            CaseChangeKind::Removed => parts.push("removed".to_string()),
+            CaseChangeKind::Modified | CaseChangeKind::Unchanged => {}
+        }
+        if let Some(change) = &self.status_change {
+            parts.push(format!("status {} -> {}", change.before, change.after));
+        }
+        if self.duration_delta_ms > 0 {
+            parts.push(format!("slower by {}ms", self.duration_delta_ms));
+        } else if self.duration_delta_ms < 0 {
+            parts.push(format!("faster by {}ms", -self.duration_delta_ms));
+        }
+        if let Some(change) = &self.output_change {
+            parts.push(format!("output changed ({} -> {})", change.before, change.after));
+        }
+        if let Some(change) = &self.tool_calls_change {
+            parts.push(format!(
+                "tool calls changed ({} -> {})",
+                change.before, change.after
+            ));
+        }
+        if let Some(change) = &self.retry_change {
+            parts.push(format!("retry count {} -> {}", change.before, change.after));
+        }
+        if let Some(change) = &self.fallback_change {
+            parts.push(format!("fallback {} -> {}", change.before, change.after));
+        }
+        if let Some(change) = &self.error_change {
+            parts.push(format!(
+                "error {:?} -> {:?}",
+                change.before.as_deref(),
+                change.after.as_deref()
+            ));
+        }
+        if parts.is_empty() {
+            "unchanged".to_string()
+        } else {
+            parts.join(", ")
+        }
+    }
+}
+
+impl CaseChangeKind {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Added => "added",
+            Self::Removed => "removed",
+            Self::Modified => "modified",
+            Self::Unchanged => "unchanged",
+        }
+    }
+}
+
+fn metadata_change(
+    baseline: Option<&TestCaseResult>,
+    candidate: Option<&TestCaseResult>,
+    keys: &[&str],
+) -> Option<ValueChange<String>> {
+    let before = metadata_alias_value(baseline, keys);
+    let after = metadata_alias_value(candidate, keys);
+    if before != after {
+        Some(ValueChange {
+            before: before.unwrap_or_default().to_string(),
+            after: after.unwrap_or_default().to_string(),
+        })
+    } else {
+        None
+    }
+}
+
+fn numeric_change(
+    baseline: Option<&TestCaseResult>,
+    candidate: Option<&TestCaseResult>,
+    keys: &[&str],
+) -> Option<ValueChange<i64>> {
+    let before = metadata_alias_value(baseline, keys).and_then(|v| v.parse::<i64>().ok());
+    let after = metadata_alias_value(candidate, keys).and_then(|v| v.parse::<i64>().ok());
+    if before != after {
+        Some(ValueChange {
+            before: before.unwrap_or_default(),
+            after: after.unwrap_or_default(),
+        })
+    } else {
+        None
+    }
+}
+
+fn bool_change(
+    baseline: Option<&TestCaseResult>,
+    candidate: Option<&TestCaseResult>,
+    keys: &[&str],
+) -> Option<ValueChange<bool>> {
+    let before = metadata_alias_value(baseline, keys).and_then(parse_boolish);
+    let after = metadata_alias_value(candidate, keys).and_then(parse_boolish);
+    if before != after {
+        Some(ValueChange {
+            before: before.unwrap_or(false),
+            after: after.unwrap_or(false),
+        })
+    } else {
+        None
+    }
+}
+
+fn metadata_alias_value<'a>(case: Option<&'a TestCaseResult>, keys: &[&str]) -> Option<&'a str> {
+    let case = case?;
+    keys.iter()
+        .find_map(|key| case.metadata.iter().find(|(k, _)| k == key).map(|(_, v)| v.as_str()))
+}
+
+fn parse_boolish(value: &str) -> Option<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "true" | "yes" | "1" | "triggered" | "fallback" => Some(true),
+        "false" | "no" | "0" | "not_triggered" | "none" => Some(false),
+        _ => None,
+    }
+}
+
+fn string_change_json(change: &ValueChange<String>) -> serde_json::Value {
+    serde_json::json!({
+        "before": change.before,
+        "after": change.after,
+    })
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -14,7 +14,8 @@ pub mod tools;
 
 pub use backend::MockLLMBackend;
 pub use behavior_diff::{
-    BehaviorDiff, BehaviorDiffSummary, CaseBehaviorDiff, CaseChangeKind, ValueChange,
+    BehaviorDiff, BehaviorDiffFormatter, BehaviorDiffSummary, CaseBehaviorDiff, CaseChangeKind,
+    JsonBehaviorDiffFormatter, MarkdownBehaviorDiffFormatter, ValueChange,
 };
 pub use bus::MockAgentBus;
 pub use clock::{Clock, MockClock, SystemClock};

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -6,12 +6,16 @@
 pub mod adversarial;
 pub mod assertions;
 pub mod backend;
+pub mod behavior_diff;
 pub mod bus;
 pub mod clock;
 pub mod report;
 pub mod tools;
 
 pub use backend::MockLLMBackend;
+pub use behavior_diff::{
+    BehaviorDiff, BehaviorDiffSummary, CaseBehaviorDiff, CaseChangeKind, ValueChange,
+};
 pub use bus::MockAgentBus;
 pub use clock::{Clock, MockClock, SystemClock};
 pub use report::{

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -20,7 +20,7 @@ pub use behavior_diff::{
 pub use bus::MockAgentBus;
 pub use clock::{Clock, MockClock, SystemClock};
 pub use report::{
-    JsonFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,
-    TextFormatter,
+    AgentRunResult, BehaviorMetadata, FallbackStatus, JsonFormatter, ReportFormatter,
+    TestCaseResult, TestReport, TestReportBuilder, TestStatus, TextFormatter,
 };
 pub use tools::MockTool;

--- a/tests/src/report/builder.rs
+++ b/tests/src/report/builder.rs
@@ -5,7 +5,8 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use crate::clock::{Clock, SystemClock};
-use crate::report::types::{TestCaseResult, TestReport, TestStatus};
+use crate::report::types::{BehaviorMetadata, TestCaseResult, TestReport, TestStatus};
+use mofa_runtime::agent::execution::ExecutionResult;
 
 /// Collects [`TestCaseResult`]s and produces a [`TestReport`].
 pub struct TestReportBuilder {
@@ -99,9 +100,54 @@ impl TestReportBuilder {
         self
     }
 
+    /// Run an async test closure, record its outcome, and attach canonical behavior metadata.
+    pub async fn record_with_behavior<F, Fut>(
+        mut self,
+        name: impl Into<String>,
+        behavior: BehaviorMetadata,
+        f: F,
+    ) -> Self
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<(), String>>,
+    {
+        let name = name.into();
+        let start = Instant::now();
+        let outcome = f().await;
+        let duration = start.elapsed();
+
+        let (status, error) = match outcome {
+            Ok(()) => (TestStatus::Passed, None),
+            Err(msg) => (TestStatus::Failed, Some(msg)),
+        };
+
+        self.results.push(
+            TestCaseResult {
+                name,
+                status,
+                duration,
+                error,
+                metadata: Vec::new(),
+            }
+            .with_behavior(&behavior),
+        );
+        self
+    }
+
     /// Manually add a pre-built result.
     pub fn add_result(mut self, result: TestCaseResult) -> Self {
         self.results.push(result);
+        self
+    }
+
+    /// Add a runtime execution result using the canonical report mapping.
+    pub fn add_execution_result(
+        mut self,
+        name: impl Into<String>,
+        execution_result: &ExecutionResult,
+    ) -> Self {
+        self.results
+            .push(TestCaseResult::from_execution_result(name, execution_result));
         self
     }
 

--- a/tests/src/report/builder.rs
+++ b/tests/src/report/builder.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use crate::clock::{Clock, SystemClock};
-use crate::report::types::{BehaviorMetadata, TestCaseResult, TestReport, TestStatus};
+use crate::report::types::{
+    AgentRunResult, BehaviorMetadata, TestCaseResult, TestReport, TestStatus,
+};
 use mofa_runtime::agent::execution::ExecutionResult;
 
 /// Collects [`TestCaseResult`]s and produces a [`TestReport`].
@@ -148,6 +150,17 @@ impl TestReportBuilder {
     ) -> Self {
         self.results
             .push(TestCaseResult::from_execution_result(name, execution_result));
+        self
+    }
+
+    /// Add a canonical run artifact using the canonical report mapping.
+    pub fn add_agent_run_result(
+        mut self,
+        name: impl Into<String>,
+        run_result: &AgentRunResult,
+    ) -> Self {
+        self.results
+            .push(TestCaseResult::from_agent_run_result(name, run_result));
         self
     }
 

--- a/tests/src/report/builder.rs
+++ b/tests/src/report/builder.rs
@@ -62,6 +62,43 @@ impl TestReportBuilder {
         self
     }
 
+    /// Run an async test closure, record its outcome, and attach metadata.
+    pub async fn record_with_metadata<F, Fut, I, K, V>(
+        mut self,
+        name: impl Into<String>,
+        metadata: I,
+        f: F,
+    ) -> Self
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<(), String>>,
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        let name = name.into();
+        let start = Instant::now();
+        let outcome = f().await;
+        let duration = start.elapsed();
+
+        let (status, error) = match outcome {
+            Ok(()) => (TestStatus::Passed, None),
+            Err(msg) => (TestStatus::Failed, Some(msg)),
+        };
+
+        self.results.push(
+            TestCaseResult {
+                name,
+                status,
+                duration,
+                error,
+                metadata: Vec::new(),
+            }
+            .with_metadata(metadata),
+        );
+        self
+    }
+
     /// Manually add a pre-built result.
     pub fn add_result(mut self, result: TestCaseResult) -> Self {
         self.results.push(result);

--- a/tests/src/report/mod.rs
+++ b/tests/src/report/mod.rs
@@ -6,4 +6,6 @@ mod types;
 
 pub use builder::TestReportBuilder;
 pub use format::{JsonFormatter, ReportFormatter, TextFormatter};
-pub use types::{TestCaseResult, TestReport, TestStatus};
+pub use types::{
+    AgentRunResult, BehaviorMetadata, FallbackStatus, TestCaseResult, TestReport, TestStatus,
+};

--- a/tests/src/report/types.rs
+++ b/tests/src/report/types.rs
@@ -2,6 +2,11 @@
 
 use std::time::Duration;
 
+pub(crate) const OUTPUT_METADATA_KEY: &str = "output";
+pub(crate) const TOOL_CALLS_METADATA_KEY: &str = "tool_calls";
+pub(crate) const RETRY_COUNT_METADATA_KEY: &str = "retry_count";
+pub(crate) const FALLBACK_TRIGGERED_METADATA_KEY: &str = "fallback_triggered";
+
 /// Outcome of a single test case.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -55,6 +60,55 @@ impl TestCaseResult {
     /// Look up the first present metadata value across multiple key aliases.
     pub fn metadata_value_any<'a>(&'a self, keys: &[&str]) -> Option<&'a str> {
         keys.iter().find_map(|key| self.metadata_value(key))
+    }
+
+    /// Attach a canonical output value used by higher-level diffing.
+    pub fn with_output(self, output: impl Into<String>) -> Self {
+        self.with_metadata([(OUTPUT_METADATA_KEY, output.into())])
+    }
+
+    /// Attach canonical tool-call trace text used by higher-level diffing.
+    pub fn with_tool_calls(self, tool_calls: impl Into<String>) -> Self {
+        self.with_metadata([(TOOL_CALLS_METADATA_KEY, tool_calls.into())])
+    }
+
+    /// Attach a canonical retry count used by higher-level diffing.
+    pub fn with_retry_count(self, retry_count: usize) -> Self {
+        self.with_metadata([(RETRY_COUNT_METADATA_KEY, retry_count.to_string())])
+    }
+
+    /// Attach canonical fallback status used by higher-level diffing.
+    pub fn with_fallback_triggered(self, fallback_triggered: bool) -> Self {
+        self.with_metadata([(
+            FALLBACK_TRIGGERED_METADATA_KEY,
+            fallback_triggered.to_string(),
+        )])
+    }
+
+    /// Read the canonical output value if present.
+    pub fn output(&self) -> Option<&str> {
+        self.metadata_value(OUTPUT_METADATA_KEY)
+    }
+
+    /// Read the canonical tool-call trace if present.
+    pub fn tool_calls(&self) -> Option<&str> {
+        self.metadata_value(TOOL_CALLS_METADATA_KEY)
+    }
+
+    /// Read the canonical retry count if present and parseable.
+    pub fn retry_count(&self) -> Option<usize> {
+        self.metadata_value(RETRY_COUNT_METADATA_KEY)
+            .and_then(|value| value.parse::<usize>().ok())
+    }
+
+    /// Read the canonical fallback status if present.
+    pub fn fallback_triggered(&self) -> Option<bool> {
+        self.metadata_value(FALLBACK_TRIGGERED_METADATA_KEY)
+            .and_then(|value| match value.trim().to_ascii_lowercase().as_str() {
+                "true" | "yes" | "1" | "triggered" | "fallback" => Some(true),
+                "false" | "no" | "0" | "not_triggered" | "none" => Some(false),
+                _ => None,
+            })
     }
 }
 

--- a/tests/src/report/types.rs
+++ b/tests/src/report/types.rs
@@ -1,11 +1,109 @@
 //! Core data types for test reports.
 
+use mofa_runtime::agent::execution::{ExecutionResult, ExecutionStatus};
 use std::time::Duration;
 
 pub(crate) const OUTPUT_METADATA_KEY: &str = "output";
 pub(crate) const TOOL_CALLS_METADATA_KEY: &str = "tool_calls";
 pub(crate) const RETRY_COUNT_METADATA_KEY: &str = "retry_count";
 pub(crate) const FALLBACK_TRIGGERED_METADATA_KEY: &str = "fallback_triggered";
+
+/// Canonical behavior metadata attached to a test case result.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct BehaviorMetadata {
+    pub output: Option<String>,
+    pub tool_calls: Option<String>,
+    pub retry_count: Option<usize>,
+    pub fallback_triggered: Option<bool>,
+}
+
+impl BehaviorMetadata {
+    /// Create an empty behavior metadata object.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Attach the final output or response text.
+    pub fn with_output(mut self, output: impl Into<String>) -> Self {
+        self.output = Some(output.into());
+        self
+    }
+
+    /// Attach a tool-call sequence or summary.
+    pub fn with_tool_calls(mut self, tool_calls: impl Into<String>) -> Self {
+        self.tool_calls = Some(tool_calls.into());
+        self
+    }
+
+    /// Attach the retry count.
+    pub fn with_retry_count(mut self, retry_count: usize) -> Self {
+        self.retry_count = Some(retry_count);
+        self
+    }
+
+    /// Attach fallback status.
+    pub fn with_fallback_triggered(mut self, fallback_triggered: bool) -> Self {
+        self.fallback_triggered = Some(fallback_triggered);
+        self
+    }
+
+    /// Apply this metadata to a test case result.
+    pub fn apply_to(&self, mut case: TestCaseResult) -> TestCaseResult {
+        if let Some(output) = &self.output {
+            case = case.with_output(output.clone());
+        }
+        if let Some(tool_calls) = &self.tool_calls {
+            case = case.with_tool_calls(tool_calls.clone());
+        }
+        if let Some(retry_count) = self.retry_count {
+            case = case.with_retry_count(retry_count);
+        }
+        if let Some(fallback_triggered) = self.fallback_triggered {
+            case = case.with_fallback_triggered(fallback_triggered);
+        }
+        case
+    }
+
+    /// Extract canonical behavior metadata from a test case result.
+    pub fn from_case(case: &TestCaseResult) -> Self {
+        Self {
+            output: case.output().map(ToString::to_string),
+            tool_calls: case.tool_calls().map(ToString::to_string),
+            retry_count: case.retry_count(),
+            fallback_triggered: case.fallback_triggered(),
+        }
+    }
+
+    /// Extract canonical behavior metadata from a runtime execution result.
+    pub fn from_execution_result(result: &ExecutionResult) -> Self {
+        let output = result.output.as_ref().map(|output| output.to_text());
+        let tool_calls = result.output.as_ref().and_then(|output| {
+            if output.tools_used.is_empty() {
+                None
+            } else {
+                Some(
+                    output
+                        .tools_used
+                        .iter()
+                        .map(|tool| tool.name.as_str())
+                        .collect::<Vec<_>>()
+                        .join(","),
+                )
+            }
+        });
+        let fallback_triggered = result
+            .metadata
+            .get("fallback")
+            .and_then(|value| value.as_bool());
+
+        Self {
+            output,
+            tool_calls,
+            retry_count: Some(result.retries),
+            fallback_triggered,
+        }
+    }
+}
 
 /// Outcome of a single test case.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -109,6 +207,36 @@ impl TestCaseResult {
                 "false" | "no" | "0" | "not_triggered" | "none" => Some(false),
                 _ => None,
             })
+    }
+
+    /// Attach canonical behavior metadata in one step.
+    pub fn with_behavior(self, behavior: &BehaviorMetadata) -> Self {
+        behavior.apply_to(self)
+    }
+
+    /// Extract canonical behavior metadata from this result.
+    pub fn behavior(&self) -> BehaviorMetadata {
+        BehaviorMetadata::from_case(self)
+    }
+
+    /// Convert a runtime execution result into a test case result.
+    pub fn from_execution_result(
+        name: impl Into<String>,
+        result: &ExecutionResult,
+    ) -> Self {
+        let status = match result.status {
+            ExecutionStatus::Success => TestStatus::Passed,
+            _ => TestStatus::Failed,
+        };
+
+        TestCaseResult {
+            name: name.into(),
+            status,
+            duration: Duration::from_millis(result.duration_ms),
+            error: result.error.clone(),
+            metadata: Vec::new(),
+        }
+        .with_behavior(&BehaviorMetadata::from_execution_result(result))
     }
 }
 

--- a/tests/src/report/types.rs
+++ b/tests/src/report/types.rs
@@ -32,6 +32,18 @@ pub struct TestCaseResult {
 }
 
 impl TestCaseResult {
+    /// Attach metadata entries to this result.
+    pub fn with_metadata<I, K, V>(mut self, metadata: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.metadata
+            .extend(metadata.into_iter().map(|(key, value)| (key.into(), value.into())));
+        self
+    }
+
     /// Look up a metadata value by key.
     pub fn metadata_value(&self, key: &str) -> Option<&str> {
         self.metadata

--- a/tests/src/report/types.rs
+++ b/tests/src/report/types.rs
@@ -1,12 +1,130 @@
 //! Core data types for test reports.
 
+use mofa_foundation::workflow::ExecutionEventEnvelope;
+use mofa_kernel::agent::types::{GlobalMessage, ToolUsage};
 use mofa_runtime::agent::execution::{ExecutionResult, ExecutionStatus};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::time::Duration;
 
 pub(crate) const OUTPUT_METADATA_KEY: &str = "output";
 pub(crate) const TOOL_CALLS_METADATA_KEY: &str = "tool_calls";
 pub(crate) const RETRY_COUNT_METADATA_KEY: &str = "retry_count";
 pub(crate) const FALLBACK_TRIGGERED_METADATA_KEY: &str = "fallback_triggered";
+
+/// Canonical, test-focused agent run artifact.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct AgentRunResult {
+    pub execution_id: String,
+    pub agent_id: String,
+    pub status: ExecutionStatus,
+    pub final_response: Option<String>,
+    pub tool_calls: Vec<ToolUsage>,
+    pub session_messages: Vec<GlobalMessage>,
+    pub session_snapshot: Option<serde_json::Value>,
+    pub memory_snapshot: Option<serde_json::Value>,
+    pub memory_effects: Option<serde_json::Value>,
+    pub retries: usize,
+    pub fallback: FallbackStatus,
+    pub duration_ms: u64,
+    pub error: Option<String>,
+    pub trace_events: Vec<ExecutionEventEnvelope>,
+    pub trace_summary: Option<String>,
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+impl AgentRunResult {
+    /// Build a canonical run artifact from a runtime execution result.
+    pub fn from_execution_result(result: &ExecutionResult) -> Self {
+        let (final_response, tool_calls) = match result.output.as_ref() {
+            Some(output) => (Some(output.to_text()), output.tools_used.clone()),
+            None => (None, Vec::new()),
+        };
+
+        let fallback_triggered = result
+            .metadata
+            .get("fallback")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
+        let fallback_reason = result
+            .metadata
+            .get("fallback_reason")
+            .and_then(|value| value.as_str())
+            .map(|value| value.to_string());
+
+        Self {
+            execution_id: result.execution_id.clone(),
+            agent_id: result.agent_id.clone(),
+            status: result.status.clone(),
+            final_response,
+            tool_calls,
+            session_messages: Vec::new(),
+            session_snapshot: None,
+            memory_snapshot: None,
+            memory_effects: None,
+            retries: result.retries,
+            fallback: FallbackStatus {
+                triggered: fallback_triggered,
+                reason: fallback_reason,
+            },
+            duration_ms: result.duration_ms,
+            error: result.error.clone(),
+            trace_events: Vec::new(),
+            trace_summary: None,
+            metadata: result.metadata.clone(),
+        }
+    }
+
+    /// Attach session messages.
+    pub fn with_session_messages(mut self, messages: Vec<GlobalMessage>) -> Self {
+        self.session_messages = messages;
+        self
+    }
+
+    /// Attach a session snapshot payload.
+    pub fn with_session_snapshot(mut self, snapshot: serde_json::Value) -> Self {
+        self.session_snapshot = Some(snapshot);
+        self
+    }
+
+    /// Attach a memory snapshot payload.
+    pub fn with_memory_snapshot(mut self, snapshot: serde_json::Value) -> Self {
+        self.memory_snapshot = Some(snapshot);
+        self
+    }
+
+    /// Attach memory effects payload.
+    pub fn with_memory_effects(mut self, effects: serde_json::Value) -> Self {
+        self.memory_effects = Some(effects);
+        self
+    }
+
+    /// Attach execution trace events.
+    pub fn with_trace_events(mut self, events: Vec<ExecutionEventEnvelope>) -> Self {
+        self.trace_events = events;
+        self
+    }
+
+    /// Attach an execution trace summary string.
+    pub fn with_trace_summary(mut self, summary: impl Into<String>) -> Self {
+        self.trace_summary = Some(summary.into());
+        self
+    }
+
+    /// Add metadata to the run artifact.
+    pub fn with_metadata(mut self, key: impl Into<String>, value: serde_json::Value) -> Self {
+        self.metadata.insert(key.into(), value);
+        self
+    }
+}
+
+/// Fallback status metadata for a run.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct FallbackStatus {
+    pub triggered: bool,
+    pub reason: Option<String>,
+}
 
 /// Canonical behavior metadata attached to a test case result.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -76,31 +194,29 @@ impl BehaviorMetadata {
 
     /// Extract canonical behavior metadata from a runtime execution result.
     pub fn from_execution_result(result: &ExecutionResult) -> Self {
-        let output = result.output.as_ref().map(|output| output.to_text());
-        let tool_calls = result.output.as_ref().and_then(|output| {
-            if output.tools_used.is_empty() {
-                None
-            } else {
-                Some(
-                    output
-                        .tools_used
-                        .iter()
-                        .map(|tool| tool.name.as_str())
-                        .collect::<Vec<_>>()
-                        .join(","),
-                )
-            }
-        });
-        let fallback_triggered = result
-            .metadata
-            .get("fallback")
-            .and_then(|value| value.as_bool());
+        let run = AgentRunResult::from_execution_result(result);
+        Self::from_agent_run_result(&run)
+    }
+
+    /// Extract canonical behavior metadata from a run artifact.
+    pub fn from_agent_run_result(run: &AgentRunResult) -> Self {
+        let tool_calls = if run.tool_calls.is_empty() {
+            None
+        } else {
+            Some(
+                run.tool_calls
+                    .iter()
+                    .map(|tool| tool.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(","),
+            )
+        };
 
         Self {
-            output,
+            output: run.final_response.clone(),
             tool_calls,
-            retry_count: Some(result.retries),
-            fallback_triggered,
+            retry_count: Some(run.retries),
+            fallback_triggered: Some(run.fallback.triggered),
         }
     }
 }
@@ -224,7 +340,16 @@ impl TestCaseResult {
         name: impl Into<String>,
         result: &ExecutionResult,
     ) -> Self {
-        let status = match result.status {
+        let run = AgentRunResult::from_execution_result(result);
+        Self::from_agent_run_result(name, &run)
+    }
+
+    /// Convert a run artifact into a test case result.
+    pub fn from_agent_run_result(
+        name: impl Into<String>,
+        run: &AgentRunResult,
+    ) -> Self {
+        let status = match run.status {
             ExecutionStatus::Success => TestStatus::Passed,
             _ => TestStatus::Failed,
         };
@@ -232,11 +357,11 @@ impl TestCaseResult {
         TestCaseResult {
             name: name.into(),
             status,
-            duration: Duration::from_millis(result.duration_ms),
-            error: result.error.clone(),
+            duration: Duration::from_millis(run.duration_ms),
+            error: run.error.clone(),
             metadata: Vec::new(),
         }
-        .with_behavior(&BehaviorMetadata::from_execution_result(result))
+        .with_behavior(&BehaviorMetadata::from_agent_run_result(run))
     }
 }
 

--- a/tests/src/report/types.rs
+++ b/tests/src/report/types.rs
@@ -31,6 +31,21 @@ pub struct TestCaseResult {
     pub metadata: Vec<(String, String)>,
 }
 
+impl TestCaseResult {
+    /// Look up a metadata value by key.
+    pub fn metadata_value(&self, key: &str) -> Option<&str> {
+        self.metadata
+            .iter()
+            .find(|(existing, _)| existing == key)
+            .map(|(_, value)| value.as_str())
+    }
+
+    /// Look up the first present metadata value across multiple key aliases.
+    pub fn metadata_value_any<'a>(&'a self, keys: &[&str]) -> Option<&'a str> {
+        keys.iter().find_map(|key| self.metadata_value(key))
+    }
+}
+
 /// Aggregated report for a test suite.
 #[derive(Debug, Clone)]
 pub struct TestReport {

--- a/tests/tests/behavior_diff_tests.rs
+++ b/tests/tests/behavior_diff_tests.rs
@@ -1,4 +1,7 @@
-use mofa_testing::behavior_diff::{BehaviorDiff, CaseChangeKind};
+use mofa_testing::behavior_diff::{
+    BehaviorDiff, BehaviorDiffFormatter, CaseChangeKind, JsonBehaviorDiffFormatter,
+    MarkdownBehaviorDiffFormatter,
+};
 use mofa_testing::report::{TestCaseResult, TestReport, TestStatus};
 use std::time::Duration;
 
@@ -238,4 +241,29 @@ fn behavior_diff_has_change_helpers() {
     assert!(changed.has_changes());
     assert_eq!(changed.changed_cases().len(), 1);
     assert_eq!(changed.changed_cases()[0].name, "same");
+}
+
+#[test]
+fn behavior_diff_formatters_render_markdown_and_json() {
+    let baseline = make_report(
+        "baseline",
+        10,
+        vec![make_result("case", TestStatus::Passed, 5, None, &[("output", "old")])],
+    );
+    let candidate = make_report(
+        "candidate",
+        20,
+        vec![make_result("case", TestStatus::Failed, 9, Some("err"), &[("output", "new")])],
+    );
+
+    let diff = BehaviorDiff::between(&baseline, &candidate);
+
+    let markdown = MarkdownBehaviorDiffFormatter.format(&diff);
+    assert!(markdown.contains("## Behavioral Diff"));
+    assert!(markdown.contains("status passed -> failed"));
+
+    let json = JsonBehaviorDiffFormatter.format(&diff);
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid diff json");
+    assert_eq!(parsed["summary"]["status_changes"], 1);
+    assert_eq!(parsed["cases"][0]["status_change"]["after"], "failed");
 }

--- a/tests/tests/behavior_diff_tests.rs
+++ b/tests/tests/behavior_diff_tests.rs
@@ -211,3 +211,31 @@ fn behavior_diff_json_contains_summary_and_case_details() {
     assert_eq!(json["cases"][0]["output_change"]["before"], "old");
     assert_eq!(json["cases"][0]["output_change"]["after"], "new");
 }
+
+#[test]
+fn behavior_diff_has_change_helpers() {
+    let baseline = make_report(
+        "baseline",
+        20,
+        vec![make_result("same", TestStatus::Passed, 10, None, &[])],
+    );
+    let candidate = make_report(
+        "candidate",
+        20,
+        vec![make_result("same", TestStatus::Passed, 10, None, &[])],
+    );
+
+    let unchanged = BehaviorDiff::between(&baseline, &candidate);
+    assert!(!unchanged.has_changes());
+    assert!(unchanged.changed_cases().is_empty());
+
+    let changed_candidate = make_report(
+        "candidate",
+        30,
+        vec![make_result("same", TestStatus::Failed, 20, Some("oops"), &[])],
+    );
+    let changed = BehaviorDiff::between(&baseline, &changed_candidate);
+    assert!(changed.has_changes());
+    assert_eq!(changed.changed_cases().len(), 1);
+    assert_eq!(changed.changed_cases()[0].name, "same");
+}

--- a/tests/tests/behavior_diff_tests.rs
+++ b/tests/tests/behavior_diff_tests.rs
@@ -1,0 +1,213 @@
+use mofa_testing::behavior_diff::{BehaviorDiff, CaseChangeKind};
+use mofa_testing::report::{TestCaseResult, TestReport, TestStatus};
+use std::time::Duration;
+
+fn make_result(
+    name: &str,
+    status: TestStatus,
+    duration_ms: u64,
+    error: Option<&str>,
+    metadata: &[(&str, &str)],
+) -> TestCaseResult {
+    TestCaseResult {
+        name: name.into(),
+        status,
+        duration: Duration::from_millis(duration_ms),
+        error: error.map(String::from),
+        metadata: metadata
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect(),
+    }
+}
+
+fn make_report(name: &str, duration_ms: u64, results: Vec<TestCaseResult>) -> TestReport {
+    TestReport {
+        suite_name: name.into(),
+        results,
+        total_duration: Duration::from_millis(duration_ms),
+        timestamp: 0,
+    }
+}
+
+#[test]
+fn behavior_diff_detects_status_and_latency_changes() {
+    let baseline = make_report(
+        "baseline",
+        100,
+        vec![make_result("agent-case", TestStatus::Passed, 10, None, &[])],
+    );
+    let candidate = make_report(
+        "candidate",
+        150,
+        vec![make_result(
+            "agent-case",
+            TestStatus::Failed,
+            45,
+            Some("tool timeout"),
+            &[],
+        )],
+    );
+
+    let diff = BehaviorDiff::between(&baseline, &candidate);
+
+    assert_eq!(diff.summary.status_changes, 1);
+    assert_eq!(diff.summary.slower_cases, 1);
+    assert_eq!(diff.summary.suite_duration_delta_ms, 50);
+
+    let case = &diff.cases[0];
+    assert_eq!(case.change, CaseChangeKind::Modified);
+    assert_eq!(
+        case.status_change.as_ref().map(|c| (&c.before, &c.after)),
+        Some((&TestStatus::Passed, &TestStatus::Failed))
+    );
+    assert_eq!(case.duration_delta_ms, 35);
+    assert_eq!(
+        case.error_change.as_ref().map(|c| (c.before.as_deref(), c.after.as_deref())),
+        Some((None, Some("tool timeout")))
+    );
+}
+
+#[test]
+fn behavior_diff_detects_metadata_behavior_changes() {
+    let baseline = make_report(
+        "baseline",
+        100,
+        vec![make_result(
+            "tool-case",
+            TestStatus::Passed,
+            30,
+            None,
+            &[
+                ("output", "answer-a"),
+                ("tool_calls", "search"),
+                ("retry_count", "0"),
+                ("fallback_triggered", "false"),
+            ],
+        )],
+    );
+    let candidate = make_report(
+        "candidate",
+        100,
+        vec![make_result(
+            "tool-case",
+            TestStatus::Passed,
+            20,
+            None,
+            &[
+                ("output", "answer-b"),
+                ("tool_calls", "search,lookup"),
+                ("retry_count", "2"),
+                ("fallback_triggered", "true"),
+            ],
+        )],
+    );
+
+    let diff = BehaviorDiff::between(&baseline, &candidate);
+    let case = &diff.cases[0];
+
+    assert_eq!(diff.summary.output_changes, 1);
+    assert_eq!(diff.summary.tool_call_changes, 1);
+    assert_eq!(diff.summary.retry_changes, 1);
+    assert_eq!(diff.summary.fallback_changes, 1);
+    assert_eq!(diff.summary.faster_cases, 1);
+
+    assert_eq!(
+        case.output_change.as_ref().map(|c| (c.before.as_str(), c.after.as_str())),
+        Some(("answer-a", "answer-b"))
+    );
+    assert_eq!(
+        case.tool_calls_change
+            .as_ref()
+            .map(|c| (c.before.as_str(), c.after.as_str())),
+        Some(("search", "search,lookup"))
+    );
+    assert_eq!(
+        case.retry_change.as_ref().map(|c| (c.before, c.after)),
+        Some((0, 2))
+    );
+    assert_eq!(
+        case.fallback_change.as_ref().map(|c| (c.before, c.after)),
+        Some((false, true))
+    );
+}
+
+#[test]
+fn behavior_diff_detects_added_removed_and_markdown_summary() {
+    let baseline = make_report(
+        "baseline",
+        100,
+        vec![
+            make_result("kept", TestStatus::Passed, 10, None, &[]),
+            make_result("removed", TestStatus::Passed, 5, None, &[]),
+        ],
+    );
+    let candidate = make_report(
+        "candidate",
+        120,
+        vec![
+            make_result("kept", TestStatus::Passed, 10, None, &[]),
+            make_result("added", TestStatus::Passed, 20, None, &[("response", "hi")]),
+        ],
+    );
+
+    let diff = BehaviorDiff::between(&baseline, &candidate);
+
+    assert_eq!(diff.summary.added_cases, 1);
+    assert_eq!(diff.summary.removed_cases, 1);
+    assert_eq!(diff.summary.unchanged_cases, 1);
+    assert!(diff
+        .cases
+        .iter()
+        .any(|case| case.name == "added" && case.change == CaseChangeKind::Added));
+    assert!(diff
+        .cases
+        .iter()
+        .any(|case| case.name == "removed" && case.change == CaseChangeKind::Removed));
+
+    let markdown = diff.to_markdown();
+    assert!(markdown.contains("## Behavioral Diff"));
+    assert!(markdown.contains("Cases added: 1"));
+    assert!(markdown.contains("`added`: added"));
+    assert!(markdown.contains("`removed`: removed"));
+}
+
+#[test]
+fn behavior_diff_json_contains_summary_and_case_details() {
+    let baseline = make_report(
+        "baseline",
+        90,
+        vec![make_result(
+            "case-a",
+            TestStatus::Passed,
+            10,
+            None,
+            &[("output", "old"), ("retry_count", "0")],
+        )],
+    );
+    let candidate = make_report(
+        "candidate",
+        100,
+        vec![make_result(
+            "case-a",
+            TestStatus::Failed,
+            15,
+            Some("bad output"),
+            &[("output", "new"), ("retry_count", "1")],
+        )],
+    );
+
+    let diff = BehaviorDiff::between(&baseline, &candidate);
+    let json = diff.to_json();
+
+    assert_eq!(json["baseline_suite"], "baseline");
+    assert_eq!(json["candidate_suite"], "candidate");
+    assert_eq!(json["summary"]["status_changes"], 1);
+    assert_eq!(json["summary"]["retry_changes"], 1);
+    assert_eq!(json["cases"][0]["name"], "case-a");
+    assert_eq!(json["cases"][0]["change"], "modified");
+    assert_eq!(json["cases"][0]["status_change"]["before"], "passed");
+    assert_eq!(json["cases"][0]["status_change"]["after"], "failed");
+    assert_eq!(json["cases"][0]["output_change"]["before"], "old");
+    assert_eq!(json["cases"][0]["output_change"]["after"], "new");
+}

--- a/tests/tests/report_tests.rs
+++ b/tests/tests/report_tests.rs
@@ -175,6 +175,30 @@ async fn builder_record_failure() {
 }
 
 #[tokio::test]
+async fn builder_record_with_metadata_attaches_behavior_fields() {
+    let report = TestReportBuilder::new("meta-suite")
+        .record_with_metadata(
+            "agent_case",
+            [
+                ("output", "final answer"),
+                ("tool_calls", "search,calculator"),
+                ("retry_count", "1"),
+                ("fallback_triggered", "false"),
+            ],
+            || async { Ok(()) },
+        )
+        .await
+        .build();
+
+    let case = &report.results[0];
+    assert_eq!(case.status, TestStatus::Passed);
+    assert_eq!(case.metadata_value("output"), Some("final answer"));
+    assert_eq!(case.metadata_value("tool_calls"), Some("search,calculator"));
+    assert_eq!(case.metadata_value("retry_count"), Some("1"));
+    assert_eq!(case.metadata_value("fallback_triggered"), Some("false"));
+}
+
+#[tokio::test]
 async fn builder_add_result_skipped() {
     let report = TestReportBuilder::new("skip-suite")
         .add_result(make_result("skipped_one", TestStatus::Skipped, 0, None))
@@ -271,6 +295,20 @@ fn json_formatter_includes_metadata() {
     let output = JsonFormatter.format(&r);
     let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
     assert_eq!(parsed["results"][0]["metadata"]["key"], "val");
+}
+
+#[test]
+fn test_case_result_with_metadata_extends_entries() {
+    let case = make_result("meta_case", TestStatus::Passed, 5, None).with_metadata([
+        ("output", "hello"),
+        ("response", "alias"),
+    ]);
+
+    assert_eq!(case.metadata_value("output"), Some("hello"));
+    assert_eq!(
+        case.metadata_value_any(&["final_response", "response"]),
+        Some("alias")
+    );
 }
 
 // ===========================================================================

--- a/tests/tests/report_tests.rs
+++ b/tests/tests/report_tests.rs
@@ -2,9 +2,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use mofa_testing::{
-    JsonFormatter, MockClock, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder,
-    TestStatus, TextFormatter,
+    BehaviorMetadata, JsonFormatter, MockClock, ReportFormatter, TestCaseResult, TestReport,
+    TestReportBuilder, TestStatus, TextFormatter,
 };
+use mofa_kernel::agent::types::{AgentOutput, ToolUsage};
+use mofa_runtime::agent::execution::{ExecutionResult, ExecutionStatus};
 
 // ---------------------------------------------------------------------------
 // Helper
@@ -199,6 +201,26 @@ async fn builder_record_with_metadata_attaches_behavior_fields() {
 }
 
 #[tokio::test]
+async fn builder_record_with_behavior_attaches_canonical_behavior() {
+    let behavior = BehaviorMetadata::new()
+        .with_output("final answer")
+        .with_tool_calls("search,calculator")
+        .with_retry_count(1)
+        .with_fallback_triggered(false);
+
+    let report = TestReportBuilder::new("behavior-suite")
+        .record_with_behavior("agent_case", behavior, || async { Ok(()) })
+        .await
+        .build();
+
+    let case = &report.results[0];
+    assert_eq!(case.output(), Some("final answer"));
+    assert_eq!(case.tool_calls(), Some("search,calculator"));
+    assert_eq!(case.retry_count(), Some(1));
+    assert_eq!(case.fallback_triggered(), Some(false));
+}
+
+#[tokio::test]
 async fn builder_add_result_skipped() {
     let report = TestReportBuilder::new("skip-suite")
         .add_result(make_result("skipped_one", TestStatus::Skipped, 0, None))
@@ -323,6 +345,90 @@ fn test_case_result_behavior_metadata_helpers_roundtrip() {
     assert_eq!(case.tool_calls(), Some("search,calculator"));
     assert_eq!(case.retry_count(), Some(2));
     assert_eq!(case.fallback_triggered(), Some(true));
+}
+
+#[test]
+fn behavior_metadata_roundtrips_from_case() {
+    let behavior = BehaviorMetadata::new()
+        .with_output("answer")
+        .with_tool_calls("search")
+        .with_retry_count(3)
+        .with_fallback_triggered(true);
+    let case = make_result("behavior_case", TestStatus::Passed, 8, None).with_behavior(&behavior);
+
+    assert_eq!(case.behavior(), behavior);
+}
+
+#[test]
+fn behavior_metadata_extracts_runtime_execution_result() {
+    let mut output = AgentOutput::text("runtime answer");
+    output.tools_used.push(ToolUsage::success(
+        "search",
+        serde_json::json!({"query": "rust"}),
+        serde_json::json!({"result": "ok"}),
+        12,
+    ));
+
+    let mut result = ExecutionResult::success(
+        "exec-1".to_string(),
+        "agent-a".to_string(),
+        output,
+        50,
+    );
+    result.retries = 2;
+    result.metadata.insert("fallback".into(), serde_json::json!(true));
+
+    let behavior = BehaviorMetadata::from_execution_result(&result);
+    assert_eq!(behavior.output.as_deref(), Some("runtime answer"));
+    assert_eq!(behavior.tool_calls.as_deref(), Some("search"));
+    assert_eq!(behavior.retry_count, Some(2));
+    assert_eq!(behavior.fallback_triggered, Some(true));
+}
+
+#[test]
+fn test_case_result_from_execution_result_maps_runtime_fields() {
+    let output = AgentOutput::text("done");
+    let result = ExecutionResult {
+        execution_id: "exec-2".to_string(),
+        agent_id: "agent-b".to_string(),
+        status: ExecutionStatus::Timeout,
+        output: Some(output),
+        error: Some("timed out".to_string()),
+        duration_ms: 125,
+        retries: 1,
+        metadata: Default::default(),
+    };
+
+    let case = TestCaseResult::from_execution_result("real-agent-case", &result);
+    assert_eq!(case.name, "real-agent-case");
+    assert_eq!(case.status, TestStatus::Failed);
+    assert_eq!(case.duration, Duration::from_millis(125));
+    assert_eq!(case.error.as_deref(), Some("timed out"));
+    assert_eq!(case.output(), Some("done"));
+    assert_eq!(case.retry_count(), Some(1));
+}
+
+#[tokio::test]
+async fn builder_add_execution_result_uses_runtime_mapping() {
+    let output = AgentOutput::text("ok");
+    let result = ExecutionResult {
+        execution_id: "exec-3".to_string(),
+        agent_id: "agent-c".to_string(),
+        status: ExecutionStatus::Success,
+        output: Some(output),
+        error: None,
+        duration_ms: 30,
+        retries: 0,
+        metadata: Default::default(),
+    };
+
+    let report = TestReportBuilder::new("runtime-suite")
+        .add_execution_result("runtime-case", &result)
+        .build();
+
+    let case = &report.results[0];
+    assert_eq!(case.status, TestStatus::Passed);
+    assert_eq!(case.output(), Some("ok"));
 }
 
 // ===========================================================================

--- a/tests/tests/report_tests.rs
+++ b/tests/tests/report_tests.rs
@@ -311,6 +311,20 @@ fn test_case_result_with_metadata_extends_entries() {
     );
 }
 
+#[test]
+fn test_case_result_behavior_metadata_helpers_roundtrip() {
+    let case = make_result("behavior_case", TestStatus::Passed, 8, None)
+        .with_output("final answer")
+        .with_tool_calls("search,calculator")
+        .with_retry_count(2)
+        .with_fallback_triggered(true);
+
+    assert_eq!(case.output(), Some("final answer"));
+    assert_eq!(case.tool_calls(), Some("search,calculator"));
+    assert_eq!(case.retry_count(), Some(2));
+    assert_eq!(case.fallback_triggered(), Some(true));
+}
+
 // ===========================================================================
 // TextFormatter
 // ===========================================================================


### PR DESCRIPTION
## Summary

Add behavioral diff reporting to `mofa-testing` so MoFA test runs can be compared as behavior, not just pass/fail.

This PR introduces a full behavioral diff flow:

- compare two test reports and detect behavioral changes
- render those changes as readable markdown and structured JSON
- attach canonical behavior metadata to test results
- map real `mofa-runtime::ExecutionResult` values into `mofa-testing` reports
- provide runnable examples, including one that goes through the real runtime execution path

This makes regressions visible in output, tool usage, retries, fallback behavior, and latency-related summaries.

## Context

Before this PR, `mofa-testing` had:

- `TestReport`
- report builders and formatters
- assertion utilities
- mock backends
- newer runtime/report wiring work

But it did not yet have a first-class way to compare two runs and explain how behavior changed.

This PR adds that missing layer.

## Behavioral Diff Execution Flow
<img width="1329" height="1070" alt="image" src="https://github.com/user-attachments/assets/7cb10a9d-26b2-4a48-8017-d7f9f9cfd69b" />

## What This PR Adds

### 1. Behavioral diff core

Added the behavioral diff core in `tests/src/behavior_diff.rs`.

New types include:

- `BehaviorDiff`: the top-level comparison result between a baseline report and a candidate report
- `BehaviorDiffSummary`: aggregate counts for behavior changes across the suite
- `CaseBehaviorDiff`: the per-test diff record that captures what changed for one case
- `CaseChangeKind`: whether a case was added, removed, modified, or unchanged
- `ValueChange<T>`: a reusable before/after wrapper for specific changed values

Core behavior:

- compare two `TestReport`s by case name
- detect added/removed/modified/unchanged cases
- detect status changes
- detect per-case duration deltas
- detect output changes
- detect tool-call changes
- detect retry-count changes
- detect fallback changes
- track suite-level summary counts

The diff uses canonical metadata keys so it can work with report-layer and runtime-layer data consistently.

### 2. Behavioral diff output formatters

Added formatter support in `tests/src/behavior_diff.rs` and exported it from `tests/src/lib.rs`.

New output surfaces:

- `BehaviorDiff::to_markdown()`: creates a readable summary that can be pasted into local reviews or CI comments
- `BehaviorDiff::to_json()`: creates structured machine-readable output for artifacts or automation
- `BehaviorDiffFormatter`: a common formatting interface for diff output
- `MarkdownBehaviorDiffFormatter`: a formatter for human-friendly rendered summaries
- `JsonBehaviorDiffFormatter`: a formatter for pretty JSON output

This gives both:

- human-readable visual proof
- machine-readable CI/artifact output

### 3. Report-layer metadata helpers

Extended `tests/src/report/types.rs`.

Added:

- `TestCaseResult::with_metadata(...)`: attaches arbitrary metadata entries to a recorded test case
- `metadata_value(...)`: retrieves one metadata field by key
- `metadata_value_any(...)`: retrieves the first value across alias keys

Then added typed behavior helpers:

- `with_output(...)`: stores the final response text in a canonical field
- `with_tool_calls(...)`: stores a normalized tool-call summary
- `with_retry_count(...)`: stores retry count in a canonical field
- `with_fallback_triggered(...)`: stores fallback state in a canonical field
- `output()`: reads back the canonical output field
- `tool_calls()`: reads back the canonical tool-call summary
- `retry_count()`: reads back the retry count as a typed value
- `fallback_triggered()`: reads back fallback state as a typed value

This removes stringly-typed metadata handling from higher-level code.

### 4. Canonical behavior metadata bridge

Added `BehaviorMetadata` in `tests/src/report/types.rs`.

This is the canonical bridge object for diff-relevant execution data:

- output
- tool calls
- retry count
- fallback triggered

Also added:

- `BehaviorMetadata::new()`: starts an empty behavior record
- builder-style setters: let caller code assemble behavior data without touching raw metadata keys
- `BehaviorMetadata::apply_to(...)`: writes canonical behavior fields into a `TestCaseResult`
- `BehaviorMetadata::from_case(...)`: extracts canonical behavior from an existing case result
- `TestCaseResult::with_behavior(...)`: attaches a complete behavior record in one step
- `TestCaseResult::behavior()`: reconstructs typed behavior metadata from a recorded case

This gives future runner code one stable type to produce.

### 5. Report builder support for behavior metadata

Extended `tests/src/report/builder.rs`.

Added:

- `record_with_metadata(...)`: records a test result and attaches arbitrary metadata during report building
- `record_with_behavior(...)`: records a test result and attaches canonical behavior data directly

This makes it easy to attach behavioral data at report-build time.

### 6. Runtime execution result mapping

Added real runtime integration by mapping `mofa-runtime` execution results into the report layer.

Changes:

- added `mofa-runtime` dependency in `tests/Cargo.toml`
- extended `tests/src/report/types.rs`
- extended `tests/src/report/builder.rs`

New adapters:

- `BehaviorMetadata::from_execution_result(&ExecutionResult)`: extracts diff-relevant behavior from a real runtime execution result
- `TestCaseResult::from_execution_result(name, &ExecutionResult)`: converts one runtime result into a diffable test case record
- `TestReportBuilder::add_execution_result(name, &ExecutionResult)`: appends runtime results directly into a report without custom glue code

Mapped runtime fields:

- `ExecutionResult.output` -> canonical output
- `AgentOutput.tools_used` -> canonical tool-call summary
- `ExecutionResult.retries` -> retry count
- `ExecutionResult.metadata["fallback"]` -> fallback status
- `ExecutionStatus` -> pass/fail status
- `duration_ms` -> test-case duration
- `error` -> failure message

This is the key wiring step that makes behavioral diff work on actual runtime-derived execution data.

### 7. Example output paths

Added two runnable examples:

- `examples/behavior_diff_example/src/main.rs`: a small example that demonstrates behavioral diff output using report-level data
- `examples/behavior_diff_runtime_example/src/main.rs`: a real runtime example that executes through `ExecutionEngine` and then diffs the resulting reports

Also registered them in `examples/Cargo.toml`.

The runtime example is especially important because it:

- runs through `mofa-runtime::ExecutionEngine`
- gets real `ExecutionResult`s
- builds reports from them
- computes a `BehaviorDiff`
- prints markdown and JSON output

This is the end-to-end proof path for the feature.

## Testing

Ran:

```bash
cargo test -p mofa-testing --test behavior_diff_tests
cargo test -p mofa-testing --test report_tests
cargo test -p mofa-testing --test report_merge_tests
cargo run --manifest-path /home/aditya/projc/mvpissues/mofa/examples/Cargo.toml -p behavior_diff_example
cargo run --manifest-path /home/aditya/projc/mvpissues/mofa/examples/Cargo.toml -p behavior_diff_runtime_example
```
<img width="963" height="820" alt="Screenshot from 2026-03-24 02-21-52" src="https://github.com/user-attachments/assets/873e363a-215c-4cec-917c-37a7e9426d50" />
<img width="936" height="439" alt="Screenshot from 2026-03-24 02-22-23" src="https://github.com/user-attachments/assets/fb5691bd-2322-41dc-ad79-4511c1b7c5e6" />


Verified:

- behavioral diff detects status changes
- behavioral diff detects output changes
- behavioral diff detects tool-call changes
- behavioral diff detects retry-count changes
- behavioral diff detects fallback changes
- behavioral diff detects added and removed cases
- markdown and JSON formatter output are correct
- typed report metadata helpers round-trip correctly
- runtime `ExecutionResult` maps correctly into `BehaviorMetadata`
- runtime `ExecutionResult` maps correctly into `TestCaseResult`
- `TestReportBuilder::add_execution_result(...)` produces diffable reports
- the runtime example produces end-to-end diff output through `ExecutionEngine`

## Why This Matters

This PR changes the testing story from:

- tests passed or failed

to:

- agent behavior changed in these specific ways

That is one of the strongest differentiators for because it enables:

- regression review
- PR comparison
- CI summaries
- future threshold gating
- future A/B and canary evaluation support

It is also directly aligned with the need-visual expectation for Behavioral Diff, while staying in the testing/reporting layer instead of prematurely expanding into GUI work.
