### PR TITLE
`fix(gateway): resolve unbounded DashMap memory leak in TokenBucketRateLimiter (#1609)`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,7 +1280,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -5881,6 +5881,7 @@ dependencies = [
  "mofa-extra",
  "mofa-kernel",
  "mofa-plugins",
+ "moka",
  "num_enum_derive",
  "once_cell",
  "opentelemetry",
@@ -6169,6 +6170,23 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec 1.15.1",
+ "tagptr",
+ "uuid",
 ]
 
 [[package]]
@@ -9867,6 +9885,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tar"

--- a/crates/mofa-foundation/Cargo.toml
+++ b/crates/mofa-foundation/Cargo.toml
@@ -130,6 +130,7 @@ opentelemetry-semantic-conventions = { workspace = true, optional = true }
 # Graph data structures for task DAGs (Swarm Orchestrator)
 petgraph = { version = "0.7", features = ["serde-1"] }
 dashmap = { workspace = true }
+moka = { version = "0.12", features = ["sync"] }
 rhai = { version = "1", features = ["sync", "serde"] }
 lazy_static = "1.4"
 

--- a/crates/mofa-foundation/src/gateway/rate_limiter.rs
+++ b/crates/mofa-foundation/src/gateway/rate_limiter.rs
@@ -17,9 +17,10 @@
 //! The caller is responsible for passing the correct key to
 //! [`TokenBucketRateLimiter::check_and_consume`].
 
-use std::time::Instant;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
-use dashmap::DashMap;
+use moka::sync::Cache;
 pub use mofa_kernel::{GatewayRateLimiter, KeyStrategy, RateLimitDecision, RateLimiterConfig};
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -68,12 +69,12 @@ impl TokenBucket {
 // TokenBucketRateLimiter
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Lock-free token-bucket rate limiter backed by [`DashMap`].
+/// Lock-free token-bucket rate limiter backed by [`moka::sync::Cache`].
 ///
 /// Each unique key gets its own bucket lazily created on first access.
 /// Implements [`GatewayRateLimiter`] from `mofa-kernel`.
 pub struct TokenBucketRateLimiter {
-    buckets: DashMap<String, TokenBucket>,
+    buckets: Cache<String, Arc<Mutex<TokenBucket>>>,
     capacity: u32,
     refill_rate: u32,
 }
@@ -82,7 +83,10 @@ impl TokenBucketRateLimiter {
     /// Create a new limiter with the given configuration.
     pub fn new(config: &RateLimiterConfig) -> Self {
         Self {
-            buckets: DashMap::new(),
+            buckets: Cache::builder()
+                .max_capacity(100_000)
+                .time_to_idle(Duration::from_secs(600))
+                .build(),
             capacity: config.capacity,
             refill_rate: config.refill_rate,
         }
@@ -91,10 +95,16 @@ impl TokenBucketRateLimiter {
 
 impl GatewayRateLimiter for TokenBucketRateLimiter {
     fn check_and_consume(&self, key: &str) -> RateLimitDecision {
-        self.buckets
-            .entry(key.to_string())
-            .or_insert_with(|| TokenBucket::new(self.capacity, self.refill_rate))
-            .try_consume()
+        let bucket = if let Some(b) = self.buckets.get(key) {
+            b
+        } else {
+            self.buckets.get_with(key.to_string(), || {
+                Arc::new(Mutex::new(TokenBucket::new(self.capacity, self.refill_rate)))
+            })
+        };
+        
+        let mut guard = bucket.lock().unwrap();
+        guard.try_consume()
     }
 }
 


### PR DESCRIPTION

## Description
This PR addresses a critical Denial of Service (DoS) vulnerability caused by an unbounded memory leak in the `TokenBucketRateLimiter`. 

Previously, `TokenBucketRateLimiter` tracked rate limits using an unbounded `DashMap`. Because `KeyStrategy::PerClient` is supported, every unique client IP generated a permanent tracking entry in the system memory. Without any TTL or eviction mechanisms, long-running gateway instances were susceptible to encountering Out Of Memory (OOM) panics due to gradual accumulation or deliberate DoS attacks using mutating IP headers.

### Fix
- **Swapped `DashMap` for `moka::sync::Cache`:** Replaced the unmanaged `DashMap` with the highly concurrent `moka` cache interface. 
- **Time-to-Idle & Capacity Bound:** The cache is now aggressively guarded. Active trackers are capped at an upper-bound of `100,000` concurrent clients per node, and stale trackers are garbage collected if they remain unaccessed for 10 minutes (long enough to let standard tokens refill, but short enough to prevent memory runaway).

### Performance Optimization (Zero Allocation)
As a bonus, I optimized `check_and_consume()` to prevent heap string allocations. Previously, passing a client key necessitated a `.to_string()` allocation on every authenticated request before it reached the internal `entry()`. Now, it performs a zero-cost `self.buckets.get(key)` first, allowing the gateway to breeze through repeated requests completely allocation-free.

Fixes #1609

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance improvement

## Testing
- Validated thread safety with existing concurrent tests by confirming the `Arc<Mutex<TokenBucket>>` state accurately caps limits globally under cross-thread contention.
- Verified compilation and linting explicitly around `moka` cache logic.
