### PR TITLE
 feat(foundation): add deterministic SwarmComposer for capability-aware DAG assignment

### DIFF
--- a/crates/mofa-foundation/src/capability_registry.rs
+++ b/crates/mofa-foundation/src/capability_registry.rs
@@ -70,6 +70,7 @@ impl CapabilityRegistry {
     pub fn query(&self, query: &str) -> Vec<&AgentManifest> {
         let keywords: Vec<String> = query
             .split_whitespace()
+            .filter(|w| !w.is_empty())
             .map(|w| w.to_lowercase())
             .collect();
 
@@ -89,15 +90,12 @@ impl CapabilityRegistry {
                     .iter()
                     .filter(|kw| haystack.contains(kw.as_str()))
                     .count();
-                if score > 0 {
-                    Some((score, m))
-                } else {
-                    None
-                }
+                if score > 0 { Some((score, m)) } else { None }
             })
             .collect();
 
-        scored.sort_by(|a, b| b.0.cmp(&a.0));
+        // Deterministic ordering: primary by score desc, secondary by agent_id asc.
+        scored.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.agent_id.cmp(&b.1.agent_id)));
         scored.into_iter().map(|(_, m)| m).collect()
     }
 
@@ -181,6 +179,28 @@ mod tests {
         let results = registry.query("write rust code");
         assert!(!results.is_empty());
         assert_eq!(results[0].agent_id, "agent-code");
+    }
+
+    #[test]
+    fn test_query_tie_breaks_by_agent_id_for_determinism() {
+        let mut registry = CapabilityRegistry::new();
+        registry.register(
+            AgentManifest::builder("agent-b", "AgentB")
+                .description("writes code")
+                .capabilities(AgentCapabilities::builder().with_tag("code").build())
+                .build(),
+        );
+        registry.register(
+            AgentManifest::builder("agent-a", "AgentA")
+                .description("writes code")
+                .capabilities(AgentCapabilities::builder().with_tag("code").build())
+                .build(),
+        );
+
+        let results = registry.query("write code");
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].agent_id, "agent-a");
+        assert_eq!(results[1].agent_id, "agent-b");
     }
 
     #[test]

