### PR TITLE
refactor(kernel): add #[non_exhaustive] to public enums

### DIFF
--- a/crates/mofa-kernel/src/agent/types/error.rs
+++ b/crates/mofa-kernel/src/agent/types/error.rs
@@ -208,6 +208,7 @@ impl GlobalError {
 ///
 /// Classifies errors by their impact and whether recovery is possible.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum ErrorSeverity {
     /// Fatal: unrecoverable, the operation cannot proceed
     Fatal,

--- a/crates/mofa-kernel/src/llm/types.rs
+++ b/crates/mofa-kernel/src/llm/types.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 #[derive(Default)]
+#[non_exhaustive]
 pub enum Role {
     System,
     #[default]
@@ -13,6 +14,7 @@ pub enum Role {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum ContentPart {
     Text { text: String },
     Image { image_url: ImageUrl },
@@ -28,6 +30,7 @@ pub struct ImageUrl {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum ImageDetail {
     Low,
     High,
@@ -42,6 +45,7 @@ pub struct AudioData {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum MessageContent {
     Text(String),
     Parts(Vec<ContentPart>),
@@ -214,6 +218,7 @@ pub struct FunctionDefinition {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum ToolChoice {
     Auto,
     None,
@@ -370,6 +375,7 @@ pub struct Choice {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum FinishReason {
     Stop,
     Length,
@@ -440,6 +446,7 @@ pub struct EmbeddingResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum EmbeddingInput {
     Single(String),
     Multiple(Vec<String>),
@@ -546,7 +553,9 @@ mod tests {
         if let Some(MessageContent::Parts(parts)) = &msg.content {
             assert_eq!(parts.len(), 2);
             assert!(matches!(&parts[0], ContentPart::Text { text } if text == "describe this"));
-            assert!(matches!(&parts[1], ContentPart::Image { image_url } if image_url.url == "https://img.example.com/a.png"));
+            assert!(
+                matches!(&parts[1], ContentPart::Image { image_url } if image_url.url == "https://img.example.com/a.png")
+            );
         } else {
             panic!("expected Parts content");
         }
@@ -668,9 +677,7 @@ mod tests {
     fn request_builder_tools_replaces() {
         let t1 = Tool::function("a", "d", json!({}));
         let t2 = Tool::function("b", "d", json!({}));
-        let req = ChatCompletionRequest::new("m")
-            .tool(t1)
-            .tools(vec![t2]);
+        let req = ChatCompletionRequest::new("m").tool(t1).tools(vec![t2]);
         assert_eq!(req.tools.as_ref().unwrap().len(), 1);
         assert_eq!(req.tools.as_ref().unwrap()[0].function.name, "b");
     }
@@ -785,10 +792,7 @@ mod tests {
 
     #[test]
     fn image_detail_serializes_lowercase() {
-        assert_eq!(
-            serde_json::to_string(&ImageDetail::Low).unwrap(),
-            "\"low\""
-        );
+        assert_eq!(serde_json::to_string(&ImageDetail::Low).unwrap(), "\"low\"");
         assert_eq!(
             serde_json::to_string(&ImageDetail::High).unwrap(),
             "\"high\""

--- a/crates/mofa-kernel/src/message_graph/executor.rs
+++ b/crates/mofa-kernel/src/message_graph/executor.rs
@@ -29,6 +29,7 @@ impl Default for MessageGraphExecutorConfig {
 
 /// Why a message entered dead-letter handling.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum DeadLetterReason {
     NoRouteMatch,
     MaxHopsExceeded { max_hops: u16, attempted_hops: u16 },
@@ -96,6 +97,7 @@ impl MessageGraphExecutionReport {
 
 /// Runtime errors for message graph execution.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum MessageGraphExecutorError {
     #[error(transparent)]
     Graph(#[from] MessageGraphError),

--- a/crates/mofa-kernel/src/message_graph/mod.rs
+++ b/crates/mofa-kernel/src/message_graph/mod.rs
@@ -25,6 +25,7 @@ pub const MESSAGES_KEY: &str = "messages";
 
 /// Error type for MessageGraph construction/validation.
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum MessageGraphError {
     #[error("graph id cannot be empty")]
     EmptyGraphId,
@@ -248,6 +249,7 @@ impl GraphState for MessageState {
 
 /// Node kind in MessageGraph.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum MessageNodeKind {
     Agent { agent_id: String },
     Topic { topic: String },
@@ -278,6 +280,7 @@ impl MessageNode {
 
 /// Route-matching rule for an edge.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum RouteRule {
     Always,
     MessageType(String),
@@ -309,6 +312,7 @@ impl RouteRule {
 
 /// Delivery mode for an edge.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum DeliveryMode {
     Direct,
     Broadcast,


### PR DESCRIPTION
Adds `#[non_exhaustive]` to 14 public enums in the kernel crate per development standards.