### PR TITLE
feat(testing): add scenario fixtures and declarative runner

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -14,4 +14,5 @@ async-trait = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 chrono = { workspace = true }

--- a/tests/fixtures/scenarios/basic.json
+++ b/tests/fixtures/scenarios/basic.json
@@ -1,0 +1,15 @@
+{
+  "case_name": "basic-json-scenario",
+  "kind": "contract",
+  "target": "testing-scenario",
+  "suite_name": "fixture-json-suite",
+  "llm": {
+    "model_name": "fixture-model-json",
+    "responses": [
+      { "prompt_substring": "ping", "response": "pong" }
+    ]
+  },
+  "expectations": {
+    "infer_total": 1
+  }
+}

--- a/tests/fixtures/scenarios/basic.yaml
+++ b/tests/fixtures/scenarios/basic.yaml
@@ -1,0 +1,11 @@
+case_name: basic-yaml-scenario
+kind: contract
+target: testing-scenario
+suite_name: fixture-yaml-suite
+llm:
+  model_name: fixture-model
+  responses:
+    - prompt_substring: hello
+      response: hi
+expectations:
+  infer_total: 1

--- a/tests/fixtures/scenarios/malformed.yaml
+++ b/tests/fixtures/scenarios/malformed.yaml
@@ -1,0 +1,6 @@
+suite_name: malformed
+llm:
+  responses:
+    - prompt_substring: broken
+      response: ok
+    - not-valid

--- a/tests/src/fixtures.rs
+++ b/tests/src/fixtures.rs
@@ -1,0 +1,50 @@
+//! Helpers for loading deterministic fixture files from `tests/fixtures`.
+
+use anyhow::{Context, Result, bail};
+use serde::de::DeserializeOwned;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Return the absolute path to the fixture root directory.
+pub fn fixtures_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("fixtures")
+}
+
+/// Return the absolute path to a fixture relative to the fixture root.
+pub fn fixture_path(relative_path: impl AsRef<Path>) -> PathBuf {
+    fixtures_root().join(relative_path)
+}
+
+/// Load a fixture from `tests/fixtures`, parsing JSON, YAML, or YML by extension.
+pub fn load_fixture<T>(relative_path: impl AsRef<Path>) -> Result<T>
+where
+    T: DeserializeOwned,
+{
+    let path = fixture_path(relative_path);
+    load_fixture_from_path(path)
+}
+
+fn load_fixture_from_path<T>(path: PathBuf) -> Result<T>
+where
+    T: DeserializeOwned,
+{
+    let raw = fs::read_to_string(&path)
+        .with_context(|| format!("failed to read fixture '{}'", path.display()))?;
+    let extension = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_ascii_lowercase())
+        .unwrap_or_default();
+
+    match extension.as_str() {
+        "json" => serde_json::from_str(&raw)
+            .with_context(|| format!("failed to parse JSON fixture '{}'", path.display())),
+        "yaml" | "yml" => serde_yaml::from_str(&raw)
+            .with_context(|| format!("failed to parse YAML fixture '{}'", path.display())),
+        other => bail!(
+            "unsupported fixture extension '{}' for '{}'",
+            other,
+            path.display()
+        ),
+    }
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -2,19 +2,31 @@
 //!
 //! Provides mock implementations, failure injection, and deterministic time
 //! control for testing MoFA agents.
+//!
+//! Contract fixtures live under `tests/fixtures/`. Prefer them when you need
+//! deterministic, portable coverage for scenario and contract tests.
 
 pub mod assertions;
 pub mod backend;
 pub mod bus;
 pub mod clock;
+pub mod fixtures;
 pub mod report;
+pub mod scenario;
 pub mod tools;
 
 pub use backend::MockLLMBackend;
 pub use bus::MockAgentBus;
 pub use clock::{Clock, MockClock, SystemClock};
