### PR TITLE
 feat(testing): add Prometheus persisted telemetry dashboard mode and LLM metrics source hook

### DIFF
--- a/crates/mofa-monitoring/src/dashboard/server.rs
+++ b/crates/mofa-monitoring/src/dashboard/server.rs
@@ -18,6 +18,7 @@ use tower_http::trace::TraceLayer;
 use tracing::{info, warn};
 
 use mofa_kernel::workflow::telemetry::{DebugEvent, SessionRecorder};
+use mofa_kernel::metrics::LLMMetricsSource;
 
 use super::api::create_api_router;
 use super::assets::{INDEX_HTML, serve_asset};
@@ -182,6 +183,22 @@ impl DashboardServer {
     /// Get the metrics collector
     pub fn collector(&self) -> Arc<MetricsCollector> {
         self.collector.clone()
+    }
+
+    /// Configure a real LLM metrics source (e.g., persistence-backed store).
+    ///
+    /// This replaces the internal collector with one that pulls LLM metrics
+    /// from the provided source while keeping the existing metrics config.
+    pub fn with_llm_metrics_source(
+        mut self,
+        source: Arc<dyn LLMMetricsSource>,
+        provider_name: impl Into<String>,
+    ) -> Self {
+        // Rebuild collector so LLM metrics are pulled from an external source.
+        let collector = MetricsCollector::new(self.config.metrics_config.clone())
+            .with_llm_metrics_source(source, provider_name.into());
+        self.collector = Arc::new(collector);
+        self
     }
 
     /// Get the WebSocket handler (if started)

--- a/examples/monitoring_dashboard/Cargo.toml
+++ b/examples/monitoring_dashboard/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 
 [dependencies]
 # Local dependencies
-mofa-sdk = { path = "../../crates/mofa-sdk",features = ["monitoring"] }
+mofa-sdk = { path = "../../crates/mofa-sdk", features = ["monitoring", "persistence-sqlite"] }
 
 # Workspace dependencies
 serde_json.workspace = true

--- a/examples/monitoring_dashboard/src/bin/persisted_telemetry.rs
+++ b/examples/monitoring_dashboard/src/bin/persisted_telemetry.rs
@@ -1,0 +1,101 @@
+//! Web-based Monitoring Dashboard (real telemetry source)
+//!
+//! This binary keeps the existing dashboard UI but sources LLM telemetry
+//! from persisted API-call records instead of synthetic demo generators.
+//!
+//! Run with:
+//!   MOFA_SQLITE_METRICS_URL='sqlite://./mofa_metrics.db?mode=rwc' \
+//!   cargo run --manifest-path examples/monitoring_dashboard/Cargo.toml --bin persisted_telemetry
+
+use mofa_sdk::dashboard::{DashboardConfig, DashboardServer};
+use mofa_sdk::persistence::{DynApiCallStore, PersistenceMetricsSource, SqliteStore};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::info;
+
+fn normalize_sqlite_url(input: &str) -> String {
+    // Preserve explicit sqlite mode options provided by the caller.
+    if input == "sqlite::memory:" || input.contains("mode=") {
+        return input.to_string();
+    }
+
+    // Ensure file URLs are writable/creatable by default.
+    if input.starts_with("sqlite://") {
+        if input.contains('?') {
+            return format!("{input}&mode=rwc");
+        }
+        return format!("{input}?mode=rwc");
+    }
+
+    // Normalize legacy `sqlite:...` forms into SQLx-compatible URLs.
+    if let Some(path) = input.strip_prefix("sqlite:") {
+        if path.starts_with('/') {
+            return format!("sqlite://{path}?mode=rwc");
+        }
+        return format!("sqlite:///{path}?mode=rwc");
+    }
+
+    input.to_string()
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    tracing_subscriber::fmt()
+        .with_env_filter("info,mofa=debug")
+        .init();
+
+    let sqlite_url_raw = std::env::var("MOFA_SQLITE_METRICS_URL")
+        .unwrap_or_else(|_| "sqlite://./mofa_metrics.db?mode=rwc".to_string());
+    let sqlite_url = normalize_sqlite_url(&sqlite_url_raw);
+    let provider_name =
+        std::env::var("MOFA_LLM_PROVIDER_NAME").unwrap_or_else(|_| "persistence".to_string());
+    let host = std::env::var("MOFA_MONITOR_HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
+    let port = std::env::var("MOFA_MONITOR_PORT")
+        .ok()
+        .and_then(|v| v.parse::<u16>().ok())
+        .unwrap_or(8080);
+
+    info!("╔══════════════════════════════════════════════════════════════╗");
+    info!("║    MoFA Monitoring Dashboard (Persisted Telemetry Source)   ║");
+    info!("╚══════════════════════════════════════════════════════════════╝");
+    info!("📊 Connecting persistence metrics source...");
+    info!("   SQLite URL: {}", sqlite_url);
+    info!("   Provider:   {}", provider_name);
+
+    // Back the LLM metrics source with persisted API-call statistics.
+    let sqlite_store = SqliteStore::connect(&sqlite_url).await?;
+    let api_store: DynApiCallStore = Arc::new(sqlite_store);
+    let metrics_source = Arc::new(PersistenceMetricsSource::new(api_store));
+
+    let config = DashboardConfig::new()
+        .with_host(&host)
+        .with_port(port)
+        .with_cors(true)
+        .with_ws_interval(Duration::from_secs(1));
+
+    let mut server = DashboardServer::new(config)
+        .with_llm_metrics_source(metrics_source, provider_name);
+
+    let router = server.build_router();
+    let collector = server.collector();
+    // Prime the first snapshot so /metrics has data on initial scrape.
+    collector.collect().await;
+    collector.start_collection();
+
+    if let Some(exporter) = server.prometheus_exporter() {
+        exporter.refresh_once().await?;
+        let _prometheus_worker = exporter.start();
+    }
+
+    let bind_addr: SocketAddr = format!("{}:{}", host, port).parse()?;
+    let listener = tokio::net::TcpListener::bind(bind_addr).await?;
+
+    info!("🌐 Web UI:    http://{}", bind_addr);
+    info!("📡 Metrics:   http://{}/metrics", bind_addr);
+    info!("🚀 Server listening on http://{}", bind_addr);
+    info!("Press Ctrl+C to stop");
+
+    axum::serve(listener, router).await?;
+    Ok(())
+}

--- a/examples/monitoring_dashboard/src/main.rs
+++ b/examples/monitoring_dashboard/src/main.rs
@@ -32,7 +32,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     info!("╚══════════════════════════════════════════════════════════════╝");
     // Create dashboard configuration
     let config = DashboardConfig::new()
-        .with_host("127.0.0.1")
+        // Bind externally so Prometheus in Docker can scrape this example.
+        .with_host("0.0.0.0")
         .with_port(8080)
         .with_cors(true)
         .with_ws_interval(Duration::from_secs(1));
@@ -58,6 +59,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     // Start metrics collection background task
     collector.clone().start_collection();
+
+    // Ensure Prometheus exporter has an initial payload and keeps refreshing.
+    if let Some(exporter) = server.prometheus_exporter() {
+        exporter.refresh_once().await?;
+        let _prometheus_worker = exporter.start();
+    }
 
     // Get WebSocket handler for sending updates
     if let Some(ws_handler) = server.ws_handler() {
@@ -99,7 +106,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     info!("╚══════════════════════════════════════════════════════════════╝");
 
     // Start the server
-    let addr: SocketAddr = "127.0.0.1:8080".parse()?;
+    // Bind externally so both host and containers can reach the dashboard.
+    let addr: SocketAddr = "0.0.0.0:8080".parse()?;
     let listener = tokio::net::TcpListener::bind(addr).await?;
 
     info!("🚀 Server listening on http://{}", addr);


### PR DESCRIPTION
## Summary
This PR adds a new **persisted telemetry** execution path for the monitoring dashboard so we can validate observability against a real persistence-backed metrics source, while keeping the existing demo dashboard behavior intact.

The key outcome is that dashboard `/metrics` can now expose `mofa_llm_*` metrics from persisted API-call statistics (SQLite-backed), not just synthetic/demo updates.

## Why
We needed a testable path for “real” telemetry source validation (especially for Prometheus/Grafana checks) without removing or destabilizing the existing dashboard mode.

<img width="1909" height="922" alt="Screenshot from 2026-04-16 10-58-44" src="https://github.com/user-attachments/assets/36a33635-cf63-48b4-baca-759d088e53e2" />

<img width="1919" height="921" alt="Screenshot from 2026-04-16 11-23-46" src="https://github.com/user-attachments/assets/098b10ac-611f-43e4-a873-36f128013788" />

<img width="1919" height="921" alt="Screenshot from 2026-04-16 13-09-08" src="https://github.com/user-attachments/assets/4613df0c-ace4-464d-b4a7-dabc642515fb" />

<img width="1919" height="921" alt="Screenshot from 2026-04-16 13-11-16" src="https://github.com/user-attachments/assets/dc15a7fb-7156-4797-92fe-772ca38cc0d5" />

<img width="1919" height="921" alt="Screenshot from 2026-04-16 13-11-47" src="https://github.com/user-attachments/assets/2064d13a-1f85-4394-b296-01ac2725f60b" />

<img width="1919" height="921" alt="Screenshot from 2026-04-16 13-12-53" src="https://github.com/user-attachments/assets/37d6b620-d455-437d-8162-afb8e10da4a3" />

<img width="1919" height="921" alt="Screenshot from 2026-04-16 13-13-12" src="https://github.com/user-attachments/assets/f8d55b9b-52d3-4ece-83ec-c495a05b669c" />

<img width="1919" height="921" alt="Screenshot from 2026-04-16 13-14-12" src="https://github.com/user-attachments/assets/b46b39b1-3035-4e6b-b18b-2271417793a4" />

<img width="1919" height="921" alt="Screenshot from 2026-04-16 13-15-59" src="https://github.com/user-attachments/assets/11a37a7a-0fec-479e-be51-cf6803f7c56d" />


## What Changed

### 1. Monitoring server: add LLM metrics source hook
- **File:** `crates/mofa-monitoring/src/dashboard/server.rs`
- Added `DashboardServer::with_llm_metrics_source(...)`.
- This method rebuilds the collector with `MetricsCollector::with_llm_metrics_source(...)`, allowing server instances to pull LLM stats from an external source (e.g., persistence layer).

### 2. Monitoring dashboard example: enable persistence-sqlite
- **File:** `examples/monitoring_dashboard/Cargo.toml`
- Updated `mofa-sdk` features to include:
  - `monitoring`
  - `persistence-sqlite`
- This allows the example binary to create SQLite-backed persistence sources.

### 3. Existing demo dashboard: scrape/accessibility fixes
- **File:** `examples/monitoring_dashboard/src/main.rs`
- Changed bind host to `0.0.0.0` (instead of loopback only) for container/host scrape compatibility.
- Added Prometheus exporter refresh/start logic to ensure `/metrics` has initialized payload and continuous refresh.

### 4. New persisted telemetry binary
- **File:** `examples/monitoring_dashboard/src/bin/persisted_telemetry.rs`
- Added a new binary mode that:
  - Connects to SQLite via `SqliteStore`
  - Wraps as `DynApiCallStore`
  - Builds `PersistenceMetricsSource`
  - Injects source through `with_llm_metrics_source(...)`
- Includes SQLite URL normalization helper for practical SQLx URL compatibility and default writable mode behavior.
- Primes one metrics snapshot before exporter refresh to avoid empty initial scrape.

## Execution Flow:
<img width="1040" height="1730" alt="image" src="https://github.com/user-attachments/assets/92867579-2e87-48ed-abe6-1400c5a681b9" />

## Behavior / Usage

### Demo mode (unchanged intent)
```bash
cargo run --manifest-path examples/monitoring_dashboard/Cargo.toml
```

### Persisted telemetry mode (new)
```bash
MOFA_SQLITE_METRICS_URL='sqlite://./mofa_metrics.db?mode=rwc' \
cargo run --manifest-path examples/monitoring_dashboard/Cargo.toml --bin persisted_telemetry
```

## Validation Performed

### Build validation
```bash
cargo check --manifest-path examples/monitoring_dashboard/Cargo.toml
```
Passes successfully.

### Runtime validation
- Started `persisted_telemetry` binary.
- Verified `/metrics` exposes LLM metric families.
- Inserted one persisted API-call record in the same SQLite DB.
- Confirmed:
```text
mofa_llm_requests_total{provider="persistence",model="default"} 1
```