### PR TITLE
fix: add missing token remaining/usage-ratio methods to BudgetStatus

### DIFF
--- a/crates/mofa-kernel/src/budget.rs
+++ b/crates/mofa-kernel/src/budget.rs
@@ -107,6 +107,48 @@ impl BudgetStatus {
         })
     }
 
+    pub fn remaining_session_tokens(&self) -> Option<u64> {
+        self.config
+            .max_tokens_per_session
+            .map(|max| max.saturating_sub(self.session_tokens))
+    }
+
+    pub fn remaining_daily_tokens(&self) -> Option<u64> {
+        self.config
+            .max_tokens_per_day
+            .map(|max| max.saturating_sub(self.daily_tokens))
+    }
+
+    pub fn daily_cost_usage_ratio(&self) -> Option<f64> {
+        self.config.max_cost_per_day.map(|max| {
+            if max > 0.0 {
+                self.daily_cost / max
+            } else {
+                1.0
+            }
+        })
+    }
+
+    pub fn session_tokens_usage_ratio(&self) -> Option<f64> {
+        self.config.max_tokens_per_session.map(|max| {
+            if max > 0 {
+                self.session_tokens as f64 / max as f64
+            } else {
+                1.0
+            }
+        })
+    }
+
+    pub fn daily_tokens_usage_ratio(&self) -> Option<f64> {
+        self.config.max_tokens_per_day.map(|max| {
+            if max > 0 {
+                self.daily_tokens as f64 / max as f64
+            } else {
+                1.0
+            }
+        })
+    }
+
     pub fn is_exceeded(&self) -> bool {
         if let Some(max) = self.config.max_cost_per_session
             && self.session_cost >= max
@@ -214,5 +256,70 @@ mod tests {
             config: BudgetConfig::default().with_max_cost_per_session(10.0).unwrap(),
         };
         assert!((status.remaining_session_cost().unwrap() - 7.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_remaining_session_tokens() {
+        let config = BudgetConfig::default()
+            .with_max_tokens_per_session(1000)
+            .unwrap();
+        let status = BudgetStatus::new(0.0, 0.0, 750, 0, config);
+        assert_eq!(status.remaining_session_tokens(), Some(250));
+    }
+
+    #[test]
+    fn test_remaining_daily_tokens() {
+        let config = BudgetConfig::default()
+            .with_max_tokens_per_day(5000)
+            .unwrap();
+        let status = BudgetStatus::new(0.0, 0.0, 0, 4200, config);
+        assert_eq!(status.remaining_daily_tokens(), Some(800));
+    }
+
+    #[test]
+    fn test_remaining_tokens_saturating() {
+        let config = BudgetConfig::default()
+            .with_max_tokens_per_session(100)
+            .unwrap();
+        let status = BudgetStatus::new(0.0, 0.0, 150, 0, config);
+        assert_eq!(status.remaining_session_tokens(), Some(0));
+    }
+
+    #[test]
+    fn test_daily_cost_usage_ratio() {
+        let config = BudgetConfig::default()
+            .with_max_cost_per_day(10.0)
+            .unwrap();
+        let status = BudgetStatus::new(0.0, 5.0, 0, 0, config);
+        assert!((status.daily_cost_usage_ratio().unwrap() - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_session_tokens_usage_ratio() {
+        let config = BudgetConfig::default()
+            .with_max_tokens_per_session(1000)
+            .unwrap();
+        let status = BudgetStatus::new(0.0, 0.0, 250, 0, config);
+        assert!((status.session_tokens_usage_ratio().unwrap() - 0.25).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_daily_tokens_usage_ratio() {
+        let config = BudgetConfig::default()
+            .with_max_tokens_per_day(5000)
+            .unwrap();
+        let status = BudgetStatus::new(0.0, 0.0, 0, 3000, config);
+        assert!((status.daily_tokens_usage_ratio().unwrap() - 0.6).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_unlimited_returns_none() {
+        let config = BudgetConfig::unlimited();
+        let status = BudgetStatus::new(5.0, 10.0, 500, 1000, config);
+        assert_eq!(status.remaining_session_tokens(), None);
+        assert_eq!(status.remaining_daily_tokens(), None);
+        assert!(status.daily_cost_usage_ratio().is_none());
+        assert!(status.session_tokens_usage_ratio().is_none());
+        assert!(status.daily_tokens_usage_ratio().is_none());
     }
 }


### PR DESCRIPTION
## 📋 Summary


`BudgetStatus` had an asymmetric API. The cost helper methods existed but equivalent token methods were missing. This PR adds the 5 missing methods and 7 unit tests to complete the API surface.


Closes #1475 



## 🧠 Context

`BudgetStatus` provides `remaining_session_cost()`, `remaining_daily_cost()`, and `session_cost_usage_ratio()` for cost tracking, but has no equivalent methods for token tracking or daily cost ratio. The `is_exceeded()` method already checks all 4 budget dimensions equally, so the query methods should match.



## 🛠️ Changes

- Added `remaining_session_tokens()` and `remaining_daily_tokens()` methods
- Added `daily_cost_usage_ratio()` to match existing `session_cost_usage_ratio()`
- Added `session_tokens_usage_ratio()` and `daily_tokens_usage_ratio()` methods
- Added 7 unit tests covering normal values, saturating underflow, ratios, and unlimited config

## 🧪 How you Tested



1. `cargo test -p mofa-kernel`: All 383 tests passed
2. `cargo test -p mofa-kernel budget`: All 13 budget tests passed (6 existing + 7 new)
3. `cargo clippy -p mofa-kernel -- -D warnings`: Zero warnings



## 📸 Screenshots / Logs (if applicable)

<img width="1190" height="428" alt="mofa" src="https://github.com/user-attachments/assets/df70d3c9-863c-4b84-a217-00a5a32af0f5" />



## ⚠️ Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (describe below)

If breaking:

---

## 🧹 Checklist

### Code Quality
-  [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [x] Tests added/updated
-  [x] `cargo test` passes locally without any error

### Documentation
- [x] Public APIs documented
- [x] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---

## 🚀 Deployment Notes (if applicable)



## 🧩 Additional Notes for Reviewers


- Token methods use `saturating_sub` instead of `.max(0.0)` (used for cost) because tokens are `u64` and cannot go negative
- All ratio methods return `1.0` when the configured max is 0, consistent with the existing `session_cost_usage_ratio()` pattern
- Only one file changed: `crates/mofa-kernel/src/budget.rs`