### PR TITLE
refactor(foundation): add non_exhaustive to Backoff and CircuitState

### DIFF
--- a/crates/mofa-foundation/src/recovery.rs
+++ b/crates/mofa-foundation/src/recovery.rs
@@ -26,6 +26,7 @@ use std::time::Duration;
 /// (e.g. `BackoffStrategy` in mofa-foundation) can interoperate by
 /// converting to/from this type.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum Backoff {
     /// No delay between retries
     None,
@@ -296,6 +297,7 @@ type FallbackOperation<T> = Box<dyn FnOnce() -> BoxedFallbackFuture<T> + Send>;
 
 /// Circuit breaker states
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum CircuitState {
     /// Normal operation — requests are allowed
     Closed,


### PR DESCRIPTION
Adds `#[non_exhaustive]` to two public enums in the foundation recovery module: `Backoff` and `CircuitState`. This ensures binary compatibility and allows future extension without breaking downstream dependencies. Follows project development standards (CLAUDE.md).