### PR TITLE
feat(testing): OpenAI Compatible Mock LLM Server + HTTP Tests and Examples

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -76,6 +76,7 @@ edition = "2024"
 anyhow = "1.0"
 async-trait = "0.1"
 axum = "0"
+reqwest = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "3"
 members = [
+    "mock_llm_server_sequences_demo",
     "mock_llm_server_demo",
     "cli_production_smoke",
     "cli_agent_logs_demo",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "3"
 members = [
+    "mock_llm_server_demo",
     "cli_production_smoke",
     "cli_agent_logs_demo",
     "cli_plugin_lifecycle",

--- a/examples/mock_llm_server_demo/Cargo.toml
+++ b/examples/mock_llm_server_demo/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "mock_llm_server_demo"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anyhow = { workspace = true }
+tokio = { workspace = true }
+serde_json = { workspace = true }
+mofa-testing = { path = "../../tests" }
+reqwest = { workspace = true }

--- a/examples/mock_llm_server_demo/src/main.rs
+++ b/examples/mock_llm_server_demo/src/main.rs
@@ -1,0 +1,105 @@
+//! Demonstrates the mock LLM server with OpenAI-compatible requests.
+
+use anyhow::Result;
+use mofa_testing::MockLlmServerBuilder;
+use serde_json::json;
+
+/// Run the mock server demo.
+#[tokio::main]
+async fn main() -> Result<()> {
+    let server = MockLlmServerBuilder::new()
+        .response_rule("ping", "pong")
+        .response_rule_with_delay("slow", "done", 50)
+        .tool_call_rule(
+            "use tool",
+            "echo_tool",
+            json!({ "input": "ping" }),
+            Some("Calling tool"),
+        )
+        .error_rule("deny", 403, "forbidden")
+        .start()
+        .await?;
+
+    let client = reqwest::Client::new();
+    let url = format!("{}/v1/chat/completions", server.base_url());
+
+    let response = client
+        .post(url)
+        .json(&json!({
+            "model": "demo-model",
+            "messages": [{"role": "user", "content": "ping"}]
+        }))
+        .send()
+        .await?
+        .json::<serde_json::Value>()
+        .await?;
+
+    println!(
+        "Response: {}",
+        serde_json::to_string_pretty(&response)?
+    );
+
+    // /v1/models example
+    let models_url = format!("{}/v1/models", server.base_url());
+    let models = client
+        .get(models_url)
+        .send()
+        .await?
+        .json::<serde_json::Value>()
+        .await?;
+    println!("Models: {}", serde_json::to_string_pretty(&models)?);
+
+    // Tool-call example
+    let tool_call = client
+        .post(format!("{}/v1/chat/completions", server.base_url()))
+        .json(&json!({
+            "model": "demo-model",
+            "messages": [{"role": "user", "content": "please use tool"}]
+        }))
+        .send()
+        .await?
+        .json::<serde_json::Value>()
+        .await?;
+    println!("Tool call: {}", serde_json::to_string_pretty(&tool_call)?);
+
+    // Delay example
+    let start = std::time::Instant::now();
+    let _ = client
+        .post(format!("{}/v1/chat/completions", server.base_url()))
+        .json(&json!({
+            "model": "demo-model",
+            "messages": [{"role": "user", "content": "slow please"}]
+        }))
+        .send()
+        .await?;
+    println!("Delayed response took ~{}ms", start.elapsed().as_millis());
+
+    // Validation error example
+    let invalid = client
+        .post(format!("{}/v1/chat/completions", server.base_url()))
+        .json(&json!({
+            "model": "demo-model",
+            "messages": []
+        }))
+        .send()
+        .await?
+        .json::<serde_json::Value>()
+        .await?;
+    println!("Validation error: {}", serde_json::to_string_pretty(&invalid)?);
+
+    // Error rule example
+    let denied = client
+        .post(format!("{}/v1/chat/completions", server.base_url()))
+        .json(&json!({
+            "model": "demo-model",
+            "messages": [{"role": "user", "content": "deny this"}]
+        }))
+        .send()
+        .await?
+        .json::<serde_json::Value>()
+        .await?;
+    println!("Rule error: {}", serde_json::to_string_pretty(&denied)?);
+
+    server.shutdown().await;
+    Ok(())
+}

--- a/examples/mock_llm_server_sequences_demo/Cargo.toml
+++ b/examples/mock_llm_server_sequences_demo/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "mock_llm_server_sequences_demo"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anyhow = { workspace = true }
+tokio = { workspace = true }
+serde_json = { workspace = true }
+mofa-testing = { path = "../../tests" }
+reqwest = { workspace = true }

--- a/examples/mock_llm_server_sequences_demo/src/main.rs
+++ b/examples/mock_llm_server_sequences_demo/src/main.rs
@@ -1,0 +1,70 @@
+//! Demonstrates response sequences in the mock LLM server.
+
+use anyhow::Result;
+use mofa_testing::{MockLlmServerBuilder, ToolCallSpec};
+use serde_json::json;
+
+/// Run the mock server sequences demo.
+#[tokio::main]
+async fn main() -> Result<()> {
+    let server = MockLlmServerBuilder::new()
+        .response_sequence("seq", vec!["first", "second"]) 
+        .tool_call_sequence(
+            "tool-seq",
+            vec![
+                ToolCallSpec {
+                    name: "alpha".to_string(),
+                    arguments: json!({ "step": 1 }),
+                    id: None,
+                },
+                ToolCallSpec {
+                    name: "beta".to_string(),
+                    arguments: json!({ "step": 2 }),
+                    id: None,
+                },
+            ],
+            Some("tool sequence"),
+        )
+        .start()
+        .await?;
+
+    let client = reqwest::Client::new();
+    let url = format!("{}/v1/chat/completions", server.base_url());
+
+    for _ in 0..3 {
+        let response = client
+            .post(&url)
+            .json(&json!({
+                "model": "demo-model",
+                "messages": [{"role": "user", "content": "seq"}]
+            }))
+            .send()
+            .await?
+            .json::<serde_json::Value>()
+            .await?;
+        println!(
+            "Sequence response: {}",
+            serde_json::to_string_pretty(&response)?
+        );
+    }
+
+    for _ in 0..2 {
+        let response = client
+            .post(&url)
+            .json(&json!({
+                "model": "demo-model",
+                "messages": [{"role": "user", "content": "tool-seq"}]
+            }))
+            .send()
+            .await?
+            .json::<serde_json::Value>()
+            .await?;
+        println!(
+            "Tool sequence response: {}",
+            serde_json::to_string_pretty(&response)?
+        );
+    }
+
+    server.shutdown().await;
+    Ok(())
+}

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -15,3 +15,6 @@ anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
+axum = { workspace = true }
+reqwest = { workspace = true }
+uuid = { workspace = true }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -8,12 +8,14 @@ pub mod assertions;
 pub mod backend;
 pub mod bus;
 pub mod clock;
+pub mod mock_llm_server;
 pub mod report;
 pub mod tools;
 
 pub use backend::MockLLMBackend;
 pub use bus::MockAgentBus;
 pub use clock::{Clock, MockClock, SystemClock};
+pub use mock_llm_server::MockLlmServer;
 pub use report::{
     JsonFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,
     TextFormatter,

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -15,7 +15,7 @@ pub mod tools;
 pub use backend::MockLLMBackend;
 pub use bus::MockAgentBus;
 pub use clock::{Clock, MockClock, SystemClock};
-pub use mock_llm_server::MockLlmServer;
+pub use mock_llm_server::{MockLlmServer, MockLlmServerBuilder, ToolCallSpec};
 pub use report::{
     JsonFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,
     TextFormatter,

--- a/tests/src/mock_llm_server.rs
+++ b/tests/src/mock_llm_server.rs
@@ -43,7 +43,18 @@ struct Rule {
 #[derive(Debug, Clone)]
 enum RuleResponse {
     Text(String),
+    ToolCall {
+        content: Option<String>,
+        tool_calls: Vec<ToolCallSpec>,
+    },
     Error { status: u16, message: String },
+}
+
+#[derive(Debug, Clone)]
+pub struct ToolCallSpec {
+    pub name: String,
+    pub arguments: serde_json::Value,
+    pub id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -88,6 +99,21 @@ struct ChatChoice {
 struct ChatMessageOut {
     role: String,
     content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_calls: Option<Vec<ToolCallOut>>,
+}
+
+#[derive(Debug, Serialize)]
+struct ToolCallOut {
+    id: String,
+    r#type: String,
+    function: ToolFunctionOut,
+}
+
+#[derive(Debug, Serialize)]
+struct ToolFunctionOut {
+    name: String,
+    arguments: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -181,11 +207,52 @@ impl MockLlmServer {
         });
     }
 
+    /// Add a tool-call response rule matched by prompt substring.
+    pub async fn add_tool_call_rule(
+        &self,
+        prompt_substring: &str,
+        tool_name: &str,
+        arguments: serde_json::Value,
+        content: Option<&str>,
+    ) {
+        let mut state = self.state.write().await;
+        state.rules.push(Rule {
+            prompt_substring: prompt_substring.to_string(),
+            response: RuleResponse::ToolCall {
+                content: content.map(|s| s.to_string()),
+                tool_calls: vec![ToolCallSpec {
+                    name: tool_name.to_string(),
+                    arguments,
+                    id: None,
+                }],
+            },
+        });
+    }
+
     /// Add a sequence of responses for a prompt substring.
     /// Each matching call consumes the next response; the last repeats.
     pub async fn add_response_sequence(&self, prompt_substring: &str, responses: Vec<&str>) {
         let mut state = self.state.write().await;
         let deque = responses.into_iter().map(|s| RuleResponse::Text(s.to_string())).collect();
+        state.sequences.push((prompt_substring.to_string(), deque));
+    }
+
+    /// Add a sequence of tool-call responses for a prompt substring.
+    /// Each matching call consumes the next response; the last repeats.
+    pub async fn add_tool_call_sequence(
+        &self,
+        prompt_substring: &str,
+        tool_calls: Vec<ToolCallSpec>,
+        content: Option<&str>,
+    ) {
+        let mut state = self.state.write().await;
+        let mut deque = VecDeque::new();
+        for call in tool_calls {
+            deque.push_back(RuleResponse::ToolCall {
+                content: content.map(|s| s.to_string()),
+                tool_calls: vec![call],
+            });
+        }
         state.sequences.push((prompt_substring.to_string(), deque));
     }
 
@@ -259,8 +326,40 @@ async fn handle_chat(
                 message: ChatMessageOut {
                     role: "assistant".to_string(),
                     content: text,
+                    tool_calls: None,
                 },
                 finish_reason: "stop".to_string(),
+            }],
+        })),
+        RuleResponse::ToolCall { content, tool_calls } => Ok(Json(ChatCompletionResponse {
+            id: format!("mock-{}", uuid::Uuid::now_v7()),
+            object: "chat.completion".to_string(),
+            created: Utc::now().timestamp() as u64,
+            model: payload
+                .model
+                .clone()
+                .unwrap_or_else(|| "mock-model".to_string()),
+            choices: vec![ChatChoice {
+                index: 0,
+                message: ChatMessageOut {
+                    role: "assistant".to_string(),
+                    content: content.unwrap_or_default(),
+                    tool_calls: Some(
+                        tool_calls
+                            .into_iter()
+                            .map(|spec| ToolCallOut {
+                                id: spec.id.unwrap_or_else(|| uuid::Uuid::now_v7().to_string()),
+                                r#type: "function".to_string(),
+                                function: ToolFunctionOut {
+                                    name: spec.name,
+                                    arguments: serde_json::to_string(&spec.arguments)
+                                        .unwrap_or_else(|_| "{}".to_string()),
+                                },
+                            })
+                            .collect(),
+                    ),
+                },
+                finish_reason: "tool_calls".to_string(),
             }],
         })),
         RuleResponse::Error { status, message } => Err((

--- a/tests/src/mock_llm_server.rs
+++ b/tests/src/mock_llm_server.rs
@@ -6,6 +6,7 @@
 use axum::{
     extract::State,
     http::StatusCode,
+    routing::get,
     routing::post,
     Json, Router,
 };
@@ -17,7 +18,7 @@ use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::{oneshot, RwLock};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct MockLlmServer {
     base_url: String,
     addr: SocketAddr,
@@ -100,6 +101,20 @@ struct ErrorBody {
     r#type: String,
 }
 
+#[derive(Debug, Serialize)]
+struct ModelsResponse {
+    object: String,
+    data: Vec<ModelInfo>,
+}
+
+#[derive(Debug, Serialize)]
+struct ModelInfo {
+    id: String,
+    object: String,
+    created: u64,
+    owned_by: String,
+}
+
 impl MockLlmServer {
     /// Start a mock LLM server on a random local port.
     pub async fn start() -> anyhow::Result<Self> {
@@ -112,6 +127,7 @@ impl MockLlmServer {
 
         let app = Router::new()
             .route("/v1/chat/completions", post(handle_chat))
+            .route("/v1/models", get(handle_models))
             .with_state(state.clone());
 
         let listener = TcpListener::bind("127.0.0.1:0").await?;
@@ -122,7 +138,9 @@ impl MockLlmServer {
         let server = axum::serve(listener, app).with_graceful_shutdown(async move {
             let _ = shutdown_rx.await;
         });
-        tokio::spawn(server);
+        tokio::spawn(async move {
+            let _ = server.await;
+        });
 
         Ok(Self {
             base_url,
@@ -257,9 +275,32 @@ async fn handle_chat(
     }
 }
 
+async fn handle_models(
+    State(state): State<Arc<RwLock<ServerState>>>,
+) -> Json<ModelsResponse> {
+    let model_id = {
+        let guard = state.read().await;
+        guard
+            .history
+            .last()
+            .and_then(|record| record.model.clone())
+            .unwrap_or_else(|| "mock-model".to_string())
+    };
+
+    Json(ModelsResponse {
+        object: "list".to_string(),
+        data: vec![ModelInfo {
+            id: model_id,
+            object: "model".to_string(),
+            created: Utc::now().timestamp() as u64,
+            owned_by: "mock-llm-server".to_string(),
+        }],
+    })
+}
+
 fn resolve_response(state: &mut ServerState, prompt: &str) -> RuleResponse {
     for (key, deque) in state.sequences.iter_mut() {
-        if prompt.contains(key) {
+        if prompt.contains(key.as_str()) {
             if deque.len() > 1 {
                 return deque.pop_front().unwrap_or_else(|| {
                     RuleResponse::Text(state.default_response.clone())

--- a/tests/src/mock_llm_server.rs
+++ b/tests/src/mock_llm_server.rs
@@ -32,12 +32,14 @@ struct ServerState {
     sequences: Vec<(String, VecDeque<RuleResponse>)>,
     default_response: String,
     history: Vec<RequestRecord>,
+    default_delay_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone)]
 struct Rule {
     prompt_substring: String,
     response: RuleResponse,
+    delay_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone)]
@@ -149,6 +151,7 @@ impl MockLlmServer {
             sequences: Vec::new(),
             default_response: "Mock fallback response.".to_string(),
             history: Vec::new(),
+            default_delay_ms: None,
         }));
 
         let app = Router::new()
@@ -192,6 +195,7 @@ impl MockLlmServer {
         state.rules.push(Rule {
             prompt_substring: prompt_substring.to_string(),
             response: RuleResponse::Text(response.to_string()),
+            delay_ms: None,
         });
     }
 
@@ -204,6 +208,7 @@ impl MockLlmServer {
                 status,
                 message: message.to_string(),
             },
+            delay_ms: None,
         });
     }
 
@@ -226,6 +231,7 @@ impl MockLlmServer {
                     id: None,
                 }],
             },
+            delay_ms: None,
         });
     }
 
@@ -254,6 +260,27 @@ impl MockLlmServer {
             });
         }
         state.sequences.push((prompt_substring.to_string(), deque));
+    }
+
+    /// Add a response rule with a fixed delay.
+    pub async fn add_response_rule_with_delay(
+        &self,
+        prompt_substring: &str,
+        response: &str,
+        delay_ms: u64,
+    ) {
+        let mut state = self.state.write().await;
+        state.rules.push(Rule {
+            prompt_substring: prompt_substring.to_string(),
+            response: RuleResponse::Text(response.to_string()),
+            delay_ms: Some(delay_ms),
+        });
+    }
+
+    /// Set a default delay for all responses (unless a rule overrides it).
+    pub async fn set_default_delay(&self, delay_ms: Option<u64>) {
+        let mut state = self.state.write().await;
+        state.default_delay_ms = delay_ms;
     }
 
     /// Set the default response when no rule matches.
@@ -298,10 +325,40 @@ async fn handle_chat(
         ));
     }
 
