### PR TITLE
feat(testing): track mock backend usage accounting

### DIFF
--- a/tests/src/backend.rs
+++ b/tests/src/backend.rs
@@ -11,6 +11,40 @@ use std::sync::{Arc, RwLock};
 
 type ResponseSequences = Vec<(String, VecDeque<String>)>;
 
+/// Per-call token and cost usage recorded by the mock backend.
+#[derive(Debug, Clone, PartialEq)]
+pub struct UsageRecord {
+    pub prompt_tokens: u64,
+    pub completion_tokens: u64,
+    pub total_tokens: u64,
+    pub cost_usd: f64,
+}
+
+/// Aggregate usage totals recorded by the mock backend.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct UsageTotals {
+    pub prompt_tokens: u64,
+    pub completion_tokens: u64,
+    pub total_tokens: u64,
+    pub cost_usd: f64,
+    pub calls: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct UsagePricing {
+    input_per_1k_tokens_usd: f64,
+    output_per_1k_tokens_usd: f64,
+}
+
+impl Default for UsagePricing {
+    fn default() -> Self {
+        Self {
+            input_per_1k_tokens_usd: 0.0,
+            output_per_1k_tokens_usd: 0.0,
+        }
+    }
+}
+
 /// Deterministic mock implementation of [`ModelOrchestrator`].
 ///
 /// Supports first-match response rules, sequenced responses, failure injection,
@@ -27,6 +61,9 @@ pub struct MockLLMBackend {
     response_sequences: Arc<RwLock<ResponseSequences>>,
     call_count: Arc<AtomicUsize>,
     rate_limit: Arc<RwLock<Option<RateLimit>>>,
+    usage_pricing: Arc<RwLock<UsagePricing>>,
+    usage_history: Arc<RwLock<Vec<UsageRecord>>>,
+    usage_totals: Arc<RwLock<UsageTotals>>,
 }
 
 struct RateLimit {
@@ -55,6 +92,9 @@ impl MockLLMBackend {
             response_sequences: Arc::new(RwLock::new(Vec::new())),
             call_count: Arc::new(AtomicUsize::new(0)),
             rate_limit: Arc::new(RwLock::new(None)),
+            usage_pricing: Arc::new(RwLock::new(UsagePricing::default())),
+            usage_history: Arc::new(RwLock::new(Vec::new())),
+            usage_totals: Arc::new(RwLock::new(UsageTotals::default())),
         }
     }
 
@@ -123,6 +163,43 @@ impl MockLLMBackend {
         self.call_count.store(0, Ordering::Relaxed);
     }
 
+    /// Set deterministic token pricing used for usage accounting.
+    pub fn set_usage_pricing(
+        &self,
+        input_per_1k_tokens_usd: f64,
+        output_per_1k_tokens_usd: f64,
+    ) {
+        *self.usage_pricing.write().expect("lock poisoned") = UsagePricing {
+            input_per_1k_tokens_usd,
+            output_per_1k_tokens_usd,
+        };
+    }
+
+    /// Return the most recent recorded usage, if any.
+    pub fn last_usage(&self) -> Option<UsageRecord> {
+        self.usage_history
+            .read()
+            .expect("lock poisoned")
+            .last()
+            .cloned()
+    }
+
+    /// Return the full usage history in call order.
+    pub fn usage_history(&self) -> Vec<UsageRecord> {
+        self.usage_history.read().expect("lock poisoned").clone()
+    }
+
+    /// Return the aggregated usage totals.
+    pub fn usage_totals(&self) -> UsageTotals {
+        self.usage_totals.read().expect("lock poisoned").clone()
+    }
+
+    /// Clear usage accounting state.
+    pub fn reset_usage(&self) {
+        self.usage_history.write().expect("lock poisoned").clear();
+        *self.usage_totals.write().expect("lock poisoned") = UsageTotals::default();
+    }
+
     /// Look up the response for a given prompt.
     /// Sequence responses take priority over static rules.
     fn resolve(&self, prompt: &str) -> String {
@@ -147,6 +224,36 @@ impl MockLLMBackend {
             }
         }
         self.fallback.clone()
