### PR TITLE
fix(foundation): saturate linear backoff and restore routing test

### DIFF
--- a/crates/mofa-foundation/src/inference/routing.rs
+++ b/crates/mofa-foundation/src/inference/routing.rs
@@ -574,6 +574,7 @@ mod tests {
             assert_eq!(back, variant);
         }
     }
+    #[test]
     fn test_degradation_ladder_degrades_to_q4_when_q8_too_large() {
         // Constrained hardware: only 4 GB available
         // Request: 13312 MB at F16 (2 bpp)

--- a/crates/mofa-foundation/src/recovery.rs
+++ b/crates/mofa-foundation/src/recovery.rs
@@ -88,7 +88,7 @@ impl Backoff {
                 initial_ms,
                 increment_ms,
             } => {
-                let ms = initial_ms + (increment_ms * attempt as u64);
+                let ms = initial_ms.saturating_add(increment_ms.saturating_mul(attempt as u64));
                 Duration::from_millis(ms)
             }
             Self::Exponential { initial_ms, max_ms } => {
@@ -497,6 +497,12 @@ mod tests {
         assert_eq!(b.delay_for(0), Duration::from_millis(100));
         assert_eq!(b.delay_for(1), Duration::from_millis(300));
         assert_eq!(b.delay_for(2), Duration::from_millis(500));
+    }
+
+    #[test]
+    fn test_backoff_linear_saturates_on_overflow() {
+        let b = Backoff::linear(u64::MAX - 5, 10);
+        assert_eq!(b.delay_for(u32::MAX), Duration::from_millis(u64::MAX));
     }
 
     #[test]


### PR DESCRIPTION
Saturates linear backoff arithmetic to prevent overflow and restores the missing DegradationLadder test.

Issue: #1579