+    // Basic request validation to keep tests deterministic.
+    if payload.messages.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: ErrorBody {
+                    message: "messages must be non-empty".to_string(),
+                    r#type: "invalid_request_error".to_string(),
+                },
+            }),
+        ));
+    }
+
+    // Require at least one non-empty message content.
+    if payload
+        .messages
+        .iter()
+        .all(|msg| msg.content.as_deref().unwrap_or("").is_empty())
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: ErrorBody {
+                    message: "messages must include content".to_string(),
+                    r#type: "invalid_request_error".to_string(),
+                },
+            }),
+        ));
+    }
+
     let prompt = build_prompt(&payload.messages);
     let raw = serde_json::to_value(&payload).unwrap_or(serde_json::Value::Null);
 
-    let response = {
+    let (response, delay_ms) = {
         let mut guard = state.write().await;
         guard.history.push(RequestRecord {
             received_at: Utc::now(),
@@ -311,6 +368,10 @@ async fn handle_chat(
         });
         resolve_response(&mut guard, &prompt)
     };
+
+    if let Some(delay) = delay_ms {
+        tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+    }
 
     match response {
         RuleResponse::Text(text) => Ok(Json(ChatCompletionResponse {
@@ -374,6 +435,7 @@ async fn handle_chat(
     }
 }
 
+/// Handle OpenAI-compatible model listing requests.
 async fn handle_models(
     State(state): State<Arc<RwLock<ServerState>>>,
 ) -> Json<ModelsResponse> {
@@ -397,27 +459,31 @@ async fn handle_models(
     })
 }
 
-fn resolve_response(state: &mut ServerState, prompt: &str) -> RuleResponse {
+fn resolve_response(state: &mut ServerState, prompt: &str) -> (RuleResponse, Option<u64>) {
     for (key, deque) in state.sequences.iter_mut() {
         if prompt.contains(key.as_str()) {
             if deque.len() > 1 {
-                return deque.pop_front().unwrap_or_else(|| {
+                let response = deque.pop_front().unwrap_or_else(|| {
                     RuleResponse::Text(state.default_response.clone())
                 });
+                return (response, state.default_delay_ms);
             }
             if let Some(last) = deque.front() {
-                return last.clone();
+                return (last.clone(), state.default_delay_ms);
             }
         }
     }
 
     for rule in state.rules.iter() {
         if prompt.contains(&rule.prompt_substring) {
-            return rule.response.clone();
+            return (rule.response.clone(), rule.delay_ms.or(state.default_delay_ms));
         }
     }
 
-    RuleResponse::Text(state.default_response.clone())
+    (
+        RuleResponse::Text(state.default_response.clone()),
+        state.default_delay_ms,
+    )
 }
 
 fn build_prompt(messages: &[ChatMessage]) -> String {

--- a/tests/src/mock_llm_server.rs
+++ b/tests/src/mock_llm_server.rs
@@ -59,6 +59,15 @@ pub struct ToolCallSpec {
     pub id: Option<String>,
 }
 
+/// Builder for configuring mock LLM server rules in tests.
+#[derive(Debug, Default)]
+pub struct MockLlmServerBuilder {
+    rules: Vec<Rule>,
+    sequences: Vec<(String, VecDeque<RuleResponse>)>,
+    default_response: Option<String>,
+    default_delay_ms: Option<u64>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct RequestRecord {
     pub received_at: DateTime<Utc>,
@@ -146,13 +155,17 @@ struct ModelInfo {
 impl MockLlmServer {
     /// Start a mock LLM server on a random local port.
     pub async fn start() -> anyhow::Result<Self> {
-        let state = Arc::new(RwLock::new(ServerState {
-            rules: Vec::new(),
-            sequences: Vec::new(),
-            default_response: "Mock fallback response.".to_string(),
-            history: Vec::new(),
-            default_delay_ms: None,
-        }));
+        MockLlmServerBuilder::default().start().await
+    }
+
+    /// Start a mock LLM server using a builder configuration.
+    pub async fn start_with_builder(builder: MockLlmServerBuilder) -> anyhow::Result<Self> {
+        builder.start().await
+    }
+
+    /// Start a mock LLM server using the provided internal state.
+    async fn start_with_state(state: ServerState) -> anyhow::Result<Self> {
+        let state = Arc::new(RwLock::new(state));
 
         let app = Router::new()
             .route("/v1/chat/completions", post(handle_chat))
@@ -306,6 +319,125 @@ impl MockLlmServer {
         if let Some(tx) = self.shutdown_tx.take() {
             let _ = tx.send(());
         }
+    }
+}
+
+impl MockLlmServerBuilder {
+    /// Create a new builder with default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the default response when no rule matches.
+    pub fn default_response(mut self, response: &str) -> Self {
+        self.default_response = Some(response.to_string());
+        self
+    }
+
+    /// Set a default delay for all responses.
+    pub fn default_delay_ms(mut self, delay_ms: u64) -> Self {
+        self.default_delay_ms = Some(delay_ms);
+        self
+    }
+
+    /// Add a static response rule.
+    pub fn response_rule(mut self, prompt_substring: &str, response: &str) -> Self {
+        self.rules.push(Rule {
+            prompt_substring: prompt_substring.to_string(),
+            response: RuleResponse::Text(response.to_string()),
+            delay_ms: None,
+        });
+        self
+    }
+
+    /// Add a static response rule with a delay.
+    pub fn response_rule_with_delay(
+        mut self,
+        prompt_substring: &str,
+        response: &str,
+        delay_ms: u64,
+    ) -> Self {
+        self.rules.push(Rule {
+            prompt_substring: prompt_substring.to_string(),
+            response: RuleResponse::Text(response.to_string()),
+            delay_ms: Some(delay_ms),
+        });
+        self
+    }
+
+    /// Add an error rule.
+    pub fn error_rule(mut self, prompt_substring: &str, status: u16, message: &str) -> Self {
+        self.rules.push(Rule {
+            prompt_substring: prompt_substring.to_string(),
+            response: RuleResponse::Error {
+                status,
+                message: message.to_string(),
+            },
+            delay_ms: None,
+        });
+        self
+    }
+
+    /// Add a tool-call rule.
+    pub fn tool_call_rule(
+        mut self,
+        prompt_substring: &str,
+        tool_name: &str,
+        arguments: serde_json::Value,
+        content: Option<&str>,
+    ) -> Self {
+        self.rules.push(Rule {
+            prompt_substring: prompt_substring.to_string(),
+            response: RuleResponse::ToolCall {
+                content: content.map(|s| s.to_string()),
+                tool_calls: vec![ToolCallSpec {
+                    name: tool_name.to_string(),
+                    arguments,
+                    id: None,
+                }],
+            },
+            delay_ms: None,
+        });
+        self
+    }
+
+    /// Add a sequence of text responses.
+    pub fn response_sequence(mut self, prompt_substring: &str, responses: Vec<&str>) -> Self {
+        let deque = responses.into_iter().map(|s| RuleResponse::Text(s.to_string())).collect();
+        self.sequences.push((prompt_substring.to_string(), deque));
+        self
+    }
+
+    /// Add a sequence of tool-call responses.
+    pub fn tool_call_sequence(
+        mut self,
+        prompt_substring: &str,
+        tool_calls: Vec<ToolCallSpec>,
+        content: Option<&str>,
+    ) -> Self {
+        let mut deque = VecDeque::new();
+        for call in tool_calls {
+            deque.push_back(RuleResponse::ToolCall {
+                content: content.map(|s| s.to_string()),
+                tool_calls: vec![call],
+            });
+        }
+        self.sequences.push((prompt_substring.to_string(), deque));
+        self
+    }
+
+    /// Start the server with the configured rules.
+    pub async fn start(self) -> anyhow::Result<MockLlmServer> {
+        let state = ServerState {
+            rules: self.rules,
+            sequences: self.sequences,
+            default_response: self
+                .default_response
+                .unwrap_or_else(|| "Mock fallback response.".to_string()),
+            history: Vec::new(),
+            default_delay_ms: self.default_delay_ms,
+        };
+        MockLlmServer::start_with_state(state).await
     }
 }
 

--- a/tests/src/mock_llm_server.rs
+++ b/tests/src/mock_llm_server.rs
@@ -1,0 +1,293 @@
+//! OpenAI-compatible mock LLM server for tests.
+//!
+//! Provides preset responses, response sequences, and error injection
+//! for `/v1/chat/completions` requests.
+
+use axum::{
+    extract::State,
+    http::StatusCode,
+    routing::post,
+    Json, Router,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::net::TcpListener;
+use tokio::sync::{oneshot, RwLock};
+
+#[derive(Debug, Clone)]
+pub struct MockLlmServer {
+    base_url: String,
+    addr: SocketAddr,
+    state: Arc<RwLock<ServerState>>,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+}
+
+#[derive(Debug, Default)]
+struct ServerState {
+    rules: Vec<Rule>,
+    sequences: Vec<(String, VecDeque<RuleResponse>)>,
+    default_response: String,
+    history: Vec<RequestRecord>,
+}
+
+#[derive(Debug, Clone)]
+struct Rule {
+    prompt_substring: String,
+    response: RuleResponse,
+}
+
+#[derive(Debug, Clone)]
+enum RuleResponse {
+    Text(String),
+    Error { status: u16, message: String },
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RequestRecord {
+    pub received_at: DateTime<Utc>,
+    pub model: Option<String>,
+    pub prompt: String,
+    pub raw: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ChatCompletionRequest {
+    model: Option<String>,
+    messages: Vec<ChatMessage>,
+    #[serde(default)]
+    stream: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ChatMessage {
+    role: Option<String>,
+    content: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ChatCompletionResponse {
+    id: String,
+    object: String,
+    created: u64,
+    model: String,
+    choices: Vec<ChatChoice>,
+}
+
+#[derive(Debug, Serialize)]
+struct ChatChoice {
+    index: usize,
+    message: ChatMessageOut,
+    finish_reason: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ChatMessageOut {
+    role: String,
+    content: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorResponse {
+    error: ErrorBody,
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorBody {
+    message: String,
+    r#type: String,
+}
+
+impl MockLlmServer {
+    /// Start a mock LLM server on a random local port.
+    pub async fn start() -> anyhow::Result<Self> {
+        let state = Arc::new(RwLock::new(ServerState {
+            rules: Vec::new(),
+            sequences: Vec::new(),
+            default_response: "Mock fallback response.".to_string(),
+            history: Vec::new(),
+        }));
+
+        let app = Router::new()
+            .route("/v1/chat/completions", post(handle_chat))
+            .with_state(state.clone());
+
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let base_url = format!("http://{}", addr);
+
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let server = axum::serve(listener, app).with_graceful_shutdown(async move {
+            let _ = shutdown_rx.await;
+        });
+        tokio::spawn(server);
+
+        Ok(Self {
+            base_url,
+            addr,
+            state,
+            shutdown_tx: Some(shutdown_tx),
+        })
+    }
+
+    /// Base URL for HTTP clients (e.g., `http://127.0.0.1:PORT`).
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// Socket address the server is bound to.
+    pub fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    /// Add a response rule matched by prompt substring.
+    pub async fn add_response_rule(&self, prompt_substring: &str, response: &str) {
+        let mut state = self.state.write().await;
+        state.rules.push(Rule {
+            prompt_substring: prompt_substring.to_string(),
+            response: RuleResponse::Text(response.to_string()),
+        });
+    }
+
+    /// Add an error rule matched by prompt substring.
+    pub async fn add_error_rule(&self, prompt_substring: &str, status: u16, message: &str) {
+        let mut state = self.state.write().await;
+        state.rules.push(Rule {
+            prompt_substring: prompt_substring.to_string(),
+            response: RuleResponse::Error {
+                status,
+                message: message.to_string(),
+            },
+        });
+    }
+
+    /// Add a sequence of responses for a prompt substring.
+    /// Each matching call consumes the next response; the last repeats.
+    pub async fn add_response_sequence(&self, prompt_substring: &str, responses: Vec<&str>) {
+        let mut state = self.state.write().await;
+        let deque = responses.into_iter().map(|s| RuleResponse::Text(s.to_string())).collect();
+        state.sequences.push((prompt_substring.to_string(), deque));
+    }
+
+    /// Set the default response when no rule matches.
+    pub async fn set_default_response(&self, response: &str) {
+        let mut state = self.state.write().await;
+        state.default_response = response.to_string();
+    }
+
+    /// Retrieve a snapshot of request history.
+    pub async fn history(&self) -> Vec<RequestRecord> {
+        let state = self.state.read().await;
+        state.history.clone()
+    }
+
+    /// Clear request history.
+    pub async fn clear_history(&self) {
+        let mut state = self.state.write().await;
+        state.history.clear();
+    }
+
+    /// Shutdown the server.
+    pub async fn shutdown(mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+async fn handle_chat(
+    State(state): State<Arc<RwLock<ServerState>>>,
+    Json(payload): Json<ChatCompletionRequest>,
+) -> Result<Json<ChatCompletionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    if payload.stream {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: ErrorBody {
+                    message: "streaming not supported by MockLlmServer".to_string(),
+                    r#type: "invalid_request_error".to_string(),
+                },
+            }),
+        ));
+    }
+
+    let prompt = build_prompt(&payload.messages);
+    let raw = serde_json::to_value(&payload).unwrap_or(serde_json::Value::Null);
+
+    let response = {
+        let mut guard = state.write().await;
+        guard.history.push(RequestRecord {
+            received_at: Utc::now(),
+            model: payload.model.clone(),
+            prompt: prompt.clone(),
+            raw,
+        });
+        resolve_response(&mut guard, &prompt)
+    };
+
+    match response {
+        RuleResponse::Text(text) => Ok(Json(ChatCompletionResponse {
+            id: format!("mock-{}", uuid::Uuid::now_v7()),
+            object: "chat.completion".to_string(),
+            created: Utc::now().timestamp() as u64,
+            model: payload
+                .model
+                .clone()
+                .unwrap_or_else(|| "mock-model".to_string()),
+            choices: vec![ChatChoice {
+                index: 0,
+                message: ChatMessageOut {
+                    role: "assistant".to_string(),
+                    content: text,
+                },
+                finish_reason: "stop".to_string(),
+            }],
+        })),
+        RuleResponse::Error { status, message } => Err((
+            StatusCode::from_u16(status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+            Json(ErrorResponse {
+                error: ErrorBody {
+                    message,
+                    r#type: "mock_error".to_string(),
+                },
+            }),
+        )),
+    }
+}
+
+fn resolve_response(state: &mut ServerState, prompt: &str) -> RuleResponse {
+    for (key, deque) in state.sequences.iter_mut() {
+        if prompt.contains(key) {
+            if deque.len() > 1 {
+                return deque.pop_front().unwrap_or_else(|| {
+                    RuleResponse::Text(state.default_response.clone())
+                });
+            }
+            if let Some(last) = deque.front() {
+                return last.clone();
+            }
+        }
+    }
+
+    for rule in state.rules.iter() {
+        if prompt.contains(&rule.prompt_substring) {
+            return rule.response.clone();
+        }
+    }
+
+    RuleResponse::Text(state.default_response.clone())
+}
+
+fn build_prompt(messages: &[ChatMessage]) -> String {
+    let mut parts = Vec::new();
+    for msg in messages {
+        let role = msg.role.as_deref().unwrap_or("unknown");
+        let content = msg.content.as_deref().unwrap_or("");
+        if !content.is_empty() {
+            parts.push(format!("{}: {}", role, content));
+        }
+    }
+    parts.join("\n")
+}

--- a/tests/tests/mock_llm_server_tests.rs
+++ b/tests/tests/mock_llm_server_tests.rs
@@ -1,4 +1,4 @@
-use mofa_testing::MockLlmServer;
+use mofa_testing::{MockLlmServer, MockLlmServerBuilder, ToolCallSpec};
 use serde_json::json;
 
 async fn post_chat(base_url: &str, body: serde_json::Value) -> (u16, serde_json::Value) {
@@ -244,6 +244,71 @@ async fn mock_llm_server_applies_delay() {
     let elapsed_ms = start.elapsed().as_millis();
 
     assert!(elapsed_ms >= 50, "expected delay, got {elapsed_ms}ms");
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn mock_llm_server_builder_configures_rules() {
+    let server = MockLlmServerBuilder::new()
+        .default_response("fallback")
+        .response_rule("hello", "world")
+        .error_rule("deny", 403, "forbidden")
+        .tool_call_sequence(
+            "tool-seq",
+            vec![
+                ToolCallSpec {
+                    name: "first".to_string(),
+                    arguments: json!({ "step": 1 }),
+                    id: None,
+                },
+                ToolCallSpec {
+                    name: "second".to_string(),
+                    arguments: json!({ "step": 2 }),
+                    id: None,
+                },
+            ],
+            Some("tool content"),
+        )
+        .start()
+        .await
+        .expect("server starts");
+
+    let (status, body) = post_chat(
+        server.base_url(),
+        json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hello there"}]
+        }),
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert_eq!(
+        body["choices"][0]["message"]["content"],
+        "world"
+    );
+
+    let (status, body) = post_chat(
+        server.base_url(),
+        json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "deny request"}]
+        }),
+    )
+    .await;
+    assert_eq!(status, 403);
+    assert_eq!(body["error"]["message"], "forbidden");
+
+    let (status, body) = post_chat(
+        server.base_url(),
+        json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "tool-seq"}]
+        }),
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert_eq!(body["choices"][0]["finish_reason"], "tool_calls");
 
     server.shutdown().await;
 }

--- a/tests/tests/mock_llm_server_tests.rs
+++ b/tests/tests/mock_llm_server_tests.rs
@@ -190,3 +190,37 @@ async fn mock_llm_server_exposes_models() {
 
     server.shutdown().await;
 }
+
+#[tokio::test]
+async fn mock_llm_server_returns_tool_calls() {
+    let server = MockLlmServer::start().await.expect("server starts");
+    server
+        .add_tool_call_rule(
+            "use tool",
+            "echo_tool",
+            json!({ "input": "ping" }),
+            Some("Calling tool"),
+        )
+        .await;
+
+    let (status, body) = post_chat(
+        server.base_url(),
+        json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "please use tool"}]
+        }),
+    )
+    .await;
+
+    assert_eq!(status, 200);
+    assert_eq!(body["choices"][0]["finish_reason"], "tool_calls");
+    let tool_call = &body["choices"][0]["message"]["tool_calls"][0];
+    assert_eq!(tool_call["type"], "function");
+    assert_eq!(tool_call["function"]["name"], "echo_tool");
+    assert!(tool_call["function"]["arguments"]
+        .as_str()
+        .unwrap()
+        .contains("\"input\""));
+
+    server.shutdown().await;
+}

--- a/tests/tests/mock_llm_server_tests.rs
+++ b/tests/tests/mock_llm_server_tests.rs
@@ -1,0 +1,159 @@
+use mofa_testing::MockLlmServer;
+use serde_json::json;
+
+async fn post_chat(base_url: &str, body: serde_json::Value) -> (u16, serde_json::Value) {
+    let client = reqwest::Client::new();
+    let url = format!("{}/v1/chat/completions", base_url);
+    let resp = client.post(url).json(&body).send().await.unwrap();
+    let status = resp.status().as_u16();
+    let json = resp.json::<serde_json::Value>().await.unwrap();
+    (status, json)
+}
+
+#[tokio::test]
+async fn mock_llm_server_returns_default_response() {
+    let server = MockLlmServer::start().await.expect("server starts");
+
+    let (status, body) = post_chat(
+        server.base_url(),
+        json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hello"}]
+        }),
+    )
+    .await;
+
+    assert_eq!(status, 200);
+    let content = body["choices"][0]["message"]["content"]
+        .as_str()
+        .unwrap();
+    assert_eq!(content, "Mock fallback response.");
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn mock_llm_server_matches_rules() {
+    let server = MockLlmServer::start().await.expect("server starts");
+    server
+        .add_response_rule("ping", "pong")
+        .await;
+
+    let (status, body) = post_chat(
+        server.base_url(),
+        json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "please ping"}]
+        }),
+    )
+    .await;
+
+    assert_eq!(status, 200);
+    let content = body["choices"][0]["message"]["content"]
+        .as_str()
+        .unwrap();
+    assert_eq!(content, "pong");
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn mock_llm_server_uses_sequences() {
+    let server = MockLlmServer::start().await.expect("server starts");
+    server
+        .add_response_sequence("seq", vec!["one", "two"]) 
+        .await;
+
+    let body = json!({
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "seq"}]
+    });
+
+    let (_, first) = post_chat(server.base_url(), body.clone()).await;
+    let (_, second) = post_chat(server.base_url(), body.clone()).await;
+    let (_, third) = post_chat(server.base_url(), body).await;
+
+    let first_content = first["choices"][0]["message"]["content"].as_str().unwrap();
+    let second_content = second["choices"][0]["message"]["content"].as_str().unwrap();
+    let third_content = third["choices"][0]["message"]["content"].as_str().unwrap();
+
+    assert_eq!(first_content, "one");
+    assert_eq!(second_content, "two");
+    assert_eq!(third_content, "two");
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn mock_llm_server_returns_errors() {
+    let server = MockLlmServer::start().await.expect("server starts");
+    server
+        .add_error_rule("boom", 429, "rate limit")
+        .await;
+
+    let (status, body) = post_chat(
+        server.base_url(),
+        json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "boom"}]
+        }),
+    )
+    .await;
+
+    assert_eq!(status, 429);
+    assert_eq!(body["error"]["message"], "rate limit");
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn mock_llm_server_tracks_history() {
+    let server = MockLlmServer::start().await.expect("server starts");
+
+    let _ = post_chat(
+        server.base_url(),
+        json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "first"}]
+        }),
+    )
+    .await;
+    let _ = post_chat(
+        server.base_url(),
+        json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "second"}]
+        }),
+    )
+    .await;
+
+    let history = server.history().await;
+    assert_eq!(history.len(), 2);
+    assert!(history[0].prompt.contains("first"));
+    assert!(history[1].prompt.contains("second"));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn mock_llm_server_rejects_streaming() {
+    let server = MockLlmServer::start().await.expect("server starts");
+
+    let (status, body) = post_chat(
+        server.base_url(),
+        json!({
+            "model": "test-model",
+            "stream": true,
+            "messages": [{"role": "user", "content": "hello"}]
+        }),
+    )
+    .await;
+
+    assert_eq!(status, 400);
+    assert!(body["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("streaming"));
+
+    server.shutdown().await;
+}

--- a/tests/tests/mock_llm_server_tests.rs
+++ b/tests/tests/mock_llm_server_tests.rs
@@ -10,6 +10,15 @@ async fn post_chat(base_url: &str, body: serde_json::Value) -> (u16, serde_json:
     (status, json)
 }
 
+async fn get_models(base_url: &str) -> (u16, serde_json::Value) {
+    let client = reqwest::Client::new();
+    let url = format!("{}/v1/models", base_url);
+    let resp = client.get(url).send().await.unwrap();
+    let status = resp.status().as_u16();
+    let json = resp.json::<serde_json::Value>().await.unwrap();
+    (status, json)
+}
+
 #[tokio::test]
 async fn mock_llm_server_returns_default_response() {
     let server = MockLlmServer::start().await.expect("server starts");
@@ -154,6 +163,30 @@ async fn mock_llm_server_rejects_streaming() {
         .as_str()
         .unwrap()
         .contains("streaming"));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn mock_llm_server_exposes_models() {
+    let server = MockLlmServer::start().await.expect("server starts");
+
+    let (status, body) = get_models(server.base_url()).await;
+    assert_eq!(status, 200);
+    assert_eq!(body["object"], "list");
+    assert_eq!(body["data"][0]["object"], "model");
+
+    let _ = post_chat(
+        server.base_url(),
+        json!({
+            "model": "demo-model",
+            "messages": [{"role": "user", "content": "hello"}]
+        }),
+    )
+    .await;
+
+    let (_, body) = get_models(server.base_url()).await;
+    assert_eq!(body["data"][0]["id"], "demo-model");
 
     server.shutdown().await;
 }

--- a/tests/tests/mock_llm_server_tests.rs
+++ b/tests/tests/mock_llm_server_tests.rs
@@ -224,3 +224,64 @@ async fn mock_llm_server_returns_tool_calls() {
 
     server.shutdown().await;
 }
+
+#[tokio::test]
+async fn mock_llm_server_applies_delay() {
+    let server = MockLlmServer::start().await.expect("server starts");
+    server
+        .add_response_rule_with_delay("slow", "done", 60)
+        .await;
+
+    let start = std::time::Instant::now();
+    let _ = post_chat(
+        server.base_url(),
+        json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "slow please"}]
+        }),
+    )
+    .await;
+    let elapsed_ms = start.elapsed().as_millis();
+
+    assert!(elapsed_ms >= 50, "expected delay, got {elapsed_ms}ms");
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn mock_llm_server_rejects_empty_messages() {
+    let server = MockLlmServer::start().await.expect("server starts");
+
+    let (status, body) = post_chat(
+        server.base_url(),
+        json!({
+            "model": "test-model",
+            "messages": []
+        }),
+    )
+    .await;
+
+    assert_eq!(status, 400);
+    assert_eq!(body["error"]["message"], "messages must be non-empty");
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn mock_llm_server_rejects_empty_content() {
+    let server = MockLlmServer::start().await.expect("server starts");
+
+    let (status, body) = post_chat(
+        server.base_url(),
+        json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": ""}]
+        }),
+    )
+    .await;
+
+    assert_eq!(status, 400);
+    assert_eq!(body["error"]["message"], "messages must include content");
+
+    server.shutdown().await;
+}


