### PR TITLE
feat(gateway): add observability middleware (request-ID, metrics, /metrics endpoint) to control-plane server

### DIFF
--- a/crates/mofa-gateway/src/handlers/metrics_handler.rs
+++ b/crates/mofa-gateway/src/handlers/metrics_handler.rs
@@ -1,0 +1,100 @@
+//! Prometheus metrics endpoint handler for the control-plane server.
+//!
+//! Exposes `GET /metrics` in Prometheus text-exposition format so that
+//! Prometheus (or any compatible scraper) can collect control-plane metrics.
+
+use axum::{extract::State, http::StatusCode, response::IntoResponse};
+use std::sync::Arc;
+
+use crate::state::AppState;
+
+/// `GET /metrics` — Prometheus scrape endpoint.
+///
+/// Returns all registered metrics from [`crate::observability::GatewayMetrics`]
+/// in Prometheus text format (`text/plain; version=0.0.4; charset=utf-8`).
+pub async fn metrics_handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    match state.metrics.export() {
+        Ok(body) => (
+            StatusCode::OK,
+            [(
+                axum::http::header::CONTENT_TYPE,
+                "text/plain; version=0.0.4; charset=utf-8",
+            )],
+            body,
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to export metrics: {e}"),
+        )
+            .into_response(),
+    }
+}
+
+/// Build the metrics router sub-tree.
+pub fn metrics_router() -> axum::Router<Arc<AppState>> {
+    use axum::routing::get;
+    axum::Router::new().route("/metrics", get(metrics_handler))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::middleware::RateLimiter;
+    use crate::observability::GatewayMetrics;
+    use axum::body::Body;
+    use axum::extract::Request;
+    use mofa_runtime::agent::registry::AgentRegistry;
+    use std::time::Duration;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn metrics_endpoint_returns_prometheus_format() {
+        let registry = Arc::new(AgentRegistry::new());
+        let rate_limiter = Arc::new(RateLimiter::new(100, Duration::from_secs(60)));
+        let metrics = Arc::new(GatewayMetrics::new());
+
+        // Record some metrics to verify they appear in output.
+        metrics.increment_requests();
+        metrics.increment_requests();
+        metrics.increment_errors();
+
+        let state = Arc::new(AppState::new(registry, rate_limiter, metrics));
+
+        let app = metrics_router().with_state(state);
+
+        let req: Request<Body> = Request::builder()
+            .uri("/metrics")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let content_type = resp
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(content_type.contains("text/plain"));
+
+        let body = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let body_str = String::from_utf8_lossy(&body);
+
+        assert!(
+            body_str.contains("gateway_requests_total"),
+            "should contain requests_total metric"
+        );
+        assert!(
+            body_str.contains("gateway_requests_errors_total"),
+            "should contain errors_total metric"
+        );
+        assert!(
+            body_str.contains("gateway_requests_duration_seconds"),
+            "should contain duration metric"
+        );
+    }
+}

--- a/crates/mofa-gateway/src/handlers/mod.rs
+++ b/crates/mofa-gateway/src/handlers/mod.rs
@@ -4,10 +4,12 @@ pub mod agents;
 pub mod chat;
 pub mod health;
 pub mod local_llm;
+pub mod metrics_handler;
 pub mod openai;
 
 pub use agents::agents_router;
 pub use chat::chat_router;
 pub use health::health_router;
 pub use local_llm::*;
+pub use metrics_handler::metrics_router;
 pub use openai::openai_router;

