### PR TITLE
fix(security): harden shell tool and remove dangerous defaults

### DIFF
--- a/crates/mofa-plugins/src/tools/shell.rs
+++ b/crates/mofa-plugins/src/tools/shell.rs
@@ -50,12 +50,10 @@ impl ShellCommandTool {
             "echo".to_string(),
             "date".to_string(),
             "whoami".to_string(),
-            "cat".to_string(),
             "head".to_string(),
             "tail".to_string(),
             "wc".to_string(),
             "grep".to_string(),
-            "find".to_string(),
         ])
     }
 
@@ -66,6 +64,14 @@ impl ShellCommandTool {
         self.allowed_commands
             .iter()
             .any(|allowed| command == allowed || command.starts_with(&format!("{} ", allowed)))
+    }
+
+    /// Check for dangerous arguments like redirection or piping
+    fn has_dangerous_args(args: &[String]) -> bool {
+        let dangerous_patterns = ["|", ">", "<", "$", "`", ";", "&", ">>", "2>", "&>"];
+        args.iter().any(|arg| {
+            dangerous_patterns.iter().any(|pattern| arg.contains(pattern))
+        })
     }
 }
 
@@ -96,6 +102,13 @@ impl ToolExecutor for ShellCommandTool {
                     .collect()
             })
             .unwrap_or_default();
+
+        if Self::has_dangerous_args(&args) {
+            return Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!(
+                "Dangerous shell operators detected in arguments: {:?}",
+                args
+            )));
+        }
 
         let mut cmd = Command::new(command);
         cmd.args(&args);


### PR DESCRIPTION
This pull request addresses several critical security vulnerabilities in the `ShellCommandTool` as part of issue #801.

### Key Changes

1.  **Harden Default Command Whitelist**: Removed potentially dangerous commands (`cat`, `find`) from the default permitted list in `ShellCommandTool::new_with_defaults()`. These commands can be used to bypass sandbox restrictions and read sensitive files.
2.  **Argument Validation**: Implemented a new `has_dangerous_args` check that identifies shell operators (e.g., `|`, `>`, `<`, `;`, `&`, `$`, `` ` ``) in command arguments. 
3.  **Prevention of Command Injection**: The executor now explicitly rejects execution tasks if any dangerous patterns are detected in the arguments, preventing attackers from chaining commands or redirecting output to unauthorized files.

These enhancements significantly improve the MoFA plugin's security posture and ensure that shell interactions remain strictly within their intended boundaries.

Addresses #801.