+    }
+
+    fn count_tokens(text: &str) -> u64 {
+        text.split_whitespace().count() as u64
+    }
+
+    fn record_usage(&self, prompt: &str, completion: &str) {
+        let prompt_tokens = Self::count_tokens(prompt);
+        let completion_tokens = Self::count_tokens(completion);
+        let pricing = *self.usage_pricing.read().expect("lock poisoned");
+        let cost_usd = (prompt_tokens as f64 / 1000.0) * pricing.input_per_1k_tokens_usd
+            + (completion_tokens as f64 / 1000.0) * pricing.output_per_1k_tokens_usd;
+        let usage = UsageRecord {
+            prompt_tokens,
+            completion_tokens,
+            total_tokens: prompt_tokens + completion_tokens,
+            cost_usd,
+        };
+
+        self.usage_history
+            .write()
+            .expect("lock poisoned")
+            .push(usage.clone());
+
+        let mut totals = self.usage_totals.write().expect("lock poisoned");
+        totals.prompt_tokens += usage.prompt_tokens;
+        totals.completion_tokens += usage.completion_tokens;
+        totals.total_tokens += usage.total_tokens;
+        totals.cost_usd += usage.cost_usd;
+        totals.calls += 1;
     }
 }
 
@@ -242,7 +349,10 @@ impl ModelOrchestrator for MockLLMBackend {
             }
         }
 
-        Ok(self.resolve(input))
+        let response = self.resolve(input);
+        self.record_usage(input, &response);
+
+        Ok(response)
     }
 
     async fn route_by_type(&self, task: &ModelType) -> OrchestratorResult<String> {

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -11,7 +11,7 @@ pub mod clock;
 pub mod report;
 pub mod tools;
 
-pub use backend::MockLLMBackend;
+pub use backend::{MockLLMBackend, UsageRecord, UsageTotals};
 pub use bus::MockAgentBus;
 pub use clock::{Clock, MockClock, SystemClock};
 pub use report::{

--- a/tests/tests/backend_usage_tests.rs
+++ b/tests/tests/backend_usage_tests.rs
@@ -1,0 +1,64 @@
+use mofa_foundation::orchestrator::{ModelOrchestrator, OrchestratorError};
+use mofa_testing::MockLLMBackend;
+
+#[tokio::test]
+async fn successful_infer_records_usage_and_cost() {
+    let backend = MockLLMBackend::new();
+    backend.add_response("hello", "mock reply");
+    backend.set_usage_pricing(0.25, 0.5);
+
+    let response = backend.infer("demo-model", "hello world").await.unwrap();
+
+    assert_eq!(response, "mock reply");
+    let usage = backend.last_usage().expect("usage recorded");
+    assert_eq!(usage.prompt_tokens, 2);
+    assert_eq!(usage.completion_tokens, 2);
+    assert_eq!(usage.total_tokens, 4);
+    assert!((usage.cost_usd - 0.0015).abs() < f64::EPSILON);
+}
+
+#[tokio::test]
+async fn deterministic_totals_across_multiple_calls() {
+    let backend = MockLLMBackend::new();
+    backend.add_response("alpha", "one two");
+    backend.set_usage_pricing(1.0, 2.0);
+
+    backend.infer("demo-model", "alpha beta").await.unwrap();
+    backend.infer("demo-model", "alpha beta gamma").await.unwrap();
+
+    let history = backend.usage_history();
+    let totals = backend.usage_totals();
+
+    assert_eq!(history.len(), 2);
+    assert_eq!(totals.calls, 2);
+    assert_eq!(totals.prompt_tokens, 5);
+    assert_eq!(totals.completion_tokens, 4);
+    assert_eq!(totals.total_tokens, 9);
+    assert!((totals.cost_usd - 0.013).abs() < f64::EPSILON);
+}
+
+#[tokio::test]
+async fn failure_path_does_not_add_usage() {
+    let backend = MockLLMBackend::new();
+    backend.fail_on("boom", OrchestratorError::Other("boom".into()));
+
+    let err = backend.infer("demo-model", "boom now").await.unwrap_err();
+    assert!(matches!(err, OrchestratorError::Other(_)));
+    assert!(backend.usage_history().is_empty());
+    assert_eq!(backend.usage_totals().calls, 0);
+}
+
+#[tokio::test]
+async fn reset_clears_usage_accounting() {
+    let backend = MockLLMBackend::new();
+    backend.add_response("hello", "world");
+    backend.set_usage_pricing(1.0, 1.0);
+
+    backend.infer("demo-model", "hello there").await.unwrap();
+    backend.reset_usage();
+
+    assert!(backend.usage_history().is_empty());
+    assert_eq!(backend.usage_totals().calls, 0);
+    assert_eq!(backend.usage_totals().total_tokens, 0);
+    assert_eq!(backend.usage_totals().cost_usd, 0.0);
+}


### PR DESCRIPTION
Adds deterministic usage accounting to MockLLMBackend with per-call history, totals, pricing, and reset support.

Issue: #1595
