### PR TITLE
docs: add ADR template and first ADR

### DIFF
--- a/docs/adr/001-dual-layer-plugin-architecture.md
+++ b/docs/adr/001-dual-layer-plugin-architecture.md
@@ -1,0 +1,55 @@
+# ADR 001: Dual-Layer Plugin Architecture
+
+* **Status**: Accepted
+* **Date**: 2025-04-08 (or current)
+* **Author(s)**: MoFA Core Team
+
+## Context and Problem Statement
+
+MoFA aims to provide an extensible AI agent framework that balances performance with runtime flexibility. A key design question is how to allow users to extend functionality (tools, memory, reasoning, etc.) without sacrificing the performance of core operations, while also enabling dynamic changes without recompilation.
+
+Key requirements:
+- Zero-cost abstractions for performance-critical paths (LLM inference, data processing).
+- Runtime programmability for business logic and workflow orchestration.
+- Hot-reload capability for certain plugins.
+- Support for multiple language bindings (Python, Java, Go, Swift) via UniFFI.
+
+## Considered Options
+
+1. **Single-layer plugin system (Rust traits only):**
+   - Define all plugin points as Rust traits.
+   - Users implement traits and compile as native Rust.
+   - Pros: Zero-cost, strong typing, simple.
+   - Cons: No dynamic loading without recompilation, unsuitable for rapid iteration, excludes non-Rust users.
+
+2. **Single-layer scripting (e.g., Rhai only):**
+   - All plugins are Rhai scripts loaded at runtime.
+   - Pros: Extremely flexible, hot-reloadable, easy for non-Rust users.
+   - Cons: Performance overhead for complex operations, limited access to native Rust ecosystem.
+
+3. **Dual-layer (Rust/WASM + scripting):**
+   - Compile-time layer: Rust/WASM plugins for performance-critical components.
+   - Runtime layer: Rhai scripts for dynamic business logic.
+   - Both layers implement the same kernel trait interfaces and can be composed.
+   - Pros: Best of both worlds; performance where needed, flexibility where appropriate.
+   - Cons: Slightly higher initial complexity; need to clearly document what belongs where.
+
+## Decision Outcome
+
+Chosen option: **Dual-layer (Rust/WASM + scripting)**.
+
+This design aligns with MoFA's microkernel architecture: the kernel (mofa-kernel) defines trait interfaces; the compile-time layer (Rust) provides high-performance implementations; the runtime layer (Rhai) allows dynamic reconfiguration without recompilation. The two layers interoperate through the same unified API, giving users the freedom to choose the appropriate implementation technology per use case.
+
+### Positive Consequences
+
+- Performance-critical code (LLM adapters, vector stores) can be native Rust/WASM.
+- Workflow orchestration, rules, and dynamic behavior can be Rhai scripts hot-reloaded at runtime.
+- Clear separation of concerns and deployment models.
+- Enables future WASM sandboxing for secure third-party plugins.
+
+### Negative Consequences
+
+- Need to maintain both Rust and Rhai integration points.
+- Users must learn two extension mechanisms (though they share the same interface).
+- Potential for misuse: placing performance-sensitive logic in Rhai where it doesn’t belong.
+- Slightly increased testing surface.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,52 @@
+# Architecture Decision Records (ADRs)
+
+This directory records architecture decisions for the MoFA project.
+
+## Format
+
+Each ADR is a markdown file named with a sequential number and a short title, e.g.:
+
+- `001-dual-layer-plugin-architecture.md`
+- `002-reasoning-strategy-abstraction.md`
+
+## Template
+
+```markdown
+# ADR NNN: Short Title
+
+* **Status**: Proposed | Accepted | Rejected | Deprecated | Superseded by [NNN](NNN-title.md)
+* **Date**: YYYY-MM-DD
+* **Author(s)**: Your Name (@github-handle)
+
+## Context and Problem Statement
+
+Describe the problem or decision being addressed. What is changed? What is the driving requirement?
+
+## Considered Options
+
+Option 1: Description...
+Option 2: Description...
+
+## Decision Outcome
+
+Chosen option: **Option Name**
+
+Explain why this option was selected over others.
+
+### Positive Consequences
+
+- What good things does this enable?
+- Simplifies what?
+
+### Negative Consequences
+
+- What downsides or trade-offs were accepted?
+- What increased complexity?
+```
+
+## How to Contribute
+
+1. Propose a new ADR by copying the template above.
+2. Discuss on GitHub Issues or Discord to gather feedback.
+3. Update status to `Accepted` once consensus is reached.
+4. Keep ADRs up to date when decisions evolve.


### PR DESCRIPTION
Adds an Architecture Decision Records (ADR) directory with a template and an initial record documenting the dual-layer plugin architecture (Rust/WASM + Rhai). ADRs provide a structured way to capture important technical decisions and their context for future maintainers.