--- a/crates/mofa-gateway/src/middleware/metrics_middleware.rs
+++ b/crates/mofa-gateway/src/middleware/metrics_middleware.rs
@@ -1,0 +1,98 @@
+//! Per-request Prometheus metrics middleware for the control-plane server.
+//!
+//! Instruments every HTTP request with:
+//! - `gateway_requests_total` counter (incremented on entry)
+//! - `gateway_requests_duration_seconds` histogram (recorded on exit)
+//! - `gateway_requests_errors_total` counter (incremented on non-2xx responses)
+
+use axum::{body::Body, extract::Request, middleware::Next, response::Response};
+use std::sync::Arc;
+use std::time::Instant;
+
+use crate::observability::SharedMetrics;
+
+/// Axum middleware that records per-request Prometheus metrics.
+///
+/// This middleware must be installed **with state** so it can access the
+/// shared [`SharedMetrics`] instance from [`crate::state::AppState`].
+///
+/// # Metrics updated
+///
+/// | Metric | Type | When |
+/// |--------|------|------|
+/// | `gateway_requests_total` | Counter | Every request |
+/// | `gateway_requests_duration_seconds` | Histogram | After response |
+/// | `gateway_requests_errors_total` | Counter | Non-2xx status |
+pub async fn metrics_middleware(
+    metrics: axum::extract::Extension<SharedMetrics>,
+    req: Request<Body>,
+    next: Next,
+) -> Response {
+    let start = Instant::now();
+
+    // Count every incoming request.
+    metrics.increment_requests();
+
+    let response = next.run(req).await;
+
+    // Record latency.
+    let duration = start.elapsed();
+    metrics.record_request_duration(duration);
+
+    // Count errors (any non-2xx status).
+    if !response.status().is_success() {
+        metrics.increment_errors();
+    }
+
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::observability::GatewayMetrics;
+    use axum::http::StatusCode;
+    use axum::{Router, body::Body, response::IntoResponse, routing::get};
+    use tower::ServiceExt;
+
+    async fn ok_handler() -> &'static str {
+        "ok"
+    }
+
+    async fn error_handler() -> impl IntoResponse {
+        (StatusCode::INTERNAL_SERVER_ERROR, "error")
+    }
+
+    fn build_router(metrics: SharedMetrics) -> Router {
+        Router::new()
+            .route("/ok", get(ok_handler))
+            .route("/err", get(error_handler))
+            .layer(axum::middleware::from_fn(metrics_middleware))
+            .layer(axum::Extension(metrics))
+    }
+
+    #[tokio::test]
+    async fn increments_requests_on_success() {
+        let metrics = Arc::new(GatewayMetrics::new());
+        let app = build_router(metrics.clone());
+
+        let req = Request::builder().uri("/ok").body(Body::empty()).unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(metrics.requests_total.get() as u64, 1);
+    }
+
+    #[tokio::test]
+    async fn increments_errors_on_non_2xx() {
+        let metrics = Arc::new(GatewayMetrics::new());
+        let app = build_router(metrics.clone());
+
+        let req = Request::builder().uri("/err").body(Body::empty()).unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(metrics.requests_total.get() as u64, 1);
+        assert_eq!(metrics.requests_errors_total.get() as u64, 1);
+    }
+}

--- a/crates/mofa-gateway/src/middleware/mod.rs
+++ b/crates/mofa-gateway/src/middleware/mod.rs
@@ -1,5 +1,8 @@
 //! Gateway middleware modules
 
+pub mod metrics_middleware;
 pub mod rate_limit;
+pub mod request_id;
 
 pub use rate_limit::RateLimiter;
+pub use request_id::request_id_middleware;

--- a/crates/mofa-gateway/src/middleware/request_id.rs
+++ b/crates/mofa-gateway/src/middleware/request_id.rs
@@ -1,0 +1,105 @@
+//! Request-ID middleware for the control-plane server.
+//!
+//! Ensures every request/response carries an `X-Request-Id` header for
+//! end-to-end correlation across logs, tracing spans, and downstream services.
+
+use axum::{
+    body::Body,
+    extract::Request,
+    http::{HeaderName, HeaderValue},
+    middleware::Next,
+    response::Response,
+};
+
+/// Extension type that handlers can extract to obtain the current request ID.
+#[derive(Debug, Clone)]
+pub struct RequestId(pub String);
+
+/// Header name used for request-ID propagation.
+static REQUEST_ID_HEADER: HeaderName = HeaderName::from_static("x-request-id");
+
+/// Axum middleware that propagates or generates an `X-Request-Id`.
+///
+/// Behaviour:
+/// 1. If the incoming request carries an `X-Request-Id` header, its value is
+///    reused verbatim.
+/// 2. Otherwise a new UUID v4 is generated.
+/// 3. The resolved ID is stored as a [`RequestId`] request extension so
+///    downstream handlers (and tracing subscribers) can read it.
+/// 4. The same ID is injected into the *response* `X-Request-Id` header.
+pub async fn request_id_middleware(mut req: Request<Body>, next: Next) -> Response {
+    // Resolve: use the client-provided ID or generate a new one.
+    let id = req
+        .headers()
+        .get(&REQUEST_ID_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .map(String::from)
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+    // Make the ID available to handlers via request extensions.
+    req.extensions_mut().insert(RequestId(id.clone()));
+
+    // Add a structured field to the current tracing span.
+    tracing::Span::current().record("request_id", &id.as_str());
+
+    let mut response = next.run(req).await;
+
+    // Echo the resolved ID back to the caller.
+    if let Ok(value) = HeaderValue::from_str(&id) {
+        response
+            .headers_mut()
+            .insert(REQUEST_ID_HEADER.clone(), value);
+    }
+
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+    use axum::{Router, body::Body, routing::get};
+    use tower::ServiceExt;
+
+    async fn echo_handler() -> &'static str {
+        "ok"
+    }
+
+    fn test_router() -> Router {
+        Router::new()
+            .route("/ping", get(echo_handler))
+            .layer(axum::middleware::from_fn(request_id_middleware))
+    }
+
+    #[tokio::test]
+    async fn generates_request_id_when_absent() {
+        let app = test_router();
+
+        let req = Request::builder().uri("/ping").body(Body::empty()).unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let header = resp.headers().get("x-request-id");
+        assert!(header.is_some(), "response must contain X-Request-Id");
+        // UUID v4 is 36 chars (8-4-4-4-12)
+        assert_eq!(header.unwrap().len(), 36);
+    }
+
+    #[tokio::test]
+    async fn preserves_client_provided_request_id() {
+        let app = test_router();
+
+        let req = Request::builder()
+            .uri("/ping")
+            .header("x-request-id", "my-custom-id-123")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let header = resp.headers().get("x-request-id").unwrap();
+        assert_eq!(header.to_str().unwrap(), "my-custom-id-123");
+    }
+}

