### PR TITLE
Refactor: Use kernel's aggregate_outputs() in SequentialCoordinator i…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5877,6 +5877,7 @@ dependencies = [
  "config",
  "criterion",
  "cron",
+ "dashmap 5.5.3",
  "error-stack",
  "futures",
  "hex",

--- a/crates/mofa-foundation/src/agent/components/coordinator.rs
+++ b/crates/mofa-foundation/src/agent/components/coordinator.rs
@@ -47,8 +47,12 @@ impl Coordinator for SequentialCoordinator {
     }
 
     async fn aggregate(&self, results: Vec<AgentOutput>) -> AgentResult<AgentOutput> {
-        let texts: Vec<String> = results.iter().map(|o| o.to_text()).collect();
-        Ok(AgentOutput::text(texts.join("\n\n---\n\n")))
+        aggregate_outputs(
+            results,
+            &AggregationStrategy::Concatenate {
+                separator: "\n\n---\n\n".to_string(),
+            },
+        )
     }
 
     fn pattern(&self) -> CoordinationPattern {


### PR DESCRIPTION
…nstead of manual text joining

## 📋 Summary
This PR refactors SequentialCoordinator::aggregate() in the coordinator component to eliminate duplicated aggregation logic and align it with the existing kernel-layer abstraction.
Why it was needed:
SequentialCoordinator was manually collecting and joining AgentOutput text with "\n\n---\n\n" — reimplementing logic that the kernel already owns via aggregate_outputs(). This created a silent inconsistency: ParallelCoordinator in the same file was already using the kernel utility correctly, while SequentialCoordinator bypassed it entirely. Any future improvements to the kernel's aggregation path (error handling, logging, metrics) would have automatically skipped SequentialCoordinator.
What changed:
Replaced the manual text-joining implementation in SequentialCoordinator::aggregate() with a delegation call to aggregate_outputs() using AggregationStrategy::Concatenate { separator: "\n\n---\n\n" } — the same strategy and separator that was previously hardcoded by hand. No behavior change; purely structural.
Impact on maintainability:

Both coordinators now share a single aggregation code path through the kernel layer
Future changes to aggregate_outputs() apply uniformly across all coordinators without needing to track down manual reimplementations
Enforces the architectural boundary: aggregation logic lives in the kernel, not in component implementations
Reduces cognitive overhead when onboarding — both coordinators are now consistent and predictable


## 🧠 Context

SequentialCoordinator was hand-rolling text aggregation logic that already exists in the kernel layer. Both coordinators live in the same file, but were using two different approaches for the same operation — making the codebase inconsistent and fragile to future kernel-level improvements.
The kernel's aggregate_outputs() with AggregationStrategy::Concatenate is the canonical way to do this. This change enforces that contract uniformly.

## 🛠️ Changes

Replaced manual text-joining logic in SequentialCoordinator::aggregate() with aggregate_outputs() from the kernel layer
Switched aggregation strategy to AggregationStrategy::Concatenate with the same "\n\n---\n\n" separator
Both coordinators now share a single, consistent aggregation code path.


## 🧪 How you Tested

Ran existing coordinator unit tests — all 6 passed with no changes needed
Verified test_sequential_aggregate() confirms output still contains all expected text across aggregated results
Confirmed identical output behavior before and after the refactor using the same separator "\n\n---\n\n"

cargo test -p mofa-foundation coordinator


## ⚠️ Breaking Changes

- [ ] No breaking changes
- [ ] Breaking change (describe below)

If breaking:

---

## 🧹 Checklist

### Code Quality
- [x ] Code follows Rust idioms and project conventions
- [x ] `cargo fmt` run
- [x ] `cargo clippy` passes without warnings

### Testing
- [ ] Tests added/updated
- [ x] `cargo test` passes locally without any error

### Documentation
- [ ] Public APIs documented
- [ ] README / docs updated (if needed)

### PR Hygiene
- [ x] PR is small and focused (one logical change)
- [x ] Branch is up to date with `main`
- [x ] No unrelated commits
- [ x] Commit messages explain **why**, not only **what**

