### PR TITLE
feat(testing): add Allure exporter for test reports

### DIFF
--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -15,7 +15,7 @@ pub use backend::MockLLMBackend;
 pub use bus::MockAgentBus;
 pub use clock::{Clock, MockClock, SystemClock};
 pub use report::{
-    JsonFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,
-    TextFormatter,
+    AllureFormatter, JsonFormatter, ReportFormatter, TestCaseResult, TestReport,
+    TestReportBuilder, TestStatus, TextFormatter,
 };
 pub use tools::MockTool;

--- a/tests/src/report/format.rs
+++ b/tests/src/report/format.rs
@@ -102,3 +102,91 @@ impl ReportFormatter for TextFormatter {
         buf
     }
 }
+
+#[derive(serde::Serialize)]
+struct AllureParameter {
+    name: String,
+    value: String,
+}
+
+#[derive(serde::Serialize)]
+struct AllureLabel {
+    name: String,
+    value: String,
+}
+
+#[derive(serde::Serialize)]
+struct AllureStatusDetails {
+    message: String,
+}
+
+#[derive(serde::Serialize)]
+struct AllureTime {
+    start: u64,
+    stop: u64,
+}
+
+#[derive(serde::Serialize)]
+struct AllureTestResult {
+    uuid: String,
+    name: String,
+    full_name: String,
+    status: String,
+    stage: String,
+    time: AllureTime,
+    labels: Vec<AllureLabel>,
+    parameters: Vec<AllureParameter>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    status_details: Option<AllureStatusDetails>,
+}
+
+/// Renders a report as deterministic Allure-compatible JSON objects.
+pub struct AllureFormatter;
+
+impl ReportFormatter for AllureFormatter {
+    fn format(&self, report: &TestReport) -> String {
+        let results: Vec<AllureTestResult> = report
+            .results
+            .iter()
+            .enumerate()
+            .map(|(index, case)| {
+                let status_details = case.error.as_ref().map(|message| AllureStatusDetails {
+                    message: message.clone(),
+                });
+
+                let parameters = case
+                    .metadata
+                    .iter()
+                    .map(|(name, value)| AllureParameter {
+                        name: name.clone(),
+                        value: value.clone(),
+                    })
+                    .collect();
+
+                AllureTestResult {
+                    uuid: format!("{}-{}", report.suite_name, index),
+                    name: case.name.clone(),
+                    full_name: format!("{}::{}", report.suite_name, case.name),
+                    status: match case.status {
+                        TestStatus::Passed => "passed".to_string(),
+                        TestStatus::Failed => "failed".to_string(),
+                        TestStatus::Skipped => "skipped".to_string(),
+                    },
+                    stage: "finished".to_string(),
+                    time: AllureTime {
+                        start: report.timestamp,
+                        stop: report.timestamp.saturating_add(case.duration.as_millis() as u64),
+                    },
+                    labels: vec![AllureLabel {
+                        name: "suite".to_string(),
+                        value: report.suite_name.clone(),
+                    }],
+                    parameters,
+                    status_details,
+                }
+            })
+            .collect();
+
+        serde_json::to_string_pretty(&results).expect("Allure export should serialize")
+    }
+}

--- a/tests/src/report/mod.rs
+++ b/tests/src/report/mod.rs
@@ -5,5 +5,5 @@ mod format;
 mod types;
 
 pub use builder::TestReportBuilder;
-pub use format::{JsonFormatter, ReportFormatter, TextFormatter};
+pub use format::{AllureFormatter, JsonFormatter, ReportFormatter, TextFormatter};
 pub use types::{TestCaseResult, TestReport, TestStatus};

--- a/tests/tests/report_tests.rs
+++ b/tests/tests/report_tests.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use mofa_testing::{
-    JsonFormatter, MockClock, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder,
-    TestStatus, TextFormatter,
+    AllureFormatter, JsonFormatter, MockClock, ReportFormatter, TestCaseResult, TestReport,
+    TestReportBuilder, TestStatus, TextFormatter,
 };
 
 // ---------------------------------------------------------------------------
@@ -256,6 +256,30 @@ fn json_formatter_empty_report() {
     let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
     assert_eq!(parsed["summary"]["total"], 0);
     assert_eq!(parsed["results"].as_array().unwrap().len(), 0);
+}
+
+// ===========================================================================
+// AllureFormatter
+// ===========================================================================
+
+#[test]
+fn allure_formatter_emits_deterministic_json() {
+    let mut report = mixed_report();
+    report.results[0].metadata = vec![("env".into(), "ci".into())];
+
+    let output = AllureFormatter.format(&report);
+    let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
+    let results = parsed.as_array().expect("array of results");
+
+    assert_eq!(results.len(), 5);
+    assert_eq!(results[0]["uuid"], "mixed-0");
+    assert_eq!(results[0]["status"], "passed");
+    assert_eq!(results[0]["parameters"][0]["name"], "env");
+    assert_eq!(results[0]["parameters"][0]["value"], "ci");
+    assert_eq!(results[1]["status"], "failed");
+    assert_eq!(results[1]["status_details"]["message"], "boom");
+    assert_eq!(results[3]["status"], "skipped");
+    assert_eq!(results[4]["full_name"], "mixed::e");
 }
 
 #[test]


### PR DESCRIPTION
Adds an Allure-compatible JSON exporter for TestReport with deterministic output and metadata mapping.

Issue: #1568