+pub use fixtures::{fixture_path, fixtures_root, load_fixture};
 pub use report::{
     JsonFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,
     TextFormatter,
+};
+pub use scenario::{
+    BusExpectation, BusScenarioSpec, ClockScenarioSpec, LlmFailureSpec, LlmResponseRule,
+    LlmResponseSequence, LlmScenarioSpec, PromptCountExpectation, ScenarioContext, ScenarioRunner,
+    ScenarioSpec, ToolCallExpectation, ToolFailureSpec, ToolInputFailureSpec, ToolResultSpec,
+    ToolScenarioSpec,
 };
 pub use tools::MockTool;

--- a/tests/src/scenario/mod.rs
+++ b/tests/src/scenario/mod.rs
@@ -1,0 +1,12 @@
+//! Declarative scenario runner for end-to-end mock-based agent evaluation.
+
+mod runner;
+mod spec;
+
+pub use runner::{ScenarioContext, ScenarioRunner};
+pub use spec::{
+    BusExpectation, BusScenarioSpec, ClockScenarioSpec, LlmFailureSpec, LlmResponseRule,
+    LlmResponseSequence, LlmScenarioSpec, PromptCountExpectation, ScenarioExpectations,
+    ScenarioSpec, ToolCallExpectation, ToolFailureSpec, ToolInputFailureSpec, ToolResultSpec,
+    ToolScenarioSpec,
+};

