### PR TITLE
fix(dependabot): use 'dependencies' label for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,4 +33,4 @@ updates:
     commit-message:
       prefix: "chore(ci):"
     labels:
-      - "ci"
+      - "dependencies"


### PR DESCRIPTION
This fixes the dependabot configuration: the GitHub Actions update workflow was incorrectly using the 'ci' label which doesn't exist. It now uses the 'dependencies' label which is valid and consistent with the cargo dependency updates.