### PR TITLE
ci: add conventional commits auto-labeler

### DIFF
--- a/.github/workflows/conventional-commits-labeler.yml
+++ b/.github/workflows/conventional-commits-labeler.yml
@@ -1,0 +1,54 @@
+name: Conventional Commits Labeler
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title and apply labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const labels = [];
+
+            // Mapping from conventional commit prefix to GitHub label
+            const mapping = {
+              'feat': 'kind/feature',
+              'fix': 'kind/bug',
+              'docs': 'kind/docs',
+              'chore': 'kind/chore',
+              'refactor': 'kind/enhancement',
+              'perf': 'kind/enhancement',
+              'style': 'kind/enhancement',
+              'ci': 'kind/chore',
+              'build': 'kind/chore',
+              'test': 'kind/feature' // approximate
+            };
+
+            for (const [prefix, label] of Object.entries(mapping)) {
+              // Match prefix at start of title, optionally followed by parentheses (scope)
+              const regex = new RegExp(`^${prefix}(\\(.*\\))?!?:`);
+              if (regex.test(title)) {
+                labels.push(label);
+              }
+            }
+
+            if (labels.length > 0) {
+              await github.rest.issues.addLabels({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: labels
+              });
+              console.log(`Added labels: ${labels.join(', ')}`);
+            } else {
+              console.log('No conventional commit prefix found in title');
+            }


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically adds labels to pull requests based on conventional commit prefixes in the PR title. For example, `feat:` adds `kind/feature`, `fix:` adds `kind/bug`, `docs:` adds `kind/docs`, etc. This helps with triage and categorization.