### PR TITLE
ci(examples): run cargo test in examples-check workflow

### DIFF
--- a/.github/workflows/examples-check.yml
+++ b/.github/workflows/examples-check.yml
@@ -27,3 +27,6 @@ jobs:
       - name: cargo check examples manifest
         run: cargo check --manifest-path examples/Cargo.toml
 
+      - name: cargo test examples manifest
+        run: cargo test --manifest-path examples/Cargo.toml
+


### PR DESCRIPTION
Extends examples-check CI beyond compile-time validation by running example workspace tests.

What changed:
- keeps existing cargo check for fast compile validation
- adds cargo test on examples/Cargo.toml to catch runtime and integration regressions

This improves confidence that examples are not only compilable but also behaviorally correct.

Closes #612