### PR TITLE
feat(testing): add Allure-compatible result exporter for test reports

### DIFF
--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -15,7 +15,7 @@ pub use backend::MockLLMBackend;
 pub use bus::MockAgentBus;
 pub use clock::{Clock, MockClock, SystemClock};
 pub use report::{
-    JsonFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,
+    JsonFormatter, JunitFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,
     TextFormatter,
 };
 pub use tools::MockTool;

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -15,7 +15,7 @@ pub use backend::MockLLMBackend;
 pub use bus::MockAgentBus;
 pub use clock::{Clock, MockClock, SystemClock};
 pub use report::{
-    JsonFormatter, JunitFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,
+    JsonFormatter, JunitFormatter, AllureFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,
     TextFormatter,
 };
 pub use tools::MockTool;

--- a/tests/src/report/format.rs
+++ b/tests/src/report/format.rs
@@ -151,3 +151,45 @@ impl ReportFormatter for JunitFormatter {
     }
 }
 
+/// Renders a report as Allure JSON format.
+pub struct AllureFormatter;
+
+impl ReportFormatter for AllureFormatter {
+    fn format(&self, report: &TestReport) -> String {
+        let results: Vec<serde_json::Value> = report
+            .results
+            .iter()
+            .map(|r| {
+                let status = match r.status {
+                    TestStatus::Passed => "passed",
+                    TestStatus::Failed => "failed",
+                    TestStatus::Skipped => "skipped",
+                };
+                
+                let mut obj = serde_json::json!({
+                    "name": r.name,
+                    "status": status,
+                    "statusDetails": {"message": r.error.clone().unwrap_or_default()},
+                    "start": report.timestamp, // Rough approx
+                    "stop": report.timestamp + r.duration.as_millis() as u64,
+                    "labels": [
+                        {"name": "suite", "value": report.suite_name}
+                    ]
+                });
+
+                if !r.metadata.is_empty() {
+                    let params: Vec<serde_json::Value> = r.metadata.iter().map(|(k, v)| {
+                        serde_json::json!({"name": k, "value": v})
+                    }).collect();
+                    obj["parameters"] = params;
+                }
+                
+                obj
+            })
+            .collect();
+            
+        // Usually allure writes multiple files, but for the formatter trait we can return a JSON array or list of objects
+        serde_json::to_string_pretty(&results).expect("allure serialization failed")
+    }
+}
+

--- a/tests/src/report/format.rs
+++ b/tests/src/report/format.rs
@@ -102,3 +102,52 @@ impl ReportFormatter for TextFormatter {
         buf
     }
 }
+
+/// Renders a report as JUnit XML format.
+pub struct JunitFormatter;
+
+impl ReportFormatter for JunitFormatter {
+    fn format(&self, report: &TestReport) -> String {
+        let mut buf = String::new();
+        buf.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        buf.push_str(&format!(
+            "<testsuite name=\"{}\" tests=\"{}\" failures=\"{}\" skipped=\"{}\" time=\"{:.3}\" timestamp=\"{}\">\n",
+            report.suite_name,
+            report.total(), report.failed(), report.skipped(),
+            report.total_duration.as_secs_f64(),
+            report.timestamp
+        ));
+
+        for r in &report.results {
+            buf.push_str(&format!(
+                "  <testcase classname=\"{}\" name=\"{}\" time=\"{:.3}\">\n",
+                report.suite_name, r.name, r.duration.as_secs_f64()
+            ));
+
+            match r.status {
+                TestStatus::Passed => {}
+                TestStatus::Failed => {
+                    let err_msg = r.error.as_deref().unwrap_or("Test failed");
+                    let safe_msg = err_msg.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;").replace("'", "&apos;");
+                    buf.push_str(&format!("    <failure message=\"{}\">{}</failure>\n", safe_msg, safe_msg));
+                }
+                TestStatus::Skipped => {
+                    buf.push_str("    <skipped/>\n");
+                }
+            }
+
+            if !r.metadata.is_empty() {
+                buf.push_str("    <system-out><![CDATA[\n");
+                for (k, v) in &r.metadata {
+                    buf.push_str(&format!("{}: {}\n", k, v));
+                }
+                buf.push_str("    ]]></system-out>\n");
+            }
+            buf.push_str("  </testcase>\n");
+        }
+
+        buf.push_str("</testsuite>\n");
+        buf
+    }
+}
+

--- a/tests/src/report/mod.rs
+++ b/tests/src/report/mod.rs
@@ -5,5 +5,5 @@ mod format;
 mod types;
 
 pub use builder::TestReportBuilder;
-pub use format::{JsonFormatter, ReportFormatter, TextFormatter};
+pub use format::{JsonFormatter, ReportFormatter, TextFormatter, JunitFormatter};
 pub use types::{TestCaseResult, TestReport, TestStatus};

--- a/tests/src/report/mod.rs
+++ b/tests/src/report/mod.rs
@@ -5,5 +5,5 @@ mod format;
 mod types;
 
 pub use builder::TestReportBuilder;
-pub use format::{JsonFormatter, ReportFormatter, TextFormatter, JunitFormatter};
+pub use format::{JsonFormatter, ReportFormatter, TextFormatter, JunitFormatter, AllureFormatter};
 pub use types::{TestCaseResult, TestReport, TestStatus};

--- a/tests/tests/allure_tests.rs
+++ b/tests/tests/allure_tests.rs
@@ -1,0 +1,16 @@
+use mofa_testing::report::{TestReportBuilder, TestCaseResult, AllureFormatter, ReportFormatter};
+use std::time::Duration;
+
+#[test]
+fn test_allure_format() {
+    let mut builder = TestReportBuilder::new("AllureSuite");
+    builder.add_result(TestCaseResult::passed("test_1", Duration::from_millis(15)));
+    builder.add_result(TestCaseResult::failed("test_2", Duration::from_millis(20), "some err"));
+    let report = builder.build();
+    let fmt = AllureFormatter;
+    let json = fmt.format(&report);
+    assert!(json.contains("AllureSuite"));
+    assert!(json.contains("passed"));
+    assert!(json.contains("failed"));
+    assert!(json.contains("some err"));
+}

--- a/tests/tests/junit_tests.rs
+++ b/tests/tests/junit_tests.rs
@@ -1,0 +1,14 @@
+use mofa_testing::report::{TestReportBuilder, TestCaseResult, JunitFormatter, ReportFormatter};
+use std::time::Duration;
+
+#[test]
+fn test_junit_format() {
+    let mut builder = TestReportBuilder::new("JunitSuite");
+    builder.add_result(TestCaseResult::passed("test_1", Duration::from_millis(15)));
+    builder.add_result(TestCaseResult::failed("test_2", Duration::from_millis(20), "some error"));
+    let report = builder.build();
+    let fmt = JunitFormatter;
+    let xml = fmt.format(&report);
+    assert!(xml.contains("testsuite name=\"JunitSuite\""));
+    assert!(xml.contains("<failure message=\"some error\">some error</failure>"));
+}


### PR DESCRIPTION
Fixes #1568

- Added AllureFormatter to export results in Allure layout
- Correctly maps status, duration, and labels
- Added unit tests