### PR TITLE
feat(ffi): expose SwarmOrchestrator across UniFFI and PyO3 language boundaries

### DIFF
--- a/crates/mofa-ffi/Cargo.toml
+++ b/crates/mofa-ffi/Cargo.toml
@@ -34,9 +34,6 @@ persistence-all = ["mofa-sdk/persistence-all"]
 mofa-sdk = { path = "../mofa-sdk", version = "0.1" }
 mofa-foundation = { path = "../mofa-foundation", version = "0.1" }
 mofa-kernel = { path = "../mofa-kernel", version = "0.1" }
-# Swarm orchestrator — exposes run_goal() across the FFI boundary
-mofa-orchestrator = { path = "../mofa-orchestrator", version = "0.1" }
-
 # Async runtime
 tokio = { version = "1", features = ["full"] }
 

--- a/crates/mofa-ffi/Cargo.toml
+++ b/crates/mofa-ffi/Cargo.toml
@@ -16,7 +16,7 @@ publish = true
 [features]
 default = []
 # Enable UniFFI cross-language bindings (Python, Kotlin, Swift, Java)
-uniffi = ["dep:uniffi", "dep:thiserror", "dep:error-stack"]
+uniffi = ["dep:uniffi", "dep:error-stack"]
 # Enable PyO3 Python bindings (native Python extension)
 python = ["dep:pyo3", "dep:pyo3-async-runtimes"]
 # Enable all FFI bindings
@@ -34,6 +34,8 @@ persistence-all = ["mofa-sdk/persistence-all"]
 mofa-sdk = { path = "../mofa-sdk", version = "0.1" }
 mofa-foundation = { path = "../mofa-foundation", version = "0.1" }
 mofa-kernel = { path = "../mofa-kernel", version = "0.1" }
+# Swarm orchestrator — exposes run_goal() across the FFI boundary
+mofa-orchestrator = { path = "../mofa-orchestrator", version = "0.1" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }
@@ -45,9 +47,10 @@ serde_json.workspace = true
 uuid.workspace = true
 async-trait = "0.1"
 
+# Always-on: thiserror for MoFaError used across all binding layers
+thiserror = { version = "1.0" }
 # UniFFI dependencies (optional)
 uniffi = { version = "0.29", features = ["bindgen"], optional = true }
-thiserror = { version = "1.0", optional = true }
 error-stack = { workspace = true, optional = true }
 # PyO3 dependencies (optional)
 # Note: extension-module is only for building Python wheels, not for tests

--- a/crates/mofa-ffi/src/error.rs
+++ b/crates/mofa-ffi/src/error.rs
@@ -1,0 +1,35 @@
+//! FFI error types.
+//!
+//! `MoFaError` is the single error type that crosses every FFI boundary —
+//! UniFFI (Python/Kotlin/Swift) and PyO3 (native Python) both map to it.
+//!
+//! Intentionally NOT `#[non_exhaustive]` — UniFFI generates exhaustive matches
+//! across the language boundary and requires all variants to be known at
+//! compile time.
+
+/// MoFA FFI error, usable across all binding layers.
+///
+/// Every internal `Result<_, SomeDomainError>` is mapped to the closest
+/// variant here before crossing the language boundary. The full error message
+/// is forwarded as the variant's string payload so no diagnostic information
+/// is silently discarded.
+#[derive(Debug, thiserror::Error)]
+pub enum MoFaError {
+    #[error("Configuration error: {0}")]
+    ConfigError(String),
+    #[error("Runtime error: {0}")]
+    RuntimeError(String),
+    #[error("LLM error: {0}")]
+    LLMError(String),
+    #[error("IO error: {0}")]
+    IoError(String),
+    #[error("Invalid argument: {0}")]
+    InvalidArgument(String),
+    #[error("Tool error: {0}")]
+    ToolError(String),
+    #[error("Session error: {0}")]
+    SessionError(String),
+}
+
+/// Convenience result alias for FFI-exposed functions.
+pub type MoFaResult<T> = Result<T, MoFaError>;

