### PR TITLE
ci: add manual workflow_dispatch for CI and examples-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, master]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/examples-check.yml
+++ b/.github/workflows/examples-check.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   cargo-check-examples:


### PR DESCRIPTION
Adds workflow_dispatch trigger to both CI workflows so maintainers/contributors can run them manually from the GitHub Actions UI.

Updated workflows:
- .github/workflows/ci.yml
- .github/workflows/examples-check.yml

No behavior changes to existing push/pull_request triggers.

Closes #1388