### PR TITLE
Remove unnecessary .unwrap() in retry error handling

### DIFF
--- a/crates/mofa-foundation/src/workflow/fault_tolerance.rs
+++ b/crates/mofa-foundation/src/workflow/fault_tolerance.rs
@@ -223,12 +223,11 @@ pub(crate) async fn execute_with_policy<S: GraphState>(
                     return Err(NodeExecutionOutcome::Error(e));
                 }
 
-                last_error = Some(e);
-
                 // Still have retries left?
                 if attempt + 1 < max_attempts {
                     let delay = policy.backoff_for_attempt(attempt);
-                    let err_msg = last_error.as_ref().unwrap().to_string();
+                    let err_msg = e.to_string();
+                    last_error = Some(e);
 
                     debug!(
                         node_id = node_id,
@@ -251,6 +250,8 @@ pub(crate) async fn execute_with_policy<S: GraphState>(
                     }
 
                     tokio::time::sleep(delay).await;
+                } else {
+                    last_error = Some(e);
                 }
             }
         }


### PR DESCRIPTION
### **1. SUMMARY**

This PR removes an unnecessary and misleading `.unwrap()` in the retry logic of the fault tolerance workflow. It simplifies error handling by using the original error value directly before moving it into `last_error`.
Primary changes are in `crates/mofa-foundation/src/workflow/fault_tolerance.rs` within `execute_with_policy`.

---

### **2. FIX**


```rust
// Before
last_error = Some(e);

if attempt + 1 < max_attempts {
    let delay = policy.backoff_for_attempt(attempt);
    let err_msg = last_error.as_ref().unwrap().to_string();
```

```rust
// After
if attempt + 1 < max_attempts {
    let delay = policy.backoff_for_attempt(attempt);
    let err_msg = e.to_string();
    last_error = Some(e);
}
```

---

### **3. VERIFICATION**

Tested the retry path with both retryable and terminal error scenarios to ensure behavior remains unchanged. Verified that error messages are logged correctly without relying on `.unwrap()`. Confirmed no panics occur and control flow remains identical.

