### PR TITLE
fix(kernel): remove redundant String allocation in RetryCondition::On…

### DIFF
--- a/crates/mofa-kernel/src/workflow/policy.rs
+++ b/crates/mofa-kernel/src/workflow/policy.rs
@@ -97,7 +97,7 @@ impl RetryCondition {
                 let lower = error_message.to_lowercase();
                 patterns
                     .iter()
-                    .any(|p| lower.contains(&p.to_lowercase().as_str().to_owned()))
+                    .any(|p| lower.contains(p.to_lowercase().as_str()))
             }
         }
     }


### PR DESCRIPTION
…Transient::matches()

The .as_str().to_owned() in the pattern matching hot path created a needless String clone on every iteration. contains() already accepts &str, so the intermediate allocation was pure waste.

Closes #1466

## 📋 Summary

<!--
Explain WHAT this PR does and WHY.
Focus on the motivation and impact rather than implementation details.
-->

## 🔗 Related Issues

Closes #

Related to #

---

## 🧠 Context

<!--
Why is this change needed?
What problem does it solve?
Any relevant background or design decisions.
-->

---

## 🛠️ Changes

<!--
High-level list of changes.
Avoid low-level diffs — reviewers can see those.
-->

- 
- 
- 

---

## 🧪 How you Tested

<!--
Provide clear steps for reviewers to validate the change.
Include commands, endpoints, or scenarios.
-->

1. 
2. 
3. 

---

## 📸 Screenshots / Logs (if applicable)

<!-- CLI output, logs, or UI screenshots -->

---

## ⚠️ Breaking Changes

- [ ] No breaking changes
- [ ] Breaking change (describe below)

If breaking:

---

## 🧹 Checklist

### Code Quality
- [ ] Code follows Rust idioms and project conventions
- [ ] `cargo fmt` run
- [ ] `cargo clippy` passes without warnings

### Testing
- [ ] Tests added/updated
- [ ] `cargo test` passes locally without any error

### Documentation
- [ ] Public APIs documented
- [ ] README / docs updated (if needed)

### PR Hygiene
- [ ] PR is small and focused (one logical change)
- [ ] Branch is up to date with `main`
- [ ] No unrelated commits
- [ ] Commit messages explain **why**, not only **what**

---

## 🚀 Deployment Notes (if applicable)

<!-- migrations, config changes, env vars, rollout steps -->

---

## 🧩 Additional Notes for Reviewers

<!-- Anything reviewers should pay attention to -->