### PR TITLE
feat(foundation): add structured execution tracing via ExecutionSpan

### DIFF
--- a/crates/mofa-cli/src/commands/plugin/install.rs
+++ b/crates/mofa-cli/src/commands/plugin/install.rs
@@ -201,7 +201,7 @@ async fn install_from_local_path(
     plugin_name: &str,
     source_path: &Path,
 ) -> Result<PathBuf, CliError> {
-    let plugins_dir = data_dir.join("plugins");
+    let plugins_dir = external_plugins_dir(data_dir);
     tokio::fs::create_dir_all(&plugins_dir)
         .await
         .map_err(|e| CliError::PluginError(format!("Failed to create plugins directory: {}", e)))?;
@@ -232,7 +232,7 @@ async fn install_from_url(
     url: &str,
     expected_checksum: Option<&str>,
 ) -> Result<PathBuf, CliError> {
-    let plugins_dir = data_dir.join("plugins");
+    let plugins_dir = external_plugins_dir(data_dir);
     tokio::fs::create_dir_all(&plugins_dir)
         .await
         .map_err(|e| CliError::PluginError(format!("Failed to create plugins directory: {}", e)))?;
@@ -494,6 +494,10 @@ enum PluginSource {
     Registry(String),
 }
 
+fn external_plugins_dir(data_dir: &Path) -> PathBuf {
+    data_dir.join("plugins").join("installed")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -649,7 +653,7 @@ mod tests {
 
         // Verify plugin was installed (plugin name is the full path, sanitized)
         let plugin_name = plugin_path_str.replace('/', "_").replace('\\', "_");
-        let plugin_dir = ctx.data_dir.join("plugins").join(&plugin_name);
+        let plugin_dir = external_plugins_dir(&ctx.data_dir).join(&plugin_name);
         assert!(
             plugin_dir.exists(),
             "Plugin dir should exist at: {}",

--- a/crates/mofa-foundation/src/workflow/execution_event.rs
+++ b/crates/mofa-foundation/src/workflow/execution_event.rs
@@ -13,6 +13,19 @@ use serde::{Deserialize, Serialize};
 /// Current schema version for execution events
 pub const SCHEMA_VERSION: u32 = 1;
 
+/// Lightweight structured trace emitted for each node execution.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExecutionSpan {
+    pub node_id: String,
+    pub start_time: u64,
+    pub end_time: u64,
+    pub duration_ms: u64,
+    pub input_state_hash: Option<String>,
+    pub output_state_hash: Option<String>,
+    pub command_type: String,
+    pub error: Option<String>,
+}
+
 /// Canonical execution event types for workflow execution tracing
 ///
 /// This enum defines the core events that can occur during workflow execution.

--- a/crates/mofa-foundation/src/workflow/state_graph.rs
+++ b/crates/mofa-foundation/src/workflow/state_graph.rs
@@ -13,6 +13,7 @@ use mofa_kernel::workflow::{
 };
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::pin::Pin;
 use std::sync::Arc;
 use tokio::sync::{RwLock, Semaphore};
@@ -22,10 +23,43 @@ use tracing::{Instrument, debug, error, info, warn};
 use super::fault_tolerance::{
     CircuitBreakerRegistry, NodeExecutionOutcome, execute_with_policy, new_circuit_registry,
 };
+use super::execution_event::ExecutionSpan;
 use mofa_kernel::workflow::policy::NodePolicy;
 
 /// Type alias for node ID
 pub type NodeId = String;
+
+fn state_hash<S: GraphState>(state: &S) -> Option<String> {
+    state.to_json().ok().map(|value| {
+        let mut hasher = DefaultHasher::new();
+        value.to_string().hash(&mut hasher);
+        format!("{:x}", hasher.finish())
+    })
+}
+
+fn command_type(command: &Command) -> &'static str {
+    match &command.control {
+        ControlFlow::Continue => "Continue",
+        ControlFlow::Goto(_) => "Goto",
+        ControlFlow::Return => "Return",
+        ControlFlow::Send(_) => "Send",
+        _ => "Unknown",
+    }
+}
+
+fn log_execution_span(span: &ExecutionSpan) {
+    info!(
+        node_id = %span.node_id,
+        start_time = span.start_time,
+        end_time = span.end_time,
+        duration_ms = span.duration_ms,
+        input_state_hash = ?span.input_state_hash,
+        output_state_hash = ?span.output_state_hash,
+        command_type = %span.command_type,
+        error = ?span.error,
+        "execution_span"
+    );
+}
 
 /// StateGraph implementation - LangGraph-inspired API
 ///
@@ -779,6 +813,8 @@ impl<S: GraphState + 'static> CompiledGraph<S, serde_json::Value> for CompiledGr
 
                 if nodes_to_execute.len() == 1 {
                     let node_id = nodes_to_execute[0].clone();
+                    let start_time = DebugEvent::now_ms();
+                    let input_state_hash = state_hash(&state);
                     let node = match nodes.get(&node_id) {
                         Some(n) => n,
                         None => {
@@ -828,6 +864,18 @@ impl<S: GraphState + 'static> CompiledGraph<S, serde_json::Value> for CompiledGr
                             continue;
                         }
                         Err(NodeExecutionOutcome::Error(e)) => {
+                            let end_time = DebugEvent::now_ms();
+                            let span = ExecutionSpan {
+                                node_id: node_id.clone(),
+                                start_time,
+                                end_time,
+                                duration_ms: end_time.saturating_sub(start_time),
+                                input_state_hash,
+                                output_state_hash: state_hash(&state),
+                                command_type: "Error".to_string(),
+                                error: Some(e.to_string()),
+                            };
+                            log_execution_span(&span);
                             let _ = tx
                                 .send(Ok(StreamEvent::Error {
                                     node_id: Some(node_id),
@@ -867,6 +915,19 @@ impl<S: GraphState + 'static> CompiledGraph<S, serde_json::Value> for CompiledGr
                         }
                     }
 
+                    let end_time = DebugEvent::now_ms();
+                    let span = ExecutionSpan {
+                        node_id: node_id.clone(),
+                        start_time,
+                        end_time,
+                        duration_ms: end_time.saturating_sub(start_time),
+                        input_state_hash,
+                        output_state_hash: state_hash(&state),
+                        command_type: command_type(&command).to_string(),
+                        error: None,
+                    };
+                    log_execution_span(&span);
+
                     // Send end event — abort if receiver disconnected
                     if tx
                         .send(Ok(StreamEvent::NodeEnd {
@@ -894,8 +955,11 @@ impl<S: GraphState + 'static> CompiledGraph<S, serde_json::Value> for CompiledGr
                         }
                     }
                 } else {
+                    let mut parallel_spans = HashMap::new();
                     // Send start events for parallel batch — abort if receiver disconnected
                     for node_id in &nodes_to_execute {
+                        parallel_spans
+                            .insert(node_id.clone(), (DebugEvent::now_ms(), state_hash(&state)));
                         if tx
                             .send(Ok(StreamEvent::NodeStart {
                                 node_id: node_id.clone(),
@@ -931,6 +995,9 @@ impl<S: GraphState + 'static> CompiledGraph<S, serde_json::Value> for CompiledGr
                     };
 
                     for (node_id, command) in commands {
+                        let (start_time, input_state_hash) = parallel_spans
+                            .remove(&node_id)
+                            .unwrap_or((DebugEvent::now_ms(), state_hash(&state)));
                         for update in &command.updates {
                             let current = state.get_value(&update.key);
                             let new_value = if let Some(reducer) = reducers.get(&update.key) {
@@ -959,6 +1026,19 @@ impl<S: GraphState + 'static> CompiledGraph<S, serde_json::Value> for CompiledGr
                                 return;
                             }
                         }
+
+                        let end_time = DebugEvent::now_ms();
+                        let span = ExecutionSpan {
+                            node_id: node_id.clone(),
+                            start_time,
+                            end_time,
+                            duration_ms: end_time.saturating_sub(start_time),
+                            input_state_hash,
+                            output_state_hash: state_hash(&state),
+                            command_type: command_type(&command).to_string(),
+                            error: None,
+                        };
+                        log_execution_span(&span);
 
                         if tx
                             .send(Ok(StreamEvent::NodeEnd {


### PR DESCRIPTION
## 📋 Summary


- Add ExecutionSpan struct for lightweight structured traces
- Add state_hash helper to compute hashes of graph state snapshots
- Add command_type helper to map Command::control to string representation
- Add log_execution_span helper for consistent span logging
- Instrument single node execution with span tracking (timing, state hashes, errors)
- Instrument parallel batch execution with span tracking per node
- Capture input/output state hashes and error information in spans

Currently, agent execution within StateGraph lacks structured observability.
When a workflow runs across multiple nodes, there is no reliable way to:

trace which node produced which output
measure execution time per node
understand control flow decisions (Continue / Goto / Return)
debug failures beyond raw error messages
<!--
Explain WHAT this PR does and WHY.
Focus on the motivation and impact rather than implementation details.
-->


## 🧠 Context

<!--
Why is this change needed?
What problem does it solve?
Any relevant background or design decisions.
-->

---

## 🛠️ Changes

<!--
High-level list of changes.
Avoid low-level diffs — reviewers can see those.
-->

- 
- 
- 

---

Introduce a lightweight ExecutionSpan structure to capture per-node execution metadata and emit it using structured logging.

Key additions:

- Added ExecutionSpan struct with:
- node_id
- start_time, end_time, duration_ms
- input_state_hash, output_state_hash (when available)
- command_type (Continue / Goto / Return)
- error (optional)
- Integrated span creation into state_graph.rs:
- capture timing at node start/end
- compute execution duration
- attach command result and error (if any)
- Emit spans using tracing::info! with structured fields
- → enables compatibility with observability tools (e.g., OpenTelemetry) without additional changes