### PR DESCRIPTION
## Summary
This PR adds a lightweight OpenAI compatible mock LLM HTTP server to `mofa-testing`, plus tests and examples that exercise the full request/response path. It enables deterministic, offline testing of MoFA’s HTTP LLM integration with preset responses, tool call replies, response sequences, latency simulation, request validation, and request history capture.

## Problem
MoFA’s existing LLM mocks are in-process and do not validate the HTTP/protocol layer. This blocks end to end testing of:
- request serialization
- OpenAI compatible endpoint behavior
- HTTP error handling and retry surfaces
- tool call payloads over the network

## Solution
Introduce a standalone mock LLM server that implements `POST /v1/chat/completions` (OpenAI compatible) and `GET /v1/models`, with a clean API for tests to configure behavior and inspect requests.

## Configuration and Request Path:
```mermaid
flowchart TB
    subgraph Config[Configuration]
        Builder[MockLlmServerBuilder]
        Rules[Rules]
        Seqs[Sequences]
        Defaults[Defaults + Delay]
        Builder --> Rules
        Builder --> Seqs
        Builder --> Defaults
    end

    Builder -->|start| Server[MockLlmServer]

    subgraph HTTP[HTTP Interface]
        Post[POST /v1/chat/completions]
        Models[GET /v1/models]
    end

    Test[Test or Example] --> Post
    Test --> Models
    Post --> Server
    Models --> Server

    Server --> Router[axum router]
    Router --> Validate[Request validation]
    Validate -->|invalid| Error400[HTTP 400 error]
    Validate -->|valid| History[Record request]

    History --> Resolve[Rule/sequence resolver]
    Resolve -->|sequence match| SeqResp[Sequence response]
    Resolve -->|rule match| RuleResp[Rule response]
    Resolve -->|no match| Fallback[Default response]

    RuleResp --> Delay[Delay simulation]
    SeqResp --> Delay
    Fallback --> Delay

    Delay --> Response[JSON response]
    Response --> Client[Client/Test]
    Error400 --> Client

    subgraph ErrorAndTooling[Error + Tooling Surfaces]
        ToolCalls[Tool-call payloads]
        ErrorRule[Error rule payloads]
    end

    RuleResp --> ToolCalls
    RuleResp --> ErrorRule
```
## Response Resolution Path:
```mermaid
flowchart TB
    T[Test] -->|POST /v1/chat/completions| S[MockLlmServer]
    S --> V[Validate request]
    V -->|invalid| E[400 invalid_request_error]
    V -->|valid| H[Record history]
    H --> R[Resolve response]

    R -->|tool call rule| TC[Tool call response]
    R -->|error rule| ER[HTTP error response]
    R -->|text rule| TX[Text response]
    R -->|sequence| SQ[Sequence response]
    R -->|fallback| FB[Default response]

    TC --> D[Apply delay]
    ER --> D
    TX --> D
    SQ --> D
    FB --> D

    D --> RESP[JSON response]
    RESP --> T
    E --> T
```