--- a/crates/mofa-foundation/src/swarm/composer.rs
+++ b/crates/mofa-foundation/src/swarm/composer.rs
@@ -1,0 +1,286 @@
+//! Swarm Composer
+//!
+//! Deterministic capability-aware subtask assignment bridge.
+
+use std::collections::{HashMap, HashSet};
+
+use petgraph::graph::NodeIndex;
+use serde::{Deserialize, Serialize};
+
+use crate::CapabilityRegistry;
+
+use super::config::{AgentSpec, AuditEvent, AuditEventKind};
+use super::dag::SubtaskDAG;
+
+/// Fallback strategy when no exact capability match is found.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FallbackPolicy {
+    /// Do not assign the subtask if no exact capability match exists.
+    None,
+    /// Use capability-registry semantic query as a secondary candidate source.
+    RegistryQuery,
+    /// Assign to any available agent using deterministic load-balanced tie-breaking.
+    AnyAgent,
+}
+
+/// Result of one composition pass.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SwarmComposeResult {
+    pub assigned: usize,
+    pub unassigned: Vec<String>,
+    pub audit_events: Vec<AuditEvent>,
+}
+
+/// Capability-aware assignment engine for swarm subtasks.
+pub struct SwarmComposer {
+    agents: Vec<AgentSpec>,
+    registry: CapabilityRegistry,
+    fallback_policy: FallbackPolicy,
+}
+
+impl SwarmComposer {
+    /// Build a composer from static swarm agent specs.
+    pub fn new(agents: Vec<AgentSpec>) -> Self {
+        let mut registry = CapabilityRegistry::new();
+        for agent in &agents {
+            registry.register(agent.to_manifest());
+        }
+        Self {
+            agents,
+            registry,
+            fallback_policy: FallbackPolicy::RegistryQuery,
+        }
+    }
+
+    /// Set fallback policy.
+    pub fn with_fallback_policy(mut self, policy: FallbackPolicy) -> Self {
+        self.fallback_policy = policy;
+        self
+    }
+
+    /// Assign agents to all currently-unassigned subtasks in the DAG.
+    ///
+    /// Determinism guarantees:
+    /// - tasks visited in sorted `subtask_id` order
+    /// - candidate tie-break by current assigned-load, then `agent_id` lexicographically
+    pub fn compose_assignments(&self, dag: &mut SubtaskDAG) -> SwarmComposeResult {
+        let mut result = SwarmComposeResult::default();
+        let mut load = self.initial_load_from_dag(dag);
+
+        let mut tasks: Vec<(NodeIndex, String)> = dag
+            .unassigned_tasks()
+            .into_iter()
+            .filter_map(|idx| dag.get_task(idx).map(|t| (idx, t.id.clone())))
+            .collect();
+        tasks.sort_by(|a, b| a.1.cmp(&b.1));
+
+        for (idx, task_id) in tasks {
+            let Some(task) = dag.get_task(idx).cloned() else {
+                continue;
+            };
+
+            match self.pick_agent_for_subtask(&task.required_capabilities, &task.description, &load)
+            {
+                Some(agent_id) => {
+                    dag.assign_agent(idx, agent_id.clone());
+                    *load.entry(agent_id.clone()).or_insert(0) += 1;
+                    result.assigned += 1;
+                    result.audit_events.push(
+                        AuditEvent::new(
+                            AuditEventKind::AgentAssigned,
+                            format!("Assigned agent '{}' to subtask '{}'", agent_id, task_id),
+                        )
+                        .with_data(serde_json::json!({
+                            "subtask_id": task_id,
+                            "agent_id": agent_id,
+                        })),
+                    );
+                }
+                None => {
+                    result.unassigned.push(task_id.clone());
+                    result.audit_events.push(
+                        AuditEvent::new(
+                            AuditEventKind::SubtaskFailed,
+                            format!("No capable agent found for subtask '{}'", task_id),
+                        )
+                        .with_data(serde_json::json!({
+                            "subtask_id": task_id,
+                            "required_capabilities": task.required_capabilities,
+                        })),
+                    );
+                }
+            }
+        }
+
+        result
+    }
+
+    fn initial_load_from_dag(&self, dag: &SubtaskDAG) -> HashMap<String, usize> {
+        let mut load = HashMap::new();
+        for (_, task) in dag.all_tasks() {
+            if let Some(agent_id) = &task.assigned_agent {
+                *load.entry(agent_id.clone()).or_insert(0) += 1;
+            }
+        }
+        load
+    }
+
+    fn pick_agent_for_subtask(
+        &self,
+        required_capabilities: &[String],
+        description: &str,
+        load: &HashMap<String, usize>,
+    ) -> Option<String> {
+        if self.agents.is_empty() {
+            return None;
+        }
+
+        let required = normalize_caps(required_capabilities);
+
+        // 1) Exact capability match: required caps are a subset of agent caps.
+        let exact_candidates: Vec<String> = self
+            .agents
+            .iter()
+            .filter(|a| required.is_subset(&normalize_caps(&a.capabilities)))
+            .map(|a| a.id.clone())
+            .collect();
+
+        if let Some(agent_id) = self.pick_least_loaded(exact_candidates, load) {
+            return Some(agent_id);
+        }
+
+        // 2) Fallback policies.
+        match self.fallback_policy {
+            FallbackPolicy::None => None,
+            FallbackPolicy::RegistryQuery => {
+                let query = format!("{} {}", description, required_capabilities.join(" "));
+                let candidates: Vec<String> = self
+                    .registry
+                    .query(&query)
+                    .into_iter()
+                    .map(|m| m.agent_id.clone())
+                    .collect();
+                self.pick_least_loaded(candidates, load)
+            }
+            FallbackPolicy::AnyAgent => {
+                let candidates = self.agents.iter().map(|a| a.id.clone()).collect();
+                self.pick_least_loaded(candidates, load)
+            }
+        }
+    }
+
+    fn pick_least_loaded(
+        &self,
+        candidates: Vec<String>,
+        load: &HashMap<String, usize>,
+    ) -> Option<String> {
+        if candidates.is_empty() {
+            return None;
+        }
+        let known: HashSet<&str> = self.agents.iter().map(|a| a.id.as_str()).collect();
+
+        candidates
+            .into_iter()
+            .filter(|id| known.contains(id.as_str()))
+            .min_by(|a, b| {
+                let la = load.get(a).copied().unwrap_or(0);
+                let lb = load.get(b).copied().unwrap_or(0);
+                la.cmp(&lb).then_with(|| a.cmp(b))
+            })
+    }
+}
+
+fn normalize_caps(caps: &[String]) -> HashSet<String> {
+    caps.iter()
+        .map(|c| c.trim().to_ascii_lowercase())
+        .filter(|c| !c.is_empty())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::swarm::dag::SwarmSubtask;
+
+    fn agent(id: &str, caps: &[&str]) -> AgentSpec {
+        AgentSpec {
+            id: id.to_string(),
+            capabilities: caps.iter().map(|s| s.to_string()).collect(),
+            model: None,
+            cost_per_token: None,
+            max_concurrency: 1,
+        }
+    }
+
+    #[test]
+    fn test_exact_match_assignment() {
+        let mut dag = SubtaskDAG::new("exact");
+        let idx = dag.add_task(
+            SwarmSubtask::new("task-1", "Analyze data")
+                .with_capabilities(vec!["analysis".to_string(), "sql".to_string()]),
+        );
+
+        let composer = SwarmComposer::new(vec![
+            agent("agent-a", &["analysis"]),
+            agent("agent-b", &["analysis", "sql"]),
+        ]);
+        let out = composer.compose_assignments(&mut dag);
+
+        assert_eq!(out.assigned, 1);
+        assert!(out.unassigned.is_empty());
+        assert_eq!(
+            dag.get_task(idx).and_then(|t| t.assigned_agent.clone()),
+            Some("agent-b".to_string())
+        );
+        assert!(
+            out.audit_events
+                .iter()
+                .any(|e| matches!(e.kind, AuditEventKind::AgentAssigned))
+        );
+    }
+
+    #[test]
+    fn test_registry_fallback_assignment() {
+        let mut dag = SubtaskDAG::new("fallback");
+        let idx = dag.add_task(
+            SwarmSubtask::new("task-1", "Write rust code")
+                .with_capabilities(vec!["missing-required-cap".to_string()]),
+        );
+
+        let composer = SwarmComposer::new(vec![
+            agent("agent-rust", &["rust", "coding"]),
+            agent("agent-docs", &["docs", "writing"]),
+        ])
+        .with_fallback_policy(FallbackPolicy::RegistryQuery);
+
+        let out = composer.compose_assignments(&mut dag);
+        assert_eq!(out.assigned, 1);
+        assert_eq!(
+            dag.get_task(idx).and_then(|t| t.assigned_agent.clone()),
+            Some("agent-rust".to_string())
+        );
+    }
+
+    #[test]
+    fn test_no_match_without_fallback() {
+        let mut dag = SubtaskDAG::new("no-match");
+        let idx = dag.add_task(
+            SwarmSubtask::new("task-1", "Unknown task")
+                .with_capabilities(vec!["nonexistent-cap".to_string()]),
+        );
+
+        let composer = SwarmComposer::new(vec![agent("agent-a", &["analysis"])])
+            .with_fallback_policy(FallbackPolicy::None);
+        let out = composer.compose_assignments(&mut dag);
+
+        assert_eq!(out.assigned, 0);
+        assert_eq!(out.unassigned, vec!["task-1".to_string()]);
+        assert!(dag.get_task(idx).unwrap().assigned_agent.is_none());
+        assert!(
+            out.audit_events
+                .iter()
+                .any(|e| matches!(e.kind, AuditEventKind::SubtaskFailed))
+        );
+    }
+}

