### PR TITLE
fix(backoff): prevent overflow in linear backoff calculation using saturating arithmetic

### DIFF
--- a/crates/mofa-foundation/src/recovery.rs
+++ b/crates/mofa-foundation/src/recovery.rs
@@ -87,7 +87,7 @@ impl Backoff {
                 initial_ms,
                 increment_ms,
             } => {
-                let ms = initial_ms + (increment_ms * attempt as u64);
+                let ms = initial_ms.saturating_add(increment_ms.saturating_mul(attempt as u64));
                 Duration::from_millis(ms)
             }
             Self::Exponential { initial_ms, max_ms } => {


### PR DESCRIPTION
## PROBLEM 
The current backoff calculation uses standard arithmetic:

initial_ms + (increment_ms * attempt as u64)

This can overflow when:

attempt becomes large
increment_ms is high


## SOLUTION
Replaced normal arithmetic with saturating operations:

saturating_mul for multiplication
saturating_add for addition

Updated code:

let ms = initial_ms
    .saturating_add(increment_ms.saturating_mul(attempt as u64));
    