### PR TITLE
fix(monitoring): correct system thread_count calculation

### DIFF
--- a/crates/mofa-monitoring/src/dashboard/metrics.rs
+++ b/crates/mofa-monitoring/src/dashboard/metrics.rs
@@ -4,7 +4,7 @@
 
 use mofa_kernel::metrics::LLMMetricsSource;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::RwLock as StdRwLock;
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
@@ -12,6 +12,12 @@ use std::time::{Duration, Instant};
 use sysinfo::{Pid, System};
 use tokio::sync::RwLock;
 use tracing::{debug, info};
+
+fn thread_count_from_tasks(tasks: Option<&HashSet<Pid>>) -> u32 {
+    tasks
+        .map(|task_set| u32::try_from(task_set.len()).unwrap_or(u32::MAX))
+        .unwrap_or(0)
+}
 
 /// Metric type
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -594,13 +600,7 @@ impl MetricsCollector {
             let pid = Pid::from_u32(std::process::id());
             let (cpu_usage, memory_used, thread_count) = sys
                 .process(pid)
-                .map(|p| {
-                    (
-                        p.cpu_usage() as f64,
-                        p.memory(),
-                        p.tasks().iter().count() as u32,
-                    )
-                })
+                .map(|p| (p.cpu_usage() as f64, p.memory(), thread_count_from_tasks(p.tasks())))
                 .unwrap_or((0.0, 0, 0));
 
             SystemMetrics {
@@ -753,6 +753,21 @@ impl MetricsCollector {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_thread_count_from_tasks_counts_all_tasks() {
+        let mut tasks = HashSet::new();
+        tasks.insert(Pid::from_u32(10));
+        tasks.insert(Pid::from_u32(20));
+        tasks.insert(Pid::from_u32(30));
+
+        assert_eq!(thread_count_from_tasks(Some(&tasks)), 3);
+    }
+
+    #[test]
+    fn test_thread_count_from_tasks_handles_none() {
+        assert_eq!(thread_count_from_tasks(None), 0);
+    }
 
     #[tokio::test]
     async fn test_counter() {


### PR DESCRIPTION
## 📋 Summary

This PR fixes incorrect `thread_count` reporting in `mofa-monitoring` system metrics.  
The previous logic could undercount by effectively treating task presence as a boolean-like value, resulting in misleading metrics (often `0` or `1`).  
This change computes thread/task count correctly and adds regression tests to prevent recurrence.

## 🔗 Related Issues

Closes #1402 

Related to #

---

## 🧠 Context

Monitoring accuracy is critical for diagnosing runtime behavior and performance.  
The existing system metrics path calculated thread count via an option-iteration pattern that did not reflect the actual number of tasks/threads.  
As a result, dashboard and exported metrics could report incorrect thread counts, reducing trust in observability data.

---

## 🛠️ Changes

- Corrected thread count computation in `crates/mofa-monitoring/src/dashboard/metrics.rs`.
- Added a small helper to count tasks safely and explicitly.
- Added regression unit tests for:
  - counting all tasks in a non-empty task set
  - returning `0` when task set is `None`
- Kept behavior unchanged for all other system metrics fields.

---

## 🧪 How you Tested

1. Verified PR scope:
   ```bash
   git diff --name-only origin/main...HEAD

2. Ran focussed Link Check
    cargo clippy -p mofa-monitoring --no-deps -- -D warnings

3. Regression Tests
     cargo test -p mofa-monitoring --lib thread_count_from_tasks -- --nocapture
---

## 📸 Screenshots / Logs (if applicable)

<!-- CLI output, logs, or UI screenshots -->

---

## ⚠️ Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (describe below)

If breaking:

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [ ] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [ ] Public APIs documented
- [ ] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---

## 🚀 Deployment Notes (if applicable)

No migrations, env var changes, or rollout coordination required.

---

## 🧩 Additional Notes for Reviewers

Please focus review on the thread_count calculation path and regression tests in metrics.rs.
This PR intentionally limits scope to observability correctness and does not alter API surface or unrelated runtime behavior.

<img width="960" height="335" alt="image" src="https://github.com/user-attachments/assets/dc7b6389-c0e7-4ff7-8fa2-562793ac80dc" />
