### PR TITLE
fix(kernel): remove unwrap() from serialization tests and docs (#1213)

### DIFF
--- a/crates/mofa-kernel/src/agent/components/context_compressor.rs
+++ b/crates/mofa-kernel/src/agent/components/context_compressor.rs
@@ -13,13 +13,14 @@
 //!
 //! ```rust,ignore
 //! use mofa_kernel::agent::components::context_compressor::{ContextCompressor, CompressionStrategy};
+//! use mofa_kernel::agent::error::AgentResult;
 //!
-//! async fn ensure_fits(compressor: &dyn ContextCompressor, messages: Vec<ChatMessage>) -> Vec<ChatMessage> {
+//! async fn ensure_fits(compressor: &dyn ContextCompressor, messages: Vec<ChatMessage>) -> AgentResult<Vec<ChatMessage>> {
 //!     let tokens = compressor.count_tokens(&messages);
 //!     if tokens > 4096 {
-//!         compressor.compress(messages, 4096).await.unwrap()
+//!         compressor.compress(messages, 4096).await
 //!     } else {
-//!         messages
+//!         Ok(messages)
 //!     }
 //! }
 //! ```

--- a/crates/mofa-kernel/src/agent/components/mcp.rs
+++ b/crates/mofa-kernel/src/agent/components/mcp.rs
@@ -328,7 +328,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mcp_tool_info_serialization() {
+    fn test_mcp_tool_info_serialization() -> crate::agent::error::AgentResult<()> {
         let tool = McpToolInfo {
             name: "list_repos".to_string(),
             description: "List GitHub repositories".to_string(),
@@ -341,9 +341,10 @@ mod tests {
             }),
         };
 
-        let json = serde_json::to_string(&tool).unwrap();
-        let deserialized: McpToolInfo = serde_json::from_str(&json).unwrap();
+        let json = serde_json::to_string(&tool)?;
+        let deserialized: McpToolInfo = serde_json::from_str(&json)?;
         assert_eq!(deserialized.name, "list_repos");
+        Ok(())
     }
 
     #[test]

--- a/crates/mofa-kernel/src/gateway/envelope.rs
+++ b/crates/mofa-kernel/src/gateway/envelope.rs
@@ -265,13 +265,14 @@ mod tests {
     }
 
     #[test]
-    fn envelope_serializes_without_deadline_field() {
+    fn envelope_serializes_without_deadline_field() -> Result<(), Box<dyn std::error::Error>> {
         let env = RequestEnvelope::new("r1", json!({"key": "val"}), loopback())
             .with_deadline(Instant::now() + Duration::from_secs(10));
-        let json = serde_json::to_string(&env).unwrap();
+        let json = serde_json::to_string(&env)?;
         assert!(!json.contains("deadline"));
         assert!(json.contains("correlation_id"));
         assert!(json.contains("created_at_ms"));
+        Ok(())
     }
 
     // ── GatewayResponse ──────────────────────────────────────────────────────
@@ -311,14 +312,15 @@ mod tests {
     }
 
     #[test]
-    fn gateway_response_serializes() {
+    fn gateway_response_serializes() -> Result<(), Box<dyn std::error::Error>> {
         let env = RequestEnvelope::new("r1", json!({}), loopback());
         let resp = AgentResponse::new(200, json!({"result": "ok"}), "agent-a", &env);
-        let json = serde_json::to_string(&resp).unwrap();
+        let json = serde_json::to_string(&resp)?;
         assert!(json.contains("status_code"));
         assert!(json.contains("latency_ms"));
         assert!(json.contains("agent_id"));
         assert!(json.contains("correlation_id"));
+        Ok(())
     }
 
     #[test]

--- a/crates/mofa-kernel/src/scheduler.rs
+++ b/crates/mofa-kernel/src/scheduler.rs
@@ -425,16 +425,17 @@ mod tests {
     // ------------------------------------------------------------------
 
     #[test]
-    fn missed_tick_policy_round_trip() {
+    fn missed_tick_policy_round_trip() -> Result<(), Box<dyn std::error::Error>> {
         for policy in [
             MissedTickPolicy::Skip,
             MissedTickPolicy::Burst,
             MissedTickPolicy::DelaySingle,
         ] {
-            let json = serde_json::to_string(&policy).unwrap();
-            let back: MissedTickPolicy = serde_json::from_str(&json).unwrap();
+            let json = serde_json::to_string(&policy)?;
+            let back: MissedTickPolicy = serde_json::from_str(&json)?;
             assert_eq!(policy, back, "round-trip failed for {:?}", policy);
         }
+        Ok(())
     }
 
     // ------------------------------------------------------------------
@@ -535,7 +536,7 @@ mod tests {
     // ------------------------------------------------------------------
 
     #[test]
-    fn schedule_definition_json_round_trip() {
+    fn schedule_definition_json_round_trip() -> Result<(), Box<dyn std::error::Error>> {
         let def = ScheduleDefinition::new_interval(
             "rt-test",
             "agent-rt",
@@ -543,14 +544,14 @@ mod tests {
             3,
             AgentInput::text("data"),
             MissedTickPolicy::DelaySingle,
-        )
-        .unwrap();
-        let json = serde_json::to_string(&def).unwrap();
-        let back: ScheduleDefinition = serde_json::from_str(&json).unwrap();
+        )?;
+        let json = serde_json::to_string(&def)?;
+        let back: ScheduleDefinition = serde_json::from_str(&json)?;
         assert_eq!(back.schedule_id, "rt-test");
         assert_eq!(back.interval_ms, Some(500));
         assert_eq!(back.max_concurrent, 3);
         assert_eq!(back.missed_tick_policy, MissedTickPolicy::DelaySingle);
+        Ok(())
     }
 
     // ------------------------------------------------------------------

--- a/crates/mofa-kernel/src/workflow/telemetry.rs
+++ b/crates/mofa-kernel/src/workflow/telemetry.rs
@@ -400,23 +400,24 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn test_debug_event_serialization() {
+    fn test_debug_event_serialization() -> Result<(), Box<dyn std::error::Error>> {
         let event = DebugEvent::NodeStart {
             node_id: "process".to_string(),
             timestamp_ms: 1700000000000,
             state_snapshot: json!({"messages": ["hello"]}),
         };
 
-        let serialized = serde_json::to_string(&event).unwrap();
-        let deserialized: DebugEvent = serde_json::from_str(&serialized).unwrap();
+        let serialized = serde_json::to_string(&event)?;
+        let deserialized: DebugEvent = serde_json::from_str(&serialized)?;
 
         assert_eq!(deserialized.event_type(), "node_start");
         assert_eq!(deserialized.node_id(), Some("process"));
         assert_eq!(deserialized.timestamp_ms(), 1700000000000);
+        Ok(())
     }
 
     #[test]
-    fn test_debug_event_all_variants_serialize() {
+    fn test_debug_event_all_variants_serialize() -> Result<(), Box<dyn std::error::Error>> {
         let events = vec![
             DebugEvent::WorkflowStart {
                 workflow_id: "wf-1".to_string(),
@@ -455,11 +456,12 @@ mod tests {
         ];
 
         for event in &events {
-            let json = serde_json::to_string(event).unwrap();
-            let round_trip: DebugEvent = serde_json::from_str(&json).unwrap();
+            let json = serde_json::to_string(event)?;
+            let round_trip: DebugEvent = serde_json::from_str(&json)?;
             assert_eq!(event.event_type(), round_trip.event_type());
             assert_eq!(event.timestamp_ms(), round_trip.timestamp_ms());
         }
+        Ok(())
     }
 
     #[test]
@@ -506,12 +508,13 @@ mod tests {
     }
 
     #[test]
-    fn test_debug_session_serialization() {
+    fn test_debug_session_serialization() -> Result<(), Box<dyn std::error::Error>> {
         let session = DebugSession::new("s-1", "wf-1", "exec-1");
-        let json = serde_json::to_string(&session).unwrap();
-        let round_trip: DebugSession = serde_json::from_str(&json).unwrap();
+        let json = serde_json::to_string(&session)?;
+        let round_trip: DebugSession = serde_json::from_str(&json)?;
         assert_eq!(round_trip.session_id, "s-1");
         assert_eq!(round_trip.status, "running");
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
This PR improves codebase hygiene by removing unchecked `unwrap()` calls in serialization logic, doc examples, and unit tests within `mofa-kernel`.

### Changes
- Updated `ContextCompressor` doc example to return `AgentResult` and use `?`.
- Refactored `McpToolInfo` tests to returns `AgentResult` and handle errors.
- Refactored `DebugEvent` and `DebugSession` tests in `telemetry.rs` to use `Result<(), Box<dyn Error>>`.
- Refactored `MissedTickPolicy` and `ScheduleDefinition` tests in `scheduler.rs`.
- Refactored `RequestEnvelope` and `AgentResponse` tests in `envelope.rs`.

### Verification
- `cargo test -p mofa-kernel` passed.
- All refactored tests now return `Result` and use `?` for serialization operations.

### Motivation
Demonstrating enterprise-grade standards for GSoC 2026. Replacing `unwrap()` with `?` (and returning `Result` in tests) prevents silent panics and makes tests more robust during development of new features. (GSoC 2026: Idea 31 related).