--- a/crates/mofa-gateway/src/server.rs
+++ b/crates/mofa-gateway/src/server.rs
@@ -9,9 +9,10 @@ use tower_http::cors::{Any, CorsLayer};
 use tower_http::trace::TraceLayer;
 use tracing::info;
 
-use crate::handlers::{agents_router, chat_router, health_router, openai_router};
+use crate::handlers::{agents_router, chat_router, health_router, metrics_router, openai_router};
 use crate::inference_bridge::InferenceBridge;
 use crate::middleware::RateLimiter;
+use crate::observability::GatewayMetrics;
 use crate::state::AppState;
 use mofa_runtime::agent::registry::AgentRegistry;
 
@@ -125,8 +126,15 @@ impl GatewayServer {
             self.config.rate_window,
         ));
 
-        // Create state
-        let state = Arc::new(AppState::new(self.registry.clone(), rate_limiter.clone()));
+        // Create shared Prometheus metrics collector.
+        let metrics = Arc::new(GatewayMetrics::new());
+
+        // Create state (now includes metrics).
+        let state = Arc::new(AppState::new(
+            self.registry.clone(),
+            rate_limiter.clone(),
+            metrics.clone(),
+        ));
 
         // Spawn background GC task for rate-limiter entries
         let gc_limiter = rate_limiter.clone();