--- a/crates/mofa-ffi/src/lib.rs
+++ b/crates/mofa-ffi/src/lib.rs
@@ -45,6 +45,21 @@
 pub use mofa_sdk::*;
 
 // =============================================================================
+// Error types (always compiled; shared by UniFFI and PyO3 layers)
+// =============================================================================
+
+pub mod error;
+pub use error::{MoFaError, MoFaResult};
+
+// =============================================================================
+// Swarm orchestrator FFI wrapper (always compiled — mofa-orchestrator is a
+// direct dep; used by both uniffi and python binding layers below)
+// =============================================================================
+
+pub mod swarm;
+pub use swarm::{SwarmOrchestratorFFI, SwarmResultFFI};
+
+// =============================================================================
 // UniFFI bindings (enabled with `uniffi` feature)
 // =============================================================================
 

--- a/crates/mofa-ffi/src/mofa.udl
+++ b/crates/mofa-ffi/src/mofa.udl
@@ -332,3 +332,36 @@ interface ToolRegistry {
     [Throws=MoFaError]
     FfiToolResult execute_tool(string name, string arguments_json);
 };
+
+// ============================================================================
+// Swarm Orchestrator Types
+// ============================================================================
+
+// Result from a complete swarm execution.
+//
+// Use execution_id to correlate with OpenTelemetry traces in Jaeger
+// and with the JSONL audit log exported by GovernanceLayer.
+dictionary SwarmResultFFI {
+    string execution_id;
+    string goal;
+    u64 tasks_succeeded;
+    u64 tasks_failed;
+    u64 wall_time_ms;
+};
+
+// High-level entry point that connects a natural-language goal to a coordinated
+// multi-agent execution across all Cognitive Swarm Orchestrator modules:
+//   TaskAnalyzer -> SwarmComposer -> HITLGovernor -> GovernanceLayer
+//   -> Schedulers -> SemanticDiscovery -> SmithObservatory
+//
+// Owns an internal Tokio runtime — callers do not need async support.
+interface SwarmOrchestratorFFI {
+    // Create a new orchestrator.
+    // The name appears in OTel gen_ai.agent.* span attributes and audit log entries.
+    constructor(string name);
+
+    // Run the full swarm pipeline for the given natural-language goal.
+    // Blocks the calling thread until execution completes or fails.
+    [Throws=MoFaError]
+    SwarmResultFFI run_goal(string goal);
+};

--- a/crates/mofa-ffi/src/python_bindings.rs
+++ b/crates/mofa-ffi/src/python_bindings.rs
@@ -2,16 +2,134 @@
 //!
 //! This module provides native Python extension bindings.
 
-use pyo3::exceptions::PyNotImplementedError;
+use pyo3::exceptions::{PyNotImplementedError, PyRuntimeError};
 use pyo3::prelude::*;
+
+use crate::swarm::{SwarmOrchestratorFFI, SwarmResultFFI};
 
 // Note: Python bindings are being refactored to use MoFAAgent directly.
 // The PyAgentWrapper will be reimplemented to wrap MoFAAgent instead of RuntimeAgent.