--- a/tests/src/scenario/runner.rs
+++ b/tests/src/scenario/runner.rs
@@ -1,0 +1,291 @@
+use crate::backend::MockLLMBackend;
+use crate::bus::MockAgentBus;
+use crate::clock::MockClock;
+use crate::report::{TestCaseResult, TestReport, TestReportBuilder, TestStatus};
+use crate::scenario::spec::{ScenarioSpec, ToolResultSpec};
+use crate::tools::MockTool;
+use mofa_foundation::orchestrator::{
+    ModelOrchestrator, ModelProviderConfig, ModelType, OrchestratorError,
+};
+use mofa_kernel::agent::components::tool::ToolResult;
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+
+#[derive(Clone)]
+pub struct ScenarioContext {
+    pub backend: Arc<MockLLMBackend>,
+    pub bus: Arc<MockAgentBus>,
+    pub clock: Arc<MockClock>,
+    pub model_name: String,
+    tools: HashMap<String, MockTool>,
+    tracked_prompts: Arc<RwLock<Vec<String>>>,
+}
+
+impl ScenarioContext {
+    pub async fn infer(&self, prompt: &str) -> Result<String, OrchestratorError> {
+        self.tracked_prompts.write().await.push(prompt.to_string());
+        self.backend.infer(&self.model_name, prompt).await
+    }
+
+    pub fn tool(&self, name: &str) -> Option<MockTool> {
+        self.tools.get(name).cloned()
+    }
+
+    pub fn tool_names(&self) -> Vec<String> {
+        self.tools.keys().cloned().collect()
+    }
+}
+
+pub struct ScenarioRunner {
+    spec: ScenarioSpec,
+}
+
+impl ScenarioRunner {
+    pub fn new(spec: ScenarioSpec) -> Self {
+        Self { spec }
+    }
+
+    pub async fn run<F, Fut>(&self, scenario: F) -> anyhow::Result<TestReport>
+    where
+        F: FnOnce(ScenarioContext) -> Fut,
+        Fut: Future<Output = Result<(), String>>,
+    {
+        let context = self.build_context().await?;
+
+        let mut builder = TestReportBuilder::new(self.spec.suite_name.clone())
+            .with_clock(context.clock.clone())
+            .record("scenario_execution", || async {
+                scenario(context.clone()).await
+            })
+            .await;
+
+        for result in self.evaluate_expectations(&context).await {
+            builder = builder.add_result(result);
+        }
+
+        Ok(builder.build())
+    }
+
+    async fn build_context(&self) -> anyhow::Result<ScenarioContext> {
+        let mut backend = MockLLMBackend::new();
+        let llm_spec = &self.spec.llm;
+        let model_name = llm_spec
+            .model_name
+            .clone()
+            .unwrap_or_else(|| "scenario-model".to_string());
+
+        if let Some(fallback) = &llm_spec.fallback {
+            backend.set_fallback(fallback);
+        }
+
+        for rule in &llm_spec.responses {
+            backend.add_response(&rule.prompt_substring, &rule.response);
+        }
+
+        for sequence in &llm_spec.response_sequences {
+            let responses = sequence.responses.iter().map(String::as_str).collect();
+            backend.add_response_sequence(&sequence.prompt_substring, responses);
+        }
+
+        for failure in &llm_spec.fail_next {
+            backend.fail_next(
+                failure.count,
+                OrchestratorError::InferenceFailed(failure.error.clone()),
+            );
+        }
+
+        for failure in &llm_spec.fail_on {
+            backend.fail_on(
+                &failure.prompt_substring,
+                OrchestratorError::Other(failure.error.clone()),
+            );
+        }
+
+        backend
+            .register_model(make_model_config(&model_name))
+            .await
+            .map_err(anyhow::Error::from)?;
+        backend
+            .load_model(&model_name)
+            .await
+            .map_err(anyhow::Error::from)?;
+
+        let clock = Arc::new(match self.spec.clock.start_ms {
+            Some(ms) => MockClock::starting_at(Duration::from_millis(ms)),
+            None => MockClock::new(),
+        });
+        if let Some(step) = self.spec.clock.auto_advance_ms {
+            clock.set_auto_advance(Duration::from_millis(step));
+        }
+
+        let bus = Arc::new(MockAgentBus::new());
+        for failure in &self.spec.bus.fail_next_send {
+            bus.fail_next_send(failure.count, &failure.error).await;
+        }
+
+        let mut tools = HashMap::new();
+        for tool_spec in &self.spec.tools {
+            let tool = MockTool::new(
+                &tool_spec.name,
+                &tool_spec.description,
+                tool_spec.schema.clone(),
+            );
+
+            if let Some(result) = &tool_spec.stubbed_result {
+                tool.set_result(to_tool_result(result)).await;
+            }
+
+            for failure in &tool_spec.fail_next {
+                tool.fail_next(failure.count, &failure.error).await;
+            }
+
+            for failure in &tool_spec.fail_on_input {
+                tool.fail_on_input(failure.input.clone(), &failure.error)
+                    .await;
+            }
+
+            if !tool_spec.result_sequence.is_empty() {
+                let sequence = tool_spec
+                    .result_sequence
+                    .iter()
+                    .map(to_tool_result)
+                    .collect();
+                tool.add_result_sequence(sequence).await;
+            }
+
+            tools.insert(tool_spec.name.clone(), tool);
+        }
+
+        Ok(ScenarioContext {
+            backend: Arc::new(backend),
+            bus,
+            clock,
+            model_name,
+            tools,
+            tracked_prompts: Arc::new(RwLock::new(Vec::new())),
+        })
+    }
+
+    async fn evaluate_expectations(&self, context: &ScenarioContext) -> Vec<TestCaseResult> {
+        let mut results = Vec::new();
+
+        if let Some(expected) = self.spec.expectations.infer_total {
+            let actual = context.backend.call_count();
+            results.push(expectation_result(
+                "expect_infer_total",
+                actual == expected,
+                format!("expected infer_total={expected}, got {actual}"),
+            ));
+        }
+
+        for expectation in &self.spec.expectations.prompt_counts {
+            let actual = {
+                let prompts = context.tracked_prompts.read().await;
+                prompts
+                    .iter()
+                    .filter(|prompt| prompt.contains(&expectation.substring))
+                    .count()
+            };
+            results.push(expectation_result(
+                &format!("expect_prompt_count::{}", expectation.substring),
+                actual == expectation.expected,
+                format!(
+                    "expected prompt substring '{}' count={}, got {}",
+                    expectation.substring, expectation.expected, actual
+                ),
+            ));
+        }
+
+        for expectation in &self.spec.expectations.tool_calls {
+            let result = match context.tool(&expectation.tool_name) {
+                Some(tool) => {
+                    let actual = tool.call_count().await;
+                    expectation_result(
+                        &format!("expect_tool_calls::{}", expectation.tool_name),
+                        actual == expectation.expected,
+                        format!(
+                            "expected tool '{}' calls={}, got {}",
+                            expectation.tool_name, expectation.expected, actual
+                        ),
+                    )
+                }
+                None => expectation_result(
+                    &format!("expect_tool_calls::{}", expectation.tool_name),
+                    false,
+                    format!(
+                        "tool '{}' not found in scenario context",
+                        expectation.tool_name
+                    ),
+                ),
+            };
+            results.push(result);
+        }
+
+        for expectation in &self.spec.expectations.bus_messages_from {
+            let actual = {
+                let messages = context.bus.captured_messages.read().await;
+                messages
+                    .iter()
+                    .filter(|(sender, _, _)| sender == &expectation.sender_id)
+                    .count()
+            };
+            results.push(expectation_result(
+                &format!("expect_bus_messages_from::{}", expectation.sender_id),
+                actual == expectation.expected,
+                format!(
+                    "expected sender '{}' messages={}, got {}",
+                    expectation.sender_id, expectation.expected, actual
+                ),
+            ));
+        }
+
+        results
+    }
+}
+
+fn make_model_config(name: &str) -> ModelProviderConfig {
+    ModelProviderConfig {
+        model_name: name.into(),
+        model_path: "/mock".into(),
+        device: "cpu".into(),
+        model_type: ModelType::Llm,
+        max_context_length: None,
+        quantization: None,
+        extra_config: HashMap::new(),
+    }
+}
+
+fn to_tool_result(spec: &ToolResultSpec) -> ToolResult {
+    let mut result = if let Some(error) = &spec.error {
+        ToolResult::failure(error)
+    } else if let Some(json) = &spec.json {
+        ToolResult::success(json.clone())
+    } else if let Some(text) = &spec.text {
+        ToolResult::success_text(text)
+    } else {
+        ToolResult::success_text("Mock execution default")
+    };
+
+    for (key, value) in &spec.metadata {
+        result.metadata.insert(key.clone(), value.clone());
+    }
+
+    result
+}
+
+fn expectation_result(name: &str, passed: bool, failure_message: String) -> TestCaseResult {
+    TestCaseResult {
+        name: name.to_string(),
+        status: if passed {
+            TestStatus::Passed
+        } else {
+            TestStatus::Failed
+        },
+        duration: Duration::ZERO,
+        error: if passed { None } else { Some(failure_message) },
+        metadata: Vec::new(),
+    }
+}

