### PR TITLE
fix(cli): correct FATAL log detection and add test coverage for prefix format

### DIFF
--- a/crates/mofa-cli/src/commands/agent/logs.rs
+++ b/crates/mofa-cli/src/commands/agent/logs.rs
@@ -165,7 +165,7 @@ async fn display_log_file(
 /// Colorize log line based on log level
 fn colorize_log_line(line: &str) -> String {
     let upper = line.to_uppercase();
-    if upper.contains("ERROR") || upper.contains(" FATAL ") {
+    if upper.contains("ERROR") || upper.contains("FATAL") {
         line.red().to_string()
     } else if upper.contains("WARN") || upper.contains(" WARNING ") {
         line.yellow().to_string()
@@ -404,5 +404,11 @@ mod tests {
     fn test_colorize_log_line_dims_bracketed_trace_prefix() {
         let line = "[TRACE] module::op starting";
         assert_eq!(colorize_log_line(line), line.bright_black().to_string());
+    }
+
+    #[test]
+    fn test_colorize_log_line_colors_fatal_prefix_without_spaces() {
+        let line = "FATAL: process crashed";
+        assert_eq!(colorize_log_line(line), line.red().to_string());
     }
 }


### PR DESCRIPTION
## Problem 
The CLI log colorization logic incorrectly checks for " FATAL" (with a leading space):

upper.contains(" FATAL")

This causes logs like:

FATAL: process crashed

to not be detected as fatal errors, since they do not contain a leading space. As a result, such logs are not colorized correctly.


## Solution
Updated the condition to correctly detect "FATAL" without requiring a leading space.
This ensures all fatal log messages are consistently identified regardless of formatting.
upper.contains("FATAL")

##  Improvements
- Fixes incorrect log level detection for fatal messages
- Ensures proper red colorization for all fatal logs
- Handles common formats like FATAL: and FATAL error