@@ -142,6 +150,7 @@ impl GatewayServer {
             .merge(health_router())
             .merge(agents_router())
             .merge(chat_router())
+            .merge(metrics_router())
             .with_state(state);
 
         // Add OpenAI router if inference bridge is configured
@@ -151,6 +160,22 @@ impl GatewayServer {
                 .merge(openai_router())
                 .layer(axum::Extension(bridge));
         }
+
+        // --- Middleware layers (outermost layer executes first) ---
+
+        // Per-request metrics: increment counters and record latency.
+        // NOTE: In axum, the last `.layer()` wraps outermost. The `Extension`
+        // must be outer so the `from_fn` middleware can extract it.
+        router = router
+            .layer(axum::middleware::from_fn(
+                crate::middleware::metrics_middleware::metrics_middleware,
+            ))
+            .layer(axum::Extension(metrics));
+
+        // Request-ID propagation: generate or echo X-Request-Id.
+        router = router.layer(axum::middleware::from_fn(
+            crate::middleware::request_id::request_id_middleware,
+        ));
 
         if self.config.enable_tracing {
             router = router.layer(TraceLayer::new_for_http());

--- a/crates/mofa-gateway/src/state.rs
+++ b/crates/mofa-gateway/src/state.rs
@@ -2,6 +2,7 @@
 
 use crate::inference_bridge::InferenceBridge;
 use crate::middleware::RateLimiter;
+use crate::observability::SharedMetrics;
 use mofa_foundation::inference::OrchestratorConfig;
 use mofa_runtime::agent::registry::AgentRegistry;
 use std::sync::Arc;
@@ -15,15 +16,22 @@ pub struct AppState {
     pub rate_limiter: Arc<RateLimiter>,
     /// Inference bridge - connects to InferenceOrchestrator (optional)
     pub inference_bridge: Option<Arc<InferenceBridge>>,
+    /// Prometheus metrics collector shared across middleware and handlers
+    pub metrics: SharedMetrics,
 }
 
 impl AppState {
     /// Create a new `AppState` wrapping the given `AgentRegistry`.
-    pub fn new(registry: Arc<AgentRegistry>, rate_limiter: Arc<RateLimiter>) -> Self {
+    pub fn new(
+        registry: Arc<AgentRegistry>,
+        rate_limiter: Arc<RateLimiter>,
+        metrics: SharedMetrics,
+    ) -> Self {
         Self {
             registry,
             rate_limiter,
             inference_bridge: None,
+            metrics,
         }
     }
 
@@ -31,6 +39,7 @@ impl AppState {
     pub fn with_inference_bridge(
         registry: Arc<AgentRegistry>,
         rate_limiter: Arc<RateLimiter>,
+        metrics: SharedMetrics,
         orchestrator_config: OrchestratorConfig,
     ) -> Self {
         let bridge = InferenceBridge::new(orchestrator_config);
@@ -38,6 +47,8 @@ impl AppState {
             registry,
             rate_limiter,
             inference_bridge: Some(Arc::new(bridge)),
+            metrics,
         }
     }
 }
+


### PR DESCRIPTION
## Summary

Wire request-ID propagation, per-request Prometheus metrics, and a `/metrics` scrape endpoint into the `GatewayServer` control-plane.

Closes #1634

## What changed

The `GatewayServer` control-plane (`server.rs`) is the primary REST API for agent management, chat, and OpenAI-compatible inference. It had **no observability middleware** — no request correlation, no per-request metrics, and no Prometheus scrape endpoint — despite the `GatewayMetrics` infrastructure already existing (only wired into the internal distributed gateway).

This PR adds three layers:

### 1. `X-Request-Id` Middleware (`middleware/request_id.rs`)
- Reads `X-Request-Id` from the incoming request (if present)
- Generates UUID v4 if absent
- Echoes resolved ID in the response header
- Stores `RequestId` in request extensions for handler/tracing access

### 2. Per-Request Metrics Middleware (`middleware/metrics_middleware.rs`)
- Increments `gateway_requests_total` on every request
- Records latency in `gateway_requests_duration_seconds` histogram
- Increments `gateway_requests_errors_total` on non-2xx responses

### 3. `GET /metrics` Endpoint (`handlers/metrics_handler.rs`)
- Returns all `GatewayMetrics` in Prometheus text-exposition format
- Content-Type: `text/plain; version=0.0.4; charset=utf-8`

### Wiring (`state.rs`, `server.rs`)
- Added `metrics: SharedMetrics` field to `AppState`
- Instantiate `GatewayMetrics` in `build_router()`
- Merge `metrics_router()` into the control-plane router
- Install both middleware layers

## Files Changed

| Action | File |
|--------|------|
| **NEW** | `crates/mofa-gateway/src/middleware/request_id.rs` |
| **NEW** | `crates/mofa-gateway/src/middleware/metrics_middleware.rs` |
| **NEW** | `crates/mofa-gateway/src/handlers/metrics_handler.rs` |
| **MODIFY** | `crates/mofa-gateway/src/middleware/mod.rs` |
| **MODIFY** | `crates/mofa-gateway/src/handlers/mod.rs` |
| **MODIFY** | `crates/mofa-gateway/src/state.rs` |
| **MODIFY** | `crates/mofa-gateway/src/server.rs` |

## Testing

5 new unit tests added:

- `request_id::tests::generates_request_id_when_absent`
- `request_id::tests::preserves_client_provided_request_id`
- `metrics_middleware::tests::increments_requests_on_success`
- `metrics_middleware::tests::increments_errors_on_non_2xx`
- `metrics_handler::tests::metrics_endpoint_returns_prometheus_format`

All CI checks pass locally:
- ✅ `cargo fmt --check`
- ✅ `cargo clippy --workspace --all-features -- -D errors`
- ✅ `cargo test -p mofa-gateway` (89 tests, 0 failures)
- ✅ `cargo build --examples`
- ✅ `cargo doc --workspace --no-deps --all-features`

## Breaking Changes

`AppState::new()` and `AppState::with_inference_bridge()` now require a `SharedMetrics` parameter. This is an internal API — no external consumers are affected.