--- a/tests/src/scenario/spec.rs
+++ b/tests/src/scenario/spec.rs
@@ -1,0 +1,167 @@
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ScenarioSpec {
+    #[serde(default)]
+    pub case_name: Option<String>,
+    #[serde(default)]
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub target: Option<String>,
+    pub suite_name: String,
+    #[serde(default)]
+    pub clock: ClockScenarioSpec,
+    #[serde(default)]
+    pub llm: LlmScenarioSpec,
+    #[serde(default)]
+    pub bus: BusScenarioSpec,
+    #[serde(default)]
+    pub tools: Vec<ToolScenarioSpec>,
+    #[serde(default)]
+    pub expectations: ScenarioExpectations,
+}
+
+impl ScenarioSpec {
+    pub fn from_yaml_str(input: &str) -> Result<Self> {
+        Ok(serde_yaml::from_str(input)?)
+    }
+
+    pub fn from_json_str(input: &str) -> Result<Self> {
+        Ok(serde_json::from_str(input)?)
+    }
+
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        let raw = fs::read_to_string(path)
+            .with_context(|| format!("failed to read scenario fixture '{}'", path.display()))?;
+
+        match path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .map(|ext| ext.to_ascii_lowercase())
+            .as_deref()
+        {
+            Some("yaml") | Some("yml") => Self::from_yaml_str(&raw),
+            Some("json") => Self::from_json_str(&raw),
+            Some(other) => bail!(
+                "unsupported scenario fixture extension '{}' for '{}'",
+                other,
+                path.display()
+            ),
+            None => bail!("scenario fixture '{}' has no extension", path.display()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ClockScenarioSpec {
+    pub start_ms: Option<u64>,
+    pub auto_advance_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LlmResponseRule {
+    pub prompt_substring: String,
+    pub response: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LlmResponseSequence {
+    pub prompt_substring: String,
+    pub responses: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LlmFailureSpec {
+    pub prompt_substring: String,
+    pub error: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LlmScenarioSpec {
+    pub model_name: Option<String>,
+    pub fallback: Option<String>,
+    #[serde(default)]
+    pub responses: Vec<LlmResponseRule>,
+    #[serde(default)]
+    pub response_sequences: Vec<LlmResponseSequence>,
+    #[serde(default)]
+    pub fail_next: Vec<ToolFailureSpec>,
+    #[serde(default)]
+    pub fail_on: Vec<LlmFailureSpec>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct BusScenarioSpec {
+    #[serde(default)]
+    pub fail_next_send: Vec<ToolFailureSpec>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolResultSpec {
+    pub text: Option<String>,
+    pub json: Option<Value>,
+    pub error: Option<String>,
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolFailureSpec {
+    pub count: usize,
+    pub error: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCallExpectation {
+    pub tool_name: String,
+    pub expected: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PromptCountExpectation {
+    pub substring: String,
+    pub expected: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BusExpectation {
+    pub sender_id: String,
+    pub expected: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolScenarioSpec {
+    pub name: String,
+    pub description: String,
+    pub schema: Value,
+    pub stubbed_result: Option<ToolResultSpec>,
+    #[serde(default)]
+    pub fail_next: Vec<ToolFailureSpec>,
+    #[serde(default)]
+    pub fail_on_input: Vec<ToolInputFailureSpec>,
+    #[serde(default)]
+    pub result_sequence: Vec<ToolResultSpec>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolInputFailureSpec {
+    pub input: Value,
+    pub error: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ScenarioExpectations {
+    pub infer_total: Option<usize>,
+    #[serde(default)]
+    pub prompt_counts: Vec<PromptCountExpectation>,
+    #[serde(default)]
+    pub tool_calls: Vec<ToolCallExpectation>,
+    #[serde(default)]
+    pub bus_messages_from: Vec<BusExpectation>,
+}

--- a/tests/tests/fixture_loader_tests.rs
+++ b/tests/tests/fixture_loader_tests.rs
@@ -1,0 +1,43 @@
+use mofa_testing::{fixture_path, load_fixture};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct GenericFixture {
+    case_name: String,
+    kind: String,
+    target: String,
+    suite_name: String,
+}
+
+#[test]
+fn load_scenario_fixture_from_yaml() {
+    let spec: GenericFixture =
+        load_fixture("scenarios/basic.yaml").expect("yaml fixture should load");
+    assert_eq!(spec.case_name, "basic-yaml-scenario");
+    assert_eq!(spec.kind, "contract");
+    assert_eq!(spec.target, "testing-scenario");
+    assert_eq!(spec.suite_name, "fixture-yaml-suite");
+}
+
+#[test]
+fn load_scenario_fixture_from_json() {
+    let spec: GenericFixture =
+        load_fixture("scenarios/basic.json").expect("json fixture should load");
+    assert_eq!(spec.case_name, "basic-json-scenario");
+    assert_eq!(spec.kind, "contract");
+    assert_eq!(spec.target, "testing-scenario");
+    assert_eq!(spec.suite_name, "fixture-json-suite");
+}
+
+#[test]
+fn scenario_spec_from_path_rejects_malformed_fixture() {
+    let err = load_fixture::<GenericFixture>(fixture_path("scenarios/malformed.yaml"))
+        .expect_err("malformed fixture must fail");
+    let message = err.to_string();
+    assert!(
+        message.contains("failed to parse YAML fixture")
+            || message.contains("did not find expected")
+            || message.contains("invalid type"),
+        "unexpected error message: {message}"
+    );
+}

--- a/tests/tests/scenario_runner_tests.rs
+++ b/tests/tests/scenario_runner_tests.rs
@@ -1,0 +1,185 @@
+use mofa_foundation::agent::components::tool::SimpleTool;
+use mofa_kernel::agent::components::tool::ToolInput;
+use mofa_kernel::bus::CommunicationMode;
+use mofa_kernel::message::AgentMessage;
+use mofa_testing::{ScenarioRunner, ScenarioSpec, TestStatus};
+use serde_json::json;
+
+#[test]
+fn scenario_spec_parses_from_yaml() {
+    let input = r#"
+suite_name: yaml-scenario
+clock:
+  start_ms: 42000
+llm:
+  model_name: test-model
+  responses:
+    - prompt_substring: summarize
+      response: compact summary
+tools:
+  - name: search
+    description: Search docs
+    schema:
+      type: object
+    stubbed_result:
+      text: Found it
+expectations:
+  infer_total: 1
+"#;
+
+    let spec = ScenarioSpec::from_yaml_str(input).unwrap();
+    assert_eq!(spec.suite_name, "yaml-scenario");
+    assert_eq!(spec.clock.start_ms, Some(42_000));
+    assert_eq!(spec.llm.model_name.as_deref(), Some("test-model"));
+    assert_eq!(spec.tools.len(), 1);
+    assert_eq!(spec.expectations.infer_total, Some(1));
+}
+
+#[test]
+fn scenario_spec_parses_from_json() {
+    let input = r#"
+{
+  "suite_name": "json-scenario",
+  "llm": {
+    "responses": [
+      { "prompt_substring": "translate", "response": "bonjour" }
+    ]
+  }
+}
+"#;
+
+    let spec = ScenarioSpec::from_json_str(input).unwrap();
+    assert_eq!(spec.suite_name, "json-scenario");
+    assert_eq!(spec.llm.responses.len(), 1);
+    assert_eq!(spec.llm.responses[0].response, "bonjour");
+}
+
+#[tokio::test]
+async fn scenario_runner_configures_fixtures_and_expectations() {
+    let spec = ScenarioSpec::from_yaml_str(
+        r#"
+suite_name: end-to-end-scenario
+clock:
+  start_ms: 2500
+llm:
+  model_name: scenario-model
+  responses:
+    - prompt_substring: summarize
+      response: "Short summary"
+tools:
+  - name: search
+    description: Search docs
+    schema:
+      type: object
+    stubbed_result:
+      text: "Found result"
+expectations:
+  infer_total: 1
+  prompt_counts:
+    - substring: summarize
+      expected: 1
+  tool_calls:
+    - tool_name: search
+      expected: 1
+  bus_messages_from:
+    - sender_id: evaluator
+      expected: 1
+"#,
+    )
+    .unwrap();
+
+    let report = ScenarioRunner::new(spec)
+        .run(|ctx| async move {
+            let response = ctx.infer("summarize this").await.unwrap();
+            assert_eq!(response, "Short summary");
+
+            let tool = ctx.tool("search").unwrap();
+            let result = tool
+                .execute(ToolInput::from_json(json!({"query": "rust"})))
+                .await;
+            assert!(result.success);
+
+            let message = AgentMessage::TaskRequest {
+                task_id: "t1".into(),
+                content: "done".into(),
+            };
+            let _ = ctx
+                .bus
+                .send_and_capture("evaluator", CommunicationMode::Broadcast, message)
+                .await;
+
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(report.timestamp, 2500);
+    assert_eq!(report.total(), 5);
+    assert_eq!(report.failed(), 0);
+    assert_eq!(report.passed(), 5);
+}
+
+#[tokio::test]
+async fn scenario_runner_records_failed_expectations() {
+    let spec = ScenarioSpec::from_yaml_str(
+        r#"
+suite_name: failing-expectation-scenario
+llm:
+  responses:
+    - prompt_substring: summarize
+      response: "Short summary"
+expectations:
+  infer_total: 2
+  prompt_counts:
+    - substring: summarize
+      expected: 2
+"#,
+    )
+    .unwrap();
+
+    let report = ScenarioRunner::new(spec)
+        .run(|ctx| async move {
+            let _ = ctx.infer("summarize this").await.unwrap();
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(report.total(), 3);
+    assert_eq!(report.passed(), 1);
+    assert_eq!(report.failed(), 2);
+    assert_eq!(report.results[1].status, TestStatus::Failed);
+    assert_eq!(report.results[2].status, TestStatus::Failed);
+}
+
+#[tokio::test]
+async fn scenario_runner_applies_fail_next_and_reports_execution_failure() {
+    let spec = ScenarioSpec::from_yaml_str(
+        r#"
+suite_name: fail-next-scenario
+llm:
+  fail_next:
+    - count: 1
+      error: "boom"
+expectations:
+  infer_total: 1
+"#,
+    )
+    .unwrap();
+
+    let report = ScenarioRunner::new(spec)
+        .run(|ctx| async move {
+            ctx.infer("anything")
+                .await
+                .map(|_| ())
+                .map_err(|err| err.to_string())
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(report.total(), 2);
+    assert_eq!(report.failed(), 1);
+    assert_eq!(report.passed(), 1);
+    assert_eq!(report.results[0].status, TestStatus::Failed);
+    assert_eq!(report.results[1].status, TestStatus::Passed);
+}


### PR DESCRIPTION

<img width="3302" height="3630" alt="pr1455" src="https://github.com/user-attachments/assets/efb4e21d-14db-4b2c-81bd-4aa07404c32e" />




## Summary

Add a declarative scenario and fixture foundation to `mofa-testing`.

This is intended to be the first layer for issue #1453  and does not complete it.

This PR introduces:
- fixture loading helpers under `tests/fixtures`
- YAML/JSON-backed `ScenarioSpec`
- a reusable `ScenarioRunner` for deterministic mock-backed scenarios
- focused tests for fixture parsing and end-to-end scenario execution

This is the base layer for later replay, regression, and benchmark-oriented testing work.

## What Changed

Added fixture helpers:
- `fixtures_root()`
- `fixture_path(...)`
- `load_fixture(...)`

Added scenario module:
- `ScenarioSpec`
- `ScenarioRunner`
- `ScenarioContext`
- expectation types for prompt, tool, and bus checks

Added scenario fixtures:
- basic YAML fixture
- basic JSON fixture
- malformed fixture coverage

Exported fixture and scenario APIs through `mofa-testing`.

Added tests for:
- fixture loading
- YAML/JSON scenario parsing
- end-to-end scenario execution
- expectation failures and failure-injection behavior

## Why

`mofa-testing` already has strong primitives like mocks, failure injection, and deterministic time, but there was no declarative way to describe and run reusable testing scenarios.

This PR adds that missing foundation so contributors can define portable test cases as fixtures instead of wiring every scenario manually in Rust.

## Scope

This PR is intentionally limited to the scenario foundation:
- fixture loading
- declarative scenario definition
- deterministic scenario execution
- basic expectation checking

It does not yet include:
- replay artifacts
- benchmark snapshots
- A/B comparison
- gate policy or CI decisions

## Testing

Ran with `CARGO_TARGET_DIR=D:\mofa-target`:

```bash
cargo test -p mofa-testing --test fixture_loader_tests --test scenario_runner_tests