## Key Features
- **Preset response rules**: substring matching rules for deterministic replies.
- **Response sequences**: stepwise responses per prompt (last repeats).
- **Tool call responses**: return `tool_calls` payloads to test tool routing flows.
- **Error injection**: return custom HTTP status + error body for given prompts.
- **Latency simulation**: per rule delay + default delay for timing tests.
- **Request validation**: explicit 400s for empty `messages` or empty content.
- **Request history**: record incoming prompts + raw payloads for assertions.
- **Models endpoint**: `GET /v1/models` for compatibility with clients that expect it.
- **Builder API**: fluent configuration for tests and examples.

## What Changed
### New
- `tests/src/mock_llm_server.rs`
  - `MockLlmServer` (axum based server)
  - `MockLlmServerBuilder` for fluent configuration
  - `ToolCallSpec` for tool call payloads
- `tests/tests/mock_llm_server_tests.rs`
  - Coverage for default response, rule match, sequences, tool calls, errors, models endpoint, latency, and validation failures
- `examples/mock_llm_server_demo/*`
  - End to end example: rules, models, tool calls, latency, validation, error rules
- `examples/mock_llm_server_sequences_demo/*`
  - End to end example: text response sequences + tool call sequences

### Updated
- `tests/src/lib.rs` (exports `MockLlmServer`, `MockLlmServerBuilder`, `ToolCallSpec`)
- `tests/Cargo.toml` (adds `axum`, `reqwest`, `uuid`)
- `examples/Cargo.toml` (registers new examples)

## API Sketch
```rust
let server = MockLlmServerBuilder::new()
    .response_rule("ping", "pong")
    .tool_call_rule("use tool", "echo_tool", json!({"input":"ping"}), Some("Calling tool"))
    .response_sequence("seq", vec!["one", "two"])  // last repeats
    .response_rule_with_delay("slow", "done", 50)
    .error_rule("deny", 403, "forbidden")
    .start()
    .await?;

let url = format!("{}/v1/chat/completions", server.base_url());
```

## Tests
- `cargo test -p mofa-testing --test mock_llm_server_tests`

## Example Output:
```
Response: (pong)
Models: (demo-model listed)
Tool call: (echo_tool with arguments)
Delayed response took ~50ms
Validation error: messages must be non-empty
Rule error: forbidden
```

## Notes
- Streaming responses are explicitly rejected for now (HTTP 400) to keep the MVP deterministic and focused.