+
+// =============================================================================
+// Swarm Orchestrator — PyO3 wrappers
+// =============================================================================
+
+/// Result of a swarm execution, returned by `SwarmOrchestrator.run_goal()`.
+///
+/// Attributes
+/// ----------
+/// execution_id : str
+///     UUID for this run. Correlates with OTel traces and audit JSONL.
+/// goal : str
+///     The original natural-language goal string.
+/// tasks_succeeded : int
+///     Number of subtasks that completed successfully.
+/// tasks_failed : int
+///     Number of subtasks that failed or were rejected by a HITL gate.
+/// wall_time_ms : int
+///     Total wall-clock execution time in milliseconds.
+#[pyclass(name = "SwarmResult")]
+#[derive(Clone)]
+pub struct PySwarmResult {
+    #[pyo3(get)]
+    pub execution_id: String,
+    #[pyo3(get)]
+    pub goal: String,
+    #[pyo3(get)]
+    pub tasks_succeeded: u64,
+    #[pyo3(get)]
+    pub tasks_failed: u64,
+    #[pyo3(get)]
+    pub wall_time_ms: u64,
+}
+
+#[pymethods]
+impl PySwarmResult {
+    fn __repr__(&self) -> String {
+        format!(
+            "SwarmResult(execution_id={:?}, goal={:?}, succeeded={}, failed={}, wall_time_ms={})",
+            self.execution_id,
+            self.goal,
+            self.tasks_succeeded,
+            self.tasks_failed,
+            self.wall_time_ms,
+        )
+    }
+}
+
+impl From<SwarmResultFFI> for PySwarmResult {
+    fn from(r: SwarmResultFFI) -> Self {
+        Self {
+            execution_id: r.execution_id,
+            goal: r.goal,
+            tasks_succeeded: r.tasks_succeeded,
+            tasks_failed: r.tasks_failed,
+            wall_time_ms: r.wall_time_ms,
+        }
+    }
+}
+
+/// High-level entry point that connects a natural-language goal to a coordinated
+/// multi-agent execution across all Cognitive Swarm Orchestrator modules.
+///
+/// Owns an internal Tokio runtime — no async machinery needed on the Python side.
+///
+/// Parameters
+/// ----------
+/// name : str
+///     Display name for this orchestrator. Appears in OTel span attributes
+///     and SwarmAuditLog entries.
+///
+/// Examples
+/// --------
+/// >>> from mofa import SwarmOrchestrator
+/// >>> orch = SwarmOrchestrator("compliance-swarm")
+/// >>> result = orch.run_goal("review Q1 loan applications for fair lending violations")
+/// >>> print(f"succeeded={result.tasks_succeeded}  id={result.execution_id}")
+#[pyclass(name = "SwarmOrchestrator")]
+pub struct PySwarmOrchestrator {
+    inner: SwarmOrchestratorFFI,
+}
+
+#[pymethods]
+impl PySwarmOrchestrator {
+    #[new]
+    fn new(name: String) -> Self {
+        Self {
+            inner: SwarmOrchestratorFFI::new(name),
+        }
+    }
+
+    /// Run the full swarm pipeline for the given natural-language goal.
+    ///
+    /// Blocks until execution completes or raises RuntimeError on failure.
+    ///
+    /// Parameters
+    /// ----------
+    /// goal : str
+    ///     Natural-language description of the task to execute.
+    ///
+    /// Returns
+    /// -------
+    /// SwarmResult
+    fn run_goal(&self, goal: String) -> PyResult<PySwarmResult> {
+        self.inner
+            .run_goal(goal)
+            .map(PySwarmResult::from)
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+    }
+}
+
+// =============================================================================
+// Module initialization
+// =============================================================================
 
 /// Python module initialization
 #[pymodule]
 pub fn mofa(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(run_agents_py, m)?)?;
+    m.add_class::<PySwarmOrchestrator>()?;
+    m.add_class::<PySwarmResult>()?;
     Ok(())
 }
 
@@ -37,5 +155,24 @@ mod tests {
             assert!(err.is_instance_of::<PyNotImplementedError>(py));
             assert!(err.to_string().contains(RUN_AGENTS_UNSUPPORTED_MESSAGE));
         });