--- a/crates/mofa-foundation/src/swarm/config.rs
+++ b/crates/mofa-foundation/src/swarm/config.rs
@@ -1,6 +1,8 @@
 //! Swarm Configuration and Result types
 
 use chrono::{DateTime, Utc};
+use mofa_kernel::agent::capabilities::AgentCapabilities;
+use mofa_kernel::agent::manifest::AgentManifest;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use uuid::Uuid;
@@ -49,6 +51,31 @@ pub struct AgentSpec {
 
 fn default_concurrency() -> u32 {
     1
+}
+
+impl AgentSpec {
+    /// Convert this `AgentSpec` into a kernel `AgentManifest` for capability discovery.
+    pub fn to_manifest(&self) -> AgentManifest {
+        let caps = AgentCapabilities::builder()
+            .tags(self.capabilities.clone())
+            .supports_coordination(true)
+            .build();
+
+        let description = if self.capabilities.is_empty() {
+            format!("Agent {}", self.id)
+        } else {
+            format!(
+                "Agent {} with capabilities: {}",
+                self.id,
+                self.capabilities.join(", ")
+            )
+        };
+
+        AgentManifest::builder(self.id.clone(), self.id.clone())
+            .description(description)
+            .capabilities(caps)
+            .build()
+    }
 }
 
 /// SLA constraints for a swarm run

--- a/crates/mofa-foundation/src/swarm/dag.rs
+++ b/crates/mofa-foundation/src/swarm/dag.rs
@@ -384,6 +384,14 @@ impl SubtaskDAG {
             .collect()
     }
 
+    /// Return node indices for subtasks that are not yet assigned to an agent.
+    pub fn unassigned_tasks(&self) -> Vec<NodeIndex> {
+        self.graph
+            .node_indices()
+            .filter(|&idx| self.graph[idx].assigned_agent.is_none())
+            .collect()
+    }
+
     /// Get the dependencies of a specific task (incoming edges)
     pub fn dependencies_of(&self, idx: NodeIndex) -> Vec<NodeIndex> {
         self.graph
@@ -414,7 +422,6 @@ impl SubtaskDAG {
             .filter(|t| matches!(t.status, SubtaskStatus::Failed(_)))
             .count()
     }
-
 
     // ── Risk & HITL helpers ───────────────────────────────────────────────
 
@@ -745,7 +752,8 @@ mod tests {
         let d = dag.add_task(SwarmSubtask::new("d", "Independent"));
 
         dag.add_dependency(a, b).unwrap(); // Sequential (hard)
-        dag.add_dependency_with_kind(a, c, DependencyKind::Soft).unwrap();
+        dag.add_dependency_with_kind(a, c, DependencyKind::Soft)
+            .unwrap();
 
         dag.mark_failed(a, "error");
         let skipped = dag.cascade_skip(a);
@@ -793,12 +801,20 @@ mod tests {
         // a fails — b should become ready (not stuck forever)
         dag.mark_failed(a, "connection timeout");
         let ready = dag.ready_tasks();
-        assert_eq!(ready, vec![b], "b must become ready when its dependency fails");
+        assert_eq!(
+            ready,
+            vec![b],
+            "b must become ready when its dependency fails"
+        );
 
         // b also fails — c should become ready
         dag.mark_failed(b, "no input data");
         let ready = dag.ready_tasks();
-        assert_eq!(ready, vec![c], "c must become ready when its dependency fails");
+        assert_eq!(
+            ready,
+            vec![c],
+            "c must become ready when its dependency fails"
+        );
 
         dag.mark_skipped(c);
         assert!(dag.is_complete());
@@ -823,7 +839,11 @@ mod tests {
 
         // d depends on both b (Completed) and c (Failed) — should be ready
         let ready = dag.ready_tasks();
-        assert_eq!(ready, vec![d], "d must become ready when all deps are terminal");
+        assert_eq!(
+            ready,
+            vec![d],
+            "d must become ready when all deps are terminal"
+        );
     }
 
     #[test]
@@ -883,6 +903,18 @@ mod tests {
             dag.get_task(a).unwrap().assigned_agent.as_deref(),
             Some("agent-1")
         );
+    }
+
+    #[test]
+    fn test_unassigned_tasks() {
+        let mut dag = SubtaskDAG::new("unassigned");
+        let a = dag.add_task(SwarmSubtask::new("a", "A"));
+        let b = dag.add_task(SwarmSubtask::new("b", "B"));
+
+        dag.assign_agent(a, "agent-1");
+        let mut unassigned = dag.unassigned_tasks();
+        unassigned.sort();
+        assert_eq!(unassigned, vec![b]);
     }
 
     // ── RiskLevel tests ───────────────────────────────────────────────────

--- a/crates/mofa-foundation/src/swarm/mod.rs
+++ b/crates/mofa-foundation/src/swarm/mod.rs
@@ -1,17 +1,19 @@
 pub mod analyzer;
+pub mod composer;
 pub mod config;
 pub mod dag;
 pub mod patterns;
 pub mod telemetry;
+pub mod scheduler;
 
 pub use analyzer::{RiskAwareAnalysis, RiskSummary, TaskAnalyzer};
+pub use composer::{FallbackPolicy, SwarmComposeResult, SwarmComposer};
 pub use config::{
     AgentSpec, AuditEvent, AuditEventKind, HITLMode, SLAConfig, SwarmConfig, SwarmMetrics,
     SwarmResult, SwarmStatus,
 };
 pub use dag::{DependencyEdge, DependencyKind, RiskLevel, SubtaskDAG, SubtaskStatus, SwarmSubtask};
 pub use patterns::CoordinationPattern;
-pub mod scheduler;
 pub use scheduler::{
     FailurePolicy, ParallelScheduler, SchedulerSummary, SequentialScheduler, SubtaskExecutorFn,
     SwarmScheduler, SwarmSchedulerConfig, TaskExecutionResult, TaskOutcome,


### PR DESCRIPTION
### Summary

  This PR introduces SwarmComposer v0, a swarm-level assignment bridge that converts decomposed subtasks into deterministic agent assignments using capability matching + fallback policy.

  ### Motivation

  Swarm decomposition (SubtaskDAG) and capability discovery (CapabilityRegistry) existed, but they were not connected by a single orchestrator-facing component. This PR closes that boundary.

  ### Changes

  - Added swarm/composer.rs:
      - SwarmComposer
      - FallbackPolicy (none, registry_query, any_agent)
      - SwarmComposeResult (assigned, unassigned, audit_events)
  - Added deterministic assignment strategy:
      - process unassigned subtasks in stable subtask_id order
      - break candidate ties by load, then agent_id
  - Added config bridge:
      - AgentSpec::to_manifest() for registry integration
  - Added DAG helper:
      - SubtaskDAG::unassigned_tasks()
  - Improved registry determinism:
      - CapabilityRegistry::query() now tie-breaks by agent_id
  - Added tests:
      - exact match assignment
      - registry fallback assignment
      - no-match with fallback disabled
      - deterministic query tie-break
      - DAG unassigned task helper

  - Kept scope assignment-only (no runtime execution side effects).
  - Prioritized deterministic behavior for reproducibility.
  - Fallback policy is explicit and configurable, not implicit.

  ### Testing

  Executed targeted tests:

  - cargo test -p mofa-foundation swarm::composer -- --nocapture
  - cargo test -p mofa-foundation swarm::dag::tests::test_unassigned_tasks -- --nocapture
  - cargo test -p mofa-foundation capability_registry::tests::test_query_tie_breaks_by_agent_id_for_determinism -- --nocapture

  ### Validation Checklist

  - [x] Focused unit tests added and passing
  - [x] Changes respect architecture layering (foundation uses kernel types)

  ### Related

  Closes: #1460 