### PR TITLE
fix(foundation): resolve Backoff overflow and dead Q4 test

### DIFF
--- a/crates/mofa-foundation/src/inference/routing.rs
+++ b/crates/mofa-foundation/src/inference/routing.rs
@@ -574,6 +574,8 @@ mod tests {
             assert_eq!(back, variant);
         }
     }
+
+    #[test]
     fn test_degradation_ladder_degrades_to_q4_when_q8_too_large() {
         // Constrained hardware: only 4 GB available
         // Request: 13312 MB at F16 (2 bpp)

--- a/crates/mofa-foundation/src/recovery.rs
+++ b/crates/mofa-foundation/src/recovery.rs
@@ -88,7 +88,7 @@ impl Backoff {
                 initial_ms,
                 increment_ms,
             } => {
-                let ms = initial_ms + (increment_ms * attempt as u64);
+                let ms = initial_ms.saturating_add(increment_ms.saturating_mul(attempt as u64));
                 Duration::from_millis(ms)
             }
             Self::Exponential { initial_ms, max_ms } => {


### PR DESCRIPTION
Fixes #1579

- Fixed potential integer overflow in `Backoff::Linear` by using `saturating_add` and `saturating_mul`.
- Added missing `#[test]` attribute to `test_degradation_ladder_degrades_to_q4_when_q8_too_large()` making it silently dead code before.