+    }
+
+    #[test]
+    fn py_swarm_orchestrator_new_does_not_panic() {
+        let _orch = PySwarmOrchestrator::new("test".to_string());
+    }
+
+    #[test]
+    fn py_swarm_result_from_ffi() {
+        let ffi = SwarmResultFFI {
+            execution_id: "abc-123".to_string(),
+            goal: "test goal".to_string(),
+            tasks_succeeded: 3,
+            tasks_failed: 1,
+            wall_time_ms: 250,
+        };
+        let py_result = PySwarmResult::from(ffi);
+        assert_eq!(py_result.execution_id, "abc-123");
+        assert_eq!(py_result.tasks_succeeded, 3);
     }
 }

--- a/crates/mofa-ffi/src/swarm.rs
+++ b/crates/mofa-ffi/src/swarm.rs
@@ -1,40 +1,29 @@
-//! FFI bindings for [`SwarmOrchestrator`].
+//! FFI bindings for the Cognitive Swarm Orchestrator.
 //!
-//! Exposes the `mofa swarm run "goal"` pipeline as a synchronous call
-//! usable from Python, Kotlin, and Swift without callers managing async runtimes.
+//! Exposes `run_goal(goal)` as a synchronous call usable from Python,
+//! Kotlin, and Swift without callers managing Tokio async runtimes.
 //!
-//! # Architecture
+//! # Implementation note
 //!
-//! ```text
-//! Python / Kotlin / Swift
-//!   |
-//!   +-- PyO3: PySwarmOrchestrator  (python feature)
-//!   +-- UniFFI: SwarmOrchestratorFFI  (uniffi feature)
-//!   |
-//!   v
-//! SwarmOrchestratorFFI  (this module, always compiled)
-//!   |
-//!   v
-//! mofa_orchestrator::SwarmOrchestrator  (async Rust)
-//!   |
-//!   v
-//! TaskAnalyzer → SwarmComposer → HITLGovernor → GovernanceLayer
-//!   → Schedulers → SemanticDiscovery → SmithObservatory
-//! ```
+//! This module contains a self-contained stub that matches the public API
+//! of `mofa_orchestrator::SwarmOrchestrator`. The stub is intentional:
+//! `mofa-orchestrator` lives on a feature branch (`feat/mofa-orchestrator-skeleton`)
+//! that has not yet merged into main. A follow-up PR will replace the stub
+//! body with a real `mofa_orchestrator::SwarmOrchestrator::run_goal` call
+//! once that branch merges, without any change to the FFI surface.
+//!
+//! All four tests below exercise the FFI layer (construction, UUID uniqueness,
+//! goal round-trip, timing field) and will continue to pass after the swap.
 
+use std::time::Instant;
 use tokio::runtime::Runtime;
-
-use mofa_orchestrator::orchestrator::{OrchestratorConfig, SwarmOrchestrator};
 
 use crate::MoFaError;
 
 /// FFI-safe result of a complete swarm execution.
 ///
-/// Returned by [`SwarmOrchestratorFFI::run_goal`] after the full pipeline
-/// (TaskAnalyzer → SwarmComposer → schedulers → HITL gates) completes or fails.
-///
-/// Use `execution_id` to correlate this result with OTel traces in Jaeger
-/// and with the JSONL audit log exported by `GovernanceLayer`.
+/// Use `execution_id` to correlate with OTel traces in Jaeger and with
+/// the JSONL audit log exported by `GovernanceLayer`.
 #[derive(Debug, Clone)]
 pub struct SwarmResultFFI {
     /// UUID for this execution run.
@@ -49,11 +38,11 @@ pub struct SwarmResultFFI {
     pub wall_time_ms: u64,
 }
 
-/// FFI wrapper around [`mofa_orchestrator::SwarmOrchestrator`].
+/// FFI wrapper around the Cognitive Swarm Orchestrator.
 ///
 /// Owns a dedicated Tokio runtime so callers in Python, Kotlin, and Swift
-/// do not need to manage async execution themselves — `run_goal` blocks until
-/// the swarm pipeline completes.
+/// do not need to manage async execution themselves — `run_goal` blocks
+/// until the swarm pipeline completes.
 ///
 /// # Python (via PyO3)
 ///
@@ -62,7 +51,7 @@ pub struct SwarmResultFFI {
 ///
 /// orch = SwarmOrchestrator("compliance-swarm")
 /// result = orch.run_goal("review Q1 loan applications for fair lending violations")
-/// print(f"succeeded={result.tasks_succeeded} id={result.execution_id}")
+/// print(f"succeeded={result.tasks_succeeded}  id={result.execution_id}")
 /// ```
 ///
 /// # Kotlin (via UniFFI)
@@ -81,7 +70,7 @@ pub struct SwarmResultFFI {
 /// print("succeeded=\(result.tasksSucceeded)  id=\(result.executionId)")
 /// ```
 pub struct SwarmOrchestratorFFI {
-    inner: SwarmOrchestrator,
+    name: String,
     rt: Runtime,
 }
 
@@ -91,9 +80,8 @@ impl SwarmOrchestratorFFI {
     /// The name appears in OpenTelemetry `gen_ai.agent.*` span attributes
     /// and in every `SwarmAuditLog` entry emitted during execution.
     pub fn new(name: String) -> Self {
-        let config = OrchestratorConfig::new(name);
         Self {
-            inner: SwarmOrchestrator::new(config),
+            name,
             rt: Runtime::new()
                 .expect("failed to create Tokio runtime for SwarmOrchestratorFFI"),
         }
@@ -103,20 +91,27 @@ impl SwarmOrchestratorFFI {
     ///
     /// Blocks the calling thread until the swarm completes or fails.
     ///
-    /// All [`OrchestratorError`] variants are mapped to [`MoFaError::RuntimeError`]
-    /// so the error message crosses the FFI boundary as a UTF-8 string.
+    /// The current body is a stub that returns a well-formed `SwarmResultFFI`
+    /// with a unique UUID execution ID. It will be replaced with a real
+    /// `mofa_orchestrator::SwarmOrchestrator::run_goal` call in the follow-up
+    /// PR that merges `feat/mofa-orchestrator-skeleton`.
     pub fn run_goal(&self, goal: String) -> Result<SwarmResultFFI, MoFaError> {
-        let result = self
-            .rt
-            .block_on(self.inner.run_goal(&goal))
-            .map_err(|e| MoFaError::RuntimeError(e.to_string()))?;
+        let start = Instant::now();
+
+        // Stub: async block that will be replaced with the real orchestrator call.
+        // The runtime ownership and blocking pattern stay identical after the swap.
+        let execution_id = self.rt.block_on(async {
+            uuid::Uuid::new_v4().to_string()
+        });
+
+        let wall_time_ms = start.elapsed().as_millis() as u64;
 
         Ok(SwarmResultFFI {
-            execution_id: result.execution_id,
-            goal: result.goal,
-            tasks_succeeded: result.tasks_succeeded as u64,
-            tasks_failed: result.tasks_failed as u64,
-            wall_time_ms: result.wall_time_ms,
+            execution_id,
+            goal,
+            tasks_succeeded: 0,
+            tasks_failed: 0,
+            wall_time_ms,
         })
     }
 }
@@ -135,7 +130,7 @@ mod tests {
         let orch = SwarmOrchestratorFFI::new("test-swarm".to_string());
         let result = orch
             .run_goal("summarize quarterly earnings".to_string())
-            .expect("run_goal must not fail against stub orchestrator");
+            .expect("run_goal must not fail");
         assert_eq!(result.goal, "summarize quarterly earnings");
         assert!(!result.execution_id.is_empty(), "execution_id must be a non-empty UUID");
     }
@@ -145,8 +140,7 @@ mod tests {
         let orch = SwarmOrchestratorFFI::new("test-swarm".to_string());
         let result = orch
             .run_goal("deploy service to staging".to_string())
-            .expect("run_goal must not fail against stub orchestrator");
-        // wall_time_ms must be non-negative (trivially true for u64 but assert type constraint)
+            .expect("run_goal must not fail");
         let _ = result.wall_time_ms;
     }
 

--- a/crates/mofa-ffi/src/swarm.rs
+++ b/crates/mofa-ffi/src/swarm.rs
@@ -1,0 +1,163 @@
+//! FFI bindings for [`SwarmOrchestrator`].
+//!
+//! Exposes the `mofa swarm run "goal"` pipeline as a synchronous call
+//! usable from Python, Kotlin, and Swift without callers managing async runtimes.
+//!
+//! # Architecture
+//!
+//! ```text
+//! Python / Kotlin / Swift
+//!   |
+//!   +-- PyO3: PySwarmOrchestrator  (python feature)
+//!   +-- UniFFI: SwarmOrchestratorFFI  (uniffi feature)
+//!   |
+//!   v
+//! SwarmOrchestratorFFI  (this module, always compiled)
+//!   |
+//!   v
+//! mofa_orchestrator::SwarmOrchestrator  (async Rust)
+//!   |
+//!   v
+//! TaskAnalyzer → SwarmComposer → HITLGovernor → GovernanceLayer
+//!   → Schedulers → SemanticDiscovery → SmithObservatory
+//! ```
+
+use tokio::runtime::Runtime;
+
+use mofa_orchestrator::orchestrator::{OrchestratorConfig, SwarmOrchestrator};
+
+use crate::MoFaError;
+
+/// FFI-safe result of a complete swarm execution.
+///
+/// Returned by [`SwarmOrchestratorFFI::run_goal`] after the full pipeline
+/// (TaskAnalyzer → SwarmComposer → schedulers → HITL gates) completes or fails.
+///
+/// Use `execution_id` to correlate this result with OTel traces in Jaeger
+/// and with the JSONL audit log exported by `GovernanceLayer`.
+#[derive(Debug, Clone)]
+pub struct SwarmResultFFI {
+    /// UUID for this execution run.
+    pub execution_id: String,
+    /// The original natural-language goal string.
+    pub goal: String,
+    /// Number of subtasks that completed successfully.
+    pub tasks_succeeded: u64,
+    /// Number of subtasks that failed or were rejected by a HITL gate.
+    pub tasks_failed: u64,
+    /// Total wall-clock time in milliseconds.
+    pub wall_time_ms: u64,
+}
+
+/// FFI wrapper around [`mofa_orchestrator::SwarmOrchestrator`].
+///
+/// Owns a dedicated Tokio runtime so callers in Python, Kotlin, and Swift
+/// do not need to manage async execution themselves — `run_goal` blocks until
+/// the swarm pipeline completes.
+///
+/// # Python (via PyO3)
+///
+/// ```python
+/// from mofa import SwarmOrchestrator
+///
+/// orch = SwarmOrchestrator("compliance-swarm")
+/// result = orch.run_goal("review Q1 loan applications for fair lending violations")
+/// print(f"succeeded={result.tasks_succeeded} id={result.execution_id}")
+/// ```
+///
+/// # Kotlin (via UniFFI)
+///
+/// ```kotlin
+/// val orch = SwarmOrchestratorFFI("compliance-swarm")
+/// val result = orch.runGoal("review Q1 loan applications for fair lending violations")
+/// println("succeeded=${result.tasksSucceeded}  id=${result.executionId}")
+/// ```
+///
+/// # Swift (via UniFFI)
+///
+/// ```swift
+/// let orch = SwarmOrchestratorFFI(name: "compliance-swarm")
+/// let result = try orch.runGoal(goal: "review Q1 loan applications for fair lending violations")
+/// print("succeeded=\(result.tasksSucceeded)  id=\(result.executionId)")
+/// ```
+pub struct SwarmOrchestratorFFI {
+    inner: SwarmOrchestrator,
+    rt: Runtime,
+}
+
+impl SwarmOrchestratorFFI {
+    /// Create a new orchestrator with the given display name.
+    ///
+    /// The name appears in OpenTelemetry `gen_ai.agent.*` span attributes
+    /// and in every `SwarmAuditLog` entry emitted during execution.
+    pub fn new(name: String) -> Self {
+        let config = OrchestratorConfig::new(name);
+        Self {
+            inner: SwarmOrchestrator::new(config),
+            rt: Runtime::new()
+                .expect("failed to create Tokio runtime for SwarmOrchestratorFFI"),
+        }
+    }
+
+    /// Run the full swarm pipeline for the given natural-language goal.
+    ///
+    /// Blocks the calling thread until the swarm completes or fails.
+    ///
+    /// All [`OrchestratorError`] variants are mapped to [`MoFaError::RuntimeError`]
+    /// so the error message crosses the FFI boundary as a UTF-8 string.
+    pub fn run_goal(&self, goal: String) -> Result<SwarmResultFFI, MoFaError> {
+        let result = self
+            .rt
+            .block_on(self.inner.run_goal(&goal))
+            .map_err(|e| MoFaError::RuntimeError(e.to_string()))?;
+
+        Ok(SwarmResultFFI {
+            execution_id: result.execution_id,
+            goal: result.goal,
+            tasks_succeeded: result.tasks_succeeded as u64,
+            tasks_failed: result.tasks_failed as u64,
+            wall_time_ms: result.wall_time_ms,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_does_not_panic() {
+        let _orch = SwarmOrchestratorFFI::new("test-swarm".to_string());
+    }
+
+    #[test]
+    fn run_goal_returns_result_with_matching_goal() {
+        let orch = SwarmOrchestratorFFI::new("test-swarm".to_string());
+        let result = orch
+            .run_goal("summarize quarterly earnings".to_string())
+            .expect("run_goal must not fail against stub orchestrator");
+        assert_eq!(result.goal, "summarize quarterly earnings");
+        assert!(!result.execution_id.is_empty(), "execution_id must be a non-empty UUID");
+    }
+
+    #[test]
+    fn run_goal_result_has_valid_timing() {
+        let orch = SwarmOrchestratorFFI::new("test-swarm".to_string());
+        let result = orch
+            .run_goal("deploy service to staging".to_string())
+            .expect("run_goal must not fail against stub orchestrator");
+        // wall_time_ms must be non-negative (trivially true for u64 but assert type constraint)
+        let _ = result.wall_time_ms;
+    }
+
+    #[test]
+    fn run_goal_execution_ids_are_unique() {
+        let orch = SwarmOrchestratorFFI::new("test-swarm".to_string());
+        let r1 = orch.run_goal("goal one".to_string()).unwrap();
+        let r2 = orch.run_goal("goal two".to_string()).unwrap();
+        assert_ne!(
+            r1.execution_id, r2.execution_id,
+            "each run_goal call must produce a unique execution_id"
+        );
+    }
+}

--- a/crates/mofa-ffi/src/uniffi_bindings.rs
+++ b/crates/mofa-ffi/src/uniffi_bindings.rs
@@ -12,36 +12,9 @@ use tokio::sync::RwLock;
 // Error Types
 // =============================================================================
 
-/// MoFA error type for UniFFI.
-///
-/// Intentionally NOT `#[non_exhaustive]` — UniFFI generates exhaustive matches
-/// across the FFI boundary and requires all variants to be known at compile time.
-///
-/// At the FFI boundary every `error_stack::Report<*>` from internal code is
-/// downcast to the closest `MoFaError` category via [`From`] impls below.
-#[derive(Debug, thiserror::Error)]
-pub enum MoFaError {
-    #[error("Configuration error: {0}")]
-    ConfigError(String),
-    #[error("Runtime error: {0}")]
-    RuntimeError(String),
-    #[error("LLM error: {0}")]
-    LLMError(String),
-    #[error("IO error: {0}")]
-    IoError(String),
-    #[error("Invalid argument: {0}")]
-    InvalidArgument(String),
-    #[error("Tool error: {0}")]
-    ToolError(String),
-    #[error("Session error: {0}")]
-    SessionError(String),
-}
-
-/// Convenience result alias for UniFFI-exposed functions.
-///
-/// Always `Result<T, MoFaError>` — `error_stack::Report` cannot cross the FFI
-/// boundary. Use the [`From`] impls below to convert internal reports here.
-pub type MoFaResult<T> = Result<T, MoFaError>;
+// MoFaError is defined in crate::error and re-exported at the crate root.
+// Re-import here for use in the From impls below.
+use crate::error::{MoFaError, MoFaResult};
 
 // ── FFI boundary conversions: Report<*> → MoFaError ───────────────────────────
 //


### PR DESCRIPTION
## Context

 **polyglot SDK bindings** — orchestration APIs callable from Python, Kotlin, and Swift. This PR delivers the FFI surface for that requirement by exposing the Cognitive Swarm Orchestrator pipeline across all three languages via `mofa-ffi`.

## Dependency on feat/mofa-orchestrator-skeleton

This PR is designed to be **merged independently** of `feat/mofa-orchestrator-skeleton`. The `SwarmOrchestratorFFI::run_goal` method currently contains a self-contained stub that:
- generates a unique UUID execution ID per call
- returns a well-formed `SwarmResultFFI` with correct field types
- runs inside an owned Tokio runtime (same pattern as the real impl)

All 4 tests pass on `main` with no external crate dependencies.

A **follow-up PR** will replace the stub body with a real `mofa_orchestrator::SwarmOrchestrator::run_goal` call once `feat/mofa-orchestrator-skeleton` merges — the FFI surface (UniFFI UDL, PyO3 classes, error types) requires zero changes at that point.

## Summary

- Adds `SwarmOrchestratorFFI` in `mofa-ffi` behind a synchronous blocking API so Python, Kotlin, and Swift callers don't manage Tokio async runtimes
- Adds `SwarmResultFFI` dictionary and `SwarmOrchestratorFFI` interface to `mofa.udl` for Kotlin/Swift codegen via UniFFI
- Adds `PySwarmOrchestrator` and `PySwarmResult` PyO3 classes registered in the `mofa` Python module
- Extracts `MoFaError` to a shared `error.rs` (always compiled) so both UniFFI and PyO3 layers share one error type
- Promotes `thiserror` to a non-optional dep (it was already indirect)

## Usage

**Python (PyO3)**
```python
from mofa import SwarmOrchestrator

orch = SwarmOrchestrator("compliance-swarm")
result = orch.run_goal("review Q1 loan applications for fair lending violations")
print(f"succeeded={result.tasks_succeeded}  id={result.execution_id}")
```

**Kotlin (UniFFI)**
```kotlin
val orch = SwarmOrchestratorFFI("compliance-swarm")
val result = orch.runGoal("review Q1 loan applications for fair lending violations")
println("succeeded=${result.tasksSucceeded}  id=${result.executionId}")
```

**Swift (UniFFI)**
```swift
let orch = SwarmOrchestratorFFI(name: "compliance-swarm")
let result = try orch.runGoal(goal: "review Q1 loan applications for fair lending violations")
print("succeeded=\(result.tasksSucceeded)  id=\(result.executionId)")
```

## Test plan

- [x] `cargo check -p mofa-ffi` passes on `main` (no external crate deps)
- [x] `cargo test -p mofa-ffi` — 4 tests pass:
  - `swarm::tests::new_does_not_panic`
  - `swarm::tests::run_goal_returns_result_with_matching_goal`
  - `swarm::tests::run_goal_result_has_valid_timing`
  - `swarm::tests::run_goal_execution_ids_are_unique`
- [x] Existing PyO3 test (`run_agents_py_returns_explicit_unsupported_